### PR TITLE
feat: blocker/dependency ordering for conflict-free concurrent workers

### DIFF
--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -247,6 +247,7 @@ export async function createSubIssuesWithDependencies(
     dependencies: string[];
     topoRank: number;
     estimatedMinutes: number;
+    fileScope: string[];
   }> = [];
 
   for (const [index, subTask] of subTasks.entries()) {
@@ -254,8 +255,13 @@ export async function createSubIssuesWithDependencies(
       ? `\n\n${t('runner.decomposition.prerequisite', { deps: subTask.dependencies.join(', ') })}`
       : '';
 
+    const fileScope = (subTask.fileScope ?? []).filter((f) => typeof f === 'string' && f.trim().length > 0);
+    const scopeStr = fileScope.length
+      ? `\n\nFile scope: ${fileScope.join(', ')}`
+      : '';
+
     const subDescription = `${subTask.description}\n\n` +
-      `${t('runner.decomposition.estimatedTime', { n: String(subTask.estimatedMinutes) })}${depsStr}\n\n` +
+      `${t('runner.decomposition.estimatedTime', { n: String(subTask.estimatedMinutes) })}${depsStr}${scopeStr}\n\n` +
       t('runner.decomposition.autoDecomposed', { parentTitle: task.title });
 
     const subResult = taskSource
@@ -278,6 +284,7 @@ export async function createSubIssuesWithDependencies(
       dependencies: subTask.dependencies || [],
       topoRank: index,
       estimatedMinutes: subTask.estimatedMinutes,
+      fileScope,
     });
 
     console.log(`[AutonomousRunner] Created sub-issue: ${subResult.identifier}`);
@@ -350,6 +357,7 @@ export async function createSubIssuesWithDependencies(
       parentIssueId: parentIssueId,
       dependencyIssueIds,
       dependencyTitles: subIssue.dependencies,
+      fileScope: subIssue.fileScope,
       topoRank: subIssue.topoRank,
       execution: {
         status: isReady ? 'todo' : 'blocked',

--- a/src/automation/taskSource.ts
+++ b/src/automation/taskSource.ts
@@ -13,6 +13,7 @@ import { getIssueStore } from '../issues/index.js';
 import type { IIssueStore } from '../issues/sqliteStore.js';
 import type { Issue, IssueStatus, IssuePriority } from '../issues/schema.js';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
+import { enrichTaskFromState } from '../taskState/store.js';
 
 /** The runner's task-state vocabulary (mirrors Linear's updateIssueState states). */
 export type TaskState = 'In Progress' | 'In Review' | 'Done' | 'Backlog' | 'Todo';
@@ -115,7 +116,9 @@ export class SqliteTaskSource implements ITaskSource {
 
   async fetchTasks(): Promise<TaskItem[]> {
     const { issues } = this.store.listIssues({ status: ['todo', 'in_progress'], limit: 200, offset: 0 });
-    return issues.map(issueToTask);
+    // Enrich from canonical task state so planner-declared fileScope (plus
+    // dependency/topoRank data) reaches the runner — mirrors the Linear path.
+    return issues.map((issue) => enrichTaskFromState(issueToTask(issue)));
   }
   async createTask(title: string, description: string, projectId?: string): Promise<SubIssueResult> {
     try {

--- a/src/locale/prompts/en.ts
+++ b/src/locale/prompts/en.ts
@@ -254,6 +254,16 @@ Analyze this task and decompose it into units completable within ${targetMinutes
 - Use clear and specific titles
 - Number in order if there are dependencies
 
+## File Scope (REQUIRED for parallel execution)
+For each sub-task, declare \`fileScope\`: the concrete files/modules it will create or modify
+(relative repo paths, e.g. \`src/foo/bar.ts\`). Workers run concurrently in isolated git
+worktrees, so two sub-tasks that touch the SAME file would conflict on merge:
+- Prefer disjoint \`fileScope\` sets so sub-tasks can run in parallel
+- If two sub-tasks must edit the same file, either merge them into one sub-task or
+  mark one as \`dependencies\` of the other so they run sequentially
+- Base \`fileScope\` on your analysis (likely files / affected modules above); if genuinely
+  unknown, return an empty array — do NOT invent paths
+
 ## Output Format (JSON)
 Output the analysis results in the following JSON format:
 
@@ -267,14 +277,16 @@ Output the analysis results in the following JSON format:
       "description": "Detailed description (what, how, completion criteria)",
       "estimatedMinutes": 20,
       "priority": 2,
-      "dependencies": []
+      "dependencies": [],
+      "fileScope": ["src/moduleA.ts", "src/moduleA.test.ts"]
     },
     {
       "title": "[Type] Next task",
       "description": "Detailed description",
       "estimatedMinutes": 25,
       "priority": 2,
-      "dependencies": ["[Type] Specific task title"]
+      "dependencies": ["[Type] Specific task title"],
+      "fileScope": ["src/moduleB.ts"]
     }
   ],
   "totalEstimatedMinutes": 45

--- a/src/locale/prompts/ko.ts
+++ b/src/locale/prompts/ko.ts
@@ -254,6 +254,16 @@ ${draftSection}${kgSection}
 - 명확하고 구체적인 제목 사용
 - 의존성이 있으면 순서대로 번호 매기기
 
+## File Scope (병렬 실행을 위해 필수)
+각 서브태스크에 \`fileScope\`를 선언하라: 생성·수정할 구체적 파일/모듈
+(repo 상대 경로, 예: \`src/foo/bar.ts\`). 워커는 격리된 git 워크트리에서 동시에 실행되므로
+같은 파일을 건드리는 두 서브태스크는 머지 시 충돌한다:
+- 서브태스크가 병렬 실행될 수 있도록 \`fileScope\`를 서로 겹치지 않게 분리하라
+- 두 서브태스크가 같은 파일을 수정해야 하면, 하나로 합치거나 한쪽을 다른 쪽의
+  \`dependencies\`로 지정해 순차 실행되게 하라
+- \`fileScope\`는 분석(관련 파일/영향 모듈)에 근거해 작성하라. 정말 알 수 없으면
+  빈 배열을 반환하라 — 경로를 지어내지 마라
+
 ## Output Format (JSON)
 분석 결과를 다음 JSON 형식으로 출력하라:
 
@@ -267,14 +277,16 @@ ${draftSection}${kgSection}
       "description": "상세 설명 (무엇을, 어떻게, 완료 기준)",
       "estimatedMinutes": 20,
       "priority": 2,
-      "dependencies": []
+      "dependencies": [],
+      "fileScope": ["src/moduleA.ts", "src/moduleA.test.ts"]
     },
     {
       "title": "[타입] 다음 작업",
       "description": "상세 설명",
       "estimatedMinutes": 25,
       "priority": 2,
-      "dependencies": ["[타입] 구체적인 작업 제목"]
+      "dependencies": ["[타입] 구체적인 작업 제목"],
+      "fileScope": ["src/moduleB.ts"]
     }
   ],
   "totalEstimatedMinutes": 45

--- a/src/orchestration/conflictDetector.test.ts
+++ b/src/orchestration/conflictDetector.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { detectFileConflicts } from './conflictDetector.js';
+import type { TaskItem } from './decisionEngine.js';
+
+// These tests exercise the planner-declared `fileScope` path. When every task
+// carries an explicit scope, detection never touches the Knowledge Graph, so
+// results are fully deterministic without any project graph on disk.
+
+function task(id: string, priority: number, fileScope: string[]): TaskItem {
+  return {
+    id,
+    source: 'linear',
+    title: `task ${id}`,
+    priority,
+    createdAt: 0,
+    issueId: id,
+    fileScope,
+  };
+}
+
+const PROJECT = '/tmp/does-not-need-a-graph';
+
+describe('detectFileConflicts (planner-declared file scope)', () => {
+  it('returns a single task as safe without inspection', async () => {
+    const result = await detectFileConflicts([task('A', 2, ['src/a.ts'])], PROJECT);
+    expect(result.safe.map((t) => t.id)).toEqual(['A']);
+    expect(result.conflictGroups).toHaveLength(0);
+  });
+
+  it('keeps tasks with disjoint scopes concurrent', async () => {
+    const result = await detectFileConflicts(
+      [task('A', 2, ['src/a.ts']), task('B', 2, ['src/b.ts'])],
+      PROJECT,
+    );
+    expect(new Set(result.safe.map((t) => t.id))).toEqual(new Set(['A', 'B']));
+    expect(result.conflictGroups).toHaveLength(0);
+  });
+
+  it('defers the lower-priority task when scopes overlap', async () => {
+    const result = await detectFileConflicts(
+      [
+        task('A', 3, ['src/shared.ts', 'src/a.ts']),
+        task('B', 1, ['src/shared.ts', 'src/b.ts']), // higher priority (1 < 3)
+      ],
+      PROJECT,
+    );
+
+    // Only the higher-priority task is safe to run now.
+    expect(result.safe.map((t) => t.id)).toEqual(['B']);
+    expect(result.conflictGroups).toHaveLength(1);
+    expect(result.conflictGroups[0].tasks.map((t) => t.id).sort()).toEqual(['A', 'B']);
+    expect(result.conflictGroups[0].sharedModules).toContain('src/shared.ts');
+  });
+
+  it('normalizes scope entries so ./Path and path collide', async () => {
+    const result = await detectFileConflicts(
+      [task('A', 2, ['./src/Shared.ts']), task('B', 2, ['src/shared.ts'])],
+      PROJECT,
+    );
+    expect(result.conflictGroups).toHaveLength(1);
+    expect(result.safe).toHaveLength(1);
+  });
+
+  it('isolates a conflict so an unrelated task still runs', async () => {
+    const result = await detectFileConflicts(
+      [
+        task('A', 2, ['src/shared.ts']),
+        task('B', 2, ['src/shared.ts']),
+        task('C', 2, ['src/independent.ts']),
+      ],
+      PROJECT,
+    );
+
+    const safeIds = new Set(result.safe.map((t) => t.id));
+    // C is disjoint → always safe.
+    expect(safeIds.has('C')).toBe(true);
+    // Exactly one of A/B runs now; the other is deferred.
+    expect([safeIds.has('A'), safeIds.has('B')].filter(Boolean)).toHaveLength(1);
+    expect(result.safe).toHaveLength(2);
+  });
+});

--- a/src/orchestration/conflictDetector.ts
+++ b/src/orchestration/conflictDetector.ts
@@ -6,7 +6,6 @@
 
 import type { TaskItem } from './decisionEngine.js';
 import { analyzeIssue } from '../knowledge/index.js';
-import type { ImpactAnalysis } from '../knowledge/types.js';
 
 // Types
 
@@ -61,8 +60,27 @@ class UnionFind {
 // Conflict Detection
 
 /**
- * Knowledge Graph를 사용하여 태스크 간 파일 영향 범위 겹침을 감지.
- * 겹치는 태스크를 ConflictGroup으로 묶고, 각 그룹에서 최고 우선순위만 safe로 반환.
+ * Normalize a file/module identifier so two declarations of the same path
+ * compare equal: lowercase, trim, strip a leading `./`. Empty/blank entries
+ * are dropped.
+ */
+function normalizeScope(entries: string[] | undefined): Set<string> {
+  const out = new Set<string>();
+  if (!entries) return out;
+  for (const raw of entries) {
+    if (typeof raw !== 'string') continue;
+    const normalized = raw.trim().replace(/^\.\//, '').toLowerCase();
+    if (normalized) out.add(normalized);
+  }
+  return out;
+}
+
+/**
+ * Detect file-scope overlap between tasks. Each task's scope prefers the
+ * planner-declared `fileScope` (authoritative), falling back to Knowledge Graph
+ * inference (`analyzeIssue`) only when no explicit scope is available.
+ * Overlapping tasks are grouped into a ConflictGroup; only the highest-priority
+ * task in each group is returned as safe to run concurrently.
  */
 export async function detectFileConflicts(
   tasks: TaskItem[],
@@ -74,16 +92,23 @@ export async function detectFileConflicts(
 
   // Step 1: 각 태스크의 영향 모듈 집합 수집
   const taskImpacts: Map<number, Set<string>> = new Map();
-  const impactResults: Map<number, ImpactAnalysis | null> = new Map();
 
   await Promise.all(
     tasks.map(async (task, idx) => {
-      const impact = await analyzeIssue(projectPath, task.title, task.description);
-      impactResults.set(idx, impact);
+      // Prefer the planner-declared file scope. It is what the worker is
+      // actually constrained to, so it is more accurate than KG inference and
+      // needs no graph lookup.
+      const declared = normalizeScope(task.fileScope);
+      if (declared.size > 0) {
+        taskImpacts.set(idx, declared);
+        return;
+      }
 
+      // Fall back to Knowledge Graph inference when no explicit scope exists.
+      const impact = await analyzeIssue(projectPath, task.title, task.description);
       if (impact) {
-        const modules = new Set([...impact.directModules, ...impact.dependentModules]);
-        taskImpacts.set(idx, modules);
+        const modules = normalizeScope([...impact.directModules, ...impact.dependentModules]);
+        if (modules.size > 0) taskImpacts.set(idx, modules);
       }
     })
   );

--- a/src/orchestration/decisionEngine.ts
+++ b/src/orchestration/decisionEngine.ts
@@ -55,6 +55,7 @@ export interface TaskItem {
   createdAt: number;
   dueDate?: number;
   blockedBy?: string[];    // Other task IDs
+  fileScope?: string[];    // Files/modules this task modifies (planner-declared) — for parallel conflict detection
   impactAnalysis?: ImpactAnalysis;  // Knowledge graph impact analysis
   estimatedMinutes?: number;
 }

--- a/src/support/planner.ts
+++ b/src/support/planner.ts
@@ -41,6 +41,7 @@ export interface SubTask {
   estimatedMinutes: number;
   priority: number;  // 1-4 (1=Urgent)
   dependencies?: string[];  // Prerequisite sub-task titles
+  fileScope?: string[];  // Files/modules this sub-task will modify — used for parallel conflict detection
 }
 
 export interface PlannerResult {

--- a/src/taskState/store.test.ts
+++ b/src/taskState/store.test.ts
@@ -45,6 +45,38 @@ describe('task state store', () => {
     expect(task.topoRank).toBe(1);
   });
 
+  it('persists and enriches planner-declared file scope', () => {
+    upsertTaskState('ISSUE-SCOPE', {
+      issueIdentifier: 'INT-SCOPE',
+      fileScope: ['src/a.ts', 'src/a.test.ts'],
+      execution: { status: 'todo', retryCount: 0 },
+      updatedAt: new Date().toISOString(),
+    });
+
+    const enriched = enrichTaskFromState({
+      id: 'ISSUE-SCOPE',
+      source: 'linear',
+      title: 'scoped task',
+      priority: 2,
+      createdAt: Date.now(),
+      issueId: 'ISSUE-SCOPE',
+    });
+
+    expect(enriched.fileScope).toEqual(['src/a.ts', 'src/a.test.ts']);
+
+    // An explicit scope already on the task wins over the stored one.
+    const overridden = enrichTaskFromState({
+      id: 'ISSUE-SCOPE',
+      source: 'linear',
+      title: 'scoped task',
+      priority: 2,
+      createdAt: Date.now(),
+      issueId: 'ISSUE-SCOPE',
+      fileScope: ['src/override.ts'],
+    });
+    expect(overridden.fileScope).toEqual(['src/override.ts']);
+  });
+
   it('keeps tasks blocked until dependencies are done, then releases them', () => {
     upsertTaskState('ISSUE-1', {
       execution: { status: 'in_progress', retryCount: 0 },

--- a/src/taskState/store.ts
+++ b/src/taskState/store.ts
@@ -49,6 +49,9 @@ export const OpenSwarmTaskStateSchema = z.object({
   childIssueIds: z.array(z.string()).default([]),
   dependencyIssueIds: z.array(z.string()).default([]),
   dependencyTitles: z.array(z.string()).default([]),
+  // Files/modules this task will touch (declared by the planner). Drives
+  // file-scope overlap detection so non-overlapping tasks run concurrently.
+  fileScope: z.array(z.string()).default([]),
   topoRank: z.number().int().nonnegative().optional(),
   linearState: z.string().optional(),
   execution: ExecutionStateSchema.default({ status: 'backlog', retryCount: 0 }),
@@ -111,6 +114,7 @@ function createDefaultState(issueId: string): OpenSwarmTaskState {
     childIssueIds: [],
     dependencyIssueIds: [],
     dependencyTitles: [],
+    fileScope: [],
     execution: {
       status: 'backlog',
       retryCount: 0,
@@ -138,6 +142,7 @@ export function upsertTaskState(issueId: string, patch: Partial<OpenSwarmTaskSta
     childIssueIds: patch.childIssueIds ?? current.childIssueIds ?? [],
     dependencyIssueIds: patch.dependencyIssueIds ?? current.dependencyIssueIds ?? [],
     dependencyTitles: patch.dependencyTitles ?? current.dependencyTitles ?? [],
+    fileScope: patch.fileScope ?? current.fileScope ?? [],
     execution: {
       ...current.execution,
       ...(patch.execution),
@@ -165,6 +170,7 @@ export function enrichTaskFromState(task: TaskItem): TaskItem {
     blockedBy: task.blockedBy && task.blockedBy.length > 0 ? task.blockedBy : state.dependencyIssueIds,
     topoRank: task.topoRank ?? state.topoRank,
     linearState: task.linearState || state.linearState,
+    fileScope: task.fileScope && task.fileScope.length > 0 ? task.fileScope : state.fileScope,
   };
 }
 


### PR DESCRIPTION
## Summary
Final piece of [INT-1607](https://linear.app/intrect/issue/INT-1607/epic-planner-led-autonomous-orchestration-backlog-grooming-plan) — let multiple workers run without git conflicts by respecting blocker order.

## Scope

* DecisionEngine already filters "Waiting on dependencies" (blocked-by) — confirmed in logs (`Filtered out STO-xxxx: Waiting on dependencies`). Build on this.
* Raise `maxConcurrentTasks` > 1 only for tasks whose blockers are resolved AND whose file scopes don't overlap.
* File-scope overlap detection (from the plan's sub-issue scope) so two workers don't edit the same files concurrently.
* worktree mode (`worktreeMode`) already isolates each task's git working tree — wire it to concurrent execution.

## Depends on

* Sub-issue 1 (decomposition creates the blockers) and sub-issue 2 (grooming sets accurate dependencies). Lowest priority — serialization (maxConcurrentTasks:1) is a safe default until then.

## Linear
Closes INT-1610

---
🤖 Generated with [OpenSwarm](https://github.com/Intrect-io/OpenSwarm)