### PR TITLE
release: v0.4.3 — fix ESM require crash in expandPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.3 — 2026-05-07
+
+### Fixed
+
+- Fixed `ReferenceError: require is not defined` crash in `expandPath` that broke every `openswarm exec`/`run --path <absolute-path>` invocation. The package is ESM (`"type": "module"`) but `src/core/config.ts` lazily called CommonJS `require('node:path')` to import `resolve`. Hoisted `resolve` into the top-level `node:path` import. (#52, reported by @shuklatushar226)
+- Fixed the same ESM-incompatible lazy `require('node:fs')` pattern in `src/automation/runnerState.ts` (`mkdirSync`), which would have crashed on the first daily-pace directory creation.
+
 ## Unreleased
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "GPL-3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "GPL-3.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump `@intrect/openswarm` to **0.4.3**.
- Ships the fix from #53 (closed via #52): `expandPath` no longer crashes ESM with `ReferenceError: require is not defined` when called with an absolute `--path`.
- Also folds in the same lazy-`require('node:fs')` fix in `src/automation/runnerState.ts`.

## Why patch now
Every `openswarm exec`/`run --path <abs>` invocation on 0.4.0–0.4.2 hits the crash before doing any work. User-facing regression with no in-tree workaround other than `~/`-prefixed paths, so a patch release is warranted.

## Changes
- `package.json` / `package-lock.json`: 0.4.2 → 0.4.3
- `CHANGELOG.md`: new `## 0.4.3 — 2026-05-07` section under the existing `Unreleased` block

## Test plan
- [x] Code fix already verified on PR #53 (typecheck, build, manual `expandPath` smoke)
- [ ] CI green on this release branch
- [ ] After merge: `git tag v0.4.3 && npm publish`

Closes #52