### PR TITLE
docs: translate all repository docs to English

### DIFF
--- a/benchmarks/RUBRIC.md
+++ b/benchmarks/RUBRIC.md
@@ -1,151 +1,191 @@
-# OpenSwarm 코딩 벤치마크 루브릭 (L0–L6)
+# OpenSwarm Coding Benchmark Rubric (L0–L6)
 
-OpenSwarm 하네스(worker = `runAgenticLoop`, openrouter 어댑터)의 코딩 능력을 난이도별로
-측정하고, 각 난이도에 **비용효율적인 모델**을 데이터로 라우팅하기 위한 루브릭.
+A rubric for measuring the coding capability of the OpenSwarm harness
+(worker = `runAgenticLoop`, openrouter adapter) per difficulty level, and for
+routing each level to the most **cost-efficient model** based on data.
 
-> 측정 대상은 **하네스 + 모델**의 결합이다. codex 어댑터(Codex CLI 위임)는 OpenSwarm
-> 하네스를 우회하므로 측정에서 제외 — 반드시 openrouter 어댑터로 돈다.
+> The unit under measurement is the **harness + model combination**. The codex
+> adapter (delegates to the Codex CLI) bypasses the OpenSwarm harness and is
+> excluded — always run measurements through the openrouter adapter.
 
-## 난이도 사다리
+## Difficulty ladder
 
-| Lv | 이름 | 검증하는 능력 | 채점 방식 | 인프라 |
-|----|------|--------------|-----------|--------|
-| **L0** | 단일 수정 | 한 줄~한 함수 버그픽스 | 정규식 (`check()`) | 즉시 |
-| **L1** | 탐색+수정 | 가드 추가, 단순 기능 | 정규식 | 즉시 |
-| **L2** | 다중 파일 | 리네임/시그니처 연쇄 (3~4 파일) | 정규식 | 즉시 |
-| **L3** | 테스트 통과 | 스텁 구현해 기존 테스트 green | **테스트 실행** (`tsx`) | 즉시 |
-| **L4** | 고난도 | 깊은 의존성 연쇄, edge case 완전성, 숨은 버그 추적, 타입 변경 | 테스트 실행 + **tsc** | 즉시 |
-| **L5** | 난해 | 알고리즘 정확성(merge-intervals/LRU), 상태기계(tokenizer), 제네릭 타입 | 테스트 실행 | 즉시 |
-| **L6** | **실전** | **실제 GitHub 이슈** (SWE-bench Lite) — 대형 repo 탐색 + 근본원인 + 정확한 patch | **공식 swebench 하니스** (Docker) | OrbStack, 분 단위 |
+| Lv | Name | Capability verified | Grading | Infra |
+|----|------|--------------------|---------|-------|
+| **L0** | Single edit | One-line to one-function bugfix | Regex (`check()`) | Instant |
+| **L1** | Locate + edit | Add a guard, simple feature | Regex | Instant |
+| **L2** | Multi-file | Rename/signature cascade (3–4 files) | Regex | Instant |
+| **L3** | Make tests pass | Implement a stub until existing tests are green | **Test run** (`tsx`) | Instant |
+| **L4** | Hard | Deep dependency chains, edge-case completeness, hidden-bug tracing, type changes | Test run + **tsc** | Instant |
+| **L5** | Very hard | Algorithmic correctness (merge-intervals/LRU), state machines (tokenizer), generic types | Test run | Instant |
+| **L6** | **Real-world** | **Real GitHub issues** (SWE-bench Lite) — large-repo exploration + root cause + exact patch | **Official swebench harness** (Docker) | OrbStack, minutes |
 
-- **L0–L5**: `benchmarks/tasks/codingTasks.ts` (합성, self-contained). 빠른 회귀 테스트.
-  `npx tsx benchmarks/modelSelect.ts --repeat N`. 채점은 LLM judge 없는 결정적 방식.
-- **L6**: `benchmarks/sweBench.ts`. SWE-bench Lite instance를 OpenSwarm worker가 풀고,
-  공식 `swebench.harness.run_evaluation`이 FAIL_TO_PASS+PASS_TO_PASS로 채점.
+- **L0–L5**: `benchmarks/tasks/codingTasks.ts` (synthetic, self-contained). Fast
+  regression suite. `npx tsx benchmarks/modelSelect.ts --repeat N`. Grading is
+  deterministic — no LLM judge.
+- **L6**: `benchmarks/sweBench.ts`. The OpenSwarm worker solves SWE-bench Lite
+  instances; the official `swebench.harness.run_evaluation` grades them via
+  FAIL_TO_PASS + PASS_TO_PASS.
 
