### PR TITLE
chore: add .env.example template for service install

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,46 @@
+# OpenSwarm environment variables
+# Copy this file to `.env` and fill in the real values.
+#   cp .env.example .env
+# Never commit `.env` to version control.
+
+# -----------------------------------------------------------------------------
+# Discord bot
+# -----------------------------------------------------------------------------
+# Bot token from https://discord.com/developers/applications
+DISCORD_TOKEN="your-discord-bot-token"
+
+# Channel ID the bot listens to / posts in
+DISCORD_CHANNEL_ID="000000000000000000"
+
+# Optional: webhook URL used for rich notifications
+DISCORD_WEBHOOK_URL=""
+
+# Comma-separated Discord user IDs allowed to issue commands
+DISCORD_ALLOWED_USERS="000000000000000000"
+
+# -----------------------------------------------------------------------------
+# Linear API
+# -----------------------------------------------------------------------------
+# Personal API key from https://linear.app/settings/api
+LINEAR_API_KEY="lin_api_xxxxxxxxxxxxxxxxxxxxxxxx"
+
+# One or more Linear team UUIDs, comma-separated
+LINEAR_TEAM_ID="00000000-0000-0000-0000-000000000000"
+
+# -----------------------------------------------------------------------------
+# NPM (optional — only required for publishing workflows)
+# -----------------------------------------------------------------------------
+NPM_TOKENS=""
+
+# -----------------------------------------------------------------------------
+# OpenAI / Codex CLI auth (optional)
+# -----------------------------------------------------------------------------
+# Overrides the default OAuth client ID used by the PKCE flow
+OPENAI_CLIENT_ID=""
+
+# -----------------------------------------------------------------------------
+# Task state (optional)
+# -----------------------------------------------------------------------------
+# Override location of the persisted task-state file
+# Default: ~/.openswarm/task-state.json
+OPENSWARM_TASK_STATE_FILE=""


### PR DESCRIPTION
## Summary
- Adds the missing `.env.example` file at the repo root with placeholder values for every env var referenced from `src/` (Discord, Linear, optional NPM/OpenAI/task-state).
- Unblocks `npm run service:install`, which already instructs users to run `cp .env.example .env` before install.

## Why
`scripts/install-service.sh` exits with `Error: .env file not found.` and suggests `cp .env.example .env`, but the template had never been committed. New users hit the dead end reported in #42.

## Safety
- Only placeholder values are included. Real `.env` is still ignored by `.gitignore:28` (`.env` rule unchanged).
- No runtime code touched.

## Test plan
- [x] `.env.example` is tracked while `.env` remains ignored (`git check-ignore` verified).
- [ ] On a fresh clone: `cp .env.example .env` → edit real tokens → `npm run service:install` proceeds past the config check.

Closes #42