### PR TITLE
fix(config): jobProfiles partial roles + carry profiles to runtime (INT-1812)

### DIFF
--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -147,6 +147,30 @@ agents:
       expect(config.autonomous?.maxReflections).toBe(3);
     });
 
+    it('should accept jobProfiles with partial role overrides', () => {
+      // Regression: roles used z.record(enum, string), which under Zod v4 requires
+      // EVERY pipeline stage as a key — so a profile naming only worker+reviewer
+      // failed validation and crashed daemon startup. A profile overrides only the
+      // stages it names.
+      const jsonContent = JSON.stringify({
+        language: 'en',
+        linear: { apiKey: 'k', teamId: 't' },
+        agents: [{ name: 'main', projectPath: '/p', enabled: true, paused: false }],
+        autonomous: {
+          enabled: true,
+          jobProfiles: [
+            { name: 'light', minMinutes: 1, maxMinutes: 15, roles: { worker: 'm1', reviewer: 'm2' } },
+          ],
+        },
+      });
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(jsonContent);
+
+      const config = loadConfig('/tmp/config.json');
+      expect(config.autonomous?.jobProfiles?.[0]?.roles).toEqual({ worker: 'm1', reviewer: 'm2' });
+    });
+
     it('should throw error when config file not found', () => {
       vi.mocked(existsSync).mockReturnValue(false);
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -203,7 +203,10 @@ const JobProfileSchema = z.object({
   minMinutes: z.number().min(0).optional(),
   maxMinutes: z.number().min(0).optional(),
   priority: z.number().int().min(1).max(4).optional(),
-  roles: z.record(PipelineStageSchema, z.string()).optional(),
+  // partialRecord, not record: a profile overrides only the stages it names
+  // (e.g. worker+reviewer). In Zod v4 `z.record(enum, …)` requires every enum
+  // key, which rejected valid partial profiles and crashed daemon startup.
+  roles: z.partialRecord(PipelineStageSchema, z.string()).optional(),
 });
 
 const PipelineGuardsConfigSchema = z.object({
@@ -509,6 +512,9 @@ function transformConfig(raw: RawConfig): SwarmConfig {
       maxReflections: raw.autonomous.maxReflections,
       dailyTaskCap: raw.autonomous.dailyTaskCap,
       interTaskCooldownMs: raw.autonomous.interTaskCooldownMs,
+      // jobProfiles was validated by the schema but dropped here, so per-task
+      // model selection silently fell back to defaultRoles. Carry it through.
+      jobProfiles: raw.autonomous.jobProfiles,
     } : undefined,
     prProcessor: raw.prProcessor ? {
       enabled: raw.prProcessor.enabled,


### PR DESCRIPTION
## Problem

Restarting the daemon on `main` (during the INT-1809/INT-1810 isolation lift) crashed at config load:

```
Config validation failed:
  - autonomous.jobProfiles.0.roles.tester: Invalid input: expected string, received undefined
```

Two bugs, the second masked by the first:

1. **Schema too strict.** `JobProfileSchema.roles` used `z.record(PipelineStageSchema, z.string())`. Under **Zod v4** a `z.record` with an enum key schema requires **every** enum key — so a profile overriding only `worker`+`reviewer` (the intended partial usage, as in the live config) fails validation → daemon won't start.
2. **Transform drops jobProfiles.** Even once parsed, `loadConfig`'s raw→runtime transform never copied `raw.autonomous.jobProfiles`, so `config.autonomous.jobProfiles` was always `undefined`. The downstream chain (service.ts → runner → runnerExecution) is fully wired, but the value never arrived → per-task model selection silently fell back to `defaultRoles`.

## Fix

- `roles: z.partialRecord(PipelineStageSchema, z.string())` — a profile overrides only the stages it names.
- Carry `jobProfiles` through the autonomous transform in `loadConfig`.
- Regression test in `config.test.ts`: `loadConfig` accepts partial-role jobProfiles and surfaces them on the runtime config.

## Verify

- Full suite green: **50 files / 834 tests**; typecheck clean.
- Daemon starts cleanly on the live config (light/heavy profiles, worker+reviewer only) and loads all allowed projects.

Closes INT-1812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)