### PR TITLE
feat(autonomy): respect dependency order + park Backlog (INT-1809 R1+R5)

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -152,6 +152,7 @@ export class AutonomousRunner {
       maxConsecutiveTasks: config.maxConsecutiveTasks,
       cooldownSeconds: config.cooldownSeconds,
       dryRun: config.dryRun,
+      includeBacklog: config.includeBacklog,
     });
 
     // Initialize TaskScheduler

--- a/src/automation/runnerTypes.ts
+++ b/src/automation/runnerTypes.ts
@@ -16,6 +16,8 @@ export interface AutonomousConfig {
   maxConsecutiveTasks: number;
   cooldownSeconds: number;
   dryRun: boolean;
+  /** Treat Linear Backlog as a work queue (legacy). Default false = Backlog parked (R5). */
+  includeBacklog?: boolean;
   pairMode?: boolean;
   pairMaxAttempts?: number;
   workerModel?: string;

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -188,6 +188,7 @@ export async function startService(config: SwarmConfig): Promise<void> {
       defaultAdapter: config.adapter,
       linearTeamId: config.linearTeamId,
       allowedProjects: config.autonomous.allowedProjects,
+      includeBacklog: config.autonomous.includeBacklog,
       heartbeatSchedule: config.autonomous.schedule,
       autoExecute: true,
       maxConsecutiveTasks: 3,

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -166,6 +166,7 @@ export async function startService(config: SwarmConfig): Promise<void> {
           description: issue.description,
           priority: issue.priority,
           state: issue.state,
+          blockedBy: issue.blockedBy,
           project: issue.project ? {
             id: issue.project.id,
             name: issue.project.name,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -413,6 +413,8 @@ export type AutonomousStartupConfig = {
   maxAttempts: number;
   /** Allowed project paths */
   allowedProjects: string[];
+  /** Treat Linear Backlog as a work queue (legacy). Default false = Backlog parked (R5). */
+  includeBacklog?: boolean;
   /** Model configuration (legacy) */
   models?: ModelConfig;
   /** Worker timeout (ms), 0 = unlimited (legacy) */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -65,6 +65,8 @@ export type LinearIssueInfo = {
   comments: LinearComment[];
   /** Linear project info */
   project?: LinearProjectInfo;
+  /** Issue UUIDs that block this issue (from structured relations + "블로커:" prose). */
+  blockedBy?: string[];
 };
 
 /**

--- a/src/linear/linear.test.ts
+++ b/src/linear/linear.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { parseBlockerIdentifiers } from './linear.js';
+
+// INT-1809: the KYTE team writes dependencies as description prose ("블로커: …")
+// rather than structured Linear relations, so the text parser is the high-value path.
+describe('parseBlockerIdentifiers', () => {
+  it('parses slash-separated ids that share a team prefix', () => {
+    // The real KT-308 case: "블로커: KT-305/306/307" — 306/307 are bare numbers.
+    expect(parseBlockerIdentifiers('블로커: KT-305/306/307')).toEqual([
+      'KT-305',
+      'KT-306',
+      'KT-307',
+    ]);
+  });
+
+  it('parses comma-separated full identifiers', () => {
+    expect(parseBlockerIdentifiers('블로커: KT-302, KT-307')).toEqual(['KT-302', 'KT-307']);
+  });
+
+  it('parses the English "Blocked by:" label', () => {
+    expect(parseBlockerIdentifiers('Blocked by: INT-1809')).toEqual(['INT-1809']);
+  });
+
+  it('tolerates markdown bold around the label', () => {
+    expect(parseBlockerIdentifiers('**블로커:** KT-305/306')).toEqual(['KT-305', 'KT-306']);
+  });
+
+  it('accepts "Depends on" without a colon', () => {
+    expect(parseBlockerIdentifiers('Depends on KT-42')).toEqual(['KT-42']);
+  });
+
+  it('only reads the blocker line, not surrounding prose', () => {
+    const desc = 'Some intro about issue 999.\n블로커: KT-100\nMore notes mentioning 12345.';
+    expect(parseBlockerIdentifiers(desc)).toEqual(['KT-100']);
+  });
+
+  it('mixes teams and dedupes', () => {
+    expect(parseBlockerIdentifiers('블로커: KT-305, INT-1610, KT-305')).toEqual([
+      'KT-305',
+      'INT-1610',
+    ]);
+  });
+
+  it('returns empty for missing or blocker-free descriptions', () => {
+    expect(parseBlockerIdentifiers(undefined)).toEqual([]);
+    expect(parseBlockerIdentifiers('No dependencies here.')).toEqual([]);
+    expect(parseBlockerIdentifiers('블로커: 없음')).toEqual([]);
+  });
+});

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -348,6 +348,94 @@ export interface GetMyIssuesOptions {
 }
 
 /**
+ * Parse blocker issue identifiers from a description's prose. The KYTE team
+ * writes dependencies as text ("블로커: KT-305/306/307", "Blocked by: KT-302, KT-307")
+ * rather than structured Linear relations, so this is the high-value path.
+ * Returns raw identifiers (e.g. "KT-305"); the caller resolves them to UUIDs.
+ *
+ * Handles Korean ("블로커"/"의존성") and English ("Blocked by"/"Blocker"/"Depends on")
+ * labels; comma / slash separators; and bare numbers that inherit the preceding
+ * team prefix ("KT-305/306" → KT-305, KT-306). Over-capture is safe: identifiers
+ * that don't resolve to a fetched issue are dropped during UUID resolution.
+ */
+export function parseBlockerIdentifiers(description?: string): string[] {
+  if (!description) return [];
+  const ids: string[] = [];
+  // Match a blocker label, then capture the rest of that line.
+  const lineRe = /(?:블로커|의존성?|blocked\s*by|blocker|depends\s*on)\s*[:：]?\s*\*{0,2}\s*([^\n\r]+)/gi;
+  let line: RegExpExecArray | null;
+  while ((line = lineRe.exec(description)) !== null) {
+    const segment = line[1];
+    let lastPrefix: string | null = null;
+    // A full identifier (TEAM-123) or a bare number reusing the last seen prefix.
+    const tokenRe = /([A-Z]{2,})-(\d+)|(\d+)/g;
+    let tok: RegExpExecArray | null;
+    while ((tok = tokenRe.exec(segment)) !== null) {
+      if (tok[1] && tok[2]) {
+        lastPrefix = tok[1];
+        ids.push(`${tok[1]}-${tok[2]}`);
+      } else if (tok[3] && lastPrefix) {
+        ids.push(`${lastPrefix}-${tok[3]}`);
+      }
+    }
+  }
+  return [...new Set(ids)];
+}
+
+/**
+ * Populate `blockedBy` (issue UUIDs) on each fetched issue from two sources:
+ *  1. Structured Linear relations — `inverseRelations()` of type "blocks" (the
+ *     relation's source `issue` is the blocker).
+ *  2. Description prose parsed by {@link parseBlockerIdentifiers}.
+ *
+ * Only blockers that are themselves in the current fetch set are kept. We never
+ * query Done issues, so a completed blocker drops out of the set and won't
+ * false-block its dependents; getTaskReadiness then gates on what remains.
+ */
+async function populateBlockedBy(
+  result: LinearIssueInfo[],
+  // SDK Issue nodes keyed by id (carry inverseRelations()); typed loosely to
+  // match the file's existing lazy-resolver usage.
+  sdkNodeById: Map<string, any>,
+): Promise<void> {
+  const fetchedIds = new Set(result.map((r) => r.id));
+  const identifierToId = new Map(result.map((r) => [r.identifier.toUpperCase(), r.id]));
+
+  await Promise.all(
+    result.map(async (info) => {
+      const blockers = new Set<string>();
+
+      // Source 1: structured relations. `_issue` carries the blocker's id on the
+      // fragment, so we read it without a per-blocker fetch.
+      const node = sdkNodeById.get(info.id);
+      if (node && typeof node.inverseRelations === 'function') {
+        try {
+          const rels: any = await withRateLimit('linear', () => node.inverseRelations()); // cxt-ignore: type_safety — SDK IssueRelationConnection
+          for (const rel of rels?.nodes ?? []) {
+            if (rel?.type !== 'blocks') continue;
+            const blockerId = rel?._issue?.id;
+            if (blockerId) blockers.add(blockerId);
+          }
+        } catch { // cxt-ignore: error_swallow,exception_hiding — best-effort, optional enrichment
+          // Relations enrichment is optional; the text parser below still applies.
+        }
+      }
+
+      // Source 2: description prose → identifiers → resolve to UUIDs.
+      for (const ident of parseBlockerIdentifiers(info.description)) {
+        const id = identifierToId.get(ident.toUpperCase());
+        if (id) blockers.add(id);
+      }
+
+      // Keep only blockers still in the fetch set (excludes Done/out-of-scope →
+      // avoids false-blocking); never self-reference.
+      const filtered = [...blockers].filter((id) => id !== info.id && fetchedIds.has(id));
+      if (filtered.length > 0) info.blockedBy = filtered;
+    }),
+  );
+}
+
+/**
  * Get assigned active issues (with caching)
  * (Todo, In Progress, Review states - excludes Backlog)
  */
@@ -428,6 +516,7 @@ export async function getMyIssues(
         } as LinearIssueInfo);
       }
 
+      await populateBlockedBy(result, new Map(withState.map(({ issue }) => [issue.id, issue])));
       return result;
     }
 
@@ -464,6 +553,8 @@ export async function getMyIssues(
           project,
         });
       }
