### PR TITLE
release: v0.4.1 — cwd-agnostic start + version sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "GPL-3.0",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,12 +4,17 @@
 // `openswarm run`, `openswarm init`, `openswarm validate`, `openswarm chat`, `openswarm start`
 
 import { Command } from 'commander';
-import { writeFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { runCli } from './runners/cliRunner.js';
 import { loadConfig, validateConfig, generateSampleConfig } from './core/config.js';
 
-const VERSION = '0.1.0';
+// Read version from package.json so it stays in sync with the published package.
+// cli.js lives at <pkg>/dist/cli.js, so package.json is one directory up.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8')) as { version: string };
+const VERSION = pkg.version;
 
 const program = new Command();
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -12,11 +12,31 @@ import { setTimeWindowConfig, DEFAULT_TIME_WINDOW } from '../support/timeWindow.
 
 // Constants
 
-const CONFIG_PATHS = [
-  join(process.cwd(), 'config.yaml'),
-  join(process.cwd(), 'config.yml'),
-  join(process.cwd(), 'config.json'),
-];
+const CONFIG_FILENAMES = ['config.yaml', 'config.yml', 'config.json'] as const;
+
+// Directories searched for config, in priority order.
+// 1. $OPENSWARM_CONFIG — explicit file path (highest priority, handled separately).
+// 2. process.cwd() — project-local overrides (existing behavior).
+// 3. ~/.config/openswarm — XDG-style user config (preferred daemon location).
+// 4. ~/.openswarm — legacy home fallback.
+function getConfigSearchDirs(): string[] {
+  const home = homedir();
+  return [
+    process.cwd(),
+    join(home, '.config', 'openswarm'),
+    join(home, '.openswarm'),
+  ];
+}
+
+function getConfigSearchPaths(): string[] {
+  const paths: string[] = [];
+  for (const dir of getConfigSearchDirs()) {
+    for (const name of CONFIG_FILENAMES) {
+      paths.push(join(dir, name));
+    }
+  }
+  return paths;
+}
 
 const DEFAULT_HEARTBEAT_INTERVAL = 30 * 60 * 1000; // 30 minutes
 const DEFAULT_GITHUB_CHECK_INTERVAL = 5 * 60 * 1000; // 5 minutes
@@ -330,10 +350,25 @@ export function expandPath(path: string, resolveRelative = false): string {
 // Config Loading
 
 /**
- * Find configuration file
+ * Find configuration file.
+ *
+ * Resolution order:
+ *   1. $OPENSWARM_CONFIG env var (explicit file path override)
+ *   2. ./config.{yaml,yml,json}           (project-local)
+ *   3. ~/.config/openswarm/config.{…}     (XDG user config)
+ *   4. ~/.openswarm/config.{…}            (legacy home fallback)
  */
 function findConfigFile(): string | null {
-  for (const path of CONFIG_PATHS) {
+  const envOverride = process.env.OPENSWARM_CONFIG;
+  if (envOverride && envOverride.length > 0) {
+    if (existsSync(envOverride)) {
+      return envOverride;
+    }
+    // Surface a clear error rather than silently falling through — user asked for this file.
+    throw new Error(`OPENSWARM_CONFIG points to a file that does not exist: ${envOverride}`);
+  }
+
+  for (const path of getConfigSearchPaths()) {
     if (existsSync(path)) {
       return path;
     }
@@ -449,8 +484,10 @@ export function loadConfig(customPath?: string): SwarmConfig {
   const configPath = customPath ?? findConfigFile();
 
   if (!configPath) {
+    const searched = getConfigSearchPaths().map((p) => `  - ${p}`).join('\n');
     throw new Error(
-      `Config file not found. Create one of: ${CONFIG_PATHS.join(', ')}`
+      `Config file not found. Searched:\n${searched}\n` +
+      `Create one of the above, or set $OPENSWARM_CONFIG to an explicit file path.`
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,12 +12,28 @@ dns.setDefaultResultOrder('ipv4first');
 delete process.env['CLAUDECODE'];
 delete process.env['CLAUDE_CODE_ENTRYPOINT'];
 
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { loadConfig, validateConfig } from './core/config.js';
 import { startService, stopService } from './core/service.js';
 
+// index.js lives at <pkg>/dist/index.js → package.json is one level up.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8')) as { version: string };
+const VERSION = pkg.version;
+
 async function main(): Promise<void> {
+  // Render a fixed-width banner (41 chars inside the box) with the current version.
+  const title = `🤖 OpenSwarm v${VERSION}`;
+  const INNER_WIDTH = 40;
+  // '🤖' counts as 2 display columns in most terminals, so pad assuming width = length + 1.
+  const visualLen = title.length + 1;
+  const padTotal = Math.max(0, INNER_WIDTH - visualLen);
+  const padLeft = Math.floor(padTotal / 2);
+  const padRight = padTotal - padLeft;
   console.log('╔════════════════════════════════════════╗');
-  console.log('║         🤖 OpenSwarm v0.1.0         ║');
+  console.log(`║${' '.repeat(padLeft)}${title}${' '.repeat(padRight)}║`);
   console.log('║   Autonomous Claude Code Orchestrator  ║');
   console.log('╚════════════════════════════════════════╝');
   console.log('');


### PR DESCRIPTION
## Summary
- `openswarm start` now works from any directory. Config resolution searches `$OPENSWARM_CONFIG` → `./config.{yaml,yml,json}` → `~/.config/openswarm/config.{yaml,yml,json}` → `~/.openswarm/config.{yaml,yml,json}`. Previously it only checked the current working directory.
- CLI `--version` and the startup banner now read from `package.json` instead of a hardcoded `0.1.0` string — no more version drift after a bump.
- Bump to `0.4.1`.

## Why
Running `openswarm start` from outside the repo root (e.g. from `~`) failed with `Config file not found: /Users/<user>/config.yaml`. A production-grade CLI should find its config via standard locations (XDG-style user config, explicit env override) regardless of cwd. The hardcoded `VERSION` in `src/cli.ts` / `src/index.ts` was already out of sync with `package.json` at `0.4.0` — same class of bug, fixed the same way.

## Changes
- `src/core/config.ts` — new `getConfigSearchPaths()` covering cwd + XDG + legacy home; `findConfigFile()` honors `$OPENSWARM_CONFIG`; improved not-found error lists every searched path.
- `src/cli.ts` — `VERSION` now derived from `package.json` via `import.meta.url`.
- `src/index.ts` — banner uses dynamic version with centered padding.
- `package.json` — `0.4.0` → `0.4.1`.

## Test plan
- [x] `openswarm --version` → `0.4.1` (local build via `npm link`)
- [x] `cd /tmp && openswarm start` → loads `~/.config/openswarm/config.yaml`, binds port 3847, `curl http://localhost:3847/` returns HTTP 200, clean shutdown on SIGTERM
- [x] `cd $REPO && openswarm start` → still loads `./config.yaml` (cwd priority preserved)
- [x] `OPENSWARM_CONFIG=/nonexistent openswarm start` → fails fast with explicit error
- [ ] Reviewer: run `openswarm start` from a third directory on a fresh checkout to confirm the XDG fallback kicks in