### PR TITLE
feat(linear): scannable formatter for OpenSwarm's Linear comments & issues (INT-1845)

### DIFF
--- a/src/__tests__/workerAuditLog.test.ts
+++ b/src/__tests__/workerAuditLog.test.ts
@@ -19,13 +19,15 @@ describe('workerAuditLog', () => {
         maxTurns: 20,
       });
 
-      expect(body).toContain('Worker Instruction');
+      expect(body).toContain('Worker instruction');
       expect(body).toContain('attempt #1/3');
       expect(body).toContain('Add logout button');
       expect(body).toContain('Wire a logout action');
       expect(body).toContain('`src/header.tsx`');
       expect(body).toContain('claude-opus-4-8');
-      expect(body).toContain('max turns 20');
+      expect(body).toContain('Max turns: 20');
+      // Convention: no decorative emoji in comment bodies.
+      expect(body).not.toMatch(/[🛠️🤖✅❌⚠️📋]/u);
     });
 
     it('labels revisions and survives missing optional fields', () => {
@@ -35,7 +37,7 @@ describe('workerAuditLog', () => {
         isRevision: true,
       });
 
-      expect(body).toContain('Worker Revision');
+      expect(body).toContain('Worker revision');
       expect(body).toContain('attempt #2');
       expect(body).not.toContain('Target files');
       expect(body).not.toContain('Effort');
@@ -65,13 +67,14 @@ describe('workerAuditLog', () => {
         durationSec: 75,
       });
 
-      expect(body).toContain('Worker Actions — Done');
+      expect(body).toContain('Worker actions — Done');
       expect(body).toContain('Implemented the endpoint');
       expect(body).toContain('Files changed (1)');
       expect(body).toContain('`src/api.ts`');
       expect(body).toContain('Commands (1)');
       expect(body).toContain('88%');
       expect(body).toContain('1m 15s');
+      expect(body).not.toMatch(/[🛠️🤖✅❌⚠️📋]/u);
     });
 
     it('surfaces halt reason with a warning verdict', () => {
@@ -81,7 +84,7 @@ describe('workerAuditLog', () => {
       });
 
       expect(body).toContain('Halted');
-      expect(body).toContain('Halt reason:');
+      expect(body).toContain('Halt reason');
       expect(body).toContain('Confidence too low');
     });
 
@@ -92,7 +95,7 @@ describe('workerAuditLog', () => {
       });
 
       expect(body).toContain('Failed');
-      expect(body).toContain('Error:');
+      expect(body).toContain('Error');
       expect(body).toContain('compile error');
     });
   });

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -21,6 +21,7 @@ import type { SubTask } from '../support/planner.js';
 import { analyzeIssue } from '../knowledge/index.js';
 import { runDraftAnalysis, type DraftAnalysis } from '../agents/draftAnalyzer.js';
 import { t } from '../locale/index.js';
+import { formatTaskDescription } from '../linear/format.js';
 import { broadcastEvent } from '../core/eventHub.js';
 import type { Notifier } from '../notify/notifier.js';
 import type { ITaskSource } from './taskSource.js';
