### PR TITLE
Phase 4: 루프 성숙도 — bad-edit 가드 + reflection 루프 (self-repair)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -94,13 +94,19 @@ autonomous:
 
   # Pipeline guards
   guards:
-    qualityGate: true
+    qualityGate: true       # bad-edit lint gate: tsc/ruff on changed files (blocking)
     fakeDataGuard: true
     conventionalCommits: true
     branchValidation: true
     uncertaintyDetection: true
     registryCheck: true
-    bsDetector: true
+    bsDetector: true        # blocks on critical code-smell patterns
+
+  # Self-repair reflection budget: max objective (lint/bs/test) failures tolerated
+  # before the loop gives up on bad edits. Lower it to cap token burn when
+  # reflection stops making progress; the loop also bails early on stagnation
+  # (identical errors twice in a row). Default: 3.
+  maxReflections: 3
 
   # Job profiles for lightweight vs heavy work
   jobProfiles:

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -17,6 +17,15 @@ import { broadcastEvent } from '../core/eventHub.js';
 import { CONFIDENCE_THRESHOLDS } from './agentPair.js';
 import * as agentPair from './agentPair.js';
 import { runGuards, type GuardsRunResult } from './pipelineGuards.js';
+import {
+  type ReflectionState,
+  type ReflectionSource,
+  createReflectionState,
+  recordReflection,
+  shouldStopReflecting,
+  buildReflectionFeedback,
+  DEFAULT_MAX_REFLECTIONS,
+} from './reflection.js';
 import { hasRepoSnapshot, scanAndCache, analyzeIssue } from '../knowledge/index.js';
 import { getRegistryStore } from '../registry/sqliteStore.js';
 import { recallRepoKnowledge } from '../memory/repoKnowledge.js';
