### PR TITLE
ci(loc-gate): convert LOC gate from blocking error to warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,18 +69,15 @@ jobs:
         continue-on-error: true
 
   loc-gate:
-    name: LOC Gate (Max 800 lines)
+    name: LOC Warning (800 lines)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Check file sizes
         run: |
-          EXIT_CODE=0
           for file in $(find src -name "*.ts" -type f); do
             lines=$(wc -l < "$file")
             if [ "$lines" -gt 800 ]; then
-              echo "::error file=$file::File exceeds 800 lines ($lines)"
-              EXIT_CODE=1
+              echo "::warning file=$file::File exceeds 800 lines ($lines)"
             fi
           done
-          exit $EXIT_CODE


### PR DESCRIPTION
## Summary
- LOC Gate를 CI 블로커에서 경고(warning annotation)로 변경
- 기존 코드베이스에 800줄 초과 .ts 파일 12개 존재하여 무관한 PR(dependabot 등)까지 블록되는 문제 해소

## Changes
- `.github/workflows/ci.yml`: `::error` → `::warning`, `exit $EXIT_CODE` 제거

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)