### PR TITLE
fix: ESM-incompatible lazy require in expandPath (#52)

### DIFF
--- a/src/automation/runnerState.ts
+++ b/src/automation/runnerState.ts
@@ -3,7 +3,7 @@
 // Task state persistence + project info query
 // ============================================
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
@@ -52,7 +52,6 @@ let paceState: PaceState | null = null;
 function ensurePaceDir(): void {
   const dir = join(homedir(), '.openswarm');
   if (!existsSync(dir)) {
-    const { mkdirSync } = require('node:fs') as typeof import('node:fs');
     mkdirSync(dir, { recursive: true });
   }
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,7 +3,7 @@
 // ============================================
 
 import { readFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { z } from 'zod';
 import YAML from 'yaml';
@@ -341,7 +341,6 @@ export function expandPath(path: string, resolveRelative = false): string {
     return join(homedir(), path.slice(2));
   }
   if (resolveRelative) {
-    const { resolve } = require('node:path') as typeof import('node:path');
     return resolve(path);
   }
   return path;


### PR DESCRIPTION
## Summary
- Hoist `resolve` from `node:path` into the static import in `src/core/config.ts` and drop the lazy `require('node:path')` that crashes in ESM.
- Apply the same fix to `src/automation/runnerState.ts`, which had the identical pattern with `require('node:fs')` for `mkdirSync`.

## Why
The package is `"type": "module"`, so CommonJS `require` is undefined. Any `openswarm exec`/`run --path <absolute-path>` hit `ReferenceError: require is not defined` at `expandPath(path, true)` before doing any work. Reported in #52 by @shuklatushar226 with a clean root-cause analysis.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `expandPath('/tmp/foo', true)` → `/tmp/foo`
- [x] `expandPath('./bar', true)` → resolves against cwd
- [x] `expandPath('~/baz', true)` → expands home
- [x] `expandPath('relative-path')` → unchanged when `resolveRelative=false`

Closes #52