### PR TITLE
fix: align license references to GPL-3.0 and add Tauri CORS origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,4 +446,4 @@ src/
 
 ## License
 
-MIT
+GPL-3.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@intrect/openswarm",
   "version": "0.4.0",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
-  "license": "MIT",
+  "license": "GPL-3.0",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -144,6 +144,8 @@ export async function startWebServer(port: number = 3847): Promise<void> {
       if (origin && (
         origin.startsWith('http://localhost:') ||
         origin.startsWith('http://127.0.0.1:') ||
+        origin.startsWith('http://tauri.localhost') ||
+        origin.startsWith('https://tauri.localhost') ||
         origin.startsWith('http://100.') // Tailscale CGNAT range (100.64.0.0/10)
       )) {
         res.setHeader('Access-Control-Allow-Origin', origin);


### PR DESCRIPTION
## Summary
- package.json: `"license": "MIT"` → `"GPL-3.0"` (LICENSE file was already GPLv3)
- README.md: license section MIT → GPL-3.0
- web.ts: add `tauri.localhost` to CORS allowed origins for OpenSwarm Desktop app

## Changes
- `package.json`
- `README.md`
- `src/support/web.ts`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)