### PR TITLE
chore(release): v0.8.0 — codex --sandbox fix (INT-1702)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "GPL-3.0",
   "type": "module",

--- a/src/adapters/codex.test.ts
+++ b/src/adapters/codex.test.ts
@@ -4,7 +4,7 @@ import { CodexCliAdapter, coerceCodexModel } from './codex.js';
 describe('CodexCliAdapter', () => {
   const adapter = new CodexCliAdapter();
 
-  it('builds a codex exec command with full-auto json mode', () => {
+  it('builds a codex exec command with sandbox json mode', () => {
     const { command } = adapter.buildCommand({
       prompt: '/tmp/prompt.txt',
       cwd: '/tmp/project',
@@ -13,7 +13,9 @@ describe('CodexCliAdapter', () => {
 
     expect(command).toContain('codex exec');
     expect(command).toContain('--json');
-    expect(command).toContain('--full-auto');
+    // --full-auto was deprecated in codex 0.137 → --sandbox workspace-write (INT-1699)
+    expect(command).toContain('--sandbox workspace-write');
+    expect(command).not.toContain('--full-auto');
     expect(command).toContain('--skip-git-repo-check');
     expect(command).toContain("-m 'gpt-5-codex'");
   });

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -65,7 +65,10 @@ export class CodexCliAdapter implements CliAdapter {
     const promptFile = options.prompt;
     const resolvedModel = options.model ? coerceCodexModel(options.model) : undefined;
     const modelFlag = resolvedModel ? ` -m ${shellEscape(resolvedModel)}` : '';
-    const cmd = `cat ${shellEscape(promptFile)} | codex exec --json --full-auto --skip-git-repo-check${modelFlag}`;
+    // `--full-auto` was deprecated in codex 0.137 (warns, still runs). Its documented
+    // replacement is `--sandbox workspace-write`: same low-friction policy (writes
+    // confined to the workspace, no approval prompts in non-interactive `exec`). (INT-1699)
+    const cmd = `cat ${shellEscape(promptFile)} | codex exec --json --sandbox workspace-write --skip-git-repo-check${modelFlag}`;
     return { command: cmd, args: [] };
   }
 


### PR DESCRIPTION
Release the stabilized main to npm (latest stuck at 0.5.0). Strategy: ship main + cherry-pick only the **critical** feat work; defer the full 88-file two-way merge.

## Changes
- **codex.ts**: `--full-auto` (deprecated in codex 0.137) → `--sandbox workspace-write`. The critical bit of INT-1699 from feat/v0.7.0.
- **version** 0.7.0 → 0.8.0.
- codex.test asserts `--sandbox`.

## What main already has (this session)
R1–R7 autonomy hardening (INT-1809/1810/1812), onboarding wizard + Linear OAuth + doctor + banner (INT-1808/1829).

## Deferred (feat/v0.7.0 unique, follow-up PRs)
`/goal` routing (INT-1603), backlog grooming (INT-1609), reviewer follow-ups (INT-1611/1613), worker audit trail (INT-1612), codex error-surfacing (rest of INT-1699). feat is 88-file two-way diverged — a full merge is its own task.

838 tests green; ready to tag v0.8.0 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)