### PR TITLE
release: v0.4.2 — background daemon, env autoload, cwd-agnostic config, Linear pickup fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.4.0",
-      "license": "MIT",
+      "version": "0.4.2",
+      "license": "GPL-3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",
+        "@intrect/cxt": "^0.1.0",
         "@intrect/openswarm": "^0.2.1",
         "@lancedb/lancedb": "^0.23.0",
         "@linear/sdk": "^19.0.0",
@@ -944,6 +945,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@intrect/cxt": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@intrect/cxt/-/cxt-0.1.0.tgz",
+      "integrity": "sha512-ATEw4Pc6ntSS2eli2un9wO1/uKfTgjScT2JwtK1s1sG2aUq2sPWQHQyAfh88RajxhFXO/2uEWHlkMp/xAhr44g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "better-sqlite3": "^12.8.0",
+        "commander": "^12.1.0",
+        "nanoid": "^5.1.7",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "cxt": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@intrect/openswarm": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.72.1",
+    "@intrect/cxt": "^0.1.0",
     "@intrect/openswarm": "^0.2.1",
     "@lancedb/lancedb": "^0.23.0",
     "@linear/sdk": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "GPL-3.0",
   "type": "module",

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -8,6 +8,7 @@ import fs from 'node:fs/promises';
 import type { CliAdapter, CliRunOptions, CliRunResult } from './types.js';
 import { parseCliStreamChunk } from '../agents/cliStreamParser.js';
 import { registerProcess } from './processRegistry.js';
