### PR TITLE
docs: add Ko-fi sponsor badge and section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/@intrect/openswarm.svg)](https://www.npmjs.com/package/@intrect/openswarm)
 [![npm downloads](https://img.shields.io/npm/dm/@intrect/openswarm.svg)](https://www.npmjs.com/package/@intrect/openswarm)
 [![license](https://img.shields.io/npm/l/@intrect/openswarm.svg)](LICENSE)
+[![ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=ko-fi&logoColor=white)](https://ko-fi.com/unohee)
 
 > Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)
 
@@ -441,6 +442,19 @@ src/
 - LanceDB cognitive memory
 - Web dashboard (port 3847)
 - Rich TUI chat interface
+
+---
+
+## Sponsor
+
+OpenSwarm is developed and maintained in my spare time by a single author.
+If the project saves you time or money, please consider chipping in —
+it directly funds ongoing updates, bug fixes, and new adapters.
+
+[![Support on Ko-fi](https://img.shields.io/badge/Support%20on-Ko--fi-FF5E5B?logo=ko-fi&logoColor=white&style=for-the-badge)](https://ko-fi.com/unohee)
+
+One-off contributions are perfectly fine — there is no subscription
+tier and no feature is paywalled. Thank you.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a Ko-fi badge to the top badge row next to npm/license.
- Adds a dedicated **Sponsor** section above the License footer so visitors know where to contribute without scrolling back up.

## Why
Single-author project; free updates can't continue indefinitely without some funding. `.github/FUNDING.yml` already links Ko-fi, but GitHub's Sponsor button is easy to miss — README placement makes the option visible to anyone landing on the repo.

## Preview
- Badge: ![ko-fi badge](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=ko-fi&logoColor=white)
- Section copy is intentionally low-pressure (no paywalled features, one-offs welcome).