### PR TITLE
feat(tools): search_memory tool — agents actively query repo knowledge (INT-1852)

### DIFF
--- a/src/adapters/tools.test.ts
+++ b/src/adapters/tools.test.ts
@@ -1,8 +1,20 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { TOOL_DEFINITIONS, executeTool, createReadCache, ToolCall } from './tools.js';
+
+// search_memory loads the memory core lazily; stub it so the tool test stays fast
+// and deterministic (no LanceDB / embedding model).
+vi.mock('../memory/index.js', () => ({
+  searchMemorySafe: async (_query: string, opts: { repo?: string }) => ({
+    success: true,
+    memories: opts?.repo
+      ? [{ type: 'constraint', title: 'Avoid double migrations', content: 'two paths touched prod tables' }]
+      : [],
+  }),
+}));
+vi.mock('../memory/repoKnowledge.js', () => ({ repoKey: (p: string) => p }));
 
 // Check if rg binary is available (not just a shell function wrapper)
 let hasRg = false;
@@ -36,10 +48,10 @@ afterAll(async () => {
 // ──────────────────────────────────────────────
 
 describe('TOOL_DEFINITIONS', () => {
-  const expectedNames = ['read_file', 'write_file', 'edit_file', 'search_files', 'bash'];
+  const expectedNames = ['read_file', 'write_file', 'edit_file', 'search_files', 'bash', 'search_memory'];
 
-  it('exports exactly 5 tool definitions', () => {
-    expect(TOOL_DEFINITIONS).toHaveLength(5);
+  it('exports exactly 6 tool definitions', () => {
+    expect(TOOL_DEFINITIONS).toHaveLength(6);
   });
 
   it.each(expectedNames)('includes "%s" tool', (name) => {
@@ -48,6 +60,25 @@ describe('TOOL_DEFINITIONS', () => {
     expect(found!.type).toBe('function');
     expect(found!.function.description).toBeTruthy();
     expect(found!.function.parameters).toBeDefined();
+  });
+});
+
+// ──────────────────────────────────────────────
+// 1b. search_memory tool
+// ──────────────────────────────────────────────
+
+describe('executeTool — search_memory', () => {
+  it('rejects an empty query', async () => {
+    const r = await executeTool(makeCall('search_memory', { query: '  ' }), TMP_DIR);
+    expect(r.is_error).toBe(true);
+    expect(r.content).toContain('query');
+  });
+
+  it('returns repo-scoped knowledge formatted with type tags', async () => {
+    const r = await executeTool(makeCall('search_memory', { query: 'migration' }), TMP_DIR);
+    expect(r.is_error).toBe(false);
+    expect(r.content).toContain('Repository knowledge');
+    expect(r.content).toContain('[constraint] Avoid double migrations');
   });
 });
 

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -103,6 +103,22 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       },
     },
   },
+  {
+    type: 'function',
+    function: {
+      name: 'search_memory',
+      description:
+        "Search this repository's accumulated knowledge from past tasks — successful approaches (patterns) and reviewer pitfalls (constraints) — by semantic query. Call this BEFORE implementing to reuse what worked here and avoid known mistakes. Scoped to the current repo automatically.",
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'What to recall, e.g. "how auth migrations were handled" or "logout button"' },
+          limit: { type: 'number', description: 'Max results (1-10). Default: 5' },
+        },
+        required: ['query'],
+      },
+    },
+  },
 ];
 
 // ============ 안전 가드 ============
@@ -393,6 +409,40 @@ export async function executeTool(
           // exit 1 + 출력 없음은 보통 무해(grep no-match) → is_error를 false로 둬 모델이 안 헤매게.
           const benign = e.code === 1 && !out.trim();
           return { tool_call_id: callId, content: body, is_error: !benign };
+        }
+      }
+
+      case 'search_memory': {
+        const query = String(args.query ?? '').trim();
+        if (!query) {
+          return { tool_call_id: callId, content: 'search_memory requires a non-empty "query".', is_error: true };
+        }
+        try {
+          // Loaded lazily: the memory core pulls in LanceDB + the embedding model,
+          // which we don't want as a static dependency of every tools.ts consumer.
+          const [{ searchMemorySafe }, { repoKey }] = await Promise.all([
+            import('../memory/index.js'),
+            import('../memory/repoKnowledge.js'),
+          ]);
+          const limit = Math.min(Math.max(Number(args.limit) || 5, 1), 10);
+          const res = await searchMemorySafe(query, {
+            repo: repoKey(cwd),
+            types: ['system_pattern', 'constraint', 'fact', 'strategy', 'belief'],
+            limit,
+            minSimilarity: 0.3,
+          });
+          if (!res.success) {
+            return { tool_call_id: callId, content: `Memory unavailable (${res.errorCode ?? 'unknown'}); proceed without it.`, is_error: false };
+          }
+          if (res.memories.length === 0) {
+            return { tool_call_id: callId, content: 'No matching repo knowledge yet for this query.', is_error: false };
+          }
+          const formatted = res.memories
+            .map((m) => `- [${m.type}] ${m.title}\n  ${m.content.replace(/\s+/g, ' ').slice(0, 300)}`)
+            .join('\n');
+          return { tool_call_id: callId, content: `Repository knowledge (${res.memories.length}):\n${formatted}`, is_error: false };
+        } catch (err) {
+          return { tool_call_id: callId, content: `search_memory failed: ${err instanceof Error ? err.message : String(err)}`, is_error: false };
         }
       }
 

--- a/src/memory/repoKnowledge.ts
+++ b/src/memory/repoKnowledge.ts
@@ -19,7 +19,7 @@ import type { WorkerResult } from '../agents/agentPair.js';
  * an exact string match, so trailing slashes or symlinked paths to the same
  * repo would otherwise split the knowledge across keys that never match.
  */
-function repoKey(projectPath: string): string {
+export function repoKey(projectPath: string): string {
   const resolved = path.resolve(projectPath);
   try {
     return realpathSync(resolved);


### PR DESCRIPTION
## Summary

The repo knowledge loop (INT-1436) only worked one way — `recallRepoKnowledge` → injected into the worker prompt. If recall returned nothing the agent got no signal, and it had no way to pull past knowledge on demand. This adds an active tool.

`search_memory(query, limit?)` in the agentic loop's tool set:
- **Repo-scoped** via `repoKey(cwd)` — the same key the recall path writes/reads
- Runs `searchMemorySafe` over `system_pattern`/`constraint`/`fact`/`strategy`/`belief` (minSimilarity 0.3)
- **Always on**, and **graceful**: if the memory DB/embedding is unavailable it returns a "proceed without it" note rather than erroring the agent
- Memory core is **lazily imported inside the case** so tools.ts keeps LanceDB + the embedding model out of its static dependency graph
- `repoKey` is now exported from `repoKnowledge.ts`

Applies to the native agentic loop (openrouter / gpt / local). The CLI-delegated adapters (codex / claude) run their own harness — out of scope.

## Tool output (example)
```
Repository knowledge (1):
- [constraint] Review rejection: add logout endpoint
  Reviewer feedback (avoid repeating this): wire it into the header, not just the route table
```

## Checklist
- [x] `npm run lint` clean · `npm run typecheck` · pre-commit hook green
- [x] `npm test` — 850 passing (tool count 5→6 + empty-query guard + mocked formatting)