+
+      await populateBlockedBy(result, new Map(allNodes.map((n) => [n.id, n])));
     }
 
     // Sort by priority

--- a/src/orchestration/decisionEngine.gating.test.ts
+++ b/src/orchestration/decisionEngine.gating.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { isActionableLinearState } from './decisionEngine.js';
+
+// INT-1809 R5: Backlog is "parked", not a work queue. Only Todo/In Progress/
+// In Review are actionable, so moving an issue to Backlog stops the daemon.
+describe('isActionableLinearState (R5)', () => {
+  it('treats Todo / In Progress / In Review as actionable', () => {
+    expect(isActionableLinearState('Todo')).toBe(true);
+    expect(isActionableLinearState('In Progress')).toBe(true);
+    expect(isActionableLinearState('In Review')).toBe(true);
+  });
+
+  it('parks Backlog by default', () => {
+    expect(isActionableLinearState('Backlog')).toBe(false);
+  });
+
+  it('opts Backlog back in when includeBacklog is set', () => {
+    expect(isActionableLinearState('Backlog', true)).toBe(true);
+  });
+
+  it('never acts on terminal states, even with includeBacklog', () => {
+    expect(isActionableLinearState('Done')).toBe(false);
+    expect(isActionableLinearState('Canceled')).toBe(false);
+    expect(isActionableLinearState('Cancelled')).toBe(false);
+    expect(isActionableLinearState('Done', true)).toBe(false);
+  });
+
+  it('does not gate unknown/undefined states (conservative)', () => {
+    expect(isActionableLinearState(undefined)).toBe(true);
+    expect(isActionableLinearState('Unknown')).toBe(true);
+  });
+});

