### PR TITLE
release: v0.4.4 — ship missing protobufjs override to npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.4 — 2026-05-07
+
+### Security
+
+- Re-publish of 0.4.3 to ensure the `protobufjs` `^7.5.5` override (CVE-2026-41242 / GHSA-xq3m-2v4x-88gg, critical RCE, CVSS 9.8) is actually present in the npm tarball. The override was merged into `main` for 0.4.3 but was not included in the package that reached npm. No code changes beyond the version bump; the override entry already lives in `package.json`.
+
 ## 0.4.3 — 2026-05-07
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "GPL-3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "GPL-3.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump `@intrect/openswarm` to **0.4.4**.
- No code changes vs. `main`; this is a **re-publish** to push the `protobufjs` override (already on `main`, merged in #55) into the actual npm tarball.

## Why
v0.4.3 reached npm via an OTP-flaky publish that completed before #55 was merged. The shipped `0.4.3` tarball contains the ESM `expandPath` fix (#52) but **not** the `"overrides": { "protobufjs": "^7.5.5" }` entry. End users of `npm install -g @intrect/openswarm@0.4.3` still resolve `protobufjs@6.11.4` and remain exposed to **CVE-2026-41242** (critical RCE, CVSS 9.8).

npm forbids re-publishing the same version, so the only path to ship the override to users is a patch bump.

## Changes
- `package.json` / `package-lock.json`: 0.4.3 → 0.4.4
- `CHANGELOG.md`: new `## 0.4.4 — 2026-05-07` section with a `### Security` note explaining the re-publish

## Test plan
- [x] `npm run build` clean
- [x] `npm ls protobufjs` resolves `protobufjs@7.5.6`
- [ ] CI green on this branch
- [ ] After merge: `git tag v0.4.4 && npm publish --access public --otp=<code>`
- [ ] Verify `npm view @intrect/openswarm@0.4.4 dist.tarball` then `npm pack` to confirm `overrides` is present in shipped `package.json`