-## 레벨별 추천 모델 (측정 기반)
+## Recommended models per level (measured)
 
-벤치 데이터(`benchmarks/results/`)로 도출. 점수 = pass_rate → $/pass → tool calls.
+Derived from benchmark data (`benchmarks/results/`). Score = pass_rate → $/pass → tool calls.
 
-| Lv | 추천 worker 모델 | 근거 |
-|----|------------------|------|
-| L0–L3 | **z-ai/glm-4.7-flash** 또는 deepseek-v4-flash | 100% pass, $0.002~0.004/pass. glm은 2759 tok/s(DeepInfra)로 최속. 경량으로 충분 |
-| L4 | 경량 + escalate | 경량 모델도 대부분 통과(100%), 실패 시 frontier escalate |
-| L5 | 경량 (일부 실패 감수) | glm/qwen이 L5-lru 등 1~2개 실패(87~95%). escalate가 흡수 |
-| **L6** | **frontier (openai/gpt-5)** | **경량은 정답 정확도 부족** — 아래 L6 측정 참조 |
+| Lv | Recommended worker model | Rationale |
+|----|--------------------------|-----------|
+| L0–L3 | **z-ai/glm-4.7-flash** or deepseek-v4-flash | 100% pass, $0.002–0.004/pass. glm is fastest at 2759 tok/s (DeepInfra). Lightweight is enough |
+| L4 | Lightweight + escalate | Lightweight models mostly pass (100%); frontier escalation absorbs failures |
+| L5 | Lightweight (tolerating some failures) | glm/qwen fail 1–2 tasks like L5-lru (87–95%). Escalation absorbs it |
+| **L6** | **Frontier (openai/gpt-5)** | **Lightweight models lack answer accuracy** — see L6 measurements below |
 
-### L6 실측 (pylint-dev__pylint-7080, 2026-06)
+### L6 measurements (pylint-dev__pylint-7080, 2026-06)
 
-| 모델 | patch | 결과 | 비고 |
-|------|-------|------|------|
-| **openai/gpt-5** | ✅ | **RESOLVED** | `expand_modules.py` 정답 위치 (`os.path.relpath`) |
-| gemini-2.5-flash | ✅ | unresolved | `pylinter.py`만 — 정답 위치 빗나감 |
-| glm-4.7-flash | ✅ | unresolved | 정답 파일 건드렸으나 부정확 |
-| qwen3-coder-30b | ✅ | unresolved | 부정확 |
-| deepseek-v4-flash | ❌ | (빈 patch) | 수정 미도달 |
-| gpt-5-mini | ❌ | (빈 patch) | 수정 미도달 |
+| Model | Patch | Result | Notes |
+|-------|-------|--------|-------|
+| **openai/gpt-5** | ✅ | **RESOLVED** | Correct location in `expand_modules.py` (`os.path.relpath`) |
+| gemini-2.5-flash | ✅ | unresolved | Only `pylinter.py` — missed the correct location |
+| glm-4.7-flash | ✅ | unresolved | Touched the right file but inaccurate |
+| qwen3-coder-30b | ✅ | unresolved | Inaccurate |
+| deepseek-v4-flash | ❌ | (empty patch) | Never reached an edit |
+| gpt-5-mini | ❌ | (empty patch) | Never reached an edit |
 
-→ **이 instance는 frontier(gpt-5)만 풀었다 (1/6).** 경량 모델은 압축 임계 수정(24k→60k) 후
-patch는 생성하지만 **정답 정확도가 frontier에 못 미친다.** SWE-bench Lite는 frontier도
-30~50%대 난이도이므로 L6은 frontier 라우팅 + 충분한 maxTurns(80) 필요.
+→ **Only the frontier model (gpt-5) solved this instance (1/6).** After the
+compaction-threshold fix (24k→60k), lightweight models do produce patches, but
+**their answer accuracy falls short of frontier**. SWE-bench Lite sits at
+30–50% difficulty even for frontier models, so L6 needs frontier routing plus
+generous maxTurns (80).
 
-### "검증 강제로 경량을 통과시킬 수 있나?" 실험 (v2, 천장 검증)
+### "Can mandatory verification push a lightweight model through?" (v2, ceiling test)
 
