### PR TITLE
docs(community): set up GitHub Discussions for feedback and roadmap

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/idea.yml
+++ b/.github/DISCUSSION_TEMPLATE/idea.yml
@@ -1,0 +1,75 @@
+title: "[Idea] "
+labels: ["idea"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing an idea for OpenSwarm! Please fill out the sections below so the community and maintainers can evaluate it.
+
+        - If you have a concrete bug, please open an [Issue](../../issues/new/choose) instead.
+        - If you have a usage question, please use the **Q&A** category.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this idea solve? Describe it independently of any specific external tool.
+      placeholder: When I try to ..., OpenSwarm currently ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution
+      description: How would you like OpenSwarm to behave? Rough sketches, API shapes, or CLI examples are welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches did you consider? Include at least one approach that does not depend on a specific external service.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of OpenSwarm does this affect?
+      options:
+        - Adapter (Claude / GPT / Codex / Ollama / LMStudio / llama.cpp / other)
+        - CLI / UX
+        - Worker / Reviewer pipeline
+        - Memory (LanceDB)
+        - Integrations (Linear / Discord / etc.)
+        - Configuration / Setup
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use Case
+      description: Briefly describe how you would actually use this in your workflow.
+
+  - type: checkboxes
+    id: disclosure
+    attributes:
+      label: Conflict of Interest Disclosure
+      description: Do you maintain or have affiliation with any project, product, or service mentioned in this proposal?
+      options:
+        - label: I have no conflict of interest related to this proposal.
+        - label: I have a relevant affiliation and have disclosed it in the description above.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing discussions and issues to confirm this is not a duplicate.
+          required: true
+        - label: I have read the CONTRIBUTING guidelines.
+          required: true

--- a/.github/DISCUSSION_TEMPLATE/roadmap-vote.yml
+++ b/.github/DISCUSSION_TEMPLATE/roadmap-vote.yml
@@ -1,0 +1,63 @@
+title: "[Roadmap] "
+labels: ["roadmap"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to **nominate a feature for the upcoming roadmap**.
+
+        - One feature per discussion. If you have multiple ideas, open separate discussions.
+        - The community can upvote with 👍 reactions. The maintainer reviews top-voted items each cycle.
+        - For free-form ideas, use the **Idea** template instead.
+
+  - type: input
+    id: title_line
+    attributes:
+      label: One-line summary
+      description: A short headline for the feature (e.g., "Add a Gemini adapter").
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why it matters
+      description: What does this unlock? Who benefits, and how?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope sketch
+      description: What is the minimum viable version? What is explicitly out of scope?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: How important is this to you?
+      options:
+        - "Blocking — I cannot use OpenSwarm without it"
+        - "High — I would use this often"
+        - "Medium — Nice to have"
+        - "Low — Just an idea"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: willingness
+    attributes:
+      label: Contribution
+      options:
+        - label: I would be willing to help implement this (PR, design review, or testing).
+        - label: I can provide test cases or example workloads.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing roadmap discussions to confirm this is not already proposed.
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,8 +27,9 @@ What actually happened.
 ## Environment
 
 - OS:
-- Python version:
-- OpenSwarm version/commit:
+- Node.js version (`node -v`):
+- OpenSwarm version (`openswarm --version`) or commit:
+- Adapter(s) in use (Claude / GPT / Codex / Ollama / LMStudio / llama.cpp):
 
 ## Logs / Screenshots
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,14 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Contributing Guidelines
+  - name: 💡 Feature ideas & roadmap
+    url: https://github.com/unohee/OpenSwarm/discussions/new?category=ideas
+    about: Have an idea or want to nominate a feature for the roadmap? Start a Discussion so the community can weigh in.
+  - name: 🙏 Usage questions (Q&A)
+    url: https://github.com/unohee/OpenSwarm/discussions/new?category=q-a
+    about: Not sure if it's a bug? Ask in Discussions Q&A first — it keeps the issue tracker focused.
+  - name: 🗳️ Roadmap polls
+    url: https://github.com/unohee/OpenSwarm/discussions/categories/polls
+    about: Vote on upcoming features in the Polls category.
+  - name: 📖 Contributing Guidelines
     url: https://github.com/unohee/OpenSwarm/blob/main/CONTRIBUTING.md
     about: Read the contributing guidelines before opening an issue.

--- a/README.md
+++ b/README.md
@@ -3,20 +3,11 @@
 [![npm version](https://img.shields.io/npm/v/@intrect/openswarm.svg)](https://www.npmjs.com/package/@intrect/openswarm)
 [![npm downloads](https://img.shields.io/npm/dm/@intrect/openswarm.svg)](https://www.npmjs.com/package/@intrect/openswarm)
 [![license](https://img.shields.io/npm/l/@intrect/openswarm.svg)](LICENSE)
-[![ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=ko-fi&logoColor=white)](https://ko-fi.com/unohee)
+[![GitHub Discussions](https://img.shields.io/github/discussions/unohee/OpenSwarm?logo=github&label=discussions)](https://github.com/unohee/OpenSwarm/discussions)
 
 > Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)
 
-## Sponsor
-
-OpenSwarm is developed and maintained in my spare time by a single author.
-If the project saves you time or money, please consider chipping in —
-it directly funds ongoing updates, bug fixes, and new adapters.
-
-[![Support on Ko-fi](https://img.shields.io/badge/Support%20on-Ko--fi-FF5E5B?logo=ko-fi&logoColor=white&style=for-the-badge)](https://ko-fi.com/unohee)
-
-One-off contributions are perfectly fine — there is no subscription
-tier and no feature is paywalled. Thank you.
+> 💬 **Help shape OpenSwarm.** Share feature ideas, vote on the roadmap, and ask questions in [**GitHub Discussions**](https://github.com/unohee/OpenSwarm/discussions). The roadmap is built in the open — your feedback decides what ships next.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `.github/DISCUSSION_TEMPLATE/{idea.yml,roadmap-vote.yml}` so community feedback and roadmap nominations land in a structured form.
- Routes feature requests and usage questions from the Issue tracker to Discussions via `contact_links`, keeping issues focused on confirmed bugs/accepted work.
- Fixes the bug report template's environment fields (Node.js + adapter, not Python).
- Promotes Discussions to the top of `README.md` (badge + callout) and removes the Ko-fi sponsor section per the new direction.

## Test plan
- [ ] Verify the bug report template renders correctly when opening a new issue.
- [ ] Verify `contact_links` show Discussions entries on the "New issue" picker.
- [ ] Open a new Discussion in the **Ideas** and **Polls** categories and confirm the templates load.
- [ ] README renders correctly on github.com (badge row + Discussions callout above the description).