--- a/src/orchestration/decisionEngine.ts
+++ b/src/orchestration/decisionEngine.ts
@@ -112,6 +112,13 @@ export interface DecisionEngineConfig {
 
   /** Dry run mode */
   dryRun: boolean;
+
+  /**
+   * Treat Linear "Backlog" as an actionable work queue (legacy behavior). When
+   * false (default), Backlog is "parked": only Todo/In Progress/In Review are
+   * actionable, so moving an issue to Backlog stops the daemon picking it up.
+   */
+  includeBacklog?: boolean;
 }
 
 // Constants
@@ -125,7 +132,26 @@ const DEFAULT_CONFIG: DecisionEngineConfig = {
   maxConsecutiveTasks: 3,
   cooldownSeconds: 300,     // 5 minutes
   dryRun: false,
+  includeBacklog: false,    // Backlog is parked, not a queue (R5)
 };
+
+/**
+ * Linear states the daemon will NOT act on. Backlog is "parked" (opt back in via
+ * DecisionEngineConfig.includeBacklog); Done/Canceled are terminal.
+ */
+const NON_ACTIONABLE_LINEAR_STATES = new Set(['Backlog', 'Done', 'Canceled', 'Cancelled']);
+
+/**
+ * R5: whether the daemon should act on an issue in the given Linear state. Only
+ * Todo/In Progress/In Review (and unknown states, conservatively) are actionable;
+ * Backlog is parked and Done/Canceled are terminal. `includeBacklog` opts back
+ * into the legacy "Backlog is a work queue" behavior.
+ */
+export function isActionableLinearState(linearState: string | undefined, includeBacklog = false): boolean {
+  if (!linearState) return true; // unknown state → don't gate (conservative)
+  if (!NON_ACTIONABLE_LINEAR_STATES.has(linearState)) return true;
+  return linearState === 'Backlog' && includeBacklog === true;
+}
 
 // Engine State
 
