### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.5.0 — 2026-06-11
+
+### Added
+
+- **OpenRouter adapter** — runs OpenSwarm's native agentic tool loop against any OpenRouter model, with OAuth PKCE (or `OPENROUTER_API` key), ZDR (`data_collection: deny`) for non-OpenAI models, automatic Anthropic prompt caching, and optional reasoning-off for mechanical roles. (#63)
+- **LM Studio adapter** — dedicated OpenAI-compatible endpoint support with auto model selection (`LMSTUDIO_BASE_URL`, `LMSTUDIO_MODEL`). (#60)
+- **Repo knowledge loop** — workers learn each repository over time: task outcomes are stored as per-repo memories (success → `system_pattern`, review rejection → `constraint` pitfall) and recalled by relevance into the next worker prompt as a "Repository Knowledge" section. (#63)
+- **L0–L6 benchmark suite** (`benchmarks/`) — synthetic L0–L5 tasks with deterministic grading plus L6 = real SWE-bench Lite instances solved by the OpenSwarm harness and graded by the official swebench harness. Includes a hybrid mode (frontier read-only diagnosis + lightweight implementer) that resolved 3/3 attempted instances; see `benchmarks/RUBRIC.md`. (#63)
+- Agentic-loop guards, all motivated by SWE-bench findings: final-answer turn on turn exhaustion, no-edit guard (`nudgeMaxOnNoEdit`, counts only successful edits), verification-harness file protection (`protectedFiles`), and configurable bash timeout (`bashTimeoutMs`) with an explicit TIMEOUT message. (#63)
+
+### Changed
+
+- Worker success is now judged primarily by git diff instead of requiring a structured JSON block from the model.
+- Default model routing is benchmark-driven: lightweight worker (`z-ai/glm-4.7-flash`) with frontier escalation; frontier planner/reviewer.
+- Compaction thresholds raised for modern context windows (24k→60k tokens, keep 16 recent messages) — fixes an infinite re-read loop on long agentic runs.
+- `loadConfig` now disables Discord/Linear integration when credentials are missing (standalone mode) instead of rejecting the config.
+- Repo memory keys are normalized via realpath so symlinked/trailing-slash paths share one knowledge store.
+
+### Fixed
+
+- Working directory is injected into agentic prompts — models no longer guess absolute paths and get every file tool call rejected.
+- bash tool failures now return stdout/stderr + exit code (grep "no match" was previously treated as a fatal error, causing infinite retries).
+- `edit_file` result snippets now locate the edit via the unique `old_string` position (previously could show the wrong region).
+- gpt/local adapters now forward the new guard options to the agentic loop.
+
 ## 0.4.4 — 2026-05-07
 
 ### Security
@@ -17,7 +42,7 @@
 
 - Forced `protobufjs` to `^7.5.5` via `package.json` `overrides` to mitigate CVE-2026-41242 / GHSA-xq3m-2v4x-88gg (critical RCE via crafted protobuf descriptors). The vulnerable copy was pulled in transitively through `@xenova/transformers` → `onnxruntime-web` → `onnx-proto`. OpenSwarm itself loads only trusted HuggingFace models, but the override removes the dependency-tree exposure entirely.
 
-## Unreleased
+## 0.4.2 — 2026-04-25 (addendum — shipped in 0.4.2 but previously unrecorded)
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",
@@ -1198,9 +1198,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/@lancedb/lancedb/node_modules/@lancedb/lancedb-darwin-x64": {
-      "optional": true
     },
     "node_modules/@linear/sdk": {
       "version": "19.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "GPL-3.0",
   "type": "module",


### PR DESCRIPTION
Version bump 0.4.4 → 0.5.0 + CHANGELOG for the features merged in #60/#63/#64/#65:

- OpenRouter adapter (native agentic loop, PKCE, ZDR, prompt caching)
- LM Studio adapter
- Repo knowledge loop (per-repo learning across tasks)
- L0–L6 benchmark suite + SWE-bench harness (hybrid 3/3 resolved)
- 7 agentic-harness fixes from SWE-bench findings
- Standalone mode (runs without Discord/Linear credentials)

Also re-files the orphaned "Unreleased" CHANGELOG section under 0.4.2 where that code actually shipped (commits from 2026-03-18).

After merge: `npm publish` + GitHub Release tag v0.5.0 (INT-1443).

🤖 Generated with [Claude Code](https://claude.com/claude-code)