### PR TITLE
feat: log worker instruction + actions to issue comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1212,6 +1212,9 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@lancedb/lancedb/node_modules/@lancedb/lancedb-darwin-x64": {
+      "optional": true
+    },
     "node_modules/@linear/sdk": {
       "version": "19.3.0",
       "resolved": "https://registry.npmjs.org/@linear/sdk/-/sdk-19.3.0.tgz",

--- a/src/__tests__/workerAuditLog.test.ts
+++ b/src/__tests__/workerAuditLog.test.ts
@@ -1,0 +1,99 @@
+// ============================================
+// Worker audit log — comment formatting tests
+// ============================================
+
+import { describe, it, expect } from 'vitest';
+import { buildWorkerStartComment, buildWorkerCompleteComment } from '../automation/workerAuditLog.js';
+import type { WorkerResult } from '../agents/agentPair.js';
+
+describe('workerAuditLog', () => {
+  describe('buildWorkerStartComment', () => {
+    it('includes task, goal, target files and effort', () => {
+      const body = buildWorkerStartComment({
+        attempt: 1,
+        maxAttempts: 3,
+        taskTitle: 'Add logout button',
+        taskGoal: 'Wire a logout action into the header',
+        targetFiles: ['src/header.tsx', 'src/auth.ts'],
+        model: 'claude-opus-4-8',
+        maxTurns: 20,
+      });
+
+      expect(body).toContain('Worker Instruction');
+      expect(body).toContain('attempt #1/3');
+      expect(body).toContain('Add logout button');
+      expect(body).toContain('Wire a logout action');
+      expect(body).toContain('`src/header.tsx`');
+      expect(body).toContain('claude-opus-4-8');
+      expect(body).toContain('max turns 20');
+    });
+
+    it('labels revisions and survives missing optional fields', () => {
+      const body = buildWorkerStartComment({
+        attempt: 2,
+        taskTitle: 'Fix flaky test',
+        isRevision: true,
+      });
+
+      expect(body).toContain('Worker Revision');
+      expect(body).toContain('attempt #2');
+      expect(body).not.toContain('Target files');
+      expect(body).not.toContain('Effort');
+    });
+
+    it('caps long target file lists with a "+N more" suffix', () => {
+      const files = Array.from({ length: 30 }, (_, i) => `src/file${i}.ts`);
+      const body = buildWorkerStartComment({ attempt: 1, taskTitle: 't', targetFiles: files });
+      expect(body).toContain('more_');
+    });
+  });
+
+  describe('buildWorkerCompleteComment', () => {
+    const base: WorkerResult = {
+      success: true,
+      summary: 'Implemented the endpoint',
+      filesChanged: ['src/api.ts'],
+      commands: ['npm test'],
+      output: '',
+    };
+
+    it('reports actions for a successful run', () => {
+      const body = buildWorkerCompleteComment({
+        attempt: 1,
+        maxAttempts: 3,
+        result: { ...base, confidencePercent: 88 },
+        durationSec: 75,
+      });
+
+      expect(body).toContain('Worker Actions — Done');
+      expect(body).toContain('Implemented the endpoint');
+      expect(body).toContain('Files changed (1)');
+      expect(body).toContain('`src/api.ts`');
+      expect(body).toContain('Commands (1)');
+      expect(body).toContain('88%');
+      expect(body).toContain('1m 15s');
+    });
+
+    it('surfaces halt reason with a warning verdict', () => {
+      const body = buildWorkerCompleteComment({
+        attempt: 2,
+        result: { ...base, success: false, haltReason: 'Confidence too low' },
+      });
+
+      expect(body).toContain('Halted');
+      expect(body).toContain('Halt reason:');
+      expect(body).toContain('Confidence too low');
+    });
+
+    it('marks failures and shows the error', () => {
+      const body = buildWorkerCompleteComment({
+        attempt: 1,
+        result: { ...base, success: false, error: 'compile error' },
+      });
+
+      expect(body).toContain('Failed');
+      expect(body).toContain('Error:');
+      expect(body).toContain('compile error');
+    });
+  });
+});

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -452,7 +452,7 @@ export class PairPipeline extends EventEmitter {
     const stageModel = overrides?.model ?? this.getModelForRole(stage, context.task);
     const prefix = context.taskPrefix;
     console.log(`[${prefix}] Stage starting: ${stage}`);
-    this.emit('stage:start', { stage, context });
+    this.emit('stage:start', { stage, context, model: stageModel });
     broadcastEvent({ type: 'pipeline:stage', data: { taskId: context.task.id, stage, status: 'start', model: stageModel } });
 
     if (this.config.verbose) {

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -9,6 +9,8 @@ import type { ExecutorResult } from '../orchestration/workflow.js';
 import type { PipelineResult } from '../agents/pairPipeline.js';
 import type { DefaultRolesConfig, PipelineStage, JobProfile } from '../core/types.js';
 import { createPipelineFromConfig, buildTaskPrefix } from '../agents/pairPipeline.js';
+import type { WorkerResult } from '../agents/agentPair.js';
+import { buildWorkerStartComment, buildWorkerCompleteComment } from './workerAuditLog.js';
 import { formatParsedTaskSummary, loadParsedTask } from '../orchestration/taskParser.js';
 import { saveCognitiveMemory } from '../memory/index.js';
 import * as workerAgent from '../agents/worker.js';
@@ -644,8 +646,25 @@ export async function executePipeline(
 
     const taskPrefix = buildTaskPrefix(task, actualPath);
 
-    pipeline.on('stage:start', ({ stage }) => {
+    pipeline.on('stage:start', ({ stage, context, model }) => {
       console.log(`[${taskPrefix}] Stage started: ${stage}`);
+      // Audit trail: comment the worker instruction (prompt summary, target
+      // files, model/effort) on each worker run. Non-blocking — fire & forget.
+      if (stage === 'worker' && task.issueId) {
+        const draft = context?.config?.draftAnalysis;
+        const body = buildWorkerStartComment({
+          attempt: context?.currentIteration ?? 1,
+          maxAttempts: ctx.pairMaxAttempts ?? 3,
+          taskTitle: task.title,
+          taskGoal: draft?.intentSummary || task.description,
+          targetFiles: draft?.relevantFiles,
+          model: model || context?.config?.roles?.worker?.model,
+          maxTurns: context?.config?.roles?.worker?.maxTurns,
+          isRevision: (context?.currentIteration ?? 1) > 1,
+        });
+        void taskSource?.addComment(task.issueId, body).catch((err) =>
+          console.error(`[${taskPrefix}] Worker start audit comment failed:`, err));
+      }
     });
 
     const taskReportCtx = {
@@ -654,9 +673,23 @@ export async function executePipeline(
       projectPath: actualPath,
     };
 
-    pipeline.on('stage:complete', async ({ stage, result }) => {
+    pipeline.on('stage:complete', async ({ stage, result, context }) => {
       console.log(`[${taskPrefix}] Stage completed: ${stage}, success=${result.success}`);
       await reportStageResult(stage, result, ctx.reportToDiscord, taskReportCtx);
+      // Audit trail: comment the actions taken (files changed, commands run,
+      // confidence, halt reason) on each worker run.
+      if (stage === 'worker' && task.issueId) {
+        try {
+          await taskSource?.addComment(task.issueId, buildWorkerCompleteComment({
+            attempt: context?.currentIteration ?? 1,
+            maxAttempts: ctx.pairMaxAttempts ?? 3,
+            result: result.result as WorkerResult,
+            durationSec: Math.floor((result.duration ?? 0) / 1000),
+          }));
+        } catch (err) {
+          console.error(`[${taskPrefix}] Worker complete audit comment failed:`, err);
+        }
+      }
     });
 
     pipeline.on('revision:start', ({ stage }) => {

--- a/src/automation/workerAuditLog.ts
+++ b/src/automation/workerAuditLog.ts
@@ -1,0 +1,112 @@
+// ============================================
+// OpenSwarm - Worker audit log
+// ============================================
+//
+// Every worker run should leave an audit trail on the issue: what it was
+// instructed to do (start) and what it actually did (complete). These build the
+// comment bodies posted via ITaskSource.addComment, so they work for Linear AND
+// the local SQLite task source (which writes addComment → addEvent). See INT-1612.
+
+import type { WorkerResult } from '../agents/agentPair.js';
+
+/** Caps so a chatty agent can't post a multi-MB comment. */
+const MAX_FILES = 20;
+const MAX_COMMANDS = 12;
+const SUMMARY_CAP = 600;
+const GOAL_CAP = 400;
+
+function cap(s: string | undefined, n: number): string {
+  if (!s) return '';
+  const trimmed = s.trim();
+  return trimmed.length > n ? `${trimmed.slice(0, n - 1)}…` : trimmed;
+}
+
+/** Render a list as inline code, capped, with an "+N more" suffix when truncated. */
+function codeList(items: string[] | undefined, max: number): string {
+  if (!items || items.length === 0) return '_(none)_';
+  const shown = items.slice(0, max).map((i) => `\`${i}\``).join(', ');
+  const extra = items.length - max;
+  return extra > 0 ? `${shown} _+${extra} more_` : shown;
+}
+
+export interface WorkerStartInfo {
+  /** 1-based iteration/attempt number. */
+  attempt: number;
+  maxAttempts?: number;
+  taskTitle: string;
+  /** Prompt summary — task description or draft intent summary. */
+  taskGoal?: string;
+  /** Files the worker is expected to touch (from draft analysis / impact). */
+  targetFiles?: string[];
+  /** Resolved model for this worker run. */
+  model?: string;
+  /** Max agentic turns (proxy for effort budget). */
+  maxTurns?: number;
+  /** True when this run follows reviewer/guard feedback (a revision). */
+  isRevision?: boolean;
+}
+
+/** Comment body posted when a worker run starts (the instruction). */
+export function buildWorkerStartComment(info: WorkerStartInfo): string {
+  const attemptLabel = info.maxAttempts
+    ? `attempt #${info.attempt}/${info.maxAttempts}`
+    : `attempt #${info.attempt}`;
+  const heading = info.isRevision ? 'Worker Revision' : 'Worker Instruction';
+
+  const lines: string[] = [`🛠️ **[${heading}]** (${attemptLabel})`, ''];
+  lines.push(`**Task:** ${cap(info.taskTitle, 200)}`);
+  if (info.taskGoal) lines.push(`**Goal:** ${cap(info.taskGoal, GOAL_CAP)}`);
+  if (info.targetFiles && info.targetFiles.length > 0) {
+    lines.push(`**Target files:** ${codeList(info.targetFiles, MAX_FILES)}`);
+  }
+
+  const budget: string[] = [];
+  if (info.model) budget.push(`model \`${info.model}\``);
+  if (info.maxTurns) budget.push(`max turns ${info.maxTurns}`);
+  if (budget.length > 0) lines.push(`**Effort:** ${budget.join(' · ')}`);
+
+  lines.push('', '---', '_Auto-generated audit log_');
+  return lines.join('\n');
+}
+
+export interface WorkerCompleteInfo {
+  attempt: number;
+  maxAttempts?: number;
+  result: WorkerResult;
+  /** Worker run duration in seconds. */
+  durationSec?: number;
+}
+
+/** Comment body posted when a worker run completes (the actions taken). */
+export function buildWorkerCompleteComment(info: WorkerCompleteInfo): string {
+  const { result } = info;
+  const attemptLabel = info.maxAttempts
+    ? `attempt #${info.attempt}/${info.maxAttempts}`
+    : `attempt #${info.attempt}`;
+  const icon = result.haltReason ? '⚠️' : result.success ? '✅' : '❌';
+  const verdict = result.haltReason ? 'Halted' : result.success ? 'Done' : 'Failed';
+
+  const lines: string[] = [`${icon} **[Worker Actions — ${verdict}]** (${attemptLabel})`, ''];
+  if (result.summary) lines.push(`**Summary:** ${cap(result.summary, SUMMARY_CAP)}`);
+
+  const files = result.filesChanged ?? [];
+  lines.push(`**Files changed (${files.length}):** ${codeList(files, MAX_FILES)}`);
+
+  const commands = result.commands ?? [];
+  if (commands.length > 0) {
+    lines.push(`**Commands (${commands.length}):** ${codeList(commands, MAX_COMMANDS)}`);
+  }
+
+  if (result.confidencePercent != null) {
+    lines.push(`**Confidence:** ${result.confidencePercent}%`);
+  }
+  if (info.durationSec != null) {
+    const d = info.durationSec;
+    lines.push(`**Duration:** ${d < 60 ? `${d}s` : `${Math.floor(d / 60)}m ${d % 60}s`}`);
+  }
+  if (result.haltReason) lines.push(`**Halt reason:** ${cap(result.haltReason, GOAL_CAP)}`);
+  if (result.error) lines.push(`**Error:** ${cap(result.error, GOAL_CAP)}`);
+
+  lines.push('', '---', '_Auto-generated audit log_');
+  return lines.join('\n');
+}


### PR DESCRIPTION
Every worker run now leaves an audit trail on the issue: what it was instructed to do and what it actually did. Comments are posted via `ITaskSource.addComment`, so it works for both Linear and the local SQLite store (which routes `addComment` → `addEvent`).

- **Worker start** → instruction comment: task, goal (draft intent or description), target files, model/effort.
- **Worker complete** → actions comment: files changed, commands run, confidence, duration, and halt reason / error.

Both fire once per worker run, so revisions get their own entries (labelled with the attempt number).

## Changes
- New `src/automation/workerAuditLog.ts` builds the two comment bodies (with caps so a chatty agent can't post a multi-MB comment).
- Wired into the existing `stage:start` / `stage:complete` pipeline events in `runnerExecution.ts`; posting is non-blocking and failures are logged, not thrown.
- `stage:start` now carries the resolved model so the instruction comment can report it.
- Unit tests for the formatters.