-검증 루프를 MANDATORY로 강화("edit 후 반드시 run_tests.sh, 실패면 반복")하고 재측정:
+We made the verification loop MANDATORY ("run run_tests.sh after every edit;
+iterate while failing") and re-measured:
 
-| 모델 | v1 (검증 선택) | v2 (검증 강제 + 모든 하네스 수정) |
-|------|----------------|----------------------------------|
-| gemini-2.5-flash | edit 1, 검증 0 → 틀린 patch | **edit 9 + test 13회 반복** → 그래도 unresolved (FAIL_TO_PASS 0/1, PASS_TO_PASS 120/120 무사) |
-| deepseek-v4-flash | edit 0 (압축 수정 전) | **여전히 edit 0** — 80턴 탐색만, 수정 결정 못 내림 |
+| Model | v1 (optional verification) | v2 (mandatory verification + all harness fixes) |
+|-------|---------------------------|------------------------------------------------|
+| gemini-2.5-flash | 1 edit, 0 verifications → wrong patch | **9 edits + 13 test runs** → still unresolved (FAIL_TO_PASS 0/1, PASS_TO_PASS 120/120 intact) |
+| deepseek-v4-flash | 0 edits (pre-compaction-fix) | **Still 0 edits** — 80 turns of exploration, never committed to a change |
 
-**결론: 이 난이도의 진단형 버그에서는 사실상 모델 천장.** 검증 강제는 행동을 크게
-바꿨지만(blind 제출 → 반복 루프), 정답에 필요한 통찰("재귀 탐색의 절대/상대경로 표현
-불일치")은 피드백 13회로도 못 얻었다. 하네스가 줄 수 있는 건 기회(루프·컨텍스트)지
-진단 깊이가 아니다.
+**Conclusion: for diagnosis-type bugs at this difficulty, it is effectively a
+model ceiling.** Mandatory verification changed behavior dramatically (blind
+submission → iterate loop), but the insight the answer required ("absolute vs
+relative path representation mismatch in recursive discovery") never emerged
+even after 13 rounds of feedback. The harness can provide opportunity (loops,
+context) — it cannot provide diagnostic depth.
 
-### 하이브리드 실험: frontier 진단 + 경량 구현 — ✅ 시도한 3 instance 전부 RESOLVED (3/3)
+### Hybrid experiment: frontier diagnosis + lightweight implementation — ✅ all 3 attempted instances RESOLVED (3/3)
 
-planner/worker 분리 가설을 실측: **gpt-5가 read-only 진단**(root cause + 구체적 fix plan)
-→ **경량 모델이 구현 + 검증 루프** → 공식 swebench 채점. **통과 누적 4회** — instance를
-바꿔도(5859, 7993), 구현자를 바꿔도(deepseek) 재현된다.
+We measured the planner/worker split hypothesis directly: **gpt-5 performs a
+read-only diagnosis** (root cause + concrete fix plan) → **a lightweight model
+implements with the verification loop** → official swebench grading.
+**4 cumulative passes** — reproducible across instances (5859, 7993) and
+across implementers (deepseek).
 
-| 구성 | instance | 결과 |
-|------|----------|------|
-| gemini 단독 (검증 강제, 9 edit + 13 test) | 7080 | unresolved — 진단 실패 |
-| **gpt-5 진단(52턴 read-only) + gemini 구현(3 edit + 2 test)** | 7080 | **RESOLVED** ✅ |
-| **gpt-5 진단 + deepseek-v4-flash 구현** (단독은 0 edit이던 모델) | 7080 | **RESOLVED** ✅ |
-| **gpt-5 진단 + gemini 구현** (새 instance 풀 파이프라인) | 5859 | **RESOLVED** ✅ |
-| gpt-5 진단 + glm-4.7-flash | 7080 | 빈 patch — **구현자 부적합** (no-edit 가드 무시, 0 edit) |
-| gpt-5 진단 + gemini (v1~v5) | 7993 | unresolved — 1차 진단서의 pseudocode 버그를 구현자가 충실 복제 |
-| **gpt-5 재진단(실패 patch+테스트 출력 피드백) + deepseek 구현** | 7993 | **RESOLVED** ✅ |
+| Configuration | Instance | Result |
+|---------------|----------|--------|
+| gemini solo (mandatory verification, 9 edits + 13 tests) | 7080 | unresolved — diagnosis failure |
+| **gpt-5 diagnosis (52 read-only turns) + gemini implementation (3 edits + 2 tests)** | 7080 | **RESOLVED** ✅ |
+| **gpt-5 diagnosis + deepseek-v4-flash implementation** (a model that made 0 edits solo) | 7080 | **RESOLVED** ✅ |
+| **gpt-5 diagnosis + gemini implementation** (full pipeline on a new instance) | 5859 | **RESOLVED** ✅ |
+| gpt-5 diagnosis + glm-4.7-flash | 7080 | Empty patch — **unfit as implementer** (ignored the no-edit guard, 0 edits) |
+| gpt-5 diagnosis + gemini (v1–v5) | 7993 | unresolved — the implementer faithfully copied a bug in the first diagnosis's pseudocode |
+| **gpt-5 re-diagnosis (fed the failing patch + test output) + deepseek implementation** | 7993 | **RESOLVED** ✅ |
 
-→ **경량 모델의 L6 천장은 "진단 깊이"이고, 그 부분만 frontier가 메우면 통과한다.**
-단 구현자 적합성은 모델별로 갈린다: deepseek ✅✅(기계적 마무리 안정) / gemini ✅(import 누락
-등 마무리 변동) / glm ✗.
+→ **A lightweight model's L6 ceiling is "diagnostic depth"; fill just that gap
+with a frontier model and it passes.** Implementer fitness varies by model:
+deepseek ✅✅ (reliable mechanical finishing) / gemini ✅ (volatile finishing —
+e.g. missed imports) / glm ✗.
 
-**재진단 escalate 루프 (7993이 입증한 완성형)**: 1차 진단의 fix plan에 버그가 있으면 경량
-구현자는 그것을 충실히 복제한다("trust this analysis" — 신뢰 경계 지침으로도 못 뚫음, 4회
-연속). 해법은 구현자 설득이 아니라 **(실패 patch + 테스트 출력)을 들고 frontier 재진단** —
-gpt-5는 피드백을 받자 자기 pseudocode의 버그(Formatter.parse literal re-escape 누락)를 정확히
-짚었고, deepseek이 그 재진단서로 완주했다. OpenSwarm worker escalate 루프와 동일 구조.
-SWE_DIAG_MODEL=openai/gpt-5 + SWE_MODEL=경량으로 실행. 진단은 재사용 가능(SWE_DIAG_FILE) —
-같은 instance의 stage 2 재시도 시 frontier 비용 0.
+**The re-diagnosis escalate loop (proven by 7993)**: when the first diagnosis's
+fix plan contains a bug, the lightweight implementer copies it faithfully
+("trust this analysis" — even an explicit trust-boundary instruction failed to
+break through, 4 consecutive runs). The remedy is not persuading the
+implementer but **re-diagnosing with the frontier model, feeding it the
+failing patch + test output** — given that feedback, gpt-5 pinpointed the bug
+in its own pseudocode (a missing Formatter.parse literal re-escape), and
+deepseek finished the job with the revised diagnosis. Structurally identical
+to the OpenSwarm worker escalate loop.
+Run with SWE_DIAG_MODEL=openai/gpt-5 + SWE_MODEL=<lightweight>. Diagnoses are
+reusable (SWE_DIAG_FILE) — retrying stage 2 on the same instance costs zero
+frontier tokens.
 
-운영 함의: L6급 작업도 "frontier planner가 분석 → 경량 worker가 구현" 분업으로 frontier
-full-solve(82턴) 대비 frontier 사용을 진단(52턴 read-only)으로 줄일 수 있다. 경량
-구현자는 변동성이 있다(같은 진단으로도 조기 포기 가능) — no-edit 가드(`nudgeMaxOnNoEdit`)와
-풍부한 진단(구체적 pseudocode 포함)이 성공 요인. best-of-N은 기대 낮음(진단 없는 gemini
-9회 시도 전부 오답).
+Operational implication: even L6-grade work can use the "frontier planner
+analyzes → lightweight worker implements" split, reducing frontier usage from
+a full solve (82 turns) to a read-only diagnosis (52 turns). Lightweight
+implementers are volatile (they can give up early even with the same
+diagnosis) — the no-edit guard (`nudgeMaxOnNoEdit`) and a rich diagnosis
+(including concrete pseudocode) are the success factors. Best-of-N has low
+expected value (all 9 undiagnosed gemini attempts were wrong).
 
-하이브리드의 추가 결함 모드 (7993에서 발견):
-- **진단서 오류 전파**: 진단서 pseudocode 자체에 버그가 있으면(Formatter.parse literal
-  re-escape 누락) 구현자가 "trust this analysis" 지시 탓에 그 버그를 충실히 복제한다(3회
-  연속 동일 patch). → stage 2 지침에 "THE TEST RESULT OUTRANKS THE PLAN" 신뢰 경계 추가.
-- **검증 하네스 자가 해체** (결함 6호): 테스트 실패 원인을 검증 스크립트로 오판해
-  run_tests.sh를 5회 수정. → `protectedFiles` 옵션 (edit/write 거부).
-- **bash 침묵 타임아웃** (결함 7호): 30초 고정 타임아웃이 docker 경유 테스트에서 출력 없이
-  죽어 "환경 고장"으로 오판 유도. → `bashTimeoutMs` 옵션 + 명시적 TIMEOUT 메시지.
+Additional hybrid failure modes (discovered on 7993):
 
-## 라우팅 원칙 (티어링)
+- **Diagnosis error propagation**: if the diagnosis pseudocode itself is buggy
+  (the missing Formatter.parse literal re-escape), the implementer copies the
+  bug faithfully because of the "trust this analysis" instruction (3
+  consecutive identical patches). → Added the "THE TEST RESULT OUTRANKS THE
+  PLAN" trust boundary to the stage-2 instructions.
+- **Verification-harness self-dismantling** (defect #6): the implementer
+  misattributed test failures to the verification script and edited
+  run_tests.sh five times. → `protectedFiles` option (rejects edit/write).
+- **Silent bash timeout** (defect #7): the fixed 30s timeout died without
+  output on docker-based test runs, leading models to conclude "the
+  environment is broken". → `bashTimeoutMs` option + explicit TIMEOUT message.
 
-- **판단 무거운 역할** (Planner/분해, Reviewer): frontier 고정 (gpt-5). 잘못된 판단이
-  하류 전체를 오염시키므로 경량화 안 함.
-- **실행 역할** (Worker/Tester/Documenter/Auditor): 경량 기본 + 실패 2회 시 frontier escalate.
-  - 단 **L6급 실전 작업은 worker도 frontier 권장** — 경량으로는 정답률이 낮다.
+## Routing principles (tiering)
 
-## L6 채점 절차
+- **Judgment-heavy roles** (Planner/decomposition, Reviewer): pinned to
+  frontier (gpt-5). A wrong judgment poisons everything downstream, so these
+  are never downgraded.
+- **Execution roles** (Worker/Tester/Documenter/Auditor): lightweight by
+  default + frontier escalation after 2 failures.
+  - But **L6-grade real-world work should use a frontier worker too** —
+    lightweight answer accuracy is too low.
+
+## L6 grading procedure
 
 ```bash
-# 1. OrbStack 사용 (Apple Silicon에서 amd64 에뮬레이션 안정). Docker Desktop은 손상됨.
+# 1. Use OrbStack (stable amd64 emulation on Apple Silicon). Docker Desktop corrupts.
 export DOCKER_HOST="unix:///Users/<you>/.orbstack/run/docker.sock"
 
-# 2. OpenSwarm worker가 instance를 풀어 prediction 생성
+# 2. The OpenSwarm worker solves the instance and produces predictions
 OPENROUTER_API=... SWE_MODEL=openai/gpt-5 \
   npx tsx benchmarks/sweBench.ts <instances.json> <preds.json>
 
-# 3. 공식 swebench 하니스로 채점 (per-model, max_workers 1 — 동시 다중은 VM 부하)
+# 3. Grade with the official swebench harness (per-model, max_workers 1 — concurrency overloads the VM)
 /path/swebench-env/bin/python -m swebench.harness.run_evaluation \
   --dataset_name SWE-bench/SWE-bench_Lite --predictions_path <preds.json> \
   --run_id <run> --instance_ids <id> --cache_level instance --max_workers 1
 ```
 
-### L6 함정 (전부 측정으로 확인)
-- **OrbStack 필수.** Docker Desktop은 amd64 SWE-bench 워크로드에서 매번 "unable to start"
-  503 손상 → 재부팅 필요. OrbStack은 안정적으로 완주.
-- 옛 instance는 당대 Python(3.6~3.9) 필수 → 공식 Docker 이미지의 conda env "testbed" 사용.
-  naive venv 불가 (`cgi`/`collections.Mapping` 제거).
-- requests 옛 instance는 외부 httpbin 의존(503) → 부적합. **순수 로직 repo**(pylint/sympy/
-  sphinx) 권장.
-- 같은 instance_id를 여러 모델로 한 prediction 파일에 넣으면 마지막 1개만 채점됨 → **모델별
-  분리 채점**.
-- 이미지 태그: `swebench/sweb.eval.x86_64.<instance_id의 __를 _1776_로>`.
+### L6 pitfalls (all confirmed by measurement)
 
-## 하네스 결함 — L6에서 발견·수정 (합성 L0–L5에선 안 드러남)
+- **OrbStack is required.** Docker Desktop corrupts with "unable to start" 503
+  on every amd64 SWE-bench workload (reboot needed). OrbStack completes
+  reliably.
+- Old instances need period-correct Python (3.6–3.9) → use the conda env
+  "testbed" inside the official Docker image. A naive venv won't work
+  (`cgi` / `collections.Mapping` were removed from modern Python).
+- Old `requests` instances depend on external httpbin (503s) → unsuitable.
+  Prefer **pure-logic repos** (pylint/sympy/sphinx).
+- Putting the same instance_id under multiple models in one prediction file
+  grades only the last one → **grade per model separately**.
+- Image tag: `swebench/sweb.eval.x86_64.<instance_id with __ replaced by _1776_>`.
 
-대형 repo에서만 발현하는 결함 3건을 L6이 잡아냈다:
-1. **cwd 미인지**: agenticLoop이 모델에게 작업 디렉터리를 안 알려줘 절대경로 추측 → 탐색 차단.
-   → user 프롬프트에 `Working directory: <cwd>` 주입.
-2. **bash exit-1 오판**: grep "매치 없음"(exit 1)을 치명 에러로 처리, stdout 미반환 → 무한 반복.
-   → 에러 시에도 stdout/stderr+exit code 반환, exit1+무출력은 benign.
-3. **압축 무한 루프** (핵심): 긴 작업(60+턴)에서 압축이 읽은 파일을 깎아 무한 재read →
-   edit 도달 못 함. → 임계 24k→60k, compactAfterMessages 24→60, keepRecent 8→16.
+## Harness defects — found and fixed at L6 (invisible on synthetic L0–L5)
+
+L6 exposed defects that only manifest in large repos:
+
+1. **cwd unawareness**: agenticLoop never told the model its working
+   directory, so it guessed absolute paths → exploration fully blocked.
+   → Inject `Working directory: <cwd>` into the user prompt.
+2. **bash exit-1 misread**: grep "no match" (exit 1) was treated as a fatal
+   error with no stdout returned → infinite retries.
+   → Return stdout/stderr + exit code even on errors; exit 1 with no output
+   is benign.
+3. **Compaction loop** (the critical one): on long runs (60+ turns),
+   compaction truncated freshly-read files, causing endless re-reads — edits
+   were never reached. → Thresholds 24k→60k tokens, compactAfterMessages
+   24→60, keepRecent 8→16.
+
+(Defects #4–#7 — final-answer turn, no-edit guard, protected files, bash
+timeout — were found later during the hybrid experiments; see the hybrid
+section above.)

--- a/scripts/README-RENDERING-PERFORMANCE.md
+++ b/scripts/README-RENDERING-PERFORMANCE.md
@@ -1,65 +1,65 @@
-# Playwright 렌더링 성능 측정 스크립트
+# Playwright Rendering Performance Script
 
-모든 프론트엔드 탭을 순회하며 렌더링 완료까지의 시간을 측정하는 자동화 스크립트입니다.
+An automation script that walks every frontend tab and measures time to render completion.
 
-## 개요
+## Overview
 
-이 스크립트는 Playwright를 활용하여 OpenSwarm 대시보드의 모든 탭에 대해 다음 메트릭을 수집합니다:
+Using Playwright, this script collects the following metrics for every tab of the OpenSwarm dashboard:
 
-- **Navigation Time**: 페이지 이동 시간
-- **DOM Content Loaded**: DOM 콘텐츠 로드 완료 시간
-- **Load Complete**: 모든 리소스 로드 완료 시간
-- **Render Complete**: 렌더링 완료 시간 (리플로우/리페인트 포함)
-- **First Paint (FP)**: 첫 픽셀 렌더링 시간
-- **First Contentful Paint (FCP)**: 첫 콘텐츠 렌더링 시간
-- **Largest Contentful Paint (LCP)**: 가장 큰 콘텐츠 렌더링 시간
+- **Navigation Time**: page navigation duration
+- **DOM Content Loaded**: time until DOM content is loaded
+- **Load Complete**: time until all resources are loaded
+- **Render Complete**: time until rendering completes (including reflow/repaint)
+- **First Paint (FP)**: time to first pixel
+- **First Contentful Paint (FCP)**: time to first content render
+- **Largest Contentful Paint (LCP)**: time to largest content render
 
-## 설치
+## Installation
 
 ```bash
 npm install
 ```
 
-Playwright는 `playwright` 패키지로 devDependencies에 포함되어 있습니다.
+Playwright is included in devDependencies via the `playwright` package.
 
-## 사용 방법
+## Usage
 
-### 기본 실행
+### Basic run
 
 ```bash
 npm run perf:measure
 ```
 
-또는 직접 실행:
+Or run directly:
 
 ```bash
 tsx scripts/playwright-rendering-performance.ts
 ```
 
-### 환경 변수를 통한 설정
+### Configuration via environment variables
 
 ```bash
-# 특정 URL에 대해 테스트
+# Test against a specific URL
 BASE_URL=http://your-server:3000 npm run perf:measure
 
-# 결과 저장 위치 변경
+# Change where results are written
 OUTPUT_DIR=./custom-results npm run perf:measure
 
-# 둘 다 설정
+# Both
 BASE_URL=http://localhost:8080 OUTPUT_DIR=./performance-data npm run perf:measure
 ```
 
-## 측정되는 탭 목록
+## Measured tabs
 
-다음 3개 탭이 순회되며 측정됩니다:
+The following 3 tabs are visited and measured:
 
-1. **REPOS** - 저장소 관리
-2. **PIPELINE** - 파이프라인 및 로그 조회
-3. **CHAT** - 에이전트 채팅
+1. **REPOS** — repository management
+2. **PIPELINE** — pipeline and log viewer
+3. **CHAT** — agent chat
 
-## 출력 형식
+## Output formats
 
-### JSON 형식 (`rendering-metrics-TIMESTAMP.json`)
+### JSON (`rendering-metrics-TIMESTAMP.json`)
 
 ```json
 {
@@ -80,7 +80,7 @@ BASE_URL=http://localhost:8080 OUTPUT_DIR=./performance-data npm run perf:measur
         "loadEventEnd": 3456.78
       }
     }
-    // ... 더 많은 탭 데이터
+    // ... more tab entries
   ],
   "summary": {
     "averageRenderTime": 3000.45,
@@ -92,7 +92,7 @@ BASE_URL=http://localhost:8080 OUTPUT_DIR=./performance-data npm run perf:measur
 }
 ```
 
-### CSV 형식 (`rendering-metrics-TIMESTAMP.csv`)
+### CSV (`rendering-metrics-TIMESTAMP.csv`)
 
 | Tab | Total (ms) | Navigation (ms) | DOMContentLoaded (ms) | Load Complete (ms) | Render Complete (ms) | FCP (ms) | LCP (ms) |
 |-----|-----------|-----------------|----------------------|-------------------|---------------------|---------|---------|
@@ -100,78 +100,78 @@ BASE_URL=http://localhost:8080 OUTPUT_DIR=./performance-data npm run perf:measur
 | PIPELINE | 3456.78 | 1100.45 | 2200.56 | 3100.67 | 3456.78 | 1400.23 | 2500.34 |
 | CHAT | 5234.56 | 1400.78 | 2500.89 | 3600.90 | 5234.56 | 1600.45 | 3000.67 |
 
-## 결과 분석
+## Interpreting results
 
-### 성능 지표 해석
+### Performance targets
 
-- **Total Render Time**: 전체 렌더링 시간. 이 값이 낮을수록 좋습니다.
-- **FCP < 2000ms**: 좋음
-- **LCP < 2500ms**: 좋음
-- **전체 렌더링 < 3000ms**: 목표
+- **Total Render Time**: end-to-end rendering time — lower is better
+- **FCP < 2000ms**: good
+- **LCP < 2500ms**: good
+- **Total rendering < 3000ms**: target
 
-### 성능 문제 식별
+### Identifying slow tabs
 
-스크립트는 자동으로 평균 렌더링 시간의 1.5배 이상인 탭을 "성능 문제 탭"으로 표시합니다:
+The script automatically flags tabs whose render time exceeds 1.5× the average:
 
 ```
-⚠️  성능 문제 탭 (평균의 1.5배 이상):
+⚠️  Slow tabs (≥ 1.5× the average):
   - instances: 5234.56ms
   - sessions: 4890.12ms
 ```
 
-## 실제 사용 예시
+## Examples
 
-### 1. 기본 성능 테스트 (로컬 개발 서버)
+### 1. Basic performance test (local dev server)
 
 ```bash
-# 1. OpenSwarm 대시보드 서버 시작
+# 1. Start the OpenSwarm dashboard server
 npm run dev
 
-# 2. 다른 터미널에서 성능 측정 (기본값: localhost:5173)
+# 2. In another terminal, run the measurement (default: localhost:5173)
 npm run perf:measure
 ```
 
-### 2. 프로덕션 환경 성능 측정
+### 2. Measuring a production environment
 
 ```bash
 BASE_URL=https://your-openswarm-domain.com npm run perf:measure
 ```
 
-### 3. 사용자 정의 결과 저장 디렉토리
+### 3. Custom results directory
 
 ```bash
 OUTPUT_DIR=./custom-results npm run perf:measure
 ```
 
-## 성능 최적화 팁
+## Optimization tips
 
-스크립트 실행 결과를 기반으로 다음과 같이 최적화할 수 있습니다:
+Based on the measurements, consider:
 
-### 렌더링 시간 감소
-- 불필요한 리렌더링 제거
-- 가상화 (virtualization) 구현
-- 코드 스플리팅 적용
+### Reducing render time
+- Remove unnecessary re-renders
+- Implement virtualization
+- Apply code splitting
 
-### FCP 개선
-- 중요한 리소스 우선로드
-- 인라인 크리티컬 CSS
-- 폰트 최적화
+### Improving FCP
+- Preload critical resources
+- Inline critical CSS
+- Optimize fonts
 
-### LCP 개선
-- 이미지 최적화
-- 지연 로딩 (Lazy Loading) 적용
-- 리소스 압축
+### Improving LCP
+- Optimize images
+- Apply lazy loading
+- Compress resources
 
-## 자동화 (CI/CD)
+## Automation (CI/CD)
 
-GitHub Actions 또는 다른 CI/CD 파이프라인에서 정기적으로 실행할 수 있습니다:
+Run periodically from GitHub Actions or any CI/CD pipeline:
 
 ```yaml
 # .github/workflows/performance.yml
 name: Performance Test
 on:
   schedule:
-    - cron: '0 0 * * *'  # 매일 자정 실행
+    - cron: '0 0 * * *'  # daily at midnight
 
 jobs:
   perf-test:
@@ -195,45 +195,45 @@ jobs:
           path: performance-results/
 ```
 
-## 트러블슈팅
+## Troubleshooting
 
-### 연결 거부 오류 (net::ERR_CONNECTION_REFUSED)
+### Connection refused (net::ERR_CONNECTION_REFUSED)
 
-**원인**: 지정된 BASE_URL에서 서버가 실행 중이 아님
+**Cause**: no server running at the configured BASE_URL
 
-**해결책**:
+**Fix**:
 ```bash
-# 1. UI 서버 실행 확인
+# 1. Make sure the UI server is running
 cd openclaw/ui && npm run dev
 
-# 2. 다른 포트에서 실행 중인 경우
+# 2. If it runs on a different port
 BASE_URL=http://localhost:3000 npm run perf:measure
 ```
 
-### 타임아웃 오류
+### Timeout errors
 
-**원인**: 페이지 로딩이 오래 걸림
+**Cause**: the page takes too long to load
 
-**해결책**:
-- 네트워크 연결 확인
-- 브라우저 개발자 도구에서 렌더링 성능 확인
-- 페이지 리소스 최적화 고려
+**Fix**:
+- Check network connectivity
+- Inspect rendering performance in browser devtools
+- Consider optimizing page resources
 
-### Playwright 설치 오류
+### Playwright installation errors
 
-**원인**: Playwright 브라우저 바이너리가 없음
+**Cause**: Playwright browser binaries are missing
 
-**해결책**:
+**Fix**:
 ```bash
 npx playwright install chromium
 ```
 
-## 추가 리소스
+## Further reading
 
-- [Playwright 공식 문서](https://playwright.dev/)
-- [Web Vitals 가이드](https://web.dev/vitals/)
-- [성능 최적화 가이드](https://web.dev/performance/)
+- [Playwright documentation](https://playwright.dev/)
+- [Web Vitals guide](https://web.dev/vitals/)
+- [Performance optimization guide](https://web.dev/performance/)
 
-## 라이선스
+## License
 
-OpenSwarm 프로젝트와 동일한 라이선스를 따릅니다.
+Same license as the OpenSwarm project.


### PR DESCRIPTION
All tracked markdown docs are now English-only:

- `benchmarks/RUBRIC.md` — the L0–L6 rubric linked from the README hero (was fully Korean). Full rewrite preserving all measured results, the hybrid experiment tables, routing principles, grading procedure, and harness-defect history.
- `scripts/README-RENDERING-PERFORMANCE.md` — Playwright rendering-performance script guide.

Verified: `grep -c '[가-힣]'` returns 0 matches across tracked .md files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)