@@ -405,6 +431,14 @@ export class DecisionEngine {
           console.log(`[DecisionEngine] Filtered out ${task.issueIdentifier}: project not allowed (${task.projectPath})`);
           return false;
         }
+      }
+
+      // R5: Linear is the source of truth for whether work is wanted. Backlog is
+      // "parked" (not a queue) and Done/Canceled are terminal — only actionable
+      // states proceed. Moving an issue to Backlog stops the daemon picking it up.
+      if (!isActionableLinearState(task.linearState, this.config.includeBacklog)) {
+        console.log(`[DecisionEngine] Filtered out ${task.issueIdentifier}: Linear state "${task.linearState}" is not actionable (parked)`);
+        return false;
       }
 
       const readiness = getTaskReadiness(task);

--- a/src/taskState/store.test.ts
+++ b/src/taskState/store.test.ts
@@ -109,6 +109,38 @@ describe('task state store', () => {
     expect(released[0].linearState).toBe('Todo');
   });
 
+  it('gates on TaskItem.blockedBy (Linear-fetched deps) until the blocker is done', () => {
+    // INT-1809: blockedBy now arrives on the TaskItem from the Linear fetch
+    // (relations + "블로커:" prose), not just from local taskState.dependencyIssueIds.
+    // getTaskReadiness must prefer it and gate execution.
+    upsertTaskState('KT-307', {
+      execution: { status: 'in_progress', retryCount: 0 },
+      linearState: 'In Progress',
+      updatedAt: new Date().toISOString(),
+    });
+
+    const task = {
+      id: 'KT-308',
+      source: 'linear' as const,
+      title: '[하네스이식 8] eval 회귀 검증',
+      priority: 2,
+      createdAt: Date.now(),
+      issueId: 'KT-308',
+      blockedBy: ['KT-307'],
+    };
+
+    const blocked = getTaskReadiness(task);
+    expect(blocked.ready).toBe(false);
+    expect(blocked.blockedBy).toEqual(['KT-307']);
+    expect(blocked.reason).toContain('Waiting on dependencies');
+
+    // Blocker completes → dependent becomes ready.
+    markTaskDone('KT-307');
+    const ready = getTaskReadiness(task);
+    expect(ready.ready).toBe(true);
+    expect(ready.blockedBy).toEqual([]);
+  });
+
   it('completes decomposed parent only after all child issues are done', () => {
     upsertTaskState('PARENT-1', {
       childIssueIds: ['CHILD-1', 'CHILD-2'],

--- a/src/taskState/store.test.ts
+++ b/src/taskState/store.test.ts
@@ -5,6 +5,8 @@ import {
   releaseDependentTasks,
   enrichTaskFromState,
   markTaskDone,
+  markTaskInProgress,
+  updateTaskLinearState,
   completeParentIfChildrenDone,
   buildTaskStateSyncComment,
   hydrateTaskStateFromComments,
@@ -139,6 +141,24 @@ describe('task state store', () => {
     const ready = getTaskReadiness(task);
     expect(ready.ready).toBe(true);
     expect(ready.blockedBy).toEqual([]);
+  });
+
+  it('reconciles stale in_progress against Linear state (R5)', () => {
+    // Operator parks an actively-running issue → local in_progress is stale.
+    markTaskInProgress('KT-400', { linearState: 'In Progress' });
+    const parked = updateTaskLinearState('KT-400', 'Backlog');
+    expect(parked.linearState).toBe('Backlog');
+    expect(parked.execution.status).toBe('backlog');
+
+    // Completed externally → mark done locally.
+    markTaskInProgress('KT-401', { linearState: 'In Progress' });
+    const done = updateTaskLinearState('KT-401', 'Done');
+    expect(done.execution.status).toBe('done');
+
+    // Still actively In Progress → execution status is left untouched.
+    markTaskInProgress('KT-402', { linearState: 'In Progress' });
+    const running = updateTaskLinearState('KT-402', 'In Progress');
+    expect(running.execution.status).toBe('in_progress');
   });
 
   it('completes decomposed parent only after all child issues are done', () => {

--- a/src/taskState/store.ts
+++ b/src/taskState/store.ts
@@ -175,7 +175,21 @@ export function enrichTaskFromState(task: TaskItem): TaskItem {
 }
 
 export function updateTaskLinearState(issueId: string, linearState: string): OpenSwarmTaskState {
-  return upsertTaskState(issueId, { linearState });
+  // R5: reconcile stale local execution status against Linear (the source of
+  // truth). If an operator parked an issue (Backlog) or it was completed/
+  // cancelled externally while we still hold 'in_progress', the local state is
+  // stale — downgrade it so the issue isn't treated as actively running. This is
+  // a local-only update; it never writes back to Linear (preserves R7).
+  const patch: Partial<OpenSwarmTaskState> = { linearState };
+  const current = getTaskState(issueId);
+  if (current?.execution.status === 'in_progress') {
+    if (linearState === 'Done') {
+      patch.execution = { ...current.execution, status: 'done' };
+    } else if (linearState === 'Backlog' || linearState === 'Canceled' || linearState === 'Cancelled') {
+      patch.execution = { ...current.execution, status: 'backlog' };
+    }
+  }
+  return upsertTaskState(issueId, patch);
 }
 
 export function markTaskInProgress(


### PR DESCRIPTION
Enforces **Autonomy Protocol R1 + R5** for INT-1809: the daemon now respects Linear dependency order and treats Linear as the single source of truth for what work is wanted.

## R1 — dependency-order gating (commit 1)

OpenSwarm ignored dependency order: **KT-308** (`블로커: KT-305/306/307`) started before its blocker **KT-307** ran. The gating was half-wired — `linearIssueToTask.blockedBy` + `getTaskReadiness` already gated, but **`getMyIssues` never populated `blockedBy`** (dead wiring from INT-1610).

- `core/types.ts` — `LinearIssueInfo.blockedBy?: string[]` (UUIDs).
- `linear.ts` — `parseBlockerIdentifiers()` parses dependency **prose** (`블로커:` / `Blocked by:` / `Depends on`), handling slash & comma lists and **bare numbers that inherit the team prefix** (`KT-305/306/307` → all three). `populateBlockedBy()` merges it with structured `inverseRelations()` (type `blocks`), resolves identifiers → UUIDs, and **keeps only blockers still in the fetch set** (Done blockers drop out → no false-blocking). Wired into slim + full fetch paths.
- `core/service.ts` — propagate `blockedBy` through the `LinearTaskSource` fetcher closure.

## R5 — Backlog parked + taskState reconcile (commit 2)

Backlog was treated as a **work queue**, so setting an issue to Backlog did **not** stop the daemon; with stale local `taskState` this caused KT-308 to respawn every heartbeat. (`getNextBacklogIssue` is dead code — the real queue is `getMyIssues`, which fetches Backlog and flows into `filterExecutableTasks`.)

- `decisionEngine.ts` — `isActionableLinearState()` gates execution: only **Todo / In Progress / In Review** (and unknown states, conservatively) are actionable; **Backlog is parked**, Done/Canceled are terminal. Opt back into the legacy queue with **`includeBacklog`** (default false), plumbed `config.autonomous.includeBacklog → runner → engine`.
- `store.updateTaskLinearState` — reconcile stale `in_progress` against Linear: parked → `backlog`, done → `done`; active In Progress untouched. **Local-only; never writes back to Linear** (preserves R7 — the gate also stops reselection, so the daemon can't revert an operator's Backlog change).

## Tests

- `parseBlockerIdentifiers` unit tests; `getTaskReadiness` blocked-by regression.
- `isActionableLinearState` matrix; `updateTaskLinearState` reconcile.
- Full suite green: **49 files / 830 tests**, typecheck clean, cxt BS clean.

## Scope

Closes **R1 + R5** of INT-1809. R7's core (no write-back reverting an operator's change) is preserved by the gate + local-only reconcile; proactive cache invalidation on external change remains an optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)