### PR TITLE
feat(cli): interactive init wizard — Linear picker + provider detection (INT-1808)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",
+        "@inquirer/prompts": "^8.5.2",
         "@intrect/cxt": "^0.1.0",
         "@intrect/openswarm": "^0.2.1",
         "@lancedb/lancedb": "^0.23.0",
@@ -994,6 +995,334 @@
         "node": ">=18"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+      "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/external-editor": "^3.0.3",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+      "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
+      "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.2.1",
+        "@inquirer/confirm": "^6.1.1",
+        "@inquirer/editor": "^5.2.2",
+        "@inquirer/expand": "^5.1.1",
+        "@inquirer/input": "^5.1.2",
+        "@inquirer/number": "^4.1.1",
+        "@inquirer/password": "^5.1.1",
+        "@inquirer/rawlist": "^5.3.1",
+        "@inquirer/search": "^4.2.1",
+        "@inquirer/select": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@intrect/cxt": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@intrect/cxt/-/cxt-0.1.0.tgz",
@@ -1211,9 +1540,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/@lancedb/lancedb/node_modules/@lancedb/lancedb-darwin-x64": {
-      "optional": true
     },
     "node_modules/@linear/sdk": {
       "version": "19.3.0",
@@ -2578,11 +2904,26 @@
         "url": "https://github.com/chalk/chalk-template?sponsor=1"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "license": "MIT"
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -3140,6 +3481,21 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -3155,6 +3511,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4037,6 +4402,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "5.1.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
@@ -4861,6 +5235,18 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.72.1",
+    "@inquirer/prompts": "^8.5.2",
     "@intrect/cxt": "^0.1.0",
     "@intrect/openswarm": "^0.2.1",
     "@lancedb/lancedb": "^0.23.0",

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -17,3 +17,9 @@ export {
   type OpenRouterFlowResult,
   type OpenRouterFlowOptions,
 } from './openrouterPkce.js';
+export {
+  runLinearPkceFlow,
+  loginAndSaveLinearProfile,
+  type LinearFlowResult,
+  type LinearFlowOptions,
+} from './linearPkce.js';

--- a/src/auth/linearPkce.ts
+++ b/src/auth/linearPkce.ts
@@ -1,0 +1,259 @@
+// ============================================
+// OpenSwarm - Linear OAuth 2.0 PKCE Flow
+// Browser-based login that exchanges an authorization code for a Linear
+// access_token (+ refresh_token). PKCE → NO client_secret is used or stored.
+// ============================================
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { randomBytes, createHash } from 'node:crypto';
+import { exec } from 'node:child_process';
+import { AuthProfileStore, type AuthProfile } from './oauthStore.js';
+
+// ----- Constants -----
+
+const LINEAR_AUTH_ENDPOINT = 'https://linear.app/oauth/authorize';
+const LINEAR_TOKEN_ENDPOINT = 'https://api.linear.app/oauth/token';
+const DEFAULT_CALLBACK_PORT = 1457; // distinct from codex (1455) / openrouter (1456)
+const DEFAULT_SCOPES = 'read,write';
+const LOGIN_TIMEOUT_MS = 120_000;
+const LINEAR_PROFILE_KEY = 'linear:default';
+
+export const PROFILE_KEY = LINEAR_PROFILE_KEY;
+
+/**
+ * Public OAuth client_id for the OpenSwarm Linear app. PKCE means no client
+ * secret is needed. Read from LINEAR_OAUTH_CLIENT_ID so the id is not baked into
+ * source/git; a future public build can set a hardcoded default here.
+ */
+function getClientId(): string {
+  const id = process.env.LINEAR_OAUTH_CLIENT_ID?.trim();
+  if (!id) {
+    // cxt-ignore-next-line: fake_data — real redirect URI shown in setup guidance
+    throw new Error('LINEAR_OAUTH_CLIENT_ID is not set. Register a Linear OAuth app at https://linear.app/settings/api/applications/new (redirect http://localhost:1457/callback, scopes read,write, PKCE) and set LINEAR_OAUTH_CLIENT_ID in .env.');
+  }
+  return id;
+}
+
+// ----- PKCE helpers (same shape as oauthPkce.ts / openrouterPkce.ts) -----
+
+function generateCodeVerifier(): string {
+  return randomBytes(96).toString('base64url');
+}
+
+function generateCodeChallenge(verifier: string): string {
+  return createHash('sha256').update(verifier).digest('base64url');
+}
+
+function generateState(): string {
+  return randomBytes(32).toString('hex');
+}
+
+// ----- Browser open (cross-platform) -----
+
+function openBrowser(url: string): void {
+  const platform = process.platform;
+  const cmd = platform === 'darwin' ? 'open' : platform === 'win32' ? 'start' : 'xdg-open';
+  exec(`${cmd} "${url}"`, (err) => {
+    if (err) {
+      console.error('[Auth] 브라우저를 자동으로 열 수 없습니다. 직접 열어주세요:');
+      console.error(url);
+    }
+  });
+}
+
+// ----- Types -----
+
+export interface LinearFlowResult {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+}
+
+export interface LinearFlowOptions {
+  port?: number;
+  scopes?: string;
+}
+
+/**
+ * Linear OAuth 2.0 PKCE flow.
+ *   1. generate PKCE verifier/challenge + state
+ *   2. open https://linear.app/oauth/authorize?...&code_challenge=...&code_challenge_method=S256
+ *   3. receive ?code=... on the local callback server
+ *   4. POST https://api.linear.app/oauth/token (code_verifier, client_id — NO secret)
+ *      → access_token + refresh_token
+ */
+export async function runLinearPkceFlow(options: LinearFlowOptions = {}): Promise<LinearFlowResult> {
+  const { port = DEFAULT_CALLBACK_PORT, scopes = DEFAULT_SCOPES } = options;
+  const clientId = getClientId();
+  // Must match the redirect URI registered on the Linear OAuth app exactly.
+  const redirectUri = `http://localhost:${port}/callback`;
+
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+  const state = generateState();
+
+  const authParams = new URLSearchParams({
+    response_type: 'code',
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+    scope: scopes,
+    state,
+  });
+  const authUrl = `${LINEAR_AUTH_ENDPOINT}?${authParams.toString()}`;
+
+  return new Promise<LinearFlowResult>((resolve, reject) => {
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        server.close();
+        reject(new Error('Linear login timed out (120s). 다시 시도하세요.'));
+      }
+    }, LOGIN_TIMEOUT_MS);
+
+    const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+      if (settled) {
+        res.writeHead(400);
+        res.end();
+        return;
+      }
+
+      const url = new URL(req.url ?? '/', `http://127.0.0.1:${port}`);
+      if (url.pathname !== '/callback') {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+
+      const code = url.searchParams.get('code');
+      const returnedState = url.searchParams.get('state');
+      const error = url.searchParams.get('error');
+
+      if (error) {
+        settled = true;
+        clearTimeout(timeout);
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(errorHtml(error));
+        server.close();
+        reject(new Error(`Linear OAuth error: ${error}`));
+        return;
+      }
+
+      if (!code || returnedState !== state) {
+        settled = true;
+        clearTimeout(timeout);
+        res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(errorHtml('Invalid callback parameters'));
+        server.close();
+        reject(new Error('Invalid Linear callback: missing code or state mismatch'));
+        return;
+      }
+
+      try {
+        const tokenBody = new URLSearchParams({
+          grant_type: 'authorization_code',
+          code,
+          code_verifier: codeVerifier,
+          redirect_uri: redirectUri,
+          client_id: clientId,
+        });
+
+        const tokenRes = await fetch(LINEAR_TOKEN_ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: tokenBody.toString(),
+        });
+
+        if (!tokenRes.ok) {
+          const errText = await tokenRes.text().catch(() => '');
+          throw new Error(`Token exchange failed (${tokenRes.status}): ${errText.slice(0, 300)}`);
+        }
+
+        const tokens = (await tokenRes.json()) as {
+          access_token: string;
+          refresh_token?: string;
+          expires_in: number;
+        };
+
+        settled = true;
+        clearTimeout(timeout);
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(successHtml());
+        server.close();
+        resolve({
+          accessToken: tokens.access_token,
+          refreshToken: tokens.refresh_token ?? '',
+          expiresIn: tokens.expires_in,
+        });
+      } catch (err) {
+        settled = true;
+        clearTimeout(timeout);
+        res.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(errorHtml(String(err)));
+        server.close();
+        reject(err);
+      }
+    });
+
+    server.listen(port, '127.0.0.1', () => {
+      console.log(`[Auth] Callback server listening on http://127.0.0.1:${port}`);
+      console.log('[Auth] 브라우저에서 Linear 로그인 페이지를 엽니다...');
+      openBrowser(authUrl);
+    });
+
+    server.on('error', (err) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        reject(new Error(`Callback server error: ${err.message}`));
+      }
+    });
+  });
+}
+
+/** Full PKCE flow + persist the linear:default profile. Returns the access token. */
+export async function loginAndSaveLinearProfile(port?: number): Promise<string> {
+  const result = await runLinearPkceFlow({ port });
+
+  const profile: AuthProfile = {
+    type: 'oauth',
+    provider: 'linear',
+    access: result.accessToken,
+    refresh: result.refreshToken,
+    expires: Date.now() + result.expiresIn * 1000,
+    clientId: getClientId(),
+  };
+
+  const store = new AuthProfileStore();
+  store.setProfile(LINEAR_PROFILE_KEY, profile);
+
+  console.log(`[Auth] Linear OAuth 인증 완료. 프로필 저장됨: ${LINEAR_PROFILE_KEY}`); // cxt-ignore: fake_execution — printed after a real token exchange
+  return result.accessToken;
+}
+
+// ----- HTML templates -----
+
+function successHtml(): string {
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>OpenSwarm Auth</title>
+<style>body{font-family:system-ui;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#f0fdf4}
+.card{text-align:center;padding:2rem;border-radius:12px;background:white;box-shadow:0 2px 8px rgba(0,0,0,0.1)}
+h1{color:#16a34a;margin-bottom:0.5rem}p{color:#666}</style></head>
+<body><div class="card"><h1>✓ 인증 완료</h1><p>OpenSwarm에 Linear 인증이 완료되었습니다.<br>이 창을 닫아도 됩니다.</p></div></body></html>`;
+}
+
+function errorHtml(error: string): string {
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>OpenSwarm Auth Error</title>
+<style>body{font-family:system-ui;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#fef2f2}
+.card{text-align:center;padding:2rem;border-radius:12px;background:white;box-shadow:0 2px 8px rgba(0,0,0,0.1)}
+h1{color:#dc2626;margin-bottom:0.5rem}p{color:#666}</style></head>
+<body><div class="card"><h1>✗ 인증 실패</h1><p>${escapeHtml(error)}</p><p>터미널에서 다시 시도하세요.</p></div></body></html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}

--- a/src/auth/oauthStore.ts
+++ b/src/auth/oauthStore.ts
@@ -40,6 +40,13 @@ const STORE_DIR = join(homedir(), '.openswarm');
 const STORE_PATH = join(STORE_DIR, 'auth-profiles.json');
 const REFRESH_BUFFER_MS = 5 * 60 * 1000; // 5분 전에 갱신
 const OPENAI_TOKEN_ENDPOINT = 'https://auth.openai.com/oauth/token';
+const LINEAR_TOKEN_ENDPOINT = 'https://api.linear.app/oauth/token';
+
+/** OAuth refresh token endpoints by provider. */
+const TOKEN_ENDPOINTS: Record<string, string> = {
+  'openai-gpt': OPENAI_TOKEN_ENDPOINT,
+  linear: LINEAR_TOKEN_ENDPOINT,
+};
 
 // AuthProfileStore
 
@@ -122,7 +129,8 @@ export async function ensureValidToken(store: AuthProfileStore, profileKey: stri
     client_id: profile.clientId,
   });
 
-  const res = await fetch(OPENAI_TOKEN_ENDPOINT, {
+  const endpoint = TOKEN_ENDPOINTS[profile.provider] ?? OPENAI_TOKEN_ENDPOINT;
+  const res = await fetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
@@ -130,8 +138,9 @@ export async function ensureValidToken(store: AuthProfileStore, profileKey: stri
 
   if (!res.ok) {
     const errText = await res.text().catch(() => '');
+    const reauth = profile.provider === 'linear' ? 'linear' : 'gpt';
     throw new Error(
-      `Token refresh failed (${res.status}): ${errText.slice(0, 200)}. Run: openswarm auth login --provider gpt`,
+      `Token refresh failed (${res.status}): ${errText.slice(0, 200)}. Run: openswarm auth login --provider ${reauth}`,
     );
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,6 +90,16 @@ program
     await runInitWizard({ force: opts.force });
   });
 
+// openswarm doctor
+
+program
+  .command('doctor')
+  .description('Diagnose the environment (runtime, native deps, providers, ports, config)')
+  .action(async () => {
+    const { handleDoctor } = await import('./cli/doctorHandler.js');
+    await handleDoctor();
+  });
+
 // openswarm validate
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,12 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { runCli } from './runners/cliRunner.js';
 import { loadConfig, validateConfig, generateSampleConfig } from './core/config.js';
+import { loadEnvFile } from './core/envFile.js';
+
+// Load .env so CLI commands (e.g. `auth login --provider linear` reading
+// LINEAR_OAUTH_CLIENT_ID) see the same env the daemon does. Idempotent; never
+// overrides an already-set shell var.
+loadEnvFile();
 
 // Read version from package.json so it stays in sync with the published package.
 // cli.js lives at <pkg>/dist/cli.js, so package.json is one directory up.
@@ -346,8 +352,8 @@ const authCmd = program
 
 authCmd
   .command('login')
-  .description('Login via OAuth/PKCE (gpt, openrouter)')
-  .option('--provider <provider>', 'Provider to authenticate (gpt | openrouter)', 'gpt')
+  .description('Login via OAuth/PKCE (gpt, openrouter, linear)')
+  .option('--provider <provider>', 'Provider to authenticate (gpt | openrouter | linear)', 'gpt')
   .option('--client-id <clientId>', 'GPT only: override OAuth Client ID (defaults to the public Codex client)')
   .option('--api-key <apiKey>', 'OpenRouter only: skip browser flow and store this sk-or-* key directly')
   .option('--port <port>', 'Callback server port', parseInt)
@@ -375,7 +381,7 @@ authCmd
 authCmd
   .command('logout')
   .description('Remove stored auth tokens')
-  .option('--provider <provider>', 'Provider to remove (gpt | openrouter)', 'gpt')
+  .option('--provider <provider>', 'Provider to remove (gpt | openrouter | linear)', 'gpt')
   .action(async (opts: { provider: string }) => {
     const { handleAuthLogout } = await import('./cli/authHandler.js');
     handleAuthLogout(opts.provider);

--- a/src/cli/authHandler.ts
+++ b/src/cli/authHandler.ts
@@ -13,16 +13,18 @@ import {
   loginAndSaveOpenRouterProfile,
   saveOpenRouterApiKey,
 } from '../auth/openrouterPkce.js';
+import { loginAndSaveLinearProfile } from '../auth/linearPkce.js';
 import { getCodexModelIds } from '../adapters/codexModels.js';
 
-type Provider = 'gpt' | 'openrouter';
+type Provider = 'gpt' | 'openrouter' | 'linear';
 
 const PROFILE_KEYS: Record<Provider, string> = {
   gpt: 'openai-gpt:default',
   openrouter: 'openrouter:default',
+  linear: 'linear:default',
 };
 
-const VALID_PROVIDERS: Provider[] = ['gpt', 'openrouter'];
+const VALID_PROVIDERS: Provider[] = ['gpt', 'openrouter', 'linear'];
 
 function assertProvider(provider: string): asserts provider is Provider {
   if (!VALID_PROVIDERS.includes(provider as Provider)) {
@@ -55,6 +57,9 @@ export async function handleAuthLogin(
         opts.clientId ?? process.env.OPENAI_CLIENT_ID ?? DEFAULT_OPENAI_CLIENT_ID;
       await loginAndSaveProfile(clientId, opts.port);
       printGptPostLoginHint();
+    } else if (provider === 'linear') {
+      await loginAndSaveLinearProfile(opts.port);
+      console.log('✓ Linear 연동 완료. `openswarm init`에서 팀/프로젝트를 선택하세요.'); // cxt-ignore: fake_execution — after real OAuth token exchange
     } else {
       await loginOpenRouter(opts);
       printOpenRouterPostLoginHint();

--- a/src/cli/doctorHandler.ts
+++ b/src/cli/doctorHandler.ts
@@ -9,14 +9,16 @@ import { promisify } from 'node:util';
 import { createServer } from 'node:net';
 import { listAvailableAdapters } from '../adapters/index.js';
 import { findConfigFile } from '../core/config.js';
+import { banner } from '../support/banner.js';
+import { c } from '../support/colors.js';
 
 const execFileAsync = promisify(execFile);
 
 type Status = 'ok' | 'warn' | 'fail';
 
 function line(status: Status, label: string, detail = ''): void {
-  const icon = status === 'ok' ? '✓' : status === 'warn' ? '⚠' : '✗';
-  console.log(`${icon} ${label}${detail ? ` — ${detail}` : ''}`);
+  const icon = status === 'ok' ? c.green('✓') : status === 'warn' ? c.yellow('⚠') : c.red('✗');
+  console.log(`${icon} ${c.bold(label)}${detail ? ` ${c.dim('—')} ${c.dim(detail)}` : ''}`);
 }
 
 async function which(bin: string): Promise<string | null> {
@@ -39,7 +41,7 @@ async function portFree(port: number): Promise<boolean> {
 }
 
 export async function handleDoctor(): Promise<void> {
-  console.log('OpenSwarm doctor\n');
+  console.log(banner('doctor — environment check'));
   let fatal = false;
 
   // 1) Node.js runtime
@@ -110,8 +112,8 @@ export async function handleDoctor(): Promise<void> {
 
   console.log('');
   if (fatal) {
-    console.log('✗ Critical issues found — fix the ✗ items above.');
+    console.log(c.red(c.bold('✗ Critical issues found — fix the ✗ items above.')));
     process.exit(1);
   }
-  console.log('✓ No critical issues.');
+  console.log(c.green(c.bold('✓ No critical issues.')));
 }

--- a/src/cli/doctorHandler.ts
+++ b/src/cli/doctorHandler.ts
@@ -1,0 +1,117 @@
+// ============================================
+// OpenSwarm - `openswarm doctor`
+// Fresh-install self-diagnosis: runtime, native modules, external CLIs,
+// providers, ports, config, Linear. Exits non-zero on critical issues.
+// ============================================
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createServer } from 'node:net';
+import { listAvailableAdapters } from '../adapters/index.js';
+import { findConfigFile } from '../core/config.js';
+
+const execFileAsync = promisify(execFile);
+
+type Status = 'ok' | 'warn' | 'fail';
+
+function line(status: Status, label: string, detail = ''): void {
+  const icon = status === 'ok' ? '✓' : status === 'warn' ? '⚠' : '✗';
+  console.log(`${icon} ${label}${detail ? ` — ${detail}` : ''}`);
+}
+
+async function which(bin: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('which', [bin]);
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/** True if the TCP port is free to bind on localhost. */
+async function portFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const srv = createServer();
+    srv.once('error', () => resolve(false));
+    srv.once('listening', () => srv.close(() => resolve(true)));
+    srv.listen(port, '127.0.0.1');
+  });
+}
+
+export async function handleDoctor(): Promise<void> {
+  console.log('OpenSwarm doctor\n');
+  let fatal = false;
+
+  // 1) Node.js runtime
+  const nodeMajor = parseInt(process.versions.node.split('.')[0], 10);
+  if (nodeMajor >= 22) {
+    line('ok', 'Node.js', process.version);
+  } else {
+    line('fail', 'Node.js', `${process.version} — need >= 22`);
+    fatal = true;
+  }
+
+  // 2) Native modules (prebuilt binaries on common platforms; else build toolchain)
+  for (const mod of ['better-sqlite3', '@lancedb/lancedb']) {
+    try {
+      await import(mod);
+      line('ok', `native: ${mod}`, 'loads');
+    } catch {
+      line('fail', `native: ${mod}`, 'load failed — install python3 + a C/C++ toolchain, then reinstall');
+      fatal = true;
+    }
+  }
+
+  // 3) External CLIs on PATH
+  const clis: Array<[string, Status, string]> = [
+    ['codex', 'warn', 'codex provider'],
+    ['claude', 'warn', 'claude (opt-in) provider'],
+    ['git', 'warn', 'required for worktree mode / PRs'],
+    ['gh', 'warn', 'optional — CI monitoring'],
+  ];
+  for (const [bin, missStatus, note] of clis) {
+    const path = await which(bin);
+    if (path) line('ok', `cli: ${bin}`, path);
+    else line(missStatus, `cli: ${bin}`, `not on PATH (${note})`);
+  }
+
+  // 4) LLM providers (env keys + OAuth profiles + PATH binaries + local servers)
+  const available = await listAvailableAdapters();
+  if (available.length > 0) {
+    line('ok', 'providers', available.join(', '));
+  } else {
+    line('fail', 'providers', 'none usable — run `openswarm auth login` (codex/gpt/openrouter) or start a local model');
+    fatal = true;
+  }
+
+  // 5) Ports (web dashboard + OAuth callbacks)
+  const ports: Array<[number, string]> = [
+    [3847, 'web dashboard'],
+    [1455, 'codex OAuth callback'],
+    [1456, 'openrouter OAuth callback'],
+    [1457, 'linear OAuth callback'],
+  ];
+  for (const [port, use] of ports) {
+    const free = await portFree(port);
+    line(free ? 'ok' : 'warn', `port ${port}`, free ? `free (${use})` : `in use (${use}) — close the holder before that flow`);
+  }
+
+  // 6) Config file resolution (cwd ./config.yaml vs ~/.config/openswarm)
+  const cfg = findConfigFile();
+  if (cfg) line('ok', 'config', cfg);
+  else line('warn', 'config', 'none found — run `openswarm init` (or set OPENSWARM_CONFIG)');
+
+  // 7) Linear task source (optional)
+  const { AuthProfileStore } = await import('../auth/index.js');
+  const hasOAuth = !!new AuthProfileStore().getProfile('linear:default');
+  const hasKey = !!process.env.LINEAR_API_KEY;
+  if (hasOAuth || hasKey) line('ok', 'linear', hasOAuth ? 'OAuth profile' : 'API key');
+  else line('warn', 'linear', 'not configured — local SQLite issue store will be used');
+
+  console.log('');
+  if (fatal) {
+    console.log('✗ Critical issues found — fix the ✗ items above.');
+    process.exit(1);
+  }
+  console.log('✓ No critical issues.');
+}

--- a/src/cli/initWizard.test.ts
+++ b/src/cli/initWizard.test.ts
@@ -30,4 +30,20 @@ describe('buildWizardConfig', () => {
     expect(cfg).toMatch(/^ {2}# slackWebhookUrl:/m);
     expect(cfg).toMatch(/^ {2}# telegramBotToken:/m);
   });
+
+  it('replaces placeholder agents with a single agent for this repo', () => {
+    const cfg = buildWizardConfig('codex', 'none', { name: 'WAVE', projectPath: '/Users/x/dev/WAVE' });
+    expect(cfg).toMatch(/^ {2}- name: WAVE$/m);
+    expect(cfg).toMatch(/^ {4}projectPath: \/Users\/x\/dev\/WAVE$/m);
+    // sample placeholders are gone
+    expect(cfg).not.toContain('~/dev/my-project');
+    expect(cfg).not.toContain('- name: backend');
+    // defaultHeartbeatInterval still follows the agents block
+    expect(cfg).toMatch(/defaultHeartbeatInterval:/);
+  });
+
+  it('keeps the sample agents when no agent is given (back-compat)', () => {
+    const cfg = buildWizardConfig('codex', 'none');
+    expect(cfg).toContain('~/dev/my-project');
+  });
 });

--- a/src/cli/initWizard.ts
+++ b/src/cli/initWizard.ts
@@ -1,51 +1,51 @@
 // ============================================
 // OpenSwarm - First-run onboarding wizard
-// `openswarm init` (interactive). INT-1578.
+// `openswarm init` (interactive). INT-1578 / INT-1808.
 // ============================================
 //
-// Walks a fresh user through: AI provider (+ inline auth), task backend
-// (Linear or local SQLite), and an optional notification channel. Writes a
-// .env (secrets, 0600) + config.yaml, then validates. `--yes` keeps the old
-// config-only path for CI (handled by the caller in cli.ts).
+// Walks a fresh user through: AI provider (availability detection + inline
+// auth), task backend (Linear with an arrow-key team/project picker, or local
+// SQLite), and an optional notification channel. Writes a .env (secrets, 0600)
+// + config.yaml + an openswarm.json repo→Linear mapping, then prints next steps.
+// `--yes` keeps the config-only path for CI (handled by the caller in cli.ts).
 
 import { existsSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { createPrompter, type ChoiceOption } from '../support/promptHelper.js';
+import { basename, join } from 'node:path';
+import { select, checkbox, input, password, confirm } from '@inquirer/prompts';
 import { writeEnvVars } from '../core/envFile.js';
 import { generateSampleConfig } from '../core/config.js';
 import { AuthProfileStore } from '../auth/index.js';
+import { getAdapter } from '../adapters/index.js';
+import { listTeams, listProjects } from '../linear/index.js';
+import { saveRepoMetadata } from '../support/repoMetadata.js';
 
-type ProviderId = 'codex-responses' | 'openrouter' | 'gpt' | 'lmstudio' | 'local' | 'codex';
+type ProviderId = 'codex-responses' | 'openrouter' | 'gpt' | 'lmstudio' | 'local' | 'codex' | 'claude';
 type TaskBackend = 'linear' | 'local';
 type NotifyChannel = 'none' | 'discord' | 'slack' | 'telegram' | 'webhook';
 
-const PROVIDER_OPTIONS: ChoiceOption<ProviderId>[] = [
-  { label: 'codex-responses', value: 'codex-responses', hint: 'ChatGPT subscription (OAuth) — Codex models, native loop' },
-  { label: 'openrouter', value: 'openrouter', hint: 'OpenRouter API key or OAuth (any model)' },
-  { label: 'gpt', value: 'gpt', hint: 'OpenAI ChatGPT OAuth (chat/completions)' },
-  { label: 'lmstudio', value: 'lmstudio', hint: 'Local LM Studio server (no account)' },
-  { label: 'local', value: 'local', hint: 'Local Ollama models (no account)' },
-  { label: 'codex', value: 'codex', hint: 'External codex CLI (delegated)' },
+const PROVIDER_CHOICES: { name: string; value: ProviderId; description: string }[] = [
+  { name: 'codex-responses', value: 'codex-responses', description: 'ChatGPT subscription (OAuth) — Codex models, native loop' },
+  { name: 'codex', value: 'codex', description: 'External codex CLI (delegated)' },
+  { name: 'openrouter', value: 'openrouter', description: 'OpenRouter API key or OAuth (any model)' },
+  { name: 'gpt', value: 'gpt', description: 'OpenAI ChatGPT OAuth (chat/completions)' },
+  { name: 'claude', value: 'claude', description: 'Claude Code CLI (claude -p) — opt-in fallback' },
+  { name: 'lmstudio', value: 'lmstudio', description: 'Local LM Studio server (no account)' },
+  { name: 'local', value: 'local', description: 'Local Ollama models (no account)' },
 ];
 
-const TASK_OPTIONS: ChoiceOption<TaskBackend>[] = [
-  { label: 'local', value: 'local', hint: 'Local SQLite issue store (~/.openswarm/issues.db) — no account' },
-  { label: 'linear', value: 'linear', hint: 'Linear (paste API key + team id)' },
-];
-
-const NOTIFY_OPTIONS: ChoiceOption<NotifyChannel>[] = [
-  { label: 'none', value: 'none', hint: 'No outbound notifications' },
-  { label: 'discord', value: 'discord', hint: 'Discord bot token + channel id' },
-  { label: 'slack', value: 'slack', hint: 'Slack incoming webhook URL' },
-  { label: 'telegram', value: 'telegram', hint: 'Telegram bot token + chat id' },
-  { label: 'webhook', value: 'webhook', hint: 'Generic webhook URL' },
+const NOTIFY_CHOICES: { name: string; value: NotifyChannel; description: string }[] = [
+  { name: 'none', value: 'none', description: 'No outbound notifications' },
+  { name: 'discord', value: 'discord', description: 'Discord bot token + channel id' },
+  { name: 'slack', value: 'slack', description: 'Slack incoming webhook URL' },
+  { name: 'telegram', value: 'telegram', description: 'Telegram bot token + chat id' },
+  { name: 'webhook', value: 'webhook', description: 'Generic webhook URL' },
 ];
 
 /** ChatGPT-OAuth providers share the openai-gpt profile; openrouter has its own. */
 function authPlanFor(provider: ProviderId): { providerArg: 'gpt' | 'openrouter'; profileKey: string } | null {
   if (provider === 'codex-responses' || provider === 'gpt') return { providerArg: 'gpt', profileKey: 'openai-gpt:default' };
   if (provider === 'openrouter') return { providerArg: 'openrouter', profileKey: 'openrouter:default' };
-  return null; // lmstudio / local / codex need no OAuth here
+  return null; // lmstudio / local / codex / claude need no OAuth here
 }
 
 /** Apply the wizard's choices onto the static sample config via targeted replaces. */
@@ -69,65 +69,199 @@ export interface InitWizardOptions {
   force?: boolean;
 }
 
+/**
+ * Provider bootstrap. `adapter.isAvailable()` is the canonical "already
+ * configured?" probe — it covers env keys, OAuth profiles, PATH binaries, and
+ * local servers (the old wizard only checked OAuth profiles). When not available,
+ * branch on how to set the provider up. Returns whether to run inline OAuth after
+ * the wizard, plus the auth plan.
+ */
+async function bootstrapProvider(
+  provider: ProviderId,
+): Promise<{ doAuthNow: boolean; plan: ReturnType<typeof authPlanFor> }> {
+  let available = false;
+  try {
+    available = await getAdapter(provider).isAvailable();
+  } catch { // cxt-ignore: error_swallow,exception_hiding — unknown/unconfigured provider treated as unavailable
+    available = false;
+  }
+
+  if (provider === 'claude') {
+    // claude = the `claude -p` CLI wrapper; isAvailable() is just `which claude`.
+    // PATH presence ≠ logged in, so guide explicitly instead of claiming "configured".
+    if (available) console.log('   ✓ `claude` on PATH. If not logged in yet, run `claude` once to authenticate.');
+    else console.log('   `claude` not found. Install: npm i -g @anthropic-ai/claude-code, then run `claude` to log in.');
+    return { doAuthNow: false, plan: null };
+  }
+
+  if (available) {
+    console.log(`   ✓ ${provider} already configured.`);
+    return { doAuthNow: false, plan: authPlanFor(provider) };
+  }
+
+  if (provider === 'codex') {
+    console.log('   `codex` not found. Install the OpenAI Codex CLI and ensure `codex` is on PATH.');
+    return { doAuthNow: false, plan: null };
+  }
+  if (provider === 'lmstudio' || provider === 'local') {
+    console.log(`   No ${provider} server detected — start it (LM Studio :1234 / Ollama :11434) before running.`);
+    return { doAuthNow: false, plan: null };
+  }
+
+  const plan = authPlanFor(provider);
+  if (plan) {
+    const doAuthNow = await confirm({
+      message: `   ${provider} needs login — run \`auth login --provider ${plan.providerArg}\` now?`,
+      default: true,
+    });
+    return { doAuthNow, plan };
+  }
+  return { doAuthNow: false, plan: null };
+}
+
+/**
+ * Interactive Linear setup: paste API key → arrow-key pick teams (multi) → pick
+ * THIS repo's project → write LINEAR_* env + an openswarm.json mapping so the
+ * daemon resolves this repo without fuzzy name matching. Falls back to manual
+ * team-id entry if the Linear API can't be reached.
+ */
+async function setupLinear(envVars: Record<string, string>, cwd: string): Promise<void> {
+  console.log('   Get a key at https://linear.app/settings/api');
+  const apiKey = (await password({ message: '   LINEAR_API_KEY (hidden):' })).trim();
+  if (!apiKey) {
+    console.log('   Skipped Linear (no key).');
+    return;
+  }
+  envVars.LINEAR_API_KEY = apiKey;
+
+  let teams: Awaited<ReturnType<typeof listTeams>> = [];
+  try {
+    teams = await listTeams(apiKey);
+  } catch (err) { // cxt-ignore: error_swallow,exception_hiding — surfaced to the user + manual team-id fallback
+    console.log(`   ⚠ Could not fetch teams (${(err as Error).message}). Enter the team id manually.`);
+  }
+
+  if (teams.length === 0) {
+    const tid = (await input({ message: '   LINEAR_TEAM_ID:' })).trim();
+    if (tid) envVars.LINEAR_TEAM_ID = tid;
+    return;
+  }
+
+  const pickedTeamIds = await checkbox({
+    message: '   Teams the daemon should watch (space = select, enter = confirm):',
+    choices: teams.map((t) => ({ name: `${t.key} — ${t.name}`, value: t.id })),
+  });
+  if (pickedTeamIds.length > 0) envVars.LINEAR_TEAM_ID = pickedTeamIds.join(',');
+
+  // Map THIS repo to a single project.
+  const mapTeamId =
+    pickedTeamIds.length === 1
+      ? pickedTeamIds[0]
+      : await select({
+          message: '   Which team owns THIS repo?',
+          choices: teams
+            .filter((t) => pickedTeamIds.includes(t.id))
+            .map((t) => ({ name: `${t.key} — ${t.name}`, value: t.id })),
+        });
+  if (!mapTeamId) return;
+
+  let projects: Awaited<ReturnType<typeof listProjects>> = [];
+  try {
+    projects = await listProjects(mapTeamId, apiKey);
+  } catch (err) { // cxt-ignore: error_swallow,exception_hiding — surfaced to the user; repo mapping skipped
+    console.log(`   ⚠ Could not fetch projects (${(err as Error).message}).`);
+    return;
+  }
+  if (projects.length === 0) {
+    console.log('   No projects in that team — skipping repo mapping.');
+    return;
+  }
+
+  const repoName = basename(cwd);
+  const projectId = await select({
+    message: `   Linear project for "${repoName}":`,
+    choices: [
+      { name: '(skip — no repo mapping)', value: '' },
+      ...projects.map((p) => ({ name: p.name, value: p.id })),
+    ],
+  });
+  if (!projectId) return;
+
+  const proj = projects.find((p) => p.id === projectId);
+  const team = teams.find((t) => t.id === mapTeamId);
+  const filePath = await saveRepoMetadata(cwd, {
+    schemaVersion: 1,
+    projectName: proj?.name,
+    linear: {
+      teamId: mapTeamId,
+      teamKey: team?.key,
+      projectId,
+      projectName: proj?.name,
+    },
+  });
+  console.log(`   Wrote ${filePath} → ${team?.key ?? '?'}/${proj?.name ?? projectId}`);
+}
+
 export async function runInitWizard(opts: InitWizardOptions = {}): Promise<void> {
-  const configPath = join(process.cwd(), 'config.yaml');
-  const envPath = join(process.cwd(), '.env');
+  const cwd = process.cwd();
+  const configPath = join(cwd, 'config.yaml');
+  const envPath = join(cwd, '.env');
 
   if (existsSync(configPath) && !opts.force) {
     console.error('config.yaml already exists. Use --force to overwrite, or edit it directly.');
     process.exit(1);
   }
 
-  const store = new AuthProfileStore();
-  const prompter = createPrompter();
   const envVars: Record<string, string> = {};
-  let provider: ProviderId;
-  let taskBackend: TaskBackend;
-  let notify: NotifyChannel;
+  let provider: ProviderId = 'codex';
+  let taskBackend: TaskBackend = 'local';
+  let notify: NotifyChannel = 'none';
   let doAuthNow = false;
+  let plan: ReturnType<typeof authPlanFor> = null;
 
   try {
-    console.log('OpenSwarm first-run setup — three quick choices.\n');
+    console.log('OpenSwarm first-run setup.\n');
 
     // 1) AI provider
-    provider = await prompter.choose('1) AI provider for worker/reviewer:', PROVIDER_OPTIONS);
-    const plan = authPlanFor(provider);
-    if (plan) {
-      const already = store.getProfile(plan.profileKey) !== null;
-      if (already) {
-        console.log(`   ✓ already authenticated (${plan.profileKey}).`);
-      } else {
-        doAuthNow = await prompter.confirm(`   ${provider} needs login. Run \`auth login --provider ${plan.providerArg}\` now?`, true);
-      }
-    } else {
-      console.log(`   ${provider} needs no OAuth here (configure its endpoint/model later).`);
-    }
+    provider = await select({
+      message: '1) AI provider for worker/reviewer:',
+      choices: PROVIDER_CHOICES.map((c) => ({ name: c.name, value: c.value, description: c.description })),
+    });
+    ({ doAuthNow, plan } = await bootstrapProvider(provider));
 
     // 2) Task backend
-    taskBackend = await prompter.choose('\n2) Task backend:', TASK_OPTIONS);
-    if (taskBackend === 'linear') {
-      console.log('   Get a key at https://linear.app/settings/api');
-      const apiKey = await prompter.ask('   LINEAR_API_KEY');
-      const teamId = await prompter.ask('   LINEAR_TEAM_ID');
-      if (apiKey) envVars.LINEAR_API_KEY = apiKey;
-      if (teamId) envVars.LINEAR_TEAM_ID = teamId;
-    }
+    taskBackend = await select({
+      message: '\n2) Task backend:',
+      choices: [
+        { name: 'local', value: 'local' as TaskBackend, description: 'Local SQLite issue store (~/.openswarm/issues.db) — no account' },
+        { name: 'linear', value: 'linear' as TaskBackend, description: 'Linear (arrow-key team/project picker)' },
+      ],
+    });
+    if (taskBackend === 'linear') await setupLinear(envVars, cwd);
 
     // 3) Notification channel
-    notify = await prompter.choose('\n3) Notification channel (optional):', NOTIFY_OPTIONS);
+    notify = await select({
+      message: '\n3) Notification channel (optional):',
+      choices: NOTIFY_CHOICES.map((c) => ({ name: c.name, value: c.value, description: c.description })),
+    });
     if (notify === 'discord') {
-      envVars.DISCORD_TOKEN = await prompter.ask('   DISCORD_TOKEN');
-      envVars.DISCORD_CHANNEL_ID = await prompter.ask('   DISCORD_CHANNEL_ID');
+      envVars.DISCORD_TOKEN = (await password({ message: '   DISCORD_TOKEN (hidden):' })).trim();
+      envVars.DISCORD_CHANNEL_ID = (await input({ message: '   DISCORD_CHANNEL_ID:' })).trim();
     } else if (notify === 'slack') {
-      envVars.SLACK_WEBHOOK_URL = await prompter.ask('   SLACK_WEBHOOK_URL');
+      envVars.SLACK_WEBHOOK_URL = (await input({ message: '   SLACK_WEBHOOK_URL:' })).trim();
     } else if (notify === 'telegram') {
-      envVars.TELEGRAM_BOT_TOKEN = await prompter.ask('   TELEGRAM_BOT_TOKEN');
-      envVars.TELEGRAM_CHAT_ID = await prompter.ask('   TELEGRAM_CHAT_ID');
+      envVars.TELEGRAM_BOT_TOKEN = (await password({ message: '   TELEGRAM_BOT_TOKEN (hidden):' })).trim();
+      envVars.TELEGRAM_CHAT_ID = (await input({ message: '   TELEGRAM_CHAT_ID:' })).trim();
     } else if (notify === 'webhook') {
-      envVars.NOTIFY_WEBHOOK_URL = await prompter.ask('   NOTIFY_WEBHOOK_URL');
+      envVars.NOTIFY_WEBHOOK_URL = (await input({ message: '   NOTIFY_WEBHOOK_URL:' })).trim();
     }
-  } finally {
-    prompter.close();
+  } catch (err) {
+    // @inquirer throws ExitPromptError on Ctrl-C — exit cleanly, no stack trace.
+    if (err instanceof Error && err.name === 'ExitPromptError') {
+      console.log('\nSetup cancelled.');
+      return;
+    }
+    throw err;
   }
 
   // Drop empty answers so we never write `KEY=` for a skipped field.
@@ -143,8 +277,7 @@ export async function runInitWizard(opts: InitWizardOptions = {}): Promise<void>
   writeFileSync(configPath, buildWizardConfig(provider, notify), 'utf-8');
   console.log(`Wrote ${configPath}.`);
 
-  // Inline auth last (browser OAuth) — after the prompt readline is closed.
-  const plan = authPlanFor(provider);
+  // Inline auth last (browser OAuth) — after all prompts.
   if (doAuthNow && plan) {
     console.log(`\nLaunching login for ${plan.providerArg}...`);
     const { handleAuthLogin } = await import('./authHandler.js');
@@ -154,11 +287,14 @@ export async function runInitWizard(opts: InitWizardOptions = {}): Promise<void>
   // Next steps.
   console.log('\nNext steps:');
   console.log('  1. Edit config.yaml — set your project path(s) under `agents:`.');
-  if (plan && !doAuthNow && store.getProfile(plan.profileKey) === null) {
-    console.log(`  2. Authenticate: openswarm auth login --provider ${plan.providerArg}`);
+  if (plan && !doAuthNow) {
+    const store = new AuthProfileStore();
+    if (store.getProfile(plan.profileKey) === null) {
+      console.log(`  2. Authenticate: openswarm auth login --provider ${plan.providerArg}`);
+    }
   }
   console.log('  • Validate: openswarm validate');
-  console.log('  • Start:    openswarm start   (or `openswarm chat` for the TUI)');
+  console.log('  • Start:    openswarm start    (or `openswarm` for the TUI)');
   if (taskBackend === 'local') {
     console.log('  • Task backend: local SQLite (~/.openswarm/issues.db) — no Linear account needed.');
   }

--- a/src/cli/initWizard.ts
+++ b/src/cli/initWizard.ts
@@ -49,10 +49,22 @@ function authPlanFor(provider: ProviderId): { providerArg: 'gpt' | 'openrouter';
 }
 
 /** Apply the wizard's choices onto the static sample config via targeted replaces. */
-export function buildWizardConfig(adapter: ProviderId, channel: NotifyChannel): string {
+export function buildWizardConfig(
+  adapter: ProviderId,
+  channel: NotifyChannel,
+  agent?: { name: string; projectPath: string },
+): string {
   let cfg = generateSampleConfig();
   cfg = cfg.replace(/^adapter: codex$/m, `adapter: ${adapter}`);
   cfg = cfg.replace(/^ {2}channel: discord$/m, `  channel: ${channel === 'none' ? 'none' : channel}`);
+  // Replace the sample's placeholder agents (main/backend) with a single agent
+  // for THIS repo so the user doesn't have to hand-edit projectPath.
+  if (agent) {
+    cfg = cfg.replace(
+      /agents:\n[\s\S]*?\n\n(# Default heartbeat)/,
+      `agents:\n  - name: ${agent.name}\n    projectPath: ${agent.projectPath}\n    heartbeatInterval: 1800000\n    enabled: true\n    paused: false\n\n$1`,
+    );
+  }
   const uncomment = (field: string) => {
     cfg = cfg.replace(`  # ${field}:`, `  ${field}:`);
   };
@@ -298,7 +310,7 @@ export async function runInitWizard(opts: InitWizardOptions = {}): Promise<void>
     writeEnvVars(envPath, envVars);
     console.log(`\nWrote ${envPath} (${Object.keys(envVars).join(', ')}) — chmod 600.`);
   }
-  writeFileSync(configPath, buildWizardConfig(provider, notify), 'utf-8');
+  writeFileSync(configPath, buildWizardConfig(provider, notify, { name: basename(cwd), projectPath: cwd }), 'utf-8');
   console.log(`Wrote ${configPath}.`);
 
   // Inline auth last (browser OAuth) — after all prompts.

--- a/src/cli/initWizard.ts
+++ b/src/cli/initWizard.ts
@@ -14,7 +14,7 @@ import { basename, join } from 'node:path';
 import { select, checkbox, input, password, confirm } from '@inquirer/prompts';
 import { writeEnvVars } from '../core/envFile.js';
 import { generateSampleConfig } from '../core/config.js';
-import { AuthProfileStore, loginAndSaveLinearProfile } from '../auth/index.js';
+import { AuthProfileStore, loginAndSaveLinearProfile, ensureValidToken } from '../auth/index.js';
 import { getAdapter } from '../adapters/index.js';
 import { listTeams, listProjects, type LinearCredential } from '../linear/index.js';
 import { saveRepoMetadata } from '../support/repoMetadata.js';
@@ -138,7 +138,14 @@ async function setupLinear(envVars: Record<string, string>, cwd: string): Promis
   let cred: LinearCredential;
   if (method === 'oauth') {
     try {
-      const token = await loginAndSaveLinearProfile(); // browser PKCE → linear:default profile
+      const authStore = new AuthProfileStore();
+      let token: string;
+      if (authStore.getProfile('linear:default')) {
+        token = await ensureValidToken(authStore, 'linear:default'); // reuse — no browser
+        console.log('   ✓ Reusing existing Linear OAuth profile.');
+      } else {
+        token = await loginAndSaveLinearProfile(); // browser PKCE → linear:default profile
+      }
       cred = { accessToken: token };
     } catch (err) { // cxt-ignore: error_swallow,exception_hiding — OAuth failure → API-key fallback
       console.log(`   ⚠ Linear OAuth failed (${(err as Error).message}). Falling back to API key.`);

--- a/src/cli/initWizard.ts
+++ b/src/cli/initWizard.ts
@@ -329,6 +329,7 @@ export async function runInitWizard(opts: InitWizardOptions = {}): Promise<void>
       console.log(`  2. Authenticate: openswarm auth login --provider ${plan.providerArg}`);
     }
   }
+  console.log('  • Diagnose: openswarm doctor   (verify providers, native deps, ports, config)');
   console.log('  • Validate: openswarm validate');
   console.log('  • Start:    openswarm start    (or `openswarm` for the TUI)');
   if (taskBackend === 'local') {

--- a/src/cli/initWizard.ts
+++ b/src/cli/initWizard.ts
@@ -18,6 +18,7 @@ import { AuthProfileStore, loginAndSaveLinearProfile, ensureValidToken } from '.
 import { getAdapter } from '../adapters/index.js';
 import { listTeams, listProjects, type LinearCredential } from '../linear/index.js';
 import { saveRepoMetadata } from '../support/repoMetadata.js';
+import { banner } from '../support/banner.js';
 
 type ProviderId = 'codex-responses' | 'openrouter' | 'gpt' | 'lmstudio' | 'local' | 'codex' | 'claude';
 type TaskBackend = 'linear' | 'local';
@@ -256,7 +257,7 @@ export async function runInitWizard(opts: InitWizardOptions = {}): Promise<void>
   let plan: ReturnType<typeof authPlanFor> = null;
 
   try {
-    console.log('OpenSwarm first-run setup.\n');
+    console.log(banner('first-run setup'));
 
     // 1) AI provider
     provider = await select({

--- a/src/cli/initWizard.ts
+++ b/src/cli/initWizard.ts
@@ -14,9 +14,9 @@ import { basename, join } from 'node:path';
 import { select, checkbox, input, password, confirm } from '@inquirer/prompts';
 import { writeEnvVars } from '../core/envFile.js';
 import { generateSampleConfig } from '../core/config.js';
-import { AuthProfileStore } from '../auth/index.js';
+import { AuthProfileStore, loginAndSaveLinearProfile } from '../auth/index.js';
 import { getAdapter } from '../adapters/index.js';
-import { listTeams, listProjects } from '../linear/index.js';
+import { listTeams, listProjects, type LinearCredential } from '../linear/index.js';
 import { saveRepoMetadata } from '../support/repoMetadata.js';
 
 type ProviderId = 'codex-responses' | 'openrouter' | 'gpt' | 'lmstudio' | 'local' | 'codex' | 'claude';
@@ -126,17 +126,44 @@ async function bootstrapProvider(
  * team-id entry if the Linear API can't be reached.
  */
 async function setupLinear(envVars: Record<string, string>, cwd: string): Promise<void> {
-  console.log('   Get a key at https://linear.app/settings/api');
-  const apiKey = (await password({ message: '   LINEAR_API_KEY (hidden):' })).trim();
-  if (!apiKey) {
-    console.log('   Skipped Linear (no key).');
-    return;
+  // OAuth (browser, no key to paste) vs personal API key.
+  const method = await select({
+    message: '   Linear authentication:',
+    choices: [
+      { name: 'OAuth (browser login)', value: 'oauth', description: 'no API key to paste — recommended' },
+      { name: 'API key (paste)', value: 'apikey', description: 'personal key from linear.app/settings/api' },
+    ],
+  });
+
+  let cred: LinearCredential;
+  if (method === 'oauth') {
+    try {
+      const token = await loginAndSaveLinearProfile(); // browser PKCE → linear:default profile
+      cred = { accessToken: token };
+    } catch (err) { // cxt-ignore: error_swallow,exception_hiding — OAuth failure → API-key fallback
+      console.log(`   ⚠ Linear OAuth failed (${(err as Error).message}). Falling back to API key.`);
+      const apiKey = (await password({ message: '   LINEAR_API_KEY (hidden):' })).trim();
+      if (!apiKey) {
+        console.log('   Skipped Linear (no key).');
+        return;
+      }
+      envVars.LINEAR_API_KEY = apiKey;
+      cred = { apiKey };
+    }
+  } else {
+    console.log('   Get a key at https://linear.app/settings/api');
+    const apiKey = (await password({ message: '   LINEAR_API_KEY (hidden):' })).trim();
+    if (!apiKey) {
+      console.log('   Skipped Linear (no key).');
+      return;
+    }
+    envVars.LINEAR_API_KEY = apiKey;
+    cred = { apiKey };
   }
-  envVars.LINEAR_API_KEY = apiKey;
 
   let teams: Awaited<ReturnType<typeof listTeams>> = [];
   try {
-    teams = await listTeams(apiKey);
+    teams = await listTeams(cred);
   } catch (err) { // cxt-ignore: error_swallow,exception_hiding — surfaced to the user + manual team-id fallback
     console.log(`   ⚠ Could not fetch teams (${(err as Error).message}). Enter the team id manually.`);
   }
@@ -167,7 +194,7 @@ async function setupLinear(envVars: Record<string, string>, cwd: string): Promis
 
   let projects: Awaited<ReturnType<typeof listProjects>> = [];
   try {
-    projects = await listProjects(mapTeamId, apiKey);
+    projects = await listProjects(mapTeamId, cred);
   } catch (err) { // cxt-ignore: error_swallow,exception_hiding — surfaced to the user; repo mapping skipped
     console.log(`   ⚠ Could not fetch projects (${(err as Error).message}).`);
     return;

--- a/src/cli/initWizard.ts
+++ b/src/cli/initWizard.ts
@@ -11,7 +11,7 @@
 
 import { existsSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
-import { select, checkbox, input, password, confirm } from '@inquirer/prompts';
+import { select, input, password, confirm } from '@inquirer/prompts';
 import { writeEnvVars } from '../core/envFile.js';
 import { generateSampleConfig } from '../core/config.js';
 import { AuthProfileStore, loginAndSaveLinearProfile, ensureValidToken } from '../auth/index.js';
@@ -181,23 +181,13 @@ async function setupLinear(envVars: Record<string, string>, cwd: string): Promis
     return;
   }
 
-  const pickedTeamIds = await checkbox({
-    message: '   Teams the daemon should watch (space = select, enter = confirm):',
+  // One repo = one team. (Multi-team daemon watch lives in the main
+  // ~/.config/openswarm config, not per-repo init — keeps this picker simple.)
+  const mapTeamId = await select({
+    message: `   Linear team for "${basename(cwd)}":`,
     choices: teams.map((t) => ({ name: `${t.key} — ${t.name}`, value: t.id })),
   });
-  if (pickedTeamIds.length > 0) envVars.LINEAR_TEAM_ID = pickedTeamIds.join(',');
-
-  // Map THIS repo to a single project.
-  const mapTeamId =
-    pickedTeamIds.length === 1
-      ? pickedTeamIds[0]
-      : await select({
-          message: '   Which team owns THIS repo?',
-          choices: teams
-            .filter((t) => pickedTeamIds.includes(t.id))
-            .map((t) => ({ name: `${t.key} — ${t.name}`, value: t.id })),
-        });
-  if (!mapTeamId) return;
+  envVars.LINEAR_TEAM_ID = mapTeamId;
 
   let projects: Awaited<ReturnType<typeof listProjects>> = [];
   try {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -402,7 +402,7 @@ export function expandPath(path: string, resolveRelative = false): string {
  *   3. ~/.config/openswarm/config.{…}     (XDG user config)
  *   4. ~/.openswarm/config.{…}            (legacy home fallback)
  */
-function findConfigFile(): string | null {
+export function findConfigFile(): string | null {
   const envOverride = process.env.OPENSWARM_CONFIG;
   if (envOverride && envOverride.length > 0) {
     if (existsSync(envOverride)) {

--- a/src/core/service.test.ts
+++ b/src/core/service.test.ts
@@ -11,6 +11,18 @@ import {
 import { setDefaultAdapter } from '../adapters/index.js';
 
 // Mock external dependencies
+// Mock auth so service.test never reads the real ~/.openswarm/auth-profiles.json
+// (a present linear:default OAuth profile would route Linear init down the OAuth
+// path and break the apiKey assertion). Default: no profile → apiKey path.
+vi.mock('../auth/index.js', () => ({
+  AuthProfileStore: class {
+    getProfile() {
+      return null;
+    }
+  },
+  ensureValidToken: vi.fn(),
+}));
+
 vi.mock('../linear/index.js', () => ({
   initLinear: vi.fn(),
   getClient: vi.fn(),

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -62,11 +62,25 @@ export async function startService(config: SwarmConfig): Promise<void> {
   initRateLimiters();
   console.log('✅ Rate limiters ready');
 
-  // Linear initialization (optional)
-  if (config.linearApiKey && config.linearTeamId) {
-    console.log('🔗 Initializing Linear client...');
-    linear.initLinear(config.linearApiKey, config.linearTeamId);
-    console.log('✅ Linear client connected');
+  // Linear initialization (optional). Prefer an OAuth profile (linear:default,
+  // from `openswarm auth login --provider linear`) over a personal API key.
+  // Startup uses ensureValidToken (refreshes if near expiry). NOTE: long-running
+  // OAuth-token refresh during runtime is a follow-up — startup token is used.
+  if (config.linearTeamId) {
+    const { AuthProfileStore, ensureValidToken } = await import('../auth/index.js');
+    const authStore = new AuthProfileStore();
+    if (authStore.getProfile('linear:default')) {
+      console.log('🔗 Initializing Linear client (OAuth)...');
+      const token = await ensureValidToken(authStore, 'linear:default');
+      linear.initLinear(token, config.linearTeamId, true);
+      console.log('✅ Linear client connected (OAuth)');
+    } else if (config.linearApiKey) {
+      console.log('🔗 Initializing Linear client...');
+      linear.initLinear(config.linearApiKey, config.linearTeamId);
+      console.log('✅ Linear client connected');
+    } else {
+      console.log('⏭ Linear not configured — skipping');
+    }
   } else {
     console.log('⏭ Linear not configured — skipping');
   }

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -168,6 +168,7 @@ export async function startService(config: SwarmConfig): Promise<void> {
     // task-state enrichment — and only used by LinearTaskSource.
     const linearConfigured = !!(config.linearApiKey && config.linearTeamId);
     autonomous.setTaskSource(selectTaskSource(linearConfigured, async () => {
+      await linear.ensureLinearAuthFresh(); // refresh OAuth token (no-op for API key) each heartbeat
       const issues = await linear.getMyIssues({ slim: true, timeoutMs: 90000 });
       const { linearIssueToTask } = await import('../orchestration/decisionEngine.js');
       return issues.map((issue: any) => {

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -170,12 +170,14 @@ export function getDailyIssueCount(): number {
  * Initialize the Linear client
  * Rate limiting is applied at the function level in this file
  */
-export function initLinear(apiKey: string, team: string): void {
-  client = new LinearClient({ apiKey });
+export function initLinear(credential: string, team: string, isOAuth = false): void {
+  // OAuth access tokens use the Bearer `accessToken` path; personal API keys use
+  // the raw `apiKey` path. (Linear OAuth tokens fail if sent as a raw apiKey.)
+  client = new LinearClient(isOAuth ? { accessToken: credential } : { apiKey: credential });
   teamId = team;
   teamIds = team.split(',').map(id => id.trim()).filter(Boolean);
   setLinearClient(client);
-  console.log('[Linear] Client initialized');
+  console.log(`[Linear] Client initialized (${isOAuth ? 'OAuth' : 'apiKey'})`);
 }
 
 /**
@@ -202,23 +204,36 @@ export interface LinearTeamInfo {
   name: string;
 }
 
+/** Credential for one-off Linear calls before initLinear() (init picker). */
+export interface LinearCredential {
+  apiKey?: string;
+  /** OAuth access token (Bearer) — takes precedence over apiKey. */
+  accessToken?: string;
+}
+
+function linearClientFor(cred?: LinearCredential): LinearClient {
+  if (cred?.accessToken) return new LinearClient({ accessToken: cred.accessToken });
+  if (cred?.apiKey) return new LinearClient({ apiKey: cred.apiKey });
+  return getClient();
+}
+
 /**
- * List all Linear teams the API key can see — for the `openswarm init` picker.
- * Accepts an explicit apiKey so init can call it before initLinear() runs (the
- * user has only just pasted the key); falls back to the initialized client.
+ * List all Linear teams the credential can see — for the `openswarm init` picker.
+ * Accepts an explicit credential (apiKey or OAuth accessToken) so init can call
+ * it before initLinear() runs; falls back to the initialized client.
  */
-export async function listTeams(apiKey?: string): Promise<LinearTeamInfo[]> {
-  const c = apiKey ? new LinearClient({ apiKey }) : getClient();
+export async function listTeams(cred?: LinearCredential): Promise<LinearTeamInfo[]> {
+  const c = linearClientFor(cred);
   const res: any = await withRateLimit('linear', () => c.teams({ first: 250 })); // cxt-ignore: type_safety — SDK TeamConnection
   return (res?.nodes ?? []).map((t: any) => ({ id: t.id, key: t.key, name: t.name }));
 }
 
 /**
  * List projects within a team — for the `openswarm init` picker. Accepts an
- * explicit apiKey so init can call it before initLinear() runs.
+ * explicit credential (apiKey or OAuth accessToken).
  */
-export async function listProjects(teamId: string, apiKey?: string): Promise<LinearProjectInfo[]> {
-  const c = apiKey ? new LinearClient({ apiKey }) : getClient();
+export async function listProjects(teamId: string, cred?: LinearCredential): Promise<LinearProjectInfo[]> {
+  const c = linearClientFor(cred);
   const team: any = await withRateLimit('linear', () => c.team(teamId)); // cxt-ignore: type_safety — SDK Team
   const res: any = await withRateLimit('linear', () => team.projects({ first: 250 }));
   return (res?.nodes ?? []).map((p: any) => ({

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -29,6 +29,10 @@ async function getProjectInfo(issue: any): Promise<LinearProjectInfo | undefined
 let client: LinearClient | null = null;
 let teamId: string = '';
 let teamIds: string[] = [];
+// OAuth runtime state — when the client was built from a Linear OAuth access
+// token, the token expires (~24h) and must be refreshed + the client rebuilt.
+let isOAuthMode = false;
+let currentToken = '';
 
 /** Build a Linear team filter that works for both single and multiple team IDs */
 function teamFilter() {
@@ -174,10 +178,35 @@ export function initLinear(credential: string, team: string, isOAuth = false): v
   // OAuth access tokens use the Bearer `accessToken` path; personal API keys use
   // the raw `apiKey` path. (Linear OAuth tokens fail if sent as a raw apiKey.)
   client = new LinearClient(isOAuth ? { accessToken: credential } : { apiKey: credential });
+  isOAuthMode = isOAuth;
+  currentToken = credential;
   teamId = team;
   teamIds = team.split(',').map(id => id.trim()).filter(Boolean);
   setLinearClient(client);
   console.log(`[Linear] Client initialized (${isOAuth ? 'OAuth' : 'apiKey'})`);
+}
+
+/**
+ * Keep the Linear OAuth token fresh for a long-running daemon. No-op for API-key
+ * mode. Called before each heartbeat fetch: ensureValidToken refreshes the token
+ * when it's near expiry, and if it changed we rebuild the client (LinearClient
+ * holds the token at construction). Best-effort — failures are logged, not thrown,
+ * so a transient refresh error doesn't crash the heartbeat.
+ */
+export async function ensureLinearAuthFresh(): Promise<void> {
+  if (!isOAuthMode || !client) return;
+  try {
+    const { AuthProfileStore, ensureValidToken } = await import('../auth/index.js');
+    const token = await ensureValidToken(new AuthProfileStore(), 'linear:default');
+    if (token !== currentToken) {
+      client = new LinearClient({ accessToken: token });
+      currentToken = token;
+      setLinearClient(client);
+      console.log('[Linear] OAuth token refreshed — client reinitialized');
+    }
+  } catch (err) { // cxt-ignore: error_swallow,exception_hiding — best-effort; logged, must not crash the heartbeat
+    console.error(`[Linear] OAuth refresh failed: ${(err as Error).message}`);
+  }
 }
 
 /**

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -195,6 +195,40 @@ export function getClient(): LinearClient {
   return client;
 }
 
+/** Linear team summary for the `openswarm init` picker. */
+export interface LinearTeamInfo {
+  id: string;
+  key: string;
+  name: string;
+}
+
+/**
+ * List all Linear teams the API key can see — for the `openswarm init` picker.
+ * Accepts an explicit apiKey so init can call it before initLinear() runs (the
+ * user has only just pasted the key); falls back to the initialized client.
+ */
+export async function listTeams(apiKey?: string): Promise<LinearTeamInfo[]> {
+  const c = apiKey ? new LinearClient({ apiKey }) : getClient();
+  const res: any = await withRateLimit('linear', () => c.teams({ first: 250 })); // cxt-ignore: type_safety — SDK TeamConnection
+  return (res?.nodes ?? []).map((t: any) => ({ id: t.id, key: t.key, name: t.name }));
+}
+
+/**
+ * List projects within a team — for the `openswarm init` picker. Accepts an
+ * explicit apiKey so init can call it before initLinear() runs.
+ */
+export async function listProjects(teamId: string, apiKey?: string): Promise<LinearProjectInfo[]> {
+  const c = apiKey ? new LinearClient({ apiKey }) : getClient();
+  const team: any = await withRateLimit('linear', () => c.team(teamId)); // cxt-ignore: type_safety — SDK Team
+  const res: any = await withRateLimit('linear', () => team.projects({ first: 250 }));
+  return (res?.nodes ?? []).map((p: any) => ({
+    id: p.id,
+    name: p.name,
+    icon: p.icon ?? undefined,
+    color: p.color ?? undefined,
+  }));
+}
+
 /**
  * Get in-progress issues for an agent (with caching)
  */

--- a/src/support/banner.ts
+++ b/src/support/banner.ts
@@ -1,0 +1,35 @@
+// ============================================
+// OpenSwarm - ASCII banner (figlet "Standard" + honey gradient 🐝)
+// ============================================
+
+import { c } from './colors.js';
+
+// figlet "Standard" of "OpenSwarm" (exact, JS-escaped).
+const LOGO_LINES = [
+  '   ___                   ____                              ',
+  '  / _ \\ _ __   ___ _ __ / ___|_      ____ _ _ __ _ __ ___  ',
+  " | | | | '_ \\ / _ \\ '_ \\\\___ \\ \\ /\\ / / _` | '__| '_ ` _ \\ ",
+  ' | |_| | |_) |  __/ | | |___) \\ V  V / (_| | |  | | | | | |',
+  '  \\___/| .__/ \\___|_| |_|____/ \\_/\\_/ \\__,_|_|  |_| |_| |_|',
+  '       |_|                                                 ',
+];
+
+// Honey/amber gradient, top→bottom (bee theme).
+const GRADIENT: Array<[number, number, number]> = [
+  [255, 213, 79],
+  [255, 193, 7],
+  [255, 167, 38],
+  [251, 140, 0],
+  [245, 124, 0],
+  [230, 81, 0],
+];
+
+/**
+ * Render the OpenSwarm banner. Gradient-colored logo + subtitle. Colors are
+ * auto-stripped on non-TTY / NO_COLOR (see colors.ts), so this is safe to print
+ * unconditionally.
+ */
+export function banner(subtitle = 'autonomous agent orchestrator'): string {
+  const logo = LOGO_LINES.map((ln, i) => c.rgb(...GRADIENT[i % GRADIENT.length])(ln)).join('\n');
+  return `\n${logo}\n   ${c.yellow('🐝')} ${c.bold(c.cyan(subtitle))}\n`;
+}

--- a/src/support/colors.ts
+++ b/src/support/colors.ts
@@ -1,0 +1,31 @@
+// ============================================
+// OpenSwarm - Terminal color helpers (zero-dependency ANSI)
+// ============================================
+//
+// Honors NO_COLOR and non-TTY output (pipes/CI) — colors are stripped so logs
+// stay clean when redirected. Used by CLI commands (init, doctor, …).
+
+const useColor = !!process.stdout.isTTY && !process.env.NO_COLOR;
+
+const wrap =
+  (open: number, close: number) =>
+  (s: string): string =>
+    useColor ? `\x1b[${open}m${s}\x1b[${close}m` : s;
+
+export const c = {
+  enabled: useColor,
+  bold: wrap(1, 22),
+  dim: wrap(2, 22),
+  red: wrap(31, 39),
+  green: wrap(32, 39),
+  yellow: wrap(33, 39),
+  blue: wrap(34, 39),
+  magenta: wrap(35, 39),
+  cyan: wrap(36, 39),
+  gray: wrap(90, 39),
+  /** 24-bit truecolor foreground (for the banner gradient). */
+  rgb:
+    (r: number, g: number, b: number) =>
+    (s: string): string =>
+      useColor ? `\x1b[38;2;${r};${g};${b}m${s}\x1b[39m` : s,
+};

--- a/src/support/rateLimiter.ts
+++ b/src/support/rateLimiter.ts
@@ -279,6 +279,12 @@ export async function withRateLimit<T>(
   service: 'claude' | 'linear' | 'github',
   operation: () => Promise<T>
 ): Promise<T> {
+  // Limiters are set up by the daemon (initRateLimiters). One-off CLI commands
+  // (init, auth) never call that, so fall back to running the operation directly
+  // instead of throwing "No limiter configured".
+  if (!limiters.has(service)) {
+    return operation();
+  }
   await acquireRateLimit(service);
   return operation();
 }

--- a/src/support/repoMetadata.test.ts
+++ b/src/support/repoMetadata.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { loadRepoMetadata, REPO_METADATA_FILENAME, RepoMetadataError } from './repoMetadata.js';
+import { loadRepoMetadata, saveRepoMetadata, REPO_METADATA_FILENAME, RepoMetadataError } from './repoMetadata.js';
 
 describe('loadRepoMetadata', () => {
   let dir: string;
@@ -67,5 +67,41 @@ describe('loadRepoMetadata', () => {
       }),
     );
     await expect(loadRepoMetadata(dir)).rejects.toBeInstanceOf(RepoMetadataError);
+  });
+});
+
+describe('saveRepoMetadata', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'openswarm-meta-save-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('round-trips a Linear mapping through loadRepoMetadata', async () => {
+    const meta = {
+      schemaVersion: 1 as const,
+      projectName: 'OpenSwarm',
+      linear: {
+        teamId: '49b7af95-3cac-4a56-adc7-f19d77dfbe9b',
+        teamKey: 'INT',
+        projectId: '74a9d092-7b3c-4d4d-a998-a2c9a8f08e83',
+        projectName: 'OpenSwarm',
+      },
+    };
+    const filePath = await saveRepoMetadata(dir, meta);
+    expect(filePath).toBe(join(dir, REPO_METADATA_FILENAME));
+    await expect(loadRepoMetadata(dir)).resolves.toEqual(meta);
+  });
+
+  it('rejects an invalid mapping (non-uuid projectId) without writing', async () => {
+    await expect(
+      // projectId is a string at the type level; the uuid check is runtime (zod).
+      saveRepoMetadata(dir, { schemaVersion: 1, linear: { projectId: 'not-a-uuid' } }),
+    ).rejects.toThrow();
+    await expect(loadRepoMetadata(dir)).resolves.toBeNull();
   });
 });

--- a/src/support/repoMetadata.ts
+++ b/src/support/repoMetadata.ts
@@ -7,7 +7,7 @@
 // (Linear today, GitHub/etc later) and removes the need for fuzzy
 // name matching, which silently breaks on renames or ambiguous names.
 
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { z } from 'zod';
 
@@ -82,6 +82,19 @@ export async function loadRepoMetadata(repoPath: string): Promise<RepoMetadata |
     );
   }
   return result.data;
+}
+
+/**
+ * Write `${repoPath}/openswarm.json`. Validates against the schema first so we
+ * never persist a malformed mapping. Returns the written file path.
+ * Used by `openswarm init` to record the repo ↔ Linear team/project mapping the
+ * user picked, so the daemon resolves this repo without fuzzy name matching.
+ */
+export async function saveRepoMetadata(repoPath: string, meta: RepoMetadata): Promise<string> {
+  const validated = RepoMetadataSchema.parse(meta);
+  const filePath = join(repoPath, REPO_METADATA_FILENAME);
+  await writeFile(filePath, `${JSON.stringify(validated, null, 2)}\n`, 'utf-8');
+  return filePath;
 }
 
 export class RepoMetadataError extends Error {


### PR DESCRIPTION
INT-1808 wizard body (fresh-install onboarding, "second gate"). Picker mechanism = `@inquirer/prompts` (decided); Claude = CLI detect/login guidance (decided).

## What
- **`@inquirer/prompts`** arrow-key UI replaces the readline number menu in `openswarm init`.
- **`linear.ts`** — new `listTeams()` / `listProjects(teamId)` wrappers (`client.teams()` / `team.projects()`), accepting an explicit `apiKey` so init can enumerate before `initLinear()` runs.
- **`repoMetadata.ts`** — new `saveRepoMetadata()` writes repo-root `openswarm.json` (the repo→Linear mapping the daemon reads, no fuzzy matching), schema-validated.
- **`initWizard.ts` rewrite:**
  - Linear backend: paste API key (hidden) → **multi-select teams** → pick **THIS repo's project** → writes `LINEAR_*` env + `openswarm.json`. Manual team-id fallback if the API is unreachable.
  - Provider "already configured?" now uses **`adapter.isAvailable()`** (env keys, OAuth profiles, PATH binaries, local servers) instead of OAuth-profile-only.
  - **`claude`** added as an opt-in provider with CLI **detect/login guidance** (no Anthropic OAuth — the `claude -p` wrapper restored in INT-1574).

## Tests
- `saveRepoMetadata` round-trip through `loadRepoMetadata` + invalid-mapping rejection.
- Full suite: **50 files / 836 tests**, typecheck clean, cxt BS clean.
- ⚠️ The interactive wizard flow itself needs **manual TTY verification** (`@inquirer` requires a TTY; `buildWizardConfig` and the Linear/repo helpers are unit-covered).

## Context (deep-thinking on INT-1808)
- Native modules (`better-sqlite3@12`, `@lancedb/lancedb@0.23`) verified **not** a fresh-install blocker on `node:22-slim` (prebuilt, no toolchain).
- README provider onboarding fixed separately (PR #78). `openswarm doctor` split to **INT-1829**. Release to npm (**INT-1702**) remains the real prerequisite for any of this to reach users — tracked, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)