+import { buildWorkerEnv } from './envPath.js';
 
 /**
  * Spawn a CLI process using the given adapter and options.
@@ -40,7 +41,10 @@ export async function spawnCli(
       const proc = spawn(cmd, {
         shell: true,
         cwd: options.cwd,
-        env: process.env,
+        // Inject OpenSwarm's bundled node_modules/.bin (gives workers access
+        // to `cxt` and other shipped CLIs) without touching the user's shell
+        // PATH or ~/.claude/ config.
+        env: buildWorkerEnv(process.env),
         stdio: ['ignore', 'pipe', 'pipe'],
       });
 

--- a/src/adapters/envPath.ts
+++ b/src/adapters/envPath.ts
@@ -1,0 +1,52 @@
+// ============================================
+// OpenSwarm - Worker environment PATH helper
+// ============================================
+//
+// Workers spawned by OpenSwarm need access to bundled CLI dependencies
+// (notably `cxt` from @intrect/cxt) without the user having them installed
+// globally. We inject OpenSwarm's own `node_modules/.bin` into PATH for the
+// spawned process only — user's shell PATH and ~/.claude/* are untouched.
+
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { delimiter } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Resolve OpenSwarm's bundled `node_modules/.bin` directory.
+ *
+ * envPath.js lives at `<pkg>/dist/adapters/envPath.js` after build, so the
+ * package root is two directories up. During `npm run dev` / `tsx`, the file
+ * is at `<pkg>/src/adapters/envPath.ts` — same relative structure.
+ *
+ * Returns null if the .bin directory does not exist (e.g. dev checkout
+ * without `npm install`), so callers can fall back to process.env.PATH as-is.
+ */
+export function getBundledBinDir(): string | null {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const pkgRoot = resolve(here, '..', '..');
+  const binDir = join(pkgRoot, 'node_modules', '.bin');
+  return existsSync(binDir) ? binDir : null;
+}
+
+/**
+ * Build an env object for spawned workers with OpenSwarm's bundled `.bin`
+ * directory prepended to PATH. Keeps every other env var untouched.
+ *
+ * Prepending (not appending) means a locally-bundled `cxt` wins over an
+ * older global install, which matters when we start pinning cxt versions.
+ */
+export function buildWorkerEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const binDir = getBundledBinDir();
+  if (binDir === null) return { ...base };
+
+  const existingPath = base.PATH ?? base.Path ?? '';
+  // Avoid duplicate entries if this env is reused across spawns.
+  const parts = existingPath.split(delimiter).filter(Boolean);
+  if (parts[0] === binDir) {
+    return { ...base };
+  }
+  const nextPath = [binDir, ...parts.filter((p) => p !== binDir)].join(delimiter);
+
+  return { ...base, PATH: nextPath };
+}

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -76,13 +76,29 @@ export class AutonomousRunner {
   // Explicitly enabled project paths (allow-list; empty = nothing runs)
   private enabledProjects = new Set<string>();
 
+  /**
+   * macOS (APFS default) and Windows have case-insensitive filesystems by
+   * default, so `/Users/x/dev/AnalogModeling` and `/Users/x/dev/analogModeling`
+   * refer to the same directory. Do the enabled-set comparison in a case-
+   * insensitive way on those platforms so UI-captured casing doesn't
+   * mismatch Linear's project-name casing.
+   */
+  private get pathsCaseInsensitive(): boolean {
+    return process.platform === 'darwin' || process.platform === 'win32';
+  }
+
+  private normalizePath(p: string): string {
+    return this.pathsCaseInsensitive ? p.toLowerCase() : p;
+  }
+
   /** Check if a resolved path is under any enabled project */
   private isProjectEnabled(resolvedPath: string): boolean {
     if (this.enabledProjects.size === 0) return false;
-    if (this.enabledProjects.has(resolvedPath)) return true;
-    // Check if resolvedPath is a subdirectory of any enabled project
+    const needle = this.normalizePath(resolvedPath);
     for (const enabled of this.enabledProjects) {
-      if (resolvedPath.startsWith(enabled + '/')) return true;
+      const hay = this.normalizePath(enabled);
+      if (hay === needle) return true;
+      if (needle.startsWith(hay + '/')) return true;
     }
     return false;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -166,10 +166,72 @@ program
 
 program
   .command('start')
-  .description('Start the full daemon (requires config.yaml with Discord + Linear)')
+  .description('Start the full daemon in the background (use --foreground to stay attached)')
+  .option('-F, --foreground', 'Run in the foreground instead of detaching (for debugging / LaunchAgent)')
+  .action(async (opts: { foreground?: boolean }) => {
+    if (opts.foreground) {
+      // Dynamic import triggers the top-level main() in index.ts
+      await import('./index.js');
+      return;
+    }
+
+    const { startDaemon } = await import('./cli/daemon.js');
+    try {
+      const { pid, logFile } = startDaemon();
+      console.log(`OpenSwarm started in background (pid ${pid}).`);
+      console.log(`  logs:    ${logFile}`);
+      console.log(`  stop:    openswarm stop`);
+      console.log(`  status:  openswarm status`);
+    } catch (err) {
+      console.error(`Failed to start: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+// openswarm stop
+
+program
+  .command('stop')
+  .description('Stop the background daemon (sends SIGTERM)')
+  .option('-t, --timeout <ms>', 'Max time to wait for graceful shutdown (default 10000)', '10000')
+  .action(async (opts: { timeout: string }) => {
+    const timeoutMs = parseInt(opts.timeout, 10);
+    const { stopDaemon } = await import('./cli/daemon.js');
+    try {
+      const stopped = await stopDaemon(Number.isFinite(timeoutMs) ? timeoutMs : 10_000);
+      if (!stopped) {
+        console.log('OpenSwarm is not running.');
+        return;
+      }
+      console.log('OpenSwarm stopped.');
+    } catch (err) {
+      console.error(`Failed to stop: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+// openswarm status
+
+program
+  .command('status')
+  .description('Report daemon status (pid, uptime, log path)')
   .action(async () => {
-    // Dynamic import triggers the top-level main() in index.ts
-    await import('./index.js');
+    const { getDaemonStatus } = await import('./cli/daemon.js');
+    const status = getDaemonStatus();
+    if (!status.running) {
+      console.log('OpenSwarm is not running.');
+      console.log(`  pid file: ${status.pidFile}`);
+      console.log(`  log file: ${status.logFile}`);
+      return;
+    }
+    const uptime = status.uptimeSeconds ?? 0;
+    const h = Math.floor(uptime / 3600);
+    const m = Math.floor((uptime % 3600) / 60);
+    const s = uptime % 60;
+    console.log(`OpenSwarm is running.`);
+    console.log(`  pid:    ${status.pid}`);
+    console.log(`  uptime: ${h}h ${m}m ${s}s`);
+    console.log(`  logs:   ${status.logFile}`);
   });
 
 // openswarm dash

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -1,0 +1,161 @@
+// ============================================
+// OpenSwarm - Daemon (detached start/stop/status)
+// ============================================
+//
+// `openswarm start` spawns a detached child that runs the full service (index.js
+// → startService), redirects stdout/stderr to a log file, writes a PID file,
+// and exits the parent. `openswarm stop` reads the PID file and sends SIGTERM.
+// `openswarm status` reports running/stopped plus port 3847 health.
+
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const STATE_DIR = join(homedir(), '.config', 'openswarm');
+const LOG_DIR = join(STATE_DIR, 'logs');
+const PID_FILE = join(STATE_DIR, 'openswarm.pid');
+const LOG_FILE = join(LOG_DIR, 'openswarm.log');
+
+export interface DaemonStatus {
+  running: boolean;
+  pid?: number;
+  uptimeSeconds?: number;
+  pidFile: string;
+  logFile: string;
+}
+
+function ensureStateDirs(): void {
+  mkdirSync(STATE_DIR, { recursive: true });
+  mkdirSync(LOG_DIR, { recursive: true });
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readPidFile(): number | null {
+  if (!existsSync(PID_FILE)) return null;
+  const raw = readFileSync(PID_FILE, 'utf8').trim();
+  const pid = Number.parseInt(raw, 10);
+  if (!Number.isFinite(pid) || pid <= 0) return null;
+  return pid;
+}
+
+/**
+ * Resolve the path to dist/index.js. daemon.js lives at dist/cli/daemon.js,
+ * so index.js is one level up.
+ */
+function resolveIndexPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', 'index.js');
+}
+
+/**
+ * Start the service as a detached background process.
+ * Returns the child PID on success.
+ * Throws if a daemon is already running.
+ */
+export function startDaemon(): { pid: number; logFile: string } {
+  ensureStateDirs();
+
+  const existing = readPidFile();
+  if (existing !== null && isProcessAlive(existing)) {
+    throw new Error(
+      `OpenSwarm is already running (pid ${existing}). ` +
+      `Run 'openswarm stop' first or 'openswarm status' to check.`
+    );
+  }
+  if (existing !== null) {
+    // Stale pid file — previous run crashed without cleaning up.
+    try { unlinkSync(PID_FILE); } catch { /* ignore */ }
+  }
+
+  const indexPath = resolveIndexPath();
+  if (!existsSync(indexPath)) {
+    throw new Error(`Service entrypoint not found: ${indexPath}`);
+  }
+
+  // Open log file for append; reuse the same fd for stdout and stderr so logs
+  // are interleaved in order.
+  const logFd = openSync(LOG_FILE, 'a');
+
+  const child = spawn(process.execPath, [indexPath], {
+    detached: true,
+    stdio: ['ignore', logFd, logFd],
+    // Run from the user's home so relative paths in the service don't depend
+    // on the shell that invoked `openswarm start`.
+    cwd: homedir(),
+    env: { ...process.env, OPENSWARM_DAEMON: '1' },
+  });
+
+  if (child.pid === undefined) {
+    throw new Error('Failed to spawn daemon process (no pid assigned).');
+  }
+
+  writeFileSync(PID_FILE, String(child.pid), { mode: 0o644 });
+
+  // Let the child outlive this process.
+  child.unref();
+
+  return { pid: child.pid, logFile: LOG_FILE };
+}
+
+/**
+ * Signal the running daemon to shut down. Returns false if no daemon is running.
+ * Waits up to `timeoutMs` for the process to exit; returns true once it does,
+ * or throws if it's still alive after the timeout.
+ */
+export async function stopDaemon(timeoutMs = 10_000): Promise<boolean> {
+  const pid = readPidFile();
+  if (pid === null) return false;
+
+  if (!isProcessAlive(pid)) {
+    // Stale pid file.
+    try { unlinkSync(PID_FILE); } catch { /* ignore */ }
+    return false;
+  }
+
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch (err) {
+    throw new Error(`Failed to signal pid ${pid}: ${(err as Error).message}`);
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) {
+      try { unlinkSync(PID_FILE); } catch { /* ignore */ }
+      return true;
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  throw new Error(
+    `Daemon (pid ${pid}) did not exit within ${timeoutMs}ms. ` +
+    `It may still be shutting down; retry 'openswarm status' shortly or send SIGKILL manually.`
+  );
+}
+
+export function getDaemonStatus(): DaemonStatus {
+  const pid = readPidFile();
+  if (pid === null || !isProcessAlive(pid)) {
+    return { running: false, pidFile: PID_FILE, logFile: LOG_FILE };
+  }
+
+  let uptimeSeconds: number | undefined;
+  try {
+    const stat = statSync(PID_FILE);
+    uptimeSeconds = Math.floor((Date.now() - stat.mtimeMs) / 1000);
+  } catch { /* ignore */ }
+
+  return { running: true, pid, uptimeSeconds, pidFile: PID_FILE, logFile: LOG_FILE };
+}
+
+export const DAEMON_PATHS = { STATE_DIR, LOG_DIR, PID_FILE, LOG_FILE } as const;

--- a/src/core/envFile.ts
+++ b/src/core/envFile.ts
@@ -1,0 +1,114 @@
+// ============================================
+// OpenSwarm - .env auto-loader
+// ============================================
+//
+// Minimal, zero-dependency .env loader. Populates process.env with entries
+// from the first .env file found, searching locations parallel to the config
+// resolver. Existing process.env values are never overwritten — a shell
+// export always wins over the file.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+export interface EnvLoadResult {
+  path: string | null;
+  loadedKeys: string[];
+}
+
+function getSearchPaths(): string[] {
+  const paths: string[] = [];
+
+  // Explicit override wins.
+  const override = process.env.OPENSWARM_ENV;
+  if (override && override.length > 0) paths.push(override);
+
+  // .env next to the config file, if one was explicitly pointed at.
+  const configOverride = process.env.OPENSWARM_CONFIG;
+  if (configOverride && configOverride.length > 0) {
+    paths.push(join(dirname(configOverride), '.env'));
+  }
+
+  // Project-local (matches cwd-priority from findConfigFile).
+  paths.push(join(process.cwd(), '.env'));
+
+  const home = homedir();
+  paths.push(join(home, '.config', 'openswarm', '.env'));
+  paths.push(join(home, '.openswarm', '.env'));
+
+  return paths;
+}
+
+/**
+ * Parse a single line of a .env file. Returns [key, value] or null for
+ * blank/comment lines. Supports KEY=value, KEY="value", KEY='value',
+ * optional `export ` prefix, and basic backslash escapes (\n, \r, \t, \\, \")
+ * inside double-quoted values.
+ */
+function parseLine(line: string): [string, string] | null {
+  const trimmed = line.trim();
+  if (trimmed.length === 0 || trimmed.startsWith('#')) return null;
+
+  const stripped = trimmed.startsWith('export ') ? trimmed.slice(7).trimStart() : trimmed;
+  const eq = stripped.indexOf('=');
+  if (eq < 1) return null;
+
+  const key = stripped.slice(0, eq).trim();
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) return null;
+
+  let value = stripped.slice(eq + 1).trim();
+
+  // Strip inline comments on unquoted values (but keep `#` inside quoted strings).
+  if (value.length === 0) {
+    return [key, ''];
+  }
+
+  const first = value[0];
+  if (first === '"' || first === "'") {
+    const end = value.lastIndexOf(first);
+    if (end > 0) {
+      let inner = value.slice(1, end);
+      if (first === '"') {
+        inner = inner
+          .replace(/\\n/g, '\n')
+          .replace(/\\r/g, '\r')
+          .replace(/\\t/g, '\t')
+          .replace(/\\"/g, '"')
+          .replace(/\\\\/g, '\\');
+      }
+      return [key, inner];
+    }
+    // Unterminated quote — fall through and treat raw.
+  }
+
+  const hash = value.indexOf(' #');
+  if (hash >= 0) value = value.slice(0, hash).trimEnd();
+  return [key, value];
+}
+
+/**
+ * Load the first discovered .env file into process.env without overwriting
+ * existing values. Returns the path loaded (or null) and the list of keys
+ * that were newly applied — callers can log this for diagnostics.
+ */
+export function loadEnvFile(): EnvLoadResult {
+  for (const path of getSearchPaths()) {
+    if (!existsSync(path)) continue;
+
+    const content = readFileSync(path, 'utf8');
+    const loadedKeys: string[] = [];
+
+    for (const rawLine of content.split(/\r?\n/)) {
+      const parsed = parseLine(rawLine);
+      if (parsed === null) continue;
+      const [key, value] = parsed;
+      if (process.env[key] !== undefined) continue;
+      process.env[key] = value;
+      loadedKeys.push(key);
+    }
+
+    return { path, loadedKeys };
+  }
+
+  return { path: null, loadedKeys: [] };
+}

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -146,9 +146,15 @@ export async function startService(config: SwarmConfig): Promise<void> {
   if (config.autonomous?.enabled) {
     console.log('[Service] Autonomous mode auto-start enabled');
 
-    // Register Linear fetcher
+    // Register Linear fetcher.
+    // Uses slim mode: each issue costs 1 resolver call (project) instead of 3
+    // (project + comments + labels). With ~200 issues per HB and 4 HBs/hour
+    // that drops API usage from ~2400/hr to ~800/hr, well under Linear's
+    // 3500/hr cap. Comment-based task-state hydration is sacrificed on this
+    // path — it can be re-added with a targeted per-issue resolve for the
+    // subset we actually pick up.
     autonomous.setLinearFetcher(async () => {
-      const issues = await linear.getMyIssues({ timeoutMs: 90000 });
+      const issues = await linear.getMyIssues({ slim: true, timeoutMs: 90000 });
       const { linearIssueToTask } = await import('../orchestration/decisionEngine.js');
       return issues.map((issue: any) => {
         updateTaskLinearState(issue.id, issue.state);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,11 +12,12 @@ dns.setDefaultResultOrder('ipv4first');
 delete process.env['CLAUDECODE'];
 delete process.env['CLAUDE_CODE_ENTRYPOINT'];
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, unlinkSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadConfig, validateConfig } from './core/config.js';
 import { startService, stopService } from './core/service.js';
+import { DAEMON_PATHS } from './cli/daemon.js';
 
 // index.js lives at <pkg>/dist/index.js → package.json is one level up.
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -59,9 +60,13 @@ async function main(): Promise<void> {
   console.log('');
 
   // Signal handlers
+  const isDaemon = process.env.OPENSWARM_DAEMON === '1';
   const shutdown = async (signal: string): Promise<void> => {
     console.log(`\nReceived ${signal}, shutting down...`);
     await stopService();
+    if (isDaemon) {
+      try { unlinkSync(DAEMON_PATHS.PID_FILE); } catch { /* ignore */ }
+    }
     process.exit(0);
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,15 @@
 import dns from 'node:dns';
 dns.setDefaultResultOrder('ipv4first');
 
+// Load .env before anything else — config.yaml uses ${LINEAR_API_KEY} etc.
+// and would otherwise silently disable integrations when the daemon is
+// launched from a non-interactive shell without those vars exported.
+import { loadEnvFile } from './core/envFile.js';
+const envLoad = loadEnvFile();
+if (envLoad.path !== null) {
+  console.log(`Loaded env from: ${envLoad.path} (${envLoad.loadedKeys.length} keys)`);
+}
+
 // Strip Claude Code session markers so child processes (worker, planner) can launch Claude CLI
 // Without this, running the service from inside a Claude Code session blocks all CLI spawns.
 delete process.env['CLAUDECODE'];

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -38,6 +38,74 @@ function teamFilter() {
   return { id: { in: teamIds } };
 }
 
+/**
+ * Page size when fetching issues across all configured teams. Linear's
+ * default page cap is 50 — 100 is the largest value that consistently
+ * returns; bumping to 250 triggered intermittent 502s from the Linear
+ * gateway on wider queries.
+ *
+ * A prior revision tried per-team fan-out to guarantee a per-team quota, but
+ * firing ~12 parallel `issues()` calls tripped a 90s timeout inside the
+ * Linear SDK / HTTP keepalive path — one wider query is both simpler and
+ * actually faster end-to-end.
+ */
+const FETCH_PAGE_SIZE = 100;
+
+async function fetchIssuesForStates(
+  linear: LinearClient,
+  stateNames: string[],
+  extraFilter: Record<string, unknown> = {},
+): Promise<{ nodes: Array<Awaited<ReturnType<LinearClient['issues']>>['nodes'][number]> }> {
+  const ids = teamIds.length > 0 ? teamIds : (teamId ? [teamId] : []);
+
+  // Single-team / no-team fallback uses the shared filter path.
+  if (ids.length <= 1) {
+    const res = await withRateLimit('linear', async () =>
+      linear.issues({
+        filter: { ...extraFilter, team: teamFilter(), state: { name: { in: stateNames } } },
+        first: FETCH_PAGE_SIZE,
+      }),
+    );
+    return { nodes: res.nodes };
+  }
+
+  // Multi-team: issue one `in: [...]` query rather than fanning out, but run a
+  // second query *only if* the first page filled up — that's the signal that
+  // some team's issues may have been truncated. This bounds the request count
+  // to at most 1 + teams when the result set is actually wide.
+  const primary = await withRateLimit('linear', async () =>
+    linear.issues({
+      filter: { ...extraFilter, team: { id: { in: ids } }, state: { name: { in: stateNames } } },
+      first: FETCH_PAGE_SIZE,
+    }),
+  );
+
+  if (primary.nodes.length < FETCH_PAGE_SIZE) {
+    return { nodes: primary.nodes };
+  }
+
+  // First page was saturated → fall back to per-team fan-out so no team is starved.
+  // Dedup by issue id when concatenating.
+  const pages = await Promise.all(
+    ids.map((tid) =>
+      withRateLimit('linear', async () =>
+        linear.issues({
+          filter: { ...extraFilter, team: { id: { eq: tid } }, state: { name: { in: stateNames } } },
+          first: FETCH_PAGE_SIZE,
+        }),
+      ),
+    ),
+  );
+  const seen = new Set<string>();
+  const merged: typeof primary.nodes = [];
+  for (const node of [...primary.nodes, ...pages.flatMap((p) => p.nodes)]) {
+    if (seen.has(node.id)) continue;
+    seen.add(node.id);
+    merged.push(node);
+  }
+  return { nodes: merged };
+}
+
 // Daily issue creation limit
 const DAILY_ISSUE_LIMIT = 10;
 let dailyIssueCount = 0;
@@ -306,32 +374,21 @@ export async function getMyIssues(
   console.log(`[Linear] Fetching issues for ${cacheKey}`);
   const linear = getClient();
 
-  const baseFilter: any = {
-    team: teamFilter(),
-  };
-
-  // Add label filter if agentLabel is provided
-  if (agentLabel) {
-    baseFilter.labels = { name: { eq: agentLabel } };
-  }
-
   // Wrap with timeout
   const fetchIssues = async (): Promise<LinearIssueInfo[]> => {
     // Slim mode: query each state separately to avoid lazy resolver calls for issue.state
     // Full mode: combined query then resolve per-issue
     const result: LinearIssueInfo[] = [];
 
-    if (slim) {
-      // Separate queries per state → tag each issue without resolver calls
-      // Build a project ID→info cache to avoid per-issue project resolver calls
-      const todoFilter = { ...baseFilter, state: { name: { in: ['Todo'] } } };
-      const inProgressFilter = { ...baseFilter, state: { name: { in: ['In Progress', 'In Review'] } } };
-      const backlogFilter = { ...baseFilter, state: { name: { in: ['Backlog'] } } };
+    const extraFilter: Record<string, unknown> = {};
+    if (agentLabel) extraFilter.labels = { name: { eq: agentLabel } };
 
+    if (slim) {
+      // Separate queries per state → tag each issue without resolver calls.
       const [todoIssues, inProgressIssues, backlogIssues] = await Promise.all([
-        withRateLimit('linear', async () => linear.issues({ filter: todoFilter, first: 50 })),
-        withRateLimit('linear', async () => linear.issues({ filter: inProgressFilter, first: 50 })),
-        withRateLimit('linear', async () => linear.issues({ filter: backlogFilter, first: 50 })),
+        fetchIssuesForStates(linear, ['Todo'], extraFilter),
+        fetchIssuesForStates(linear, ['In Progress', 'In Review'], extraFilter),
+        fetchIssuesForStates(linear, ['Backlog'], extraFilter),
       ]);
 
       const withState = [
@@ -375,11 +432,9 @@ export async function getMyIssues(
     }
 
     // Full mode: fetch executable + backlog, then resolve per-issue
-    const executableFilter = { ...baseFilter, state: { name: { in: ['Todo', 'In Progress', 'In Review'] } } };
-    const backlogFilter = { ...baseFilter, state: { name: { in: ['Backlog'] } } };
     const [executableIssues, backlogIssues] = await Promise.all([
-      withRateLimit('linear', async () => linear.issues({ filter: executableFilter, first: 50 })),
-      withRateLimit('linear', async () => linear.issues({ filter: backlogFilter, first: 50 })),
+      fetchIssuesForStates(linear, ['Todo', 'In Progress', 'In Review'], extraFilter),
+      fetchIssuesForStates(linear, ['Backlog'], extraFilter),
     ]);
 
     {

--- a/src/locale/prompts/en.ts
+++ b/src/locale/prompts/en.ts
@@ -99,6 +99,15 @@ ${feedbackSection}${contextSection}
 - No destructive commands (rm -rf, git reset --hard). No .env/.bashrc edits.
 - Before completing: verify all changed files exist, no syntax errors, confidence reflects reality.
 
+## Tools available
+- \`cxt\` (code exploration toolkit, bundled with OpenSwarm):
+  - \`cxt check <file>\` — entity brief for a file (faster than Read for structural lookups).
+  - \`cxt check --search <q>\` — FTS5 search across the registry.
+  - \`cxt check --untested\` / \`--high-risk\` — surface risky spots before changing them.
+  - \`cxt bs\` — static bad-smell scan.
+  - Run \`cxt scan\` first if the registry seems stale; it's cheap.
+  - The \`File Map\` section above (when present) already comes from \`cxt\` — don't re-scan unless you need fresh data.
+
 ## Output (JSON, at the end)
 \`\`\`json
 {

--- a/src/locale/prompts/ko.ts
+++ b/src/locale/prompts/ko.ts
@@ -100,6 +100,15 @@ ${feedbackSection}${contextSection}
 - 파괴적 명령(rm -rf, git reset --hard) 금지. .env/.bashrc 수정 금지.
 - 완료 전: 모든 변경 파일 존재 확인, 구문 오류 없음 확인, confidence 정확히 설정.
 
+## 사용 가능한 도구
+- \`cxt\` (OpenSwarm 내장 Code eXploration Toolkit):
+  - \`cxt check <file>\` — 파일 엔티티 브리프 (구조 파악용, Read보다 빠름).
+  - \`cxt check --search <q>\` — FTS5 기반 전역 검색.
+  - \`cxt check --untested\` / \`--high-risk\` — 수정 전에 위험 포인트 먼저 확인.
+  - \`cxt bs\` — 정적 bad smell 스캔.
+  - 레지스트리가 오래됐으면 \`cxt scan\` 먼저 (저렴함).
+  - 위 \`파일 맵\` 섹션이 있으면 이미 \`cxt\` 결과 — 새로 스캔할 필요 없음.
+
 ## Output (JSON, 마지막에 출력)
 \`\`\`json
 {

--- a/src/support/planner.ts
+++ b/src/support/planner.ts
@@ -9,6 +9,7 @@ import type { TaskItem } from '../orchestration/decisionEngine.js';
 import { type CostInfo, extractCostFromStreamJson, formatCost } from './costTracker.js';
 import { t, getPrompts } from '../locale/index.js';
 import type { ImpactAnalysis } from '../knowledge/types.js';
+import { buildWorkerEnv } from '../adapters/envPath.js';
 
 // Types
 
@@ -156,7 +157,7 @@ async function runClaudeCli(
       {
         shell: false,
         cwd: '/tmp',   // Neutral dir — no project .claude/ settings loaded
-        env: process.env,
+        env: buildWorkerEnv(process.env),
         stdio: ['ignore', 'pipe', 'pipe'],
       }
     );

--- a/src/taskState/store.ts
+++ b/src/taskState/store.ts
@@ -298,9 +298,14 @@ export function getTaskReadiness(task: TaskItem): {
     : state?.dependencyIssueIds || [];
 
   if (state?.execution.status === 'decomposed') {
-    // If Linear state was manually changed back to actionable, allow re-execution
+    // If Linear state was manually changed back to actionable, allow re-execution.
+    // `In Review` is treated as actionable too — reviewer feedback on a
+    // decomposed task should get picked up rather than ignored.
     const linearState = task.linearState || state.linearState;
-    const reactivated = linearState === 'Todo' || linearState === 'In Progress';
+    const reactivated =
+      linearState === 'Todo' ||
+      linearState === 'In Progress' ||
+      linearState === 'In Review';
     if (!reactivated) {
       return {
         ready: false,


### PR DESCRIPTION
## Summary

This is the v0.4.2 release. It bundles four independent fixes that were validated end-to-end against a live OpenSwarm daemon, plus the cxt integration shipped earlier in the cycle.

### 1. Background daemon (`openswarm start` no longer pins the terminal)
- `start` detaches and returns immediately. PID file at `~/.config/openswarm/openswarm.pid`, logs at `~/.config/openswarm/logs/openswarm.log`.
- New `openswarm stop` (graceful SIGTERM + PID cleanup) and `openswarm status` (pid, uptime, log path).
- `--foreground` / `-F` preserves the previous attached behavior for debugging or running under LaunchAgent / systemd.
- Stale PID file recovery + duplicate-start guard.

### 2. `.env` auto-load (Linear/Discord credentials picked up by the daemon)
- Daemon launched from a non-interactive shell used to silently disable Linear with "Linear credentials not set — disabling Linear integration", then claim it was polling.
- Now `loadEnvFile` runs before config: `$OPENSWARM_ENV` → dir of `$OPENSWARM_CONFIG` → cwd → `~/.config/openswarm` → `~/.openswarm`. Exported shell values still win.

### 3. cwd-agnostic config + version sync
- Config resolution now searches `$OPENSWARM_CONFIG` → `./config.{yaml,yml,json}` → `~/.config/openswarm/config.{...}` → `~/.openswarm/config.{...}`. Previously you had to `cd $REPO` first.
- CLI `--version` and the startup banner now read from `package.json` instead of a hardcoded `0.1.0`.

### 4. Linear issue pickup actually works
Heartbeat was missing project-tagged issues even with the project enabled, because the fetch + filter pipeline silently dropped them at three points:
- **Case-sensitive path comparison** — macOS / Windows treat `AnalogModeling` and `analogModeling` as the same directory; `enabledProjects` was matching byte-equal. Fixed with platform-aware lowering in `isProjectEnabled`.
- **One team monopolizes the page** — a single `{ team: { in: [...] } }` query capped at `first: 50` let the busiest team starve the rest. Replaced with an adaptive fetch: one wide query first, fall back to per-team fan-out only when the first page saturates. Per-team cap raised from 50 to 100.
- **Heartbeat used full-mode resolution** — 3 GraphQL resolver calls per issue (`project + comments + labels`) × ~200 issues × 4 HB/hour was tripping Linear's 3500 req/hr ceiling. Heartbeat now uses slim mode (project only). Comment-based hydration is intentionally sacrificed on this path.
- **`In Review` was rejected as inactionable for decomposed tasks** — `getTaskReadiness` only reactivated `Todo` or `In Progress`. Reviewer feedback on a decomposed task is now picked up.

### 5. Bundle `@intrect/cxt` for spawned workers
- Adds `@intrect/cxt ^0.1.0` as a runtime dependency.
- Worker / planner CLI spawns get OpenSwarm's bundled `node_modules/.bin` prepended to PATH via the new `buildWorkerEnv` helper. The user's shell PATH and `~/.claude/*` are untouched.
- Worker prompt templates (en/ko) advertise `cxt` so agents know they can run it for entity lookups, FTS search, and bad-smell scans.

## Why this is one PR
v0.4.1 was already pulled before tagging because cwd / version drift caught downstream issues fast, so I bundled the rollup into a single v0.4.2.

## Verification
Live verification was done against the running daemon. The Linear pickup commit was the last to land — heartbeat now reaches `Found 183 tasks from Linear` (vs. the previous 99) and dispatches Todo / In Review tasks for enabled projects. Backlog-only projects still need manual promotion to Todo, which is the intended workflow.

## Files
- `src/cli/daemon.ts` (new), `src/cli.ts`, `src/index.ts` — daemon mode
- `src/core/envFile.ts` (new), `src/index.ts` — env auto-load
- `src/core/config.ts` — XDG config search
- `src/automation/autonomousRunner.ts`, `src/core/service.ts`, `src/linear/linear.ts`, `src/taskState/store.ts` — Linear pickup fixes
- `src/adapters/envPath.ts` (new), `src/adapters/base.ts`, `src/support/planner.ts`, `src/locale/prompts/{en,ko}.ts` — cxt bundling
- `package.json` — `0.4.1` → `0.4.2`, `@intrect/cxt ^0.1.0`