@@ -255,18 +256,15 @@ export async function createSubIssuesWithDependencies(
   }> = [];
 
   for (const [index, subTask] of subTasks.entries()) {
-    const depsStr = subTask.dependencies?.length
-      ? `\n\n${t('runner.decomposition.prerequisite', { deps: subTask.dependencies.join(', ') })}`
-      : '';
-
     const fileScope = (subTask.fileScope ?? []).filter((f) => typeof f === 'string' && f.trim().length > 0);
-    const scopeStr = fileScope.length
-      ? `\n\nFile scope: ${fileScope.join(', ')}`
-      : '';
 
-    const subDescription = `${subTask.description}\n\n` +
-      `${t('runner.decomposition.estimatedTime', { n: String(subTask.estimatedMinutes) })}${depsStr}${scopeStr}\n\n` +
-      t('runner.decomposition.autoDecomposed', { parentTitle: task.title });
+    const subDescription = formatTaskDescription({
+      summary: subTask.description,
+      dependsOn: subTask.dependencies,
+      fileScope,
+      estimateMinutes: subTask.estimatedMinutes,
+      parentTitle: task.title,
+    });
 
     const subResult = taskSource
       ? await taskSource.createSubIssue(parentIssueId, subTask.title, subDescription, {

--- a/src/automation/workerAuditLog.ts
+++ b/src/automation/workerAuditLog.ts
@@ -8,6 +8,7 @@
 // the local SQLite task source (which writes addComment → addEvent). See INT-1612.
 
 import type { WorkerResult } from '../agents/agentPair.js';
+import { formatAutomationComment, type CommentSection } from '../linear/format.js';
 
 /** Caps so a chatty agent can't post a multi-MB comment. */
 const MAX_FILES = 20;
@@ -51,22 +52,20 @@ export function buildWorkerStartComment(info: WorkerStartInfo): string {
   const attemptLabel = info.maxAttempts
     ? `attempt #${info.attempt}/${info.maxAttempts}`
     : `attempt #${info.attempt}`;
-  const heading = info.isRevision ? 'Worker Revision' : 'Worker Instruction';
+  const heading = info.isRevision ? 'Worker revision' : 'Worker instruction';
 
-  const lines: string[] = [`🛠️ **[${heading}]** (${attemptLabel})`, ''];
-  lines.push(`**Task:** ${cap(info.taskTitle, 200)}`);
-  if (info.taskGoal) lines.push(`**Goal:** ${cap(info.taskGoal, GOAL_CAP)}`);
+  const sections: CommentSection[] = [{ label: 'Task', body: cap(info.taskTitle, 200) }];
+  if (info.taskGoal) sections.push({ label: 'Goal', body: cap(info.taskGoal, GOAL_CAP) });
   if (info.targetFiles && info.targetFiles.length > 0) {
-    lines.push(`**Target files:** ${codeList(info.targetFiles, MAX_FILES)}`);
+    sections.push({ label: 'Target files', body: codeList(info.targetFiles, MAX_FILES) });
   }
 
-  const budget: string[] = [];
-  if (info.model) budget.push(`model \`${info.model}\``);
-  if (info.maxTurns) budget.push(`max turns ${info.maxTurns}`);
-  if (budget.length > 0) lines.push(`**Effort:** ${budget.join(' · ')}`);
-
-  lines.push('', '---', '_Auto-generated audit log_');
-  return lines.join('\n');
+  return formatAutomationComment({
+    heading: `${heading} (${attemptLabel})`,
+    sections,
+    meta: { Model: info.model, 'Max turns': info.maxTurns },
+    attribution: 'Worker audit log',
+  });
 }
 
 export interface WorkerCompleteInfo {
@@ -83,30 +82,32 @@ export function buildWorkerCompleteComment(info: WorkerCompleteInfo): string {
   const attemptLabel = info.maxAttempts
     ? `attempt #${info.attempt}/${info.maxAttempts}`
     : `attempt #${info.attempt}`;
-  const icon = result.haltReason ? '⚠️' : result.success ? '✅' : '❌';
   const verdict = result.haltReason ? 'Halted' : result.success ? 'Done' : 'Failed';
 
-  const lines: string[] = [`${icon} **[Worker Actions — ${verdict}]** (${attemptLabel})`, ''];
-  if (result.summary) lines.push(`**Summary:** ${cap(result.summary, SUMMARY_CAP)}`);
-
   const files = result.filesChanged ?? [];
-  lines.push(`**Files changed (${files.length}):** ${codeList(files, MAX_FILES)}`);
-
   const commands = result.commands ?? [];
+
+  const sections: CommentSection[] = [
+    { label: `Files changed (${files.length})`, body: codeList(files, MAX_FILES) },
+  ];
   if (commands.length > 0) {
-    lines.push(`**Commands (${commands.length}):** ${codeList(commands, MAX_COMMANDS)}`);
+    sections.push({ label: `Commands (${commands.length})`, body: codeList(commands, MAX_COMMANDS) });
   }
+  if (result.haltReason) sections.push({ label: 'Halt reason', body: cap(result.haltReason, GOAL_CAP) });
+  if (result.error) sections.push({ label: 'Error', body: cap(result.error, GOAL_CAP) });
 
-  if (result.confidencePercent != null) {
-    lines.push(`**Confidence:** ${result.confidencePercent}%`);
-  }
-  if (info.durationSec != null) {
-    const d = info.durationSec;
-    lines.push(`**Duration:** ${d < 60 ? `${d}s` : `${Math.floor(d / 60)}m ${d % 60}s`}`);
-  }
-  if (result.haltReason) lines.push(`**Halt reason:** ${cap(result.haltReason, GOAL_CAP)}`);
-  if (result.error) lines.push(`**Error:** ${cap(result.error, GOAL_CAP)}`);
+  const duration = info.durationSec != null
+    ? (info.durationSec < 60 ? `${info.durationSec}s` : `${Math.floor(info.durationSec / 60)}m ${info.durationSec % 60}s`)
+    : undefined;
 
-  lines.push('', '---', '_Auto-generated audit log_');
-  return lines.join('\n');
+  return formatAutomationComment({
+    heading: `Worker actions — ${verdict} (${attemptLabel})`,
+    summary: result.summary ? cap(result.summary, SUMMARY_CAP) : undefined,
+    sections,
+    meta: {
+      Confidence: result.confidencePercent != null ? `${result.confidencePercent}%` : undefined,
+      Duration: duration,
+    },
+    attribution: 'Worker audit log',
+  });
 }

--- a/src/linear/format.test.ts
+++ b/src/linear/format.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isoDate,
+  codeRef,
+  formatAutomationComment,
+  formatIssueDescription,
+  formatTaskDescription,
+} from './format.js';
+
+describe('linear/format', () => {
+  describe('isoDate', () => {
+    it('renders an absolute YYYY-MM-DD date', () => {
+      expect(isoDate(new Date('2026-06-23T13:33:00Z'))).toBe('2026-06-23');
+    });
+  });
+
+  describe('codeRef', () => {
+    it('joins file and line, or returns the path alone', () => {
+      expect(codeRef('src/a.ts', 42)).toBe('src/a.ts:42');
+      expect(codeRef('src/a.ts')).toBe('src/a.ts');
+    });
+  });
+
+  describe('formatAutomationComment', () => {
+    it('leads with a bold conclusion-first heading and a footer with absolute date', () => {
+      const body = formatAutomationComment({
+        heading: 'Task complete',
+        date: new Date('2026-06-23T00:00:00Z'),
+      });
+      expect(body.startsWith('**Task complete**')).toBe(true);
+      expect(body).toContain('Automated by OpenSwarm · 2026-06-23');
+    });
+
+    it('renders string bodies as paragraphs and array bodies as bullet lists', () => {
+      const body = formatAutomationComment({
+        heading: 'Revision requested',
+        summary: 'Worker will revise.',
+        sections: [
+          { label: 'Feedback', body: 'Fix the null guard' },
+          { label: 'Issues', body: ['missing test', 'wrong path'] },
+        ],
+      });
+      expect(body).toContain('**Feedback**\nFix the null guard');
+      expect(body).toContain('**Issues**\n- missing test\n- wrong path');
+    });
+
+    it('drops empty sections and empty meta values', () => {
+      const body = formatAutomationComment({
+        heading: 'Work complete',
+        sections: [{ label: 'Empty', body: [] }, { label: 'Kept', body: 'x' }],
+        meta: { Agent: 'main', Skipped: undefined, Blank: '' },
+      });
+      expect(body).not.toContain('**Empty**');
+      expect(body).toContain('**Kept**');
+      expect(body).toContain('Agent: main');
+      expect(body).not.toContain('Skipped');
+      expect(body).not.toContain('Blank');
+    });
+
+    it('uses a custom attribution and carries no decorative emoji', () => {
+      const body = formatAutomationComment({
+        heading: 'Task complete',
+        sections: [{ label: 'Worker', body: 'done' }],
+        attribution: 'Worker/Reviewer/Tester pipeline',
+      });
+      expect(body).toContain('Worker/Reviewer/Tester pipeline ·');
+      expect(body).not.toMatch(/[🤖✅❌⚠️📋🔨🧪]/u);
+    });
+  });
+
+  describe('formatIssueDescription', () => {
+    it('emits Problem/Cause/Solution/Verification in order, omitting empties', () => {
+      const body = formatIssueDescription({
+        problem: 'crashes on start',
+        solution: 'guard the null',
+      });
+      expect(body).toBe('**Problem** — crashes on start\n\n**Solution** — guard the null');
+      expect(body).not.toContain('Cause');
+    });
+  });
+
+  describe('formatTaskDescription', () => {
+    it('builds summary + scannable facts + attribution footer', () => {
+      const body = formatTaskDescription({
+        summary: 'Add a logout button',
+        dependsOn: ['INT-100'],
+        fileScope: ['src/header.tsx'],
+        estimateMinutes: 20,
+        parentTitle: 'Auth epic',
+      });
+      expect(body.startsWith('Add a logout button')).toBe(true);
+      expect(body).toContain('- Depends on: INT-100');
+      expect(body).toContain('- File scope: src/header.tsx');
+      expect(body).toContain('- Estimate: 20 min');
+      expect(body).toContain('_Auto-decomposed from "Auth epic" by Planner_');
+    });
+
+    it('omits optional blocks when absent', () => {
+      const body = formatTaskDescription({ summary: 'Just do it' });
+      expect(body).toBe('Just do it');
+    });
+  });
+});

--- a/src/linear/format.ts
+++ b/src/linear/format.ts
@@ -1,0 +1,145 @@
+// ============================================
+// OpenSwarm — Linear output formatter
+// ============================================
+//
+// Implements the scannable-update convention used across the workspace
+// (conclusion-first, structured bullets, code references, absolute dates,
+// and NO decorative emoji in issue/comment bodies). Structure — not emoji —
+// carries the scannability.
+//
+// Pure string builders: no I/O, no side effects. This keeps the rules in one
+// place and makes the formatting unit-testable.
+
+/** Absolute date `YYYY-MM-DD` — bodies never use relative or full-ISO dates. */
+export function isoDate(d: Date = new Date()): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/** A `file:line` code reference (or just the path when no line is given). */
+export function codeRef(file: string, line?: number): string {
+  return line != null ? `${file}:${line}` : file;
+}
+
+const BULLET = '- ';
+
+/** Render a section body: a string becomes a paragraph, an array becomes a bullet list. */
+function renderBody(body: string | string[]): string {
+  if (Array.isArray(body)) {
+    return body
+      .filter((line) => line && line.trim())
+      .map((line) => `${BULLET}${line}`)
+      .join('\n');
+  }
+  return body.trim();
+}
+
+export interface CommentSection {
+  /** Bold sub-label, e.g. "Worker". Rendered as `**label**`. */
+  label: string;
+  /** Body under the label — string → paragraph, array → bullet list. */
+  body: string | string[];
+}
+
+export interface AutomationCommentInput {
+  /** Conclusion-first heading, e.g. "Task complete". Rendered bold. */
+  heading: string;
+  /** Optional one-line TL;DR directly under the heading. */
+  summary?: string;
+  /** Structured sections — empty ones are dropped. */
+  sections?: CommentSection[];
+  /** Footer key→value facts (session, attempts, …), joined on one muted line. */
+  meta?: Record<string, string | number | undefined>;
+  /** Footer attribution. Default: "Automated by OpenSwarm". */
+  attribution?: string;
+  /** Footer date (absolute). Defaults to today. */
+  date?: Date;
+}
+
+/**
+ * Build a scannable automation comment: bold conclusion-first heading, optional
+ * TL;DR, structured sections, and a single muted footer line (facts + attribution
+ * + absolute date). No decorative emoji in the body.
+ */
+export function formatAutomationComment(input: AutomationCommentInput): string {
+  const parts: string[] = [`**${input.heading}**`];
+
+  if (input.summary?.trim()) parts.push(input.summary.trim());
+
+  for (const section of input.sections ?? []) {
+    const rendered = renderBody(section.body);
+    if (rendered) parts.push(`**${section.label}**\n${rendered}`);
+  }
+
+  const facts = input.meta
+    ? Object.entries(input.meta)
+        .filter(([, v]) => v !== undefined && v !== '')
+        .map(([k, v]) => `${k}: ${v}`)
+    : [];
+  facts.push(`${input.attribution ?? 'Automated by OpenSwarm'} · ${isoDate(input.date)}`);
+
+  return `${parts.join('\n\n')}\n\n---\n${facts.join(' · ')}`;
+}
+
+export interface IssueDescriptionInput {
+  problem?: string;
+  cause?: string;
+  solution?: string;
+  verification?: string;
+}
+
+/**
+ * Build a bug/work issue description in the Problem / Cause / Solution /
+ * Verification layout. Empty sections are omitted.
+ */
+export function formatIssueDescription(input: IssueDescriptionInput): string {
+  const order: [keyof IssueDescriptionInput, string][] = [
+    ['problem', 'Problem'],
+    ['cause', 'Cause'],
+    ['solution', 'Solution'],
+    ['verification', 'Verification'],
+  ];
+  return order
+    .filter(([key]) => input[key]?.trim())
+    .map(([key, label]) => `**${label}** — ${input[key]!.trim()}`)
+    .join('\n\n');
+}
+
+export interface TaskDescriptionInput {
+  /** One-line (or short) summary of the sub-task. */
+  summary: string;
+  scope?: string[];
+  verify?: string[];
+  dependsOn?: string[];
+  fileScope?: string[];
+  estimateMinutes?: number;
+  /** Parent title for the auto-decomposition attribution footer. */
+  parentTitle?: string;
+}
+
+/**
+ * Build a decomposition sub-issue description: a summary, then scannable
+ * Scope / Verify sections and a facts list (depends-on, file scope, estimate),
+ * with an attribution footer.
+ */
+export function formatTaskDescription(input: TaskDescriptionInput): string {
+  const parts: string[] = [input.summary.trim()];
+
+  if (input.scope?.length) {
+    parts.push(`**Scope**\n${input.scope.map((s) => `${BULLET}${s}`).join('\n')}`);
+  }
+  if (input.verify?.length) {
+    parts.push(`**Verify**\n${input.verify.map((s) => `${BULLET}${s}`).join('\n')}`);
+  }
+
+  const facts: string[] = [];
+  if (input.dependsOn?.length) facts.push(`Depends on: ${input.dependsOn.join(', ')}`);
+  if (input.fileScope?.length) facts.push(`File scope: ${input.fileScope.join(', ')}`);
+  if (input.estimateMinutes != null) facts.push(`Estimate: ${input.estimateMinutes} min`);
+  if (facts.length) parts.push(facts.map((f) => `${BULLET}${f}`).join('\n'));
+
+  let body = parts.join('\n\n');
+  if (input.parentTitle) {
+    body += `\n\n---\n_Auto-decomposed from "${input.parentTitle}" by Planner_`;
+  }
+  return body;
+}

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -4,7 +4,7 @@
 
 import { LinearClient } from '@linear/sdk';
 import type { LinearIssueInfo, LinearProjectInfo } from '../core/types.js';
-import { getDateLocale } from '../locale/index.js';
+import { formatAutomationComment, type CommentSection } from './format.js';
 import { setLinearClient } from './projectUpdater.js';
 import { withRateLimit } from '../support/rateLimiter.js';
 
@@ -790,14 +790,23 @@ export async function addComment(
 export async function logHalt(
   issueId: string, sessionId: string, confidence: number, iteration: number, reason: string,
 ): Promise<void> {
-  await addComment(issueId,
-    `⚠️ **[Automation] HALT - Low Confidence**\n\nSession: \`${sessionId}\` | Confidence: ${confidence}% | Attempt: #${iteration}\nReason: ${reason}\n\n**Action Required:** Review task requirements / provide context / break into sub-tasks\n\n---\n_Auto-generated_`);
+  await addComment(issueId, formatAutomationComment({
+    heading: 'HALT — low confidence',
+    summary: `Confidence ${confidence}% is below threshold on attempt #${iteration}; manual input needed.`,
+    sections: [
+      { label: 'Reason', body: reason },
+      { label: 'Suggested next step', body: ['Review the task requirements', 'Provide more context', 'Break it into smaller sub-tasks'] },
+    ],
+    meta: { Session: sessionId, Confidence: `${confidence}%`, Attempt: `#${iteration}` },
+  }));
 }
 
 /** Log work start comment for an agent */
 export async function logWorkStart(issueId: string, sessionName: string): Promise<void> {
-  await addComment(issueId,
-    `🤖 **[${sessionName}] Work Started**\n\nTime: ${new Date().toISOString()}\n\n---\n_Auto-generated_`);
+  await addComment(issueId, formatAutomationComment({
+    heading: 'Work started',
+    meta: { Agent: sessionName },
+  }));
   await updateIssueState(issueId, 'In Progress');
 }
 
@@ -809,14 +818,11 @@ export async function logProgress(
   sessionName: string,
   progress: string
 ): Promise<void> {
-  const timestamp = new Date().toISOString();
-  const body = `🤖 **[${sessionName}] Progress Update**
-
-${progress}
-
-Time: ${timestamp}`;
-
-  await addComment(issueId, body);
+  await addComment(issueId, formatAutomationComment({
+    heading: 'Progress update',
+    summary: progress,
+    meta: { Agent: sessionName },
+  }));
 }
 
 /**
@@ -827,14 +833,11 @@ export async function logWorkComplete(
   sessionName: string,
   summary?: string
 ): Promise<void> {
-  const timestamp = new Date().toISOString();
-  const body = `🤖 **[${sessionName}] ✅ Work Complete**
-
-${summary ?? ''}
-
-Time: ${timestamp}`;
-
-  await addComment(issueId, body);
+  await addComment(issueId, formatAutomationComment({
+    heading: 'Work complete',
+    summary: summary?.trim() || undefined,
+    meta: { Agent: sessionName },
+  }));
   await updateIssueState(issueId, 'Done');
 }
 
@@ -846,16 +849,11 @@ export async function logBlocked(
   sessionName: string,
   reason: string
 ): Promise<void> {
-  const timestamp = new Date().toISOString();
-  const body = `🤖 **[${sessionName}] ⚠️ Blocked**
-
-Reason: ${reason}
-
-User intervention required
-
-Time: ${timestamp}`;
-
-  await addComment(issueId, body);
+  await addComment(issueId, formatAutomationComment({
+    heading: 'Blocked — user intervention required',
+    sections: [{ label: 'Reason', body: reason }],
+    meta: { Agent: sessionName },
+  }));
   // Use 'Todo' instead of 'Blocked' (Blocked state may not exist in team workflow)
   await updateIssueState(issueId, 'Todo');
 }
@@ -870,19 +868,11 @@ export async function logPairStart(
   sessionId: string,
   projectPath: string
 ): Promise<void> {
-  const timestamp = new Date().toLocaleString(getDateLocale());
-  const body = `👥 **[Pair Session] Work Started**
-
-🆔 Session: \`${sessionId}\`
-📁 Project: \`${projectPath}\`
-⏰ Time: ${timestamp}
-
-Starting work in Worker/Reviewer pair mode.
-
----
-_Auto-generated_`;
-
-  await addComment(issueId, body);
+  await addComment(issueId, formatAutomationComment({
+    heading: 'Pair session started',
+    summary: 'Starting work in Worker/Reviewer pair mode.',
+    meta: { Session: sessionId, Project: projectPath },
+  }));
   await updateIssueState(issueId, 'In Progress');
 }
 
@@ -894,16 +884,11 @@ export async function logPairReview(
   sessionId: string,
   attempt: number
 ): Promise<void> {
-  const timestamp = new Date().toLocaleString(getDateLocale());
-  const body = `🔍 **[Pair Session] Reviewing**
-
-🆔 Session: \`${sessionId}\`
-🔢 Attempt: #${attempt}
-⏰ Time: ${timestamp}
-
-Reviewer is reviewing Worker's output.`;
-
-  await addComment(issueId, body);
+  await addComment(issueId, formatAutomationComment({
+    heading: 'Reviewing',
+    summary: "Reviewer is evaluating the Worker's output.",
+    meta: { Session: sessionId, Attempt: `#${attempt}` },
+  }));
   await updateIssueState(issueId, 'In Review');
 }
 
@@ -916,24 +901,15 @@ export async function logPairRevision(
   feedback: string,
   issues: string[]
 ): Promise<void> {
-  const timestamp = new Date().toLocaleString(getDateLocale());
-  const issueList = issues.length > 0
-    ? issues.map((i, idx) => `${idx + 1}. ${i}`).join('\n')
-    : '(none)';
-
-  const body = `🔄 **[Pair Session] Revision Requested**
-
-🆔 Session: \`${sessionId}\`
-⏰ Time: ${timestamp}
-
-**Feedback:** ${feedback}
-
-**Issues:**
-${issueList}
-
-Worker will proceed with revisions.`;
-
-  await addComment(issueId, body);
+  await addComment(issueId, formatAutomationComment({
+    heading: 'Revision requested',
+    summary: 'Worker will proceed with revisions.',
+    sections: [
+      { label: 'Feedback', body: feedback },
+      { label: 'Issues', body: issues.length > 0 ? issues : ['(none)'] },
+    ],
+    meta: { Session: sessionId },
+  }));
   await updateIssueState(issueId, 'In Progress');
 }
 
@@ -960,95 +936,61 @@ export async function logPairComplete(
     remainingWork?: string;
   }
 ): Promise<void> {
-  const timestamp = new Date().toLocaleString(getDateLocale());
   const durationStr = stats.duration < 60
     ? `${stats.duration}s`
     : `${Math.floor(stats.duration / 60)}m ${stats.duration % 60}s`;
 
-  const filesStr = stats.filesChanged.length > 0
-    ? stats.filesChanged.slice(0, 10).map(f => `- \`${f}\``).join('\n')
-    : '(none)';
+  const sections: CommentSection[] = [];
 
-  // Build sections
-  const sections = [];
-
-  // Worker section
   if (stats.workerSummary) {
-    sections.push(`## 🔨 Worker Report
-
-**What was done:**
-${stats.workerSummary}`);
-
+    sections.push({ label: 'Worker', body: stats.workerSummary.trim() });
     if (stats.workerCommands && stats.workerCommands.length > 0) {
-      const cmdStr = stats.workerCommands.slice(0, 5).map(c => `- \`${c}\``).join('\n');
-      sections.push(`**Commands executed:**
-${cmdStr}`);
+      sections.push({ label: 'Commands', body: stats.workerCommands.slice(0, 5).map((c) => `\`${c}\``) });
     }
   }
 
-  // Reviewer section
   if (stats.reviewerFeedback) {
-    sections.push(`## ✅ Reviewer Report
-
-**Decision:** ${stats.reviewerDecision || 'APPROVE'}
-
-**Feedback:**
-${stats.reviewerFeedback}`);
+    sections.push({
+      label: `Reviewer — ${stats.reviewerDecision || 'APPROVE'}`,
+      body: stats.reviewerFeedback.trim(),
+    });
   }
 
-  // Tester section
   if (stats.testResults) {
     const { passed, failed, coverage, failedTests } = stats.testResults;
     const totalTests = passed + failed;
     const passRate = totalTests > 0 ? ((passed / totalTests) * 100).toFixed(1) : '0';
-
-    let testSection = `## 🧪 Test Results
-
-- ✅ Passed: ${passed}/${totalTests} (${passRate}%)`;
-
-    if (coverage !== undefined) {
-      testSection += `\n- 📊 Coverage: ${coverage.toFixed(1)}%`;
-    }
-
+    const lines = [`Passed ${passed}/${totalTests} (${passRate}%)`];
+    if (coverage !== undefined) lines.push(`Coverage ${coverage.toFixed(1)}%`);
     if (failed > 0 && failedTests && failedTests.length > 0) {
-      const failedStr = failedTests.slice(0, 3).map(t => `- ❌ ${t}`).join('\n');
-      testSection += `\n\n**Failed tests:**\n${failedStr}`;
-      if (failedTests.length > 3) {
-        testSection += `\n- ... and ${failedTests.length - 3} more`;
-      }
+      const extra = failedTests.length > 3 ? ` (+${failedTests.length - 3} more)` : '';
+      lines.push(`Failed: ${failedTests.slice(0, 3).join(', ')}${extra}`);
     }
-
-    sections.push(testSection);
+    sections.push({ label: 'Tests', body: lines });
   }
 
-  // Remaining work section
   if (stats.remainingWork) {
-    sections.push(`## 📋 Remaining Work
-
-${stats.remainingWork}`);
+    sections.push({ label: 'Remaining work', body: stats.remainingWork.trim() });
   }
 
-  const body = `✅ **[Automation] Task Complete**
+  sections.push({
+    label: 'Changed files',
+    body: stats.filesChanged.length > 0
+      ? stats.filesChanged.slice(0, 10).map((f) => `\`${f}\``)
+      : ['(none)'],
+  });
 
-🆔 Session: \`${sessionId}\`
-⏰ Completed: ${timestamp}
-
-**📊 Summary:**
-- 🔄 Iterations: ${stats.attempts}
-- ⏱️ Duration: ${durationStr}
-- 📁 Files changed: ${stats.filesChanged.length}
-
-**Changed files:**
-${filesStr}
-
----
-
-${sections.join('\n\n---\n\n')}
-
----
-_Automated by Worker/Reviewer/Tester pipeline_`;
-
-  await addComment(issueId, body);
+  await addComment(issueId, formatAutomationComment({
+    heading: 'Task complete',
+    sections,
+    meta: {
+      Session: sessionId,
+      Iterations: stats.attempts,
+      Duration: durationStr,
+      Files: stats.filesChanged.length,
+    },
+    attribution: 'Worker/Reviewer/Tester pipeline',
+  }));
   await updateIssueState(issueId, 'Done');
 }
 
@@ -1061,27 +1003,18 @@ export async function logPairFailed(
   reason: 'rejected' | 'max_attempts' | 'error',
   details: string
 ): Promise<void> {
-  const timestamp = new Date().toLocaleString(getDateLocale());
   const reasonText = {
-    rejected: '❌ Reviewer rejected the work',
-    max_attempts: '⚠️ Maximum retry attempts exceeded',
-    error: '💥 An error occurred',
+    rejected: 'Reviewer rejected the work',
+    max_attempts: 'Maximum retry attempts exceeded',
+    error: 'An error occurred',
   }[reason];
 
-  const body = `❌ **[Pair Session] Work Failed**
-
-🆔 Session: \`${sessionId}\`
-⏰ Time: ${timestamp}
-
-**Reason:** ${reasonText}
-
-**Details:**
-${details}
-
----
-_Manual intervention required_`;
-
-  await addComment(issueId, body);
+  await addComment(issueId, formatAutomationComment({
+    heading: 'Work failed — manual intervention required',
+    summary: reasonText,
+    sections: [{ label: 'Details', body: details }],
+    meta: { Session: sessionId },
+  }));
   // Don't change state on failure; let the user decide
 }
 
@@ -1226,21 +1159,15 @@ export async function markAsDecomposed(
   subIssueCount: number,
   totalMinutes: number
 ): Promise<void> {
-  const timestamp = new Date().toLocaleString(getDateLocale());
-  const body = `📋 **[Planner] Task Decomposition Complete**
-
-⏰ Time: ${timestamp}
-
-**Decomposition result:**
-- Sub-issues created: ${subIssueCount}
-- Total estimated time: ${totalMinutes}min
-
-This issue has been decomposed into sub-issues.
-The parent issue remains active while child issues execute.
-Once all sub-issues are completed, OpenSwarm will close this issue automatically.
-
----
-_Auto-decomposed by Planner agent_`;
+  const body = formatAutomationComment({
+    heading: 'Decomposed into sub-issues',
+    summary: 'The parent stays active while child issues execute; it closes automatically once all sub-issues complete.',
+    sections: [{
+      label: 'Result',
+      body: [`Sub-issues created: ${subIssueCount}`, `Total estimated time: ${totalMinutes} min`],
+    }],
+    attribution: 'Planner agent',
+  });
 
   await addComment(issueId, body);
 


### PR DESCRIPTION
## Summary

OpenSwarm now writes Linear comments and issues using the workspace **scannable-update convention**: conclusion-first headings, structured bullets, code references, absolute `YYYY-MM-DD` dates, and **no decorative emoji in bodies** (structure carries scannability).

- **New `src/linear/format.ts`** — pure, testable builders:
  - `formatAutomationComment` — bold conclusion-first heading + TL;DR + sections + one muted footer line (facts · attribution · date)
  - `formatIssueDescription` — Problem / Cause / Solution / Verification (empties omitted)
  - `formatTaskDescription` — decomposition sub-issues: summary + Scope/Verify + facts
  - `isoDate` / `codeRef` helpers
- **Rewired writers** — all `linear.ts` `log*` comment builders (work start/progress/complete, halt, blocked, pair start/review/revision/complete/failed, decomposed), decomposition sub-issue descriptions (`runnerExecution`), and the worker audit log (`workerAuditLog`) now go through the formatter. Dropped emoji + locale ISO timestamps.

## Before → after (completion comment)

Before: `✅ **[Automation] Task Complete**` · `🆔 Session…` · `⏰ Completed…` · `## 🔨 Worker Report` …
After:

```
**Task complete**

**Worker**
Implemented the logout endpoint…

**Tests**
- Passed 12/12 (100%)
- Coverage 87.4%

---
Session: pair-7a3f · Iterations: 2 · Duration: 3m 5s · Files: 2 · Worker/Reviewer/Tester pipeline · 2026-06-23
```

## Type of change

- [x] New feature (formatting)

## Checklist

- [x] `npm run lint` — 0 errors (changed files 0 warnings)
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` — 847 passing (added `format.test.ts`, updated `workerAuditLog.test.ts`)
- [x] Conventional Commits

Convention source: workspace `linear-format.md`. Output is English (repo standard). Status-update (§1) formatting deferred as follow-up.