### PR TITLE
feat(projectUpdater): PO agent with multi-signal health scoring

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -72,6 +72,7 @@ src/
 ├── automation/             # Autonomous execution & scheduling
 │   ├── autonomousRunner.ts # Main autonomous loop (heartbeat→decide→execute)
 │   ├── runnerExecution.ts  # Execution helpers & pipeline delegation
+│   ├── runnerState.ts      # Task state, pipeline history, rejection tracking
 │   ├── scheduler.ts        # Cron-based dynamic scheduler
 │   └── prProcessor.ts      # PR auto-improvement pipeline
 │
@@ -89,11 +90,22 @@ src/
 │
 ├── linear/                 # Linear project management
 │   ├── index.ts            # Barrel re-export
-│   └── linear.ts           # Linear API client (issues, projects, state)
+│   ├── linear.ts           # Linear API client (issues, projects, state)
+│   └── projectUpdater.ts   # PO agent: project status updates & overview
 │
 ├── github/                 # GitHub CI/PR integration
 │   ├── index.ts            # Barrel re-export
 │   └── github.ts           # GitHub CLI wrapper (CI status, PRs)
+│
+├── knowledge/              # Code knowledge graph
+│   ├── index.ts            # Public API, singleton cache, scan throttle
+│   ├── graph.ts            # KnowledgeGraph data structure
+│   ├── scanner.ts          # Project scanning (full + incremental)
+│   ├── analyzer.ts         # Impact analysis, module health, review focus
+│   ├── store.ts            # Graph persistence (save/load/list)
+│   ├── gitInfo.ts          # Git churn & recent change enrichment
+│   ├── repository.ts       # Module state, tech debt, issue linking
+│   └── types.ts            # Zod schemas & TypeScript types
 │
 ├── support/                # Utility & support tools
 │   ├── chat.ts, dev.ts, editParser.ts, gitTracker.ts
@@ -142,7 +154,8 @@ index.ts
             ├→ support/projectMapper.ts (Linear project → local path fuzzy matching)
             ├→ support/planner.ts (Large task decomposition via Claude CLI)
             ├→ memory/ (Cognitive memory: LanceDB + Xenova embeddings)