@@ -40,6 +49,13 @@ export interface PipelineConfig {
   skipDocumenterIfNoChange?: boolean;
   /** Max total iterations (one cycle = Worker → Reviewer → Tester) */
   maxIterations?: number;
+  /**
+   * Max objective self-repair attempts (lint/bs/test failures) before the loop
+   * gives up on bad edits. Independent of maxIterations so an operator can cap
+   * token burn on reflection without shrinking the reviewer-revise budget.
+   * Default: DEFAULT_MAX_REFLECTIONS (3).
+   */
+  maxReflections?: number;
   /** Per-role configuration */
   roles?: {
     worker?: RoleConfig;
@@ -125,6 +141,15 @@ export interface PipelineContext {
   auditorResult?: AuditorResult;
   skillDocumenterResult?: SkillDocumenterResult;
   guardsResult?: GuardsRunResult;
+  /** Accumulated objective (lint/bs/test) errors for self-repair reflection */
+  reflection: ReflectionState;
+  /**
+   * Source of the latest revise feedback. 'objective' failures (lint/bs/test)
+   * flow through the reflection trail and are preserved across fresh-context
+   * resets; 'review' feedback (reviewer/halt) is subjective and dropped on a
+   * fresh-context retry.
+   */
+  feedbackSource?: 'objective' | 'review';
 }
 
 /**
@@ -174,6 +199,7 @@ export class PairPipeline extends EventEmitter {
       continueOnTestFail: false,
       skipDocumenterIfNoChange: true,
       maxIterations: 3,
+      maxReflections: DEFAULT_MAX_REFLECTIONS,
       ...config,
     };
     // Initialize stuck detector
@@ -252,6 +278,7 @@ export class PairPipeline extends EventEmitter {
       config: this.config,
       currentIteration: 0,
       taskPrefix,
+      reflection: createReflectionState(),
     };
 
     try {
@@ -486,15 +513,24 @@ export class PairPipeline extends EventEmitter {
             this.emit('log', { line: `[verbose] Worker context: ${modCount} affected modules, ${briefCount} file briefs` });
           }
 
+          // Self-repair feedback: objective lint/test errors (reflection trail)
+          // are always carried forward — they are ground truth and survive a
+          // fresh-context reset. Subjective reviewer feedback is dropped on fresh
+          // context and only included when it was the latest revise reason.
+          const reflectionPart = buildReflectionFeedback(context.reflection);
+          const includeReview =
+            !useFreshContext && context.feedbackSource === 'review' && !!context.reviewResult;
+          const reviewPart = includeReview
+            ? reviewerAgent.buildRevisionPrompt(context.reviewResult!)
+            : undefined;
+          const combinedFeedback =
+            [reflectionPart, reviewPart].filter(Boolean).join('\n\n') || undefined;
+
           result = await workerAgent.runWorker({
             taskTitle: context.task.title,
             taskDescription: context.task.description || '',
             projectPath: context.projectPath,
-            previousFeedback: useFreshContext
-              ? undefined // Fresh context: no previous feedback
-              : (context.reviewResult
-                  ? reviewerAgent.buildRevisionPrompt(context.reviewResult)
-                  : undefined),
+            previousFeedback: combinedFeedback,
             timeoutMs: this.config.roles?.worker?.timeoutMs ?? 0,
             model: overrides?.model ?? this.config.roles?.worker?.model,
             maxTurns: this.config.roles?.worker?.maxTurns,
@@ -746,6 +782,37 @@ export class PairPipeline extends EventEmitter {
     }
   }
 
+  /**
+   * Decide whether to stop the bounded self-repair loop after an objective
+   * (lint/bs/test) failure. Aborts when the agent is stagnating (identical
+   * errors twice in a row) or has spent its reflection budget — either way
+   * further retries only burn tokens (the regression guard from the task spec).
+   * Returns true when the caller should terminate the pipeline as failed.
+   */
+  private shouldAbortSelfRepair(
+    context: PipelineContext,
+    progressed: boolean,
+    source: ReflectionSource,
+  ): boolean {
+    const max = this.config.maxReflections ?? DEFAULT_MAX_REFLECTIONS;
+    const budgetSpent = shouldStopReflecting(context.reflection, max);
+    if (progressed && !budgetSpent) return false;
+
+    const reason = !progressed
+      ? `self-repair stagnated: identical ${source} errors repeated`
+      : `self-repair budget exhausted (${context.reflection.reflectionCount}/${max} objective failures)`;
+    console.warn(`[${context.taskPrefix}] Aborting self-repair — ${reason}`);
+    this.emit('log', { line: `🛑 ${reason}` });
+    this.emit('reflection:abort', {
+      reason,
+      source,
+      reflectionCount: context.reflection.reflectionCount,
+      context,
+    });
+    agentPair.updateSessionStatus(context.session.id, 'failed');
+    return true;
+  }
+
   // ============================================
   // Full Iteration Loop
   // ============================================
@@ -853,14 +920,27 @@ export class PairPipeline extends EventEmitter {
         context.guardsResult = guardsResult;
 
         if (!guardsResult.allPassed) {
-          // Blocking guard failed → inject revise, skip reviewer
-          console.log(`[${context.taskPrefix}] Blocking guard failed: ${guardsResult.combinedIssues.join('; ')}`);
+          // Blocking guard failed → bad edit. Skip the (expensive) reviewer and
+          // drive a bounded self-repair retry with the exact errors preserved.
+          const blocking = guardsResult.results.filter(r => !r.passed && r.blocking);
+          const blockingIssues = blocking.flatMap(r => r.issues);
+          console.log(`[${context.taskPrefix}] Blocking guard failed: ${blockingIssues.join('; ')}`);
+
+          // qualityGate is the lint/type bad-edit check; bsDetector is code-smell.
+          const source: ReflectionSource = blocking.some(r => r.guard === 'qualityGate') ? 'lint' : 'bs';
+          const { progressed } = recordReflection(context.reflection, {
+            iteration: context.currentIteration,
+            source,
+            errors: blockingIssues,
+          });
+
           context.reviewResult = {
             decision: 'revise',
-            feedback: `Pipeline guard failed: ${guardsResult.combinedIssues.join('; ')}`,
-            issues: guardsResult.combinedIssues,
+            feedback: `Pipeline guard failed: ${blockingIssues.join('; ')}`,
+            issues: blockingIssues,
             suggestions: ['Fix the issues flagged by quality guards'],
           };
+          context.feedbackSource = 'objective';
           agentPair.trackFailure(context.session.id);
           this.emit('iteration:fail', {
             iteration: context.currentIteration,
@@ -868,6 +948,10 @@ export class PairPipeline extends EventEmitter {
             context,
           });
           agentPair.updateSessionStatus(context.session.id, 'revising');
+
+          if (this.shouldAbortSelfRepair(context, progressed, source)) {
+            return { success: false };
+          }
           continue;
         }
 
@@ -897,13 +981,15 @@ export class PairPipeline extends EventEmitter {
             context,
           });
 
-          // Inject revise to retry
+          // Inject revise to retry. Low confidence is a subjective signal, so it
+          // travels through the reviewer channel (dropped on a fresh-context reset).
           context.reviewResult = {
             decision: 'revise',
             feedback: `[HALT] Confidence too low (${confidence}%). ${haltReason}`,
             issues: [haltReason],
             suggestions: ['Review task requirements', 'Provide additional context', 'Break into sub-tasks'],
           };
+          context.feedbackSource = 'review';
           agentPair.trackFailure(context.session.id);
           this.emit('iteration:fail', {
             iteration: context.currentIteration,
@@ -958,8 +1044,10 @@ export class PairPipeline extends EventEmitter {
         }
 
         if (decision === 'revise') {
-          // revise = next iteration
+          // revise = next iteration. Reviewer feedback is subjective → it travels
+          // through the reviewer channel and is dropped on a fresh-context reset.
           console.log(`[${context.taskPrefix}] Reviewer requested revision`);
+          context.feedbackSource = 'review';
           agentPair.trackFailure(context.session.id); // Track for fresh context decision
           this.emit('iteration:fail', {
             iteration: context.currentIteration,
@@ -988,9 +1076,20 @@ export class PairPipeline extends EventEmitter {
         stages.push(testerResult);
 
         if (!testerResult.success && !this.config.continueOnTestFail) {
-          // Test failed → set feedback then next iteration
+          // Test failure is objective ground truth → record into the reflection
+          // trail and drive a bounded self-repair retry.
           console.log(`[${context.taskPrefix}] Tester failed, retrying...`);
           agentPair.trackFailure(context.session.id); // Track for fresh context decision
+
+          const failedTests = context.testerResult?.failedTests ?? [];
+          const testErrors = failedTests.length > 0
+            ? failedTests
+            : [context.testerResult?.error || `Tests failed (${context.testerResult?.testsFailed ?? 0} failing)`];
+          const { progressed } = recordReflection(context.reflection, {
+            iteration: context.currentIteration,
+            source: 'test',
+            errors: testErrors,
+          });
 
           if (context.testerResult) {
             context.reviewResult = {
@@ -1000,6 +1099,7 @@ export class PairPipeline extends EventEmitter {
               suggestions: context.testerResult.suggestions,
             };
           }
+          context.feedbackSource = 'objective';
 
           this.emit('iteration:fail', {
             iteration: context.currentIteration,
@@ -1007,6 +1107,10 @@ export class PairPipeline extends EventEmitter {
             context,
           });
           agentPair.updateSessionStatus(context.session.id, 'revising');
+
+          if (this.shouldAbortSelfRepair(context, progressed, 'test')) {
+            return { success: false };
+          }
           continue;
         }
         } // end else (has code change)
@@ -1129,6 +1233,7 @@ export function createPipelineFromConfig(
   guards?: Partial<PipelineGuardsConfig>,
   jobProfiles?: JobProfile[],
   draftAnalysis?: PipelineConfig['draftAnalysis'],
+  maxReflections?: number,
 ): PairPipeline {
   const stages: PipelineStage[] = [];
 
@@ -1154,6 +1259,7 @@ export function createPipelineFromConfig(
   return new PairPipeline({
     stages,
     maxIterations,
+    maxReflections,
     roles,
     guards,
     jobProfiles,

--- a/src/agents/reflection.test.ts
+++ b/src/agents/reflection.test.ts
@@ -1,0 +1,193 @@
+// Created: 2026-06-22
+// Purpose: Unit tests for self-repair reflection (bad-edit guard + bounded reflection loop)
+// Test Status: Complete
+
+import { describe, it, expect } from 'vitest';
+import {
+  createReflectionState,
+  isObjective,
+  recordReflection,
+  shouldStopReflecting,
+  buildReflectionFeedback,
+  DEFAULT_MAX_REFLECTIONS,
+  MAX_TRAIL_ENTRIES,
+  type ReflectionState,
+} from './reflection.js';
+
+describe('reflection', () => {
+  describe('createReflectionState', () => {
+    it('starts empty with zero count', () => {
+      const s = createReflectionState();
+      expect(s.entries).toEqual([]);
+      expect(s.reflectionCount).toBe(0);
+    });
+  });
+
+  describe('isObjective', () => {
+    it('treats lint/bs/test as objective', () => {
+      expect(isObjective('lint')).toBe(true);
+      expect(isObjective('bs')).toBe(true);
+      expect(isObjective('test')).toBe(true);
+    });
+
+    it('treats review as subjective', () => {
+      expect(isObjective('review')).toBe(false);
+    });
+  });
+
+  describe('recordReflection', () => {
+    it('increments count for objective sources only', () => {
+      const s = createReflectionState();
+      recordReflection(s, { iteration: 1, source: 'lint', errors: ['e1'] });
+      expect(s.reflectionCount).toBe(1);
+      recordReflection(s, { iteration: 2, source: 'review', errors: ['opinion'] });
+      expect(s.reflectionCount).toBe(1); // review does not count
+      recordReflection(s, { iteration: 3, source: 'test', errors: ['t1'] });
+      expect(s.reflectionCount).toBe(2);
+    });
+
+    it('reports progress on the first objective failure', () => {
+      const s = createReflectionState();
+      const { progressed } = recordReflection(s, { iteration: 1, source: 'lint', errors: ['TS2304'] });
+      expect(progressed).toBe(true);
+    });
+
+    it('reports no progress when identical objective errors repeat', () => {
+      const s = createReflectionState();
+      recordReflection(s, { iteration: 1, source: 'lint', errors: ['TS2304: Cannot find name x'] });
+      const second = recordReflection(s, { iteration: 2, source: 'lint', errors: ['TS2304: Cannot find name x'] });
+      expect(second.progressed).toBe(false);
+    });
+
+    it('reports progress when objective errors change', () => {
+      const s = createReflectionState();
+      recordReflection(s, { iteration: 1, source: 'lint', errors: ['TS2304'] });
+      const second = recordReflection(s, { iteration: 2, source: 'lint', errors: ['TS2345'] });
+      expect(second.progressed).toBe(true);
+    });
+
+    it('compares against the most recent OBJECTIVE entry, ignoring interleaved review', () => {
+      const s = createReflectionState();
+      recordReflection(s, { iteration: 1, source: 'test', errors: ['boom'] });
+      recordReflection(s, { iteration: 2, source: 'review', errors: ['style nit'] });
+      const third = recordReflection(s, { iteration: 3, source: 'test', errors: ['boom'] });
+      expect(third.progressed).toBe(false); // same as the prior objective (test), not the review
+    });
+
+    it('treats differently-ordered identical errors as different (order-sensitive)', () => {
+      const s = createReflectionState();
+      recordReflection(s, { iteration: 1, source: 'lint', errors: ['a', 'b'] });
+      const second = recordReflection(s, { iteration: 2, source: 'lint', errors: ['b', 'a'] });
+      expect(second.progressed).toBe(true);
+    });
+
+    it('trims and drops empty error lines, capping per-entry', () => {
+      const s = createReflectionState();
+      const many = Array.from({ length: 20 }, (_, i) => `  err${i}  `);
+      recordReflection(s, { iteration: 1, source: 'lint', errors: ['', '  ', ...many] });
+      expect(s.entries[0].errors.length).toBeLessThanOrEqual(5);
+      expect(s.entries[0].errors[0]).toBe('err0'); // trimmed, empties dropped
+    });
+  });
+
+  describe('shouldStopReflecting', () => {
+    it('is false until the budget is reached', () => {
+      const s = createReflectionState();
+      recordReflection(s, { iteration: 1, source: 'lint', errors: ['e'] });
+      expect(shouldStopReflecting(s, 3)).toBe(false);
+      recordReflection(s, { iteration: 2, source: 'lint', errors: ['e2'] });
+      expect(shouldStopReflecting(s, 3)).toBe(false);
+      recordReflection(s, { iteration: 3, source: 'lint', errors: ['e3'] });
+      expect(shouldStopReflecting(s, 3)).toBe(true);
+    });
+
+    it('defaults to DEFAULT_MAX_REFLECTIONS', () => {
+      const s = createReflectionState();
+      for (let i = 0; i < DEFAULT_MAX_REFLECTIONS; i++) {
+        recordReflection(s, { iteration: i + 1, source: 'test', errors: [`e${i}`] });
+      }
+      expect(shouldStopReflecting(s)).toBe(true);
+    });
+
+    it('lets an operator lower the budget to fail fast', () => {
+      const s = createReflectionState();
+      recordReflection(s, { iteration: 1, source: 'lint', errors: ['e'] });
+      expect(shouldStopReflecting(s, 1)).toBe(true);
+    });
+
+    it('does not count review failures toward the budget', () => {
+      const s = createReflectionState();
+      recordReflection(s, { iteration: 1, source: 'review', errors: ['r1'] });
+      recordReflection(s, { iteration: 2, source: 'review', errors: ['r2'] });
+      recordReflection(s, { iteration: 3, source: 'review', errors: ['r3'] });
+      expect(shouldStopReflecting(s, 3)).toBe(false);
+    });
+  });
+
+  describe('buildReflectionFeedback', () => {
+    it('returns empty string when there are no objective entries', () => {
+      const s = createReflectionState();
+      expect(buildReflectionFeedback(s)).toBe('');
+      recordReflection(s, { iteration: 1, source: 'review', errors: ['just an opinion'] });
+      expect(buildReflectionFeedback(s)).toBe('');
+    });
+
+    it('renders objective errors with a bad-edit framing', () => {
+      const s = createReflectionState();
+      recordReflection(s, { iteration: 1, source: 'lint', errors: ['TS2304: Cannot find name foo'] });
+      const out = buildReflectionFeedback(s);
+      expect(out).toContain('Self-Repair Reflection');
+      expect(out).toContain('invalid edits');
+      expect(out).toContain('TS2304: Cannot find name foo');
+      expect(out).toContain('lint / type check failed');
+    });
+
+    it('omits subjective review entries from the rendered feedback', () => {
+      const s = createReflectionState();
+      recordReflection(s, { iteration: 1, source: 'test', errors: ['test_login failed'] });
+      recordReflection(s, { iteration: 2, source: 'review', errors: ['rename this variable'] });
+      const out = buildReflectionFeedback(s);
+      expect(out).toContain('test_login failed');
+      expect(out).not.toContain('rename this variable');
+    });
+
+    it('caps the trail to the most recent MAX_TRAIL_ENTRIES objective entries', () => {
+      const s = createReflectionState();
+      for (let i = 1; i <= MAX_TRAIL_ENTRIES + 2; i++) {
+        recordReflection(s, { iteration: i, source: 'lint', errors: [`unique-error-${i}`] });
+      }
+      const out = buildReflectionFeedback(s);
+      // Oldest entries fall off the window
+      expect(out).not.toContain('unique-error-1');
+      expect(out).not.toContain('unique-error-2');
+      // Most recent survive
+      expect(out).toContain(`unique-error-${MAX_TRAIL_ENTRIES + 2}`);
+    });
+  });
+
+  describe('integration: bounded self-repair scenario', () => {
+    it('progresses while errors change, then exhausts the budget', () => {
+      const s: ReflectionState = createReflectionState();
+      const max = 3;
+      const r1 = recordReflection(s, { iteration: 1, source: 'lint', errors: ['A'] });
+      expect(r1.progressed).toBe(true);
+      expect(shouldStopReflecting(s, max)).toBe(false);
+
+      const r2 = recordReflection(s, { iteration: 2, source: 'lint', errors: ['B'] });
+      expect(r2.progressed).toBe(true);
+      expect(shouldStopReflecting(s, max)).toBe(false);
+
+      const r3 = recordReflection(s, { iteration: 3, source: 'test', errors: ['C'] });
+      expect(r3.progressed).toBe(true);
+      expect(shouldStopReflecting(s, max)).toBe(true); // budget spent
+    });
+
+    it('detects stagnation before the budget is spent', () => {
+      const s = createReflectionState();
+      recordReflection(s, { iteration: 1, source: 'lint', errors: ['same'] });
+      const repeat = recordReflection(s, { iteration: 2, source: 'lint', errors: ['same'] });
+      expect(repeat.progressed).toBe(false); // stagnation signal fires at count=2 of 3
+      expect(shouldStopReflecting(s, 3)).toBe(false);
+    });
+  });
+});

--- a/src/agents/reflection.ts
+++ b/src/agents/reflection.ts
@@ -1,0 +1,170 @@
+// ============================================
+// OpenSwarm - Self-Repair Reflection
+// Bad-edit guard + bounded reflection loop
+// ============================================
+//
+// claude -p (and most CLI coding agents) lack the native sub-agent / structured
+// self-repair that the first-party Claude harness has. When an edit breaks the
+// build, the agent often reports success anyway. This module gives the pipeline a
+// lightweight self-repair loop, modeled on two proven techniques:
+//
+//   - SWE-agent "bad-edit guard": an edit that fails lint is treated as invalid;
+//     the concrete lint error is fed straight back so the next attempt fixes it
+//     (ablation: removing it dropped resolve rate 18% → 15%).
+//   - Aider "reflection": lint/test errors from the previous attempt are preserved
+//     into the next prompt, up to a bounded reflection count (default 3).
+//
+// The worker here is an autonomous CLI process, so we cannot intercept a single
+// tool-edit to discard it the way SWE-agent does. The equivalent is: lint the
+// changed files after the worker finishes, and on failure drive a bounded retry
+// with the exact error preserved — objective errors survive even a fresh-context
+// reset, because unlike a reviewer's subjective opinion a lint/test failure is
+// ground truth worth carrying forward.
+
+// Types
+
+/**
+ * Where a reflection entry came from.
+ * Objective sources (lint/bs/test) are ground-truth failures that count toward
+ * the self-repair budget and are preserved across fresh-context resets.
+ * Subjective sources (review) are opinion and are handled by the existing
+ * reviewer-feedback channel, not this trail.
+ */
+export type ReflectionSource = 'lint' | 'bs' | 'test' | 'review';
+
+export interface ReflectionEntry {
+  /** 1-based pipeline iteration this failure was observed in */
+  iteration: number;
+  source: ReflectionSource;
+  /** Human-readable error lines (already trimmed by the caller) */
+  errors: string[];
+}
+
+export interface ReflectionState {
+  entries: ReflectionEntry[];
+  /**
+   * Number of objective self-repair attempts recorded (lint/bs/test).
+   * Subjective review revises do NOT increment this — they are not self-repair.
+   */
+  reflectionCount: number;
+}
+
+// Constants
+
+/** Default cap on objective self-repair attempts before giving up. */
+export const DEFAULT_MAX_REFLECTIONS = 3;
+/** Keep only the most recent N objective entries in the prompt (avoid bloat). */
+export const MAX_TRAIL_ENTRIES = 3;
+/** Cap error lines per entry so a chatty compiler cannot blow up the prompt. */
+const MAX_ERRORS_PER_ENTRY = 5;
+
+const OBJECTIVE_SOURCES: readonly ReflectionSource[] = ['lint', 'bs', 'test'];
+
+// State
+
+export function createReflectionState(): ReflectionState {
+  return { entries: [], reflectionCount: 0 };
+}
+
+/** True for ground-truth failures that drive (and bound) self-repair. */
+export function isObjective(source: ReflectionSource): boolean {
+  return OBJECTIVE_SOURCES.includes(source);
+}
+
+/** The most recent objective entry, or undefined if none yet. */
+function lastObjectiveEntry(state: ReflectionState): ReflectionEntry | undefined {
+  for (let i = state.entries.length - 1; i >= 0; i--) {
+    if (isObjective(state.entries[i].source)) return state.entries[i];
+  }
+  return undefined;
+}
+
+/** Two error lists are "the same failure" when their trimmed lines match exactly. */
+function sameErrors(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((line, i) => line.trim() === b[i].trim());
+}
+
+/**
+ * Record a failure as a reflection entry.
+ *
+ * For objective sources this increments the self-repair count and reports
+ * whether progress was made — `progressed: false` means this attempt produced
+ * the exact same errors as the previous objective attempt (stagnation: the agent
+ * is stuck and further retries will only burn tokens).
+ *
+ * Subjective (review) entries are stored for completeness but never count toward
+ * the budget and always report progress (the reviewer channel handles them).
+ */
+export function recordReflection(
+  state: ReflectionState,
+  entry: ReflectionEntry,
+): { progressed: boolean } {
+  const trimmed: ReflectionEntry = {
+    iteration: entry.iteration,
+    source: entry.source,
+    errors: entry.errors.map((e) => e.trim()).filter(Boolean).slice(0, MAX_ERRORS_PER_ENTRY),
+  };
+
+  if (!isObjective(trimmed.source)) {
+    state.entries.push(trimmed);
+    return { progressed: true };
+  }
+
+  const prev = lastObjectiveEntry(state);
+  const progressed = !prev || !sameErrors(prev.errors, trimmed.errors);
+
+  state.entries.push(trimmed);
+  state.reflectionCount += 1;
+  return { progressed };
+}
+
+/** True once the bounded self-repair budget is spent. */
+export function shouldStopReflecting(
+  state: ReflectionState,
+  max: number = DEFAULT_MAX_REFLECTIONS,
+): boolean {
+  return state.reflectionCount >= max;
+}
+
+/**
+ * Build the worker-prompt section that carries forward objective errors from
+ * prior attempts. Returns '' when there is nothing objective to reflect on, so
+ * the caller can simply concatenate.
+ *
+ * Only objective entries are emitted (subjective review feedback travels through
+ * the reviewer channel). The list is capped to the most recent MAX_TRAIL_ENTRIES.
+ */
+export function buildReflectionFeedback(state: ReflectionState): string {
+  const objective = state.entries.filter((e) => isObjective(e.source));
+  if (objective.length === 0) return '';
+
+  const recent = objective.slice(-MAX_TRAIL_ENTRIES);
+  const lines: string[] = [];
+  lines.push('## Self-Repair Reflection (previous attempts failed these checks)');
+  lines.push(
+    'Your prior edits were rejected by automated checks below. Treat them as invalid edits: ' +
+      'fix the exact errors and do NOT repeat the same mistakes.',
+  );
+
+  for (const entry of recent) {
+    lines.push('');
+    lines.push(`### Attempt @ iteration ${entry.iteration} — ${labelForSource(entry.source)}`);
+    entry.errors.forEach((err, i) => lines.push(`${i + 1}. ${err}`));
+  }
+
+  return lines.join('\n');
+}
+
+function labelForSource(source: ReflectionSource): string {
+  switch (source) {
+    case 'lint':
+      return 'lint / type check failed';
+    case 'bs':
+      return 'code-smell guard failed';
+    case 'test':
+      return 'tests failed';
+    case 'review':
+      return 'reviewer feedback';
+  }
+}

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -977,6 +977,7 @@ export class AutonomousRunner {
       worktreeMode: this.config.worktreeMode ?? false,
       scheduleNextHeartbeat: () => this.scheduleNextHeartbeat(),
       guards: this.config.guards,
+      maxReflections: this.config.maxReflections,
     };
   }
 

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -135,6 +135,8 @@ export interface ExecutionContext {
   scheduleNextHeartbeat?: () => void;
   /** Pipeline guards configuration */
   guards?: Partial<import('../core/types.js').PipelineGuardsConfig>;
+  /** Max objective self-repair attempts (lint/bs/test) before giving up (default: 3) */
+  maxReflections?: number;
 }
 
 // Project Path Resolution
@@ -640,6 +642,7 @@ export async function executePipeline(
         impactAnalysis: draftResult.impactAnalysis,
         registrySnapshot: draftResult.registrySnapshot,
       } : undefined,
+      ctx.maxReflections,
     );
 
     const taskPrefix = buildTaskPrefix(task, actualPath);

--- a/src/automation/runnerTypes.ts
+++ b/src/automation/runnerTypes.ts
@@ -33,6 +33,8 @@ export interface AutonomousConfig {
   decomposition?: import('../core/types.js').DecompositionConfig;
   worktreeMode?: boolean;
   guards?: Partial<import('../core/types.js').PipelineGuardsConfig>;
+  /** Max objective self-repair attempts (lint/bs/test) before giving up (default: 3) */
+  maxReflections?: number;
   /** Per-project task cap in 5h rolling window (default: 6) */
   dailyTaskCap?: number;
   /** Cooldown between task completions in ms (default: 1800000 = 30min) */

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -107,6 +107,46 @@ agents:
       }
     });
 
+    it('should wire autonomous.guards and maxReflections through to runtime config', () => {
+      // Regression: guards/maxReflections were absent from the zod schema and the
+      // transform, so config.autonomous.guards silently resolved to undefined and
+      // the bad-edit lint gate never ran. Lock the wiring in place.
+      const jsonContent = JSON.stringify({
+        language: 'en',
+        linear: { apiKey: 'k', teamId: 't' },
+        agents: [{ name: 'main', projectPath: '/p', enabled: true, paused: false }],
+        autonomous: {
+          enabled: true,
+          guards: { qualityGate: true, bsDetector: true, fakeDataGuard: false },
+          maxReflections: 2,
+        },
+      });
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(jsonContent);
+
+      const config = loadConfig('/tmp/config.json');
+      expect(config.autonomous?.guards?.qualityGate).toBe(true);
+      expect(config.autonomous?.guards?.bsDetector).toBe(true);
+      expect(config.autonomous?.guards?.fakeDataGuard).toBe(false);
+      expect(config.autonomous?.maxReflections).toBe(2);
+    });
+
+    it('should default autonomous.maxReflections to 3 when omitted', () => {
+      const jsonContent = JSON.stringify({
+        language: 'en',
+        linear: { apiKey: 'k', teamId: 't' },
+        agents: [{ name: 'main', projectPath: '/p', enabled: true, paused: false }],
+        autonomous: { enabled: true },
+      });
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(jsonContent);
+
+      const config = loadConfig('/tmp/config.json');
+      expect(config.autonomous?.maxReflections).toBe(3);
+    });
+
     it('should throw error when config file not found', () => {
       vi.mocked(existsSync).mockReturnValue(false);
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -206,6 +206,17 @@ const JobProfileSchema = z.object({
   roles: z.record(PipelineStageSchema, z.string()).optional(),
 });
 
+const PipelineGuardsConfigSchema = z.object({
+  qualityGate: z.boolean().optional(),
+  fakeDataGuard: z.boolean().optional(),
+  conventionalCommits: z.boolean().optional(),
+  branchValidation: z.boolean().optional(),
+  uncertaintyDetection: z.boolean().optional(),
+  haltToLinear: z.boolean().optional(),
+  registryCheck: z.boolean().optional(),
+  bsDetector: z.boolean().optional(),
+}).optional();
+
 const AutonomousConfigSchema = z.object({
   /** Auto-enable on service start */
   enabled: z.boolean().default(false),
@@ -235,6 +246,10 @@ const AutonomousConfigSchema = z.object({
   worktreeMode: z.boolean().default(false),
   /** Dynamic job profiles for model selection */
   jobProfiles: z.array(JobProfileSchema).optional(),
+  /** Pipeline quality guards (bad-edit lint gate, BS detector, etc.) */
+  guards: PipelineGuardsConfigSchema,
+  /** Max objective self-repair attempts (lint/bs/test) before giving up */
+  maxReflections: z.number().min(1).max(10).default(3),
   /** Daily task completion cap (default: 6) */
   dailyTaskCap: z.number().min(1).max(50).default(6),
   /** Cooldown between task completions in ms (default: 1800000 = 30min) */
@@ -490,6 +505,8 @@ function transformConfig(raw: RawConfig): SwarmConfig {
         plannerTimeoutMs: raw.autonomous.decomposition.plannerTimeoutMs,
       } : undefined,
       worktreeMode: raw.autonomous.worktreeMode,
+      guards: raw.autonomous.guards,
+      maxReflections: raw.autonomous.maxReflections,
       dailyTaskCap: raw.autonomous.dailyTaskCap,
       interTaskCooldownMs: raw.autonomous.interTaskCooldownMs,
     } : undefined,

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -211,6 +211,8 @@ export async function startService(config: SwarmConfig): Promise<void> {
       worktreeMode: config.autonomous.worktreeMode ?? false,
       // Pipeline guards
       guards: config.autonomous.guards,
+      // Bad-edit / reflection self-repair budget
+      maxReflections: config.autonomous.maxReflections,
       // Daily pace control
       dailyTaskCap: config.autonomous.dailyTaskCap ?? 6,
       interTaskCooldownMs: config.autonomous.interTaskCooldownMs ?? 1_800_000,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -429,6 +429,13 @@ export type AutonomousStartupConfig = {
   worktreeMode?: boolean;
   /** Pipeline guards configuration */
   guards?: Partial<PipelineGuardsConfig>;
+  /**
+   * Max objective self-repair attempts (lint/bs/test failures) tolerated before
+   * the bad-edit/reflection loop gives up. Independent of maxAttempts so it can
+   * be lowered to cap token burn when reflection stops making progress.
+   * Default: 3.
+   */
+  maxReflections?: number;
   /** Daily task completion cap (default: 6) */
   dailyTaskCap?: number;
   /** Cooldown between task completions in ms (default: 1800000 = 30min) */


### PR DESCRIPTION
## Summary
claude -p의 native 능력(서브에이전트·todo·정교한 중단복구) 부재를 메우는 self-repair. 이번 세션의 nudge 땜질이 그 부재의 증거.

## 할 일 (저비용·고근거 순)

1. **bad-edit 가드** — lint로 무효 편집 discard+retry (SWE-agent, ablation 18→15%).
2. **reflection 루프** — lint/test 에러를 다음 프롬프트에 보존, max 3회 (Aider). 이번 세션 fresh-context feedback 보존과 같은 방향, self-repair로 확장.
3. (후순위·고비용) Task형 서브에이전트로 하위문제 분리.

## 검증

* ladder + REVISE율 감소.
* 회귀: reflection이 토큰만 태우고 pass-rate 정체면 max 하향.

## Linear
Closes INT-1679

---
🤖 Generated with [OpenSwarm](https://github.com/Intrect-io/OpenSwarm)