### PR TITLE
refactor(linear): human-sounding automated Linear comments (INT-1845)

### DIFF
--- a/src/__tests__/workerAuditLog.test.ts
+++ b/src/__tests__/workerAuditLog.test.ts
@@ -25,7 +25,7 @@ describe('workerAuditLog', () => {
       expect(body).toContain('Wire a logout action');
       expect(body).toContain('`src/header.tsx`');
       expect(body).toContain('claude-opus-4-8');
-      expect(body).toContain('Max turns: 20');
+      expect(body).toContain('Max turns 20');
       // Convention: no decorative emoji in comment bodies.
       expect(body).not.toMatch(/[🛠️🤖✅❌⚠️📋]/u);
     });

--- a/src/linear/format.test.ts
+++ b/src/linear/format.test.ts
@@ -22,16 +22,16 @@ describe('linear/format', () => {
   });
 
   describe('formatAutomationComment', () => {
-    it('leads with a bold conclusion-first heading and a footer with absolute date', () => {
+    it('leads with a bold heading and a quiet italic sign-off with an absolute date', () => {
       const body = formatAutomationComment({
         heading: 'Task complete',
         date: new Date('2026-06-23T00:00:00Z'),
       });
       expect(body.startsWith('**Task complete**')).toBe(true);
-      expect(body).toContain('Automated by OpenSwarm · 2026-06-23');
+      expect(body).toContain('_via OpenSwarm · 2026-06-23_');
     });
 
-    it('renders string bodies as paragraphs and array bodies as bullet lists', () => {
+    it('keeps short facts inline and renders lists as bullets', () => {
       const body = formatAutomationComment({
         heading: 'Revision requested',
         summary: 'Worker will revise.',
@@ -40,8 +40,8 @@ describe('linear/format', () => {
           { label: 'Issues', body: ['missing test', 'wrong path'] },
         ],
       });
-      expect(body).toContain('**Feedback**\nFix the null guard');
-      expect(body).toContain('**Issues**\n- missing test\n- wrong path');
+      expect(body).toContain('**Feedback:** Fix the null guard');
+      expect(body).toContain('**Issues:**\n- missing test\n- wrong path');
     });
 
     it('drops empty sections and empty meta values', () => {
@@ -50,9 +50,9 @@ describe('linear/format', () => {
         sections: [{ label: 'Empty', body: [] }, { label: 'Kept', body: 'x' }],
         meta: { Agent: 'main', Skipped: undefined, Blank: '' },
       });
-      expect(body).not.toContain('**Empty**');
-      expect(body).toContain('**Kept**');
-      expect(body).toContain('Agent: main');
+      expect(body).not.toContain('**Empty');
+      expect(body).toContain('**Kept:** x');
+      expect(body).toContain('Agent main');
       expect(body).not.toContain('Skipped');
       expect(body).not.toContain('Blank');
     });
@@ -60,10 +60,10 @@ describe('linear/format', () => {
     it('uses a custom attribution and carries no decorative emoji', () => {
       const body = formatAutomationComment({
         heading: 'Task complete',
-        sections: [{ label: 'Worker', body: 'done' }],
+        sections: [{ label: 'Reviewer', body: 'looks good' }],
         attribution: 'Worker/Reviewer/Tester pipeline',
       });
-      expect(body).toContain('Worker/Reviewer/Tester pipeline ·');
+      expect(body).toContain('_Worker/Reviewer/Tester pipeline ·');
       expect(body).not.toMatch(/[🤖✅❌⚠️📋🔨🧪]/u);
     });
   });
@@ -92,7 +92,7 @@ describe('linear/format', () => {
       expect(body).toContain('- Depends on: INT-100');
       expect(body).toContain('- File scope: src/header.tsx');
       expect(body).toContain('- Estimate: 20 min');
-      expect(body).toContain('_Auto-decomposed from "Auth epic" by Planner_');
+      expect(body).toContain('_Split out from "Auth epic" during planning._');
     });
 
     it('omits optional blocks when absent', () => {

--- a/src/linear/format.ts
+++ b/src/linear/format.ts
@@ -2,13 +2,13 @@
 // OpenSwarm — Linear output formatter
 // ============================================
 //
-// Implements the scannable-update convention used across the workspace
-// (conclusion-first, structured bullets, code references, absolute dates,
-// and NO decorative emoji in issue/comment bodies). Structure — not emoji —
-// carries the scannability.
+// Writes Linear comments/issues the way an engineer would: a plain-language lead,
+// short facts kept inline, lists only where they help, and a quiet sign-off — not
+// a telemetry dump. Still scannable (conclusion first, code refs, absolute dates),
+// just without the robotic feel.
 //
-// Pure string builders: no I/O, no side effects. This keeps the rules in one
-// place and makes the formatting unit-testable.
+// Pure string builders: no I/O, no side effects, so the style lives in one place
+// and stays unit-testable.
 
 /** Absolute date `YYYY-MM-DD` — bodies never use relative or full-ISO dates. */
 export function isoDate(d: Date = new Date()): string {
@@ -22,43 +22,48 @@ export function codeRef(file: string, line?: number): string {
 
 const BULLET = '- ';
 
-/** Render a section body: a string becomes a paragraph, an array becomes a bullet list. */
-function renderBody(body: string | string[]): string {
-  if (Array.isArray(body)) {
-    return body
-      .filter((line) => line && line.trim())
-      .map((line) => `${BULLET}${line}`)
-      .join('\n');
-  }
-  return body.trim();
-}
-
 export interface CommentSection {
-  /** Bold sub-label, e.g. "Worker". Rendered as `**label**`. */
+  /** Short label, e.g. "Reviewer". */
   label: string;
-  /** Body under the label — string → paragraph, array → bullet list. */
+  /** A one-liner (kept inline), a multi-line note, or a list (rendered as bullets). */
   body: string | string[];
 }
 
+/**
+ * Render a section the way someone would jot it down: a short single-line fact
+ * goes inline (`**Label:** value`); a list or a multi-line note gets its own block.
+ */
+function renderSection(section: CommentSection): string {
+  if (Array.isArray(section.body)) {
+    const items = section.body.filter((line) => line && line.trim());
+    return items.length ? `**${section.label}:**\n${items.map((l) => `${BULLET}${l}`).join('\n')}` : '';
+  }
+  const text = section.body.trim();
+  if (!text) return '';
+  return text.includes('\n')
+    ? `**${section.label}:**\n${text}`
+    : `**${section.label}:** ${text}`;
+}
+
 export interface AutomationCommentInput {
-  /** Conclusion-first heading, e.g. "Task complete". Rendered bold. */
+  /** Short bold lead, e.g. "Task complete". */
   heading: string;
-  /** Optional one-line TL;DR directly under the heading. */
+  /** A natural one- or two-line summary in plain language — the voice of the comment. */
   summary?: string;
-  /** Structured sections — empty ones are dropped. */
+  /** Supporting details — empty ones are dropped. */
   sections?: CommentSection[];
-  /** Footer key→value facts (session, attempts, …), joined on one muted line. */
+  /** Trace facts for the quiet sign-off (session, attempts, …). */
   meta?: Record<string, string | number | undefined>;
-  /** Footer attribution. Default: "Automated by OpenSwarm". */
+  /** Sign-off attribution. Default: "via OpenSwarm". */
   attribution?: string;
-  /** Footer date (absolute). Defaults to today. */
+  /** Sign-off date (absolute). Defaults to today. */
   date?: Date;
 }
 
 /**
- * Build a scannable automation comment: bold conclusion-first heading, optional
- * TL;DR, structured sections, and a single muted footer line (facts + attribution
- * + absolute date). No decorative emoji in the body.
+ * Build a comment that reads like a person wrote it: bold lead, a plain-language
+ * summary, a few supporting details, and a single muted (italic) sign-off line
+ * carrying just enough trace to find the run later.
  */
 export function formatAutomationComment(input: AutomationCommentInput): string {
   const parts: string[] = [`**${input.heading}**`];
@@ -66,18 +71,21 @@ export function formatAutomationComment(input: AutomationCommentInput): string {
   if (input.summary?.trim()) parts.push(input.summary.trim());
 
   for (const section of input.sections ?? []) {
-    const rendered = renderBody(section.body);
-    if (rendered) parts.push(`**${section.label}**\n${rendered}`);
+    const rendered = renderSection(section);
+    if (rendered) parts.push(rendered);
   }
 
-  const facts = input.meta
-    ? Object.entries(input.meta)
-        .filter(([, v]) => v !== undefined && v !== '')
-        .map(([k, v]) => `${k}: ${v}`)
-    : [];
-  facts.push(`${input.attribution ?? 'Automated by OpenSwarm'} · ${isoDate(input.date)}`);
+  const trace: string[] = [];
+  const attribution = input.attribution ?? 'via OpenSwarm';
+  if (attribution) trace.push(attribution);
+  if (input.meta) {
+    for (const [key, value] of Object.entries(input.meta)) {
+      if (value !== undefined && value !== '') trace.push(`${key} ${value}`);
+    }
+  }
+  trace.push(isoDate(input.date));
 
-  return `${parts.join('\n\n')}\n\n---\n${facts.join(' · ')}`;
+  return `${parts.join('\n\n')}\n\n_${trace.join(' · ')}_`;
 }
 
 export interface IssueDescriptionInput {
@@ -112,23 +120,23 @@ export interface TaskDescriptionInput {
   dependsOn?: string[];
   fileScope?: string[];
   estimateMinutes?: number;
-  /** Parent title for the auto-decomposition attribution footer. */
+  /** Parent title for the auto-decomposition sign-off. */
   parentTitle?: string;
 }
 
 /**
  * Build a decomposition sub-issue description: a summary, then scannable
- * Scope / Verify sections and a facts list (depends-on, file scope, estimate),
- * with an attribution footer.
+ * Scope / Verify sections and a short facts list (depends-on, file scope,
+ * estimate), with a quiet sign-off.
  */
 export function formatTaskDescription(input: TaskDescriptionInput): string {
   const parts: string[] = [input.summary.trim()];
 
   if (input.scope?.length) {
-    parts.push(`**Scope**\n${input.scope.map((s) => `${BULLET}${s}`).join('\n')}`);
+    parts.push(`**Scope:**\n${input.scope.map((s) => `${BULLET}${s}`).join('\n')}`);
   }
   if (input.verify?.length) {
-    parts.push(`**Verify**\n${input.verify.map((s) => `${BULLET}${s}`).join('\n')}`);
+    parts.push(`**Verify:**\n${input.verify.map((s) => `${BULLET}${s}`).join('\n')}`);
   }
 
   const facts: string[] = [];
@@ -139,7 +147,7 @@ export function formatTaskDescription(input: TaskDescriptionInput): string {
 
   let body = parts.join('\n\n');
   if (input.parentTitle) {
-    body += `\n\n---\n_Auto-decomposed from "${input.parentTitle}" by Planner_`;
+    body += `\n\n_Split out from "${input.parentTitle}" during planning._`;
   }
   return body;
 }

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -942,11 +942,8 @@ export async function logPairComplete(
 
   const sections: CommentSection[] = [];
 
-  if (stats.workerSummary) {
-    sections.push({ label: 'Worker', body: stats.workerSummary.trim() });
-    if (stats.workerCommands && stats.workerCommands.length > 0) {
-      sections.push({ label: 'Commands', body: stats.workerCommands.slice(0, 5).map((c) => `\`${c}\``) });
-    }
+  if (stats.workerCommands && stats.workerCommands.length > 0) {
+    sections.push({ label: 'Commands run', body: stats.workerCommands.slice(0, 5).map((c) => `\`${c}\``) });
   }
 
   if (stats.reviewerFeedback) {
@@ -982,6 +979,7 @@ export async function logPairComplete(
 
   await addComment(issueId, formatAutomationComment({
     heading: 'Task complete',
+    summary: stats.workerSummary?.trim() || undefined,
     sections,
     meta: {
       Session: sessionId,


### PR DESCRIPTION
## Summary

Follow-up to #83. The formatter was correct but read mechanically — stacked `**Label**` blocks and a `Key: Value · …` telemetry footer. This softens the voice so comments read like an engineer wrote them, while staying scannable.

- Short single-line facts render **inline** (`**Reviewer:** approved — looks correct`) instead of a stacked header+body; lists still use bullets
- The telemetry footer becomes a single quiet **italic sign-off** (`_attribution · trace · date_`); default attribution `via OpenSwarm`
- Completion comment **leads with the worker's own summary** as plain prose
- Sub-issue sign-off reworded (`Split out from "…" during planning`)

## Before → after

Before:
```
**Task complete**

**Worker**
Implemented the logout endpoint…

---
Session: pair-7a3f · Iterations: 2 · Duration: 3m 5s · Files: 2 · Worker/Reviewer/Tester pipeline · 2026-06-23
```
After:
```
**Task complete**

Wired the logout endpoint into the header and added tests — all green.

**Reviewer:** Approved — looks correct, tests cover the new path.

**Tests:**
- Passed 12/12 (100%)
- Coverage 87.4%

_Worker/Reviewer/Tester pipeline · Session pair-7a3f · Iterations 2 · Duration 3m 5s · 2026-06-23_
```

## Checklist
- [x] `npm run lint` clean · `npm run typecheck` · `npm run build`
- [x] `npm test` — 847 passing (format.test.ts + workerAuditLog.test.ts updated)