-            └→ linear/ (Issue state + comment management)
+            ├→ linear/ (Issue state + comment management)
+            └→ linear/projectUpdater.ts (PO agent: metrics + knowledge graph → Linear updates)
 ```
 
 ---
@@ -405,11 +418,12 @@ OpenSwarm/
 │   ├── core/                 # core/service.ts, config.ts, types.ts
 │   ├── agents/               # worker, reviewer, tester, documenter, pairPipeline...
 │   ├── orchestration/        # decisionEngine, workflow, workflowExecutor, taskParser...
-│   ├── automation/           # autonomousRunner, runnerExecution, scheduler, prProcessor
+│   ├── automation/           # autonomousRunner, runnerState, runnerExecution, scheduler, prProcessor
 │   ├── memory/               # memoryCore, memoryOps, codex (LanceDB + Xenova)
 │   ├── discord/              # discordCore, discordHandlers, discordPair
-│   ├── linear/               # linear.ts (Linear SDK integration)
+│   ├── linear/               # linear.ts, projectUpdater.ts (Linear SDK + PO agent)
 │   ├── github/               # github.ts (CI monitoring via gh CLI)
+│   ├── knowledge/            # Knowledge graph: scanner, analyzer, store, repository
 │   ├── support/              # tmux, web, planner, projectMapper, timeWindow, ...
 │   ├── __tests__/            # vitest test files
 │   └── locale/               # i18n: en.ts, ko.ts, prompts/
@@ -432,7 +446,8 @@ OpenSwarm/
 
 | Commit | Description |
 |--------|-------------|
-| (current) | SRP-based src/ layer hierarchy refactoring (flat 49 files → 9 domain dirs) |
+| (current) | PO agent: projectUpdater rewrite with multi-signal health scoring + knowledge graph |
+| 8518cf3 | SRP-based src/ layer hierarchy refactoring (flat 49 files → 9 domain dirs) |
 | 48a35ea | TypeScript strict types + ESM import unification + locale i18n |
 | 40c340b | Discord/Memory module separation (barrel re-export) |
 | 38f8f71 | PR auto-improvement pipeline + interactive chat CLI |
@@ -444,4 +459,4 @@ OpenSwarm/
 
 ---
 
-*Last updated: 2026-02-17*
+*Last updated: 2026-03-03*

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -189,6 +189,7 @@ export class AutonomousRunner {
           duration: result.totalDuration,
           issueIdentifier: task.issueIdentifier,
           cost: result.totalCost?.costUsd,
+          projectPath: result.taskContext?.projectPath,
         }).catch(e => console.warn('[Scheduler] Project update failed:', e));
       }
 
@@ -272,6 +273,7 @@ export class AutonomousRunner {
           duration: result.totalDuration,
           issueIdentifier: task.issueIdentifier,
           cost: result.totalCost?.costUsd,
+          projectPath: result.taskContext?.projectPath,
         }).catch(e => console.warn('[Scheduler] Project update failed:', e));
       }
 

--- a/src/automation/runnerState.ts
+++ b/src/automation/runnerState.ts
@@ -169,6 +169,11 @@ export function isRejectionLimitReached(issueId: string): boolean {
   return getRejectionCount(issueId) >= MAX_REJECTION_ATTEMPTS;
 }
 
+export function getAllRejectionEntries(): RejectionEntry[] {
+  const state = ensureRejectionStateLoaded();
+  return Object.values(state.rejections);
+}
+
 // ============================================
 // Decomposition State (track parent-child relationships and daily limits)
 // ============================================

--- a/src/linear/projectUpdater.ts
+++ b/src/linear/projectUpdater.ts
@@ -1,10 +1,13 @@
 // ============================================
-// OpenSwarm - Linear Project Updater
-// Project Status Update + Overview auto-refresh
+// OpenSwarm - Linear Project Updater (PO Agent)
+// Rich project status updates + overview auto-refresh
+// Uses pipeline history, rejection state, knowledge graph
 // ============================================
 
 import { LinearClient } from '@linear/sdk';
-import { getPipelineHistory, type PipelineHistoryEntry } from '../automation/runnerState.js';
+import { getPipelineHistory, getAllRejectionEntries, type PipelineHistoryEntry, type RejectionEntry } from '../automation/runnerState.js';
+import { getGraph, toProjectSlug, getProjectHealth, type ModuleHealth } from '../knowledge/index.js';
+import type { ProjectSummary } from '../knowledge/index.js';
 import { getDateLocale } from '../locale/index.js';
 
 // Debounce: prevent duplicate calls within 60 seconds per project
@@ -29,7 +32,398 @@ export interface CompletedTaskInfo {
   duration: number;
   issueIdentifier?: string;
   cost?: number;
+  projectPath?: string;
 }
+
+// ============================================
+// Metrics Collection
+// ============================================
+
+interface TodayActivity {
+  completed: number;
+  failed: number;
+  cost: number;
+  entries: PipelineHistoryEntry[];
+}
+
+interface RollingMetrics {
+  totalTasks: number;
+  successCount: number;
+  failCount: number;
+  successRate: number;
+  avgDuration: number;
+  totalCost: number;
+  startDate: string;
+  endDate: string;
+  // 7-day trend (current 7d vs previous 7d)
+  trend: {
+    tasks: number;
+    successRate: number;
+    cost: number;
+  };
+}
+
+interface KnowledgeMetrics {
+  summary: ProjectSummary;
+  riskModules: ModuleHealth[];
+}
+
+interface ProjectMetrics {
+  today: TodayActivity;
+  rolling: RollingMetrics;
+  rejections: RejectionEntry[];
+  knowledge: KnowledgeMetrics | null;
+}
+
+function collectProjectMetrics(projectName: string): ProjectMetrics {
+  const now = new Date();
+  const todayStr = now.toISOString().slice(0, 10);
+  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const fourteenDaysAgo = new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000);
+
+  // Pipeline history for this project
+  const allHistory = getPipelineHistory(100);
+  const projectHistory = allHistory.filter(e => e.projectName === projectName);
+
+  // Today's activity
+  const todayEntries = projectHistory.filter(e => e.completedAt.startsWith(todayStr));
+  const todayCompleted = todayEntries.filter(e => e.success);
+  const todayFailed = todayEntries.filter(e => !e.success);
+  const todayCost = todayEntries.reduce((sum, e) => sum + (e.cost?.costUsd ?? 0), 0);
+
+  // 30-day rolling metrics
+  const rollingEntries = projectHistory.filter(e => new Date(e.completedAt) >= thirtyDaysAgo);
+  const rollingSuccess = rollingEntries.filter(e => e.success);
+  const rollingFail = rollingEntries.filter(e => !e.success);
+  const rollingCost = rollingEntries.reduce((sum, e) => sum + (e.cost?.costUsd ?? 0), 0);
+  const rollingAvgDuration = rollingEntries.length > 0
+    ? rollingEntries.reduce((sum, e) => sum + e.totalDuration, 0) / rollingEntries.length
+    : 0;
+
+  // 7-day trend: current 7d vs previous 7d
+  const current7d = rollingEntries.filter(e => new Date(e.completedAt) >= sevenDaysAgo);
+  const prev7d = rollingEntries.filter(e => {
+    const d = new Date(e.completedAt);
+    return d >= fourteenDaysAgo && d < sevenDaysAgo;
+  });
+
+  const current7dRate = current7d.length > 0
+    ? current7d.filter(e => e.success).length / current7d.length * 100
+    : 0;
+  const prev7dRate = prev7d.length > 0
+    ? prev7d.filter(e => e.success).length / prev7d.length * 100
+    : 0;
+  const current7dCost = current7d.reduce((sum, e) => sum + (e.cost?.costUsd ?? 0), 0);
+  const prev7dCost = prev7d.reduce((sum, e) => sum + (e.cost?.costUsd ?? 0), 0);
+
+  // Rolling date range
+  const rollingDates = rollingEntries.map(e => e.completedAt.slice(0, 10));
+  const startDate = rollingDates.length > 0 ? rollingDates[rollingDates.length - 1] : todayStr;
+  const endDate = rollingDates.length > 0 ? rollingDates[0] : todayStr;
+
+  // Rejection state
+  let rejections: RejectionEntry[] = [];
+  try {
+    rejections = getAllRejectionEntries().filter(r => r.count > 0);
+  } catch { /* graceful fallback */ }
+
+  // Knowledge graph is async — collected separately by caller via collectKnowledgeMetrics()
+
+  return {
+    today: {
+      completed: todayCompleted.length,
+      failed: todayFailed.length,
+      cost: todayCost,
+      entries: todayEntries,
+    },
+    rolling: {
+      totalTasks: rollingEntries.length,
+      successCount: rollingSuccess.length,
+      failCount: rollingFail.length,
+      successRate: rollingEntries.length > 0
+        ? Math.round(rollingSuccess.length / rollingEntries.length * 100)
+        : 0,
+      avgDuration: rollingAvgDuration,
+      totalCost: rollingCost,
+      startDate,
+      endDate,
+      trend: {
+        tasks: current7d.length - prev7d.length,
+        successRate: Math.round((current7dRate - prev7dRate) * 10) / 10,
+        cost: Math.round((current7dCost - prev7dCost) * 100) / 100,
+      },
+    },
+    rejections,
+    knowledge: null,
+  };
+}
+
+async function collectKnowledgeMetrics(projectPath: string): Promise<KnowledgeMetrics | null> {
+  try {
+    const slug = toProjectSlug(projectPath);
+    const graph = await getGraph(slug);
+    if (!graph) return null;
+    const { summary, riskModules } = getProjectHealth(graph);
+    return { summary, riskModules };
+  } catch {
+    return null;
+  }
+}
+
+// ============================================
+// Health Determination
+// ============================================
+
+type HealthStatus = 'onTrack' | 'atRisk' | 'offTrack';
+
+function determineHealth(metrics: ProjectMetrics): { health: HealthStatus; score: number } {
+  let score = 100;
+
+  // Success rate signal
+  if (metrics.rolling.totalTasks > 0) {
+    if (metrics.rolling.successRate < 50) score -= 40;
+    else if (metrics.rolling.successRate < 70) score -= 20;
+    else if (metrics.rolling.successRate < 85) score -= 10;
+  }
+
+  // Active rejections
+  if (metrics.rejections.length >= 3) score -= 20;
+  else if (metrics.rejections.length >= 1) score -= 10;
+
+  // Declining trend
+  if (metrics.rolling.trend.successRate < -15) score -= 15;
+  else if (metrics.rolling.trend.successRate < -5) score -= 5;
+
+  // No activity in 30 days
+  if (metrics.rolling.totalTasks === 0) score -= 10;
+
+  // Today's failures exceed completions
+  if (metrics.today.failed > metrics.today.completed && metrics.today.failed > 0) score -= 15;
+
+  // Knowledge graph risk modules
+  if (metrics.knowledge) {
+    const highRisk = metrics.knowledge.riskModules.filter(m => m.risk === 'high');
+    if (highRisk.length >= 5) score -= 10;
+    else if (highRisk.length >= 2) score -= 5;
+  }
+
+  // Clamp
+  score = Math.max(0, Math.min(100, score));
+
+  let health: HealthStatus;
+  if (score >= 70) health = 'onTrack';
+  else if (score >= 40) health = 'atRisk';
+  else health = 'offTrack';
+
+  return { health, score };
+}
+
+// ============================================
+// Status Update Body Builder
+// ============================================
+
+function buildStatusUpdateBody(
+  projectName: string,
+  metrics: ProjectMetrics,
+): string {
+  const today = new Date().toLocaleDateString(getDateLocale(), {
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  });
+
+  const lines: string[] = [];
+  lines.push(`## ${projectName} -- Status Update (${today})`);
+  lines.push('');
+
+  // Today's Activity
+  lines.push('### Today\'s Activity');
+  lines.push('| Metric | Value |');
+  lines.push('|--------|-------|');
+  lines.push(`| Completed | ${metrics.today.completed} |`);
+  lines.push(`| Failed | ${metrics.today.failed} |`);
+  lines.push(`| Cost | $${metrics.today.cost.toFixed(2)} |`);
+  lines.push('');
+
+  // 30-Day Metrics
+  if (metrics.rolling.totalTasks > 0) {
+    const trendTasks = formatTrend(metrics.rolling.trend.tasks, '');
+    const trendRate = formatTrend(metrics.rolling.trend.successRate, '%');
+    const trendCost = formatTrend(metrics.rolling.trend.cost, '', '$');
+
+    lines.push(`### 30-Day Metrics (${metrics.rolling.startDate} ~ ${metrics.rolling.endDate})`);
+    lines.push('| Metric | Value | Trend (7d) |');
+    lines.push('|--------|-------|------------|');
+    lines.push(`| Tasks | ${metrics.rolling.totalTasks} | ${trendTasks} |`);
+    lines.push(`| Success Rate | ${metrics.rolling.successRate}% | ${trendRate} |`);
+    lines.push(`| Avg Duration | ${formatDuration(metrics.rolling.avgDuration)} | - |`);
+    lines.push(`| Total Cost | $${metrics.rolling.totalCost.toFixed(2)} | ${trendCost} |`);
+    lines.push('');
+  }
+
+  // Recent Tasks (up to 10)
+  const recentEntries = metrics.today.entries.length > 0
+    ? metrics.today.entries.slice(0, 10)
+    : getPipelineHistory(10).filter(e => e.projectName === projectName).slice(0, 5);
+
+  if (recentEntries.length > 0) {
+    lines.push('### Recent Tasks');
+    lines.push('| | ID | Task | Duration/Cost | PR |');
+    lines.push('|-|----|------|---------------|----|');
+    for (const e of recentEntries) {
+      const icon = e.success ? '\u2713' : '\u2717';
+      const id = e.issueIdentifier || '-';
+      const title = e.taskTitle.length > 40 ? e.taskTitle.slice(0, 37) + '...' : e.taskTitle;
+      const dur = formatDuration(e.totalDuration);
+      const cost = e.cost?.costUsd ? `$${e.cost.costUsd.toFixed(2)}` : '-';
+      const pr = e.prUrl ? `[PR](${e.prUrl})` : '-';
+      lines.push(`| ${icon} | ${id} | ${title} | ${dur} ${cost} | ${pr} |`);
+    }
+    lines.push('');
+  }
+
+  // Failed Tasks
+  const failedEntries = metrics.today.entries.filter(e => !e.success);
+  if (failedEntries.length > 0) {
+    lines.push('### Failed Tasks');
+    for (const e of failedEntries) {
+      const id = e.issueIdentifier || e.taskTitle.slice(0, 20);
+      const reason = e.reviewerFeedback || e.finalStatus;
+      lines.push(`- **${id}**: ${reason}`);
+    }
+    lines.push('');
+  }
+
+  // Blocked / Rejected Items
+  if (metrics.rejections.length > 0) {
+    lines.push('### Blocked / Rejected Items');
+    for (const r of metrics.rejections.slice(0, 10)) {
+      const latestReason = r.reasons.length > 0 ? r.reasons[r.reasons.length - 1] : 'unknown';
+      const shortId = r.issueId.slice(0, 8);
+      lines.push(`- Issue ${shortId}...: ${r.count} rejection(s) -- ${latestReason.slice(0, 80)}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// ============================================
+// Overview Section Builder
+// ============================================
+
+function buildOverviewSection(
+  stateCounts: Map<string, number>,
+  priorityCounts: Map<number, number>,
+  metrics: ProjectMetrics,
+): string {
+  const now = new Date().toLocaleString(getDateLocale());
+
+  const lines: string[] = [];
+  lines.push(AUTOMATION_SECTION_MARKER);
+  lines.push(`> Last updated: ${now}`);
+  lines.push('');
+
+  // Issue Distribution - By State
+  lines.push('### Issue Distribution');
+  lines.push('**By State:**');
+  lines.push('| State | Count |');
+  lines.push('|-------|-------|');
+  const stateOrder = ['Done', 'In Progress', 'In Review', 'Todo', 'Backlog', 'Cancelled', 'Triage'];
+  for (const state of stateOrder) {
+    if (stateCounts.has(state)) {
+      lines.push(`| ${state} | ${stateCounts.get(state)} |`);
+    }
+  }
+  // Include any states not in the predefined order
+  for (const [state, count] of stateCounts) {
+    if (!stateOrder.includes(state)) {
+      lines.push(`| ${state} | ${count} |`);
+    }
+  }
+  lines.push('');
+
+  // Issue Distribution - By Priority
+  if (priorityCounts.size > 0) {
+    const priorityLabels: Record<number, string> = { 0: 'No Priority', 1: 'Urgent', 2: 'High', 3: 'Medium', 4: 'Low' };
+    lines.push('**By Priority:**');
+    lines.push('| Priority | Count |');
+    lines.push('|----------|-------|');
+    for (const p of [1, 2, 3, 4, 0]) {
+      if (priorityCounts.has(p)) {
+        lines.push(`| ${priorityLabels[p] ?? `P${p}`} | ${priorityCounts.get(p)} |`);
+      }
+    }
+    lines.push('');
+  }
+
+  // Automation Performance (30d)
+  lines.push('### Automation Performance (30d)');
+  lines.push('| Metric | Value |');
+  lines.push('|--------|-------|');
+  lines.push(`| Tasks Completed | ${metrics.rolling.successCount} / ${metrics.rolling.totalTasks} |`);
+  lines.push(`| Success Rate | ${metrics.rolling.successRate}% |`);
+  lines.push(`| Avg Duration | ${formatDuration(metrics.rolling.avgDuration)} |`);
+  lines.push(`| Total Cost | $${metrics.rolling.totalCost.toFixed(2)} |`);
+  lines.push(`| Active Rejections | ${metrics.rejections.length} |`);
+  lines.push('');
+
+  // Code Health (if knowledge graph available)
+  if (metrics.knowledge) {
+    const s = metrics.knowledge.summary;
+    const testCoverage = s.totalModules > 0
+      ? Math.round((1 - s.untestedModules.length / s.totalModules) * 100)
+      : 0;
+    const highRisk = metrics.knowledge.riskModules.filter(m => m.risk === 'high');
+    const highDebt = s.highTechDebtModules ?? [];
+
+    lines.push('### Code Health');
+    lines.push('| Metric | Value |');
+    lines.push('|--------|-------|');
+    lines.push(`| Modules | ${s.totalModules} |`);
+    lines.push(`| Test Files | ${s.totalTestFiles} |`);
+    lines.push(`| Test Coverage | ${testCoverage}% |`);
+    lines.push(`| High-Risk Modules | ${highRisk.length} |`);
+    lines.push(`| High Tech Debt | ${highDebt.length} |`);
+    lines.push('');
+
+    if (s.hotModules.length > 0) {
+      lines.push(`**Hot Modules**: ${s.hotModules.slice(0, 5).map(m => `\`${m}\``).join(', ')}`);
+    }
+    if (highDebt.length > 0) {
+      lines.push(`**Tech Debt Watch**: ${highDebt.slice(0, 5).map(m => `\`${m}\``).join(', ')}`);
+    }
+    if (s.hotModules.length > 0 || highDebt.length > 0) {
+      lines.push('');
+    }
+  }
+
+  // Risk Areas
+  const riskLines: string[] = [];
+  if (metrics.rejections.length > 0) {
+    riskLines.push(`- ${metrics.rejections.length} task(s) blocked by reviewer rejection`);
+  }
+  if (metrics.knowledge) {
+    const untested = metrics.knowledge.summary.untestedModules.length;
+    if (untested > 0) {
+      riskLines.push(`- ${untested} modules without tests`);
+    }
+  }
+  if (metrics.rolling.totalTasks > 0 && metrics.rolling.successRate < 70) {
+    riskLines.push(`- Low automation success rate: ${metrics.rolling.successRate}%`);
+  }
+
+  if (riskLines.length > 0) {
+    lines.push('### Risk Areas');
+    lines.push(riskLines.join('\n'));
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// ============================================
+// Public API
+// ============================================
 
 /**
  * Update Linear project Status + Overview after task completion
@@ -45,7 +439,7 @@ export async function updateProjectAfterTask(
   lastUpdateTime.set(projectId, Date.now());
 
   await postStatusUpdate(projectId, projectName, task);
-  await refreshProjectOverview(projectId);
+  await refreshProjectOverview(projectId, task.projectPath);
 }
 
 // ============================================
@@ -55,48 +449,23 @@ export async function updateProjectAfterTask(
 async function postStatusUpdate(
   projectId: string,
   projectName: string,
-  _task: CompletedTaskInfo,
+  task: CompletedTaskInfo,
 ): Promise<void> {
   const linear = getClient();
-  const today = new Date().toLocaleDateString(getDateLocale(), { year: 'numeric', month: '2-digit', day: '2-digit' });
 
-  // Filter today's records
-  const todayStr = new Date().toISOString().slice(0, 10);
-  const history = getPipelineHistory(100);
-  const todayEntries = history.filter(e =>
-    e.projectName === projectName && e.completedAt.startsWith(todayStr)
-  );
+  // Collect metrics
+  const metrics = collectProjectMetrics(projectName);
 
-  const completed = todayEntries.filter(e => e.success);
-  const failed = todayEntries.filter(e => !e.success);
-  const totalCost = todayEntries.reduce((sum, e) => sum + (e.cost?.costUsd ?? 0), 0);
+  // Async knowledge graph collection
+  if (task.projectPath) {
+    metrics.knowledge = await collectKnowledgeMetrics(task.projectPath);
+  }
 
-  // Summarize recent 5 entries
-  const recentLines = todayEntries.slice(0, 5).map(e => {
-    const id = e.issueIdentifier || e.taskTitle.slice(0, 20);
-    const icon = e.success ? '\u2713' : '\u2717';
-    const dur = formatDuration(e.totalDuration);
-    const costStr = e.cost?.costUsd ? ` $${e.cost.costUsd.toFixed(2)}` : '';
-    return `- ${icon} ${id}: ${e.taskTitle.slice(0, 40)} (${dur}${costStr})`;
-  }).join('\n');
-
-  const body = `## Automation Activity (${today})
-
-### Recent
-${recentLines || '(none)'}
-
-### Stats
-| Item | Value |
-|------|-------|
-| Completed | ${completed.length} |
-| Failed | ${failed.length} |
-| Total Cost | $${totalCost.toFixed(2)} |
-`;
+  // Build body
+  const body = buildStatusUpdateBody(projectName, metrics);
 
   // Determine health
-  let health: string = 'onTrack';
-  if (failed.length > completed.length) health = 'offTrack';
-  else if (failed.length > 0) health = 'atRisk';
+  const { health } = determineHealth(metrics);
 
   try {
     await linear.createProjectUpdate({
@@ -116,44 +485,34 @@ ${recentLines || '(none)'}
 
 const AUTOMATION_SECTION_MARKER = '## Automation Status';
 
-async function refreshProjectOverview(projectId: string): Promise<void> {
+async function refreshProjectOverview(projectId: string, projectPath?: string): Promise<void> {
   const linear = getClient();
 
   try {
     const project = await linear.project(projectId);
     if (!project) return;
 
-    // Issue stats: count issues by state for this project
+    // Issue stats: count issues by state and priority
     const issues = await project.issues({ first: 250 });
     const stateCounts = new Map<string, number>();
+    const priorityCounts = new Map<number, number>();
+
     for (const issue of issues.nodes) {
       const state = (await issue.state)?.name ?? 'Unknown';
       stateCounts.set(state, (stateCounts.get(state) ?? 0) + 1);
+      priorityCounts.set(issue.priority, (priorityCounts.get(issue.priority) ?? 0) + 1);
     }
 
-    // Recent 5 pipeline history entries
-    const history = getPipelineHistory(50);
-    const projectHistory = history.filter(e => e.projectName === project.name).slice(0, 5);
-    const recentStr = projectHistory.map(e => {
-      const id = e.issueIdentifier || '?';
-      return `${id} ${e.success ? '\u2713' : '\u2717'}`;
-    }).join(', ') || '(none)';
+    // Collect metrics
+    const metrics = collectProjectMetrics(project.name);
 
-    const now = new Date().toLocaleString(getDateLocale());
-    const stateRows = ['Done', 'In Progress', 'In Review', 'Todo', 'Backlog']
-      .filter(s => stateCounts.has(s))
-      .map(s => `| ${s} | ${stateCounts.get(s)} |`)
-      .join('\n');
+    // Async knowledge graph
+    if (projectPath) {
+      metrics.knowledge = await collectKnowledgeMetrics(projectPath);
+    }
 
-    const section = `${AUTOMATION_SECTION_MARKER}
-> Last updated: ${now}
-
-| State | Issues |
-|-------|--------|
-${stateRows}
-
-**Recent 5**: ${recentStr}
-`;
+    // Build overview section
+    const section = buildOverviewSection(stateCounts, priorityCounts, metrics);
 
     // Replace automation section in existing description, or append
     const currentDesc = project.description ?? '';
@@ -161,10 +520,8 @@ ${stateRows}
 
     let newDesc: string;
     if (markerIdx >= 0) {
-      // Replace existing section (from marker to end)
       newDesc = currentDesc.slice(0, markerIdx) + section;
     } else {
-      // Append to end of existing description
       newDesc = currentDesc + '\n\n' + section;
     }
 
@@ -183,4 +540,10 @@ function formatDuration(ms: number): string {
   const sec = Math.floor(ms / 1000);
   if (sec < 60) return `${sec}s`;
   return `${Math.floor(sec / 60)}m ${sec % 60}s`;
+}
+
+function formatTrend(value: number, suffix: string, prefix = ''): string {
+  if (value === 0) return '-';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${prefix}${value}${suffix}`;
 }


### PR DESCRIPTION
## Summary
- **Rewrite `projectUpdater.ts`** as a PO (Product Owner) agent that produces structured, data-rich Linear project reports
- **Add `getAllRejectionEntries()`** export to `runnerState.ts` for rejection state aggregation
- **Pass `projectPath`** from `autonomousRunner.ts` to enable knowledge graph lookups in project updates
- **Update `ARCHITECTURE.md`** to document `knowledge/`, `projectUpdater.ts`, and `runnerState.ts`

### New Capabilities
| Feature | Description |
|---------|-------------|
| `collectProjectMetrics()` | Aggregates pipeline history (30-day rolling), rejection state, and knowledge graph data |
| `determineHealth()` | 6-signal health scoring (success rate, rejections, trend, activity, daily failures, risk modules) |
| `buildStatusUpdateBody()` | Structured markdown: Today activity, 30-Day Metrics with 7d trends, Recent Tasks table |
| `buildOverviewSection()` | Issue Distribution (state + priority), Automation Performance (30d), Code Health, Risk Areas |

### Before/After
- **Before**: Status updates showed only today task count and issue state tallies
- **After**: Rich structured reports with 30-day rolling metrics, 7-day trend comparison, knowledge graph integration, and multi-signal health assessment

## Test plan
- [x] Typecheck passes (`npx tsc --noEmit`)
- [x] oxlint passes with 0 warnings
- [ ] Trigger `updateProjectAfterTask()` via OpenSwarm with a test task
- [ ] Verify graceful degradation when pipeline history is empty
- [ ] Verify graceful degradation when knowledge graph not scanned yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)