### PR TITLE
feat(mcp): expose repo memory to codex/claude CLI adapters via MCP server (INT-1855)

### DIFF
--- a/src/adapters/claude.test.ts
+++ b/src/adapters/claude.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { ClaudeCliAdapter } from './claude.js';
+
+describe('ClaudeCliAdapter.buildCommand', () => {
+  it('wires the memory MCP server via --mcp-config and keeps bypass permissions', () => {
+    const { command } = new ClaudeCliAdapter().buildCommand({
+      prompt: '/tmp/prompt.txt',
+      cwd: '/tmp/project',
+      model: 'claude-sonnet-4',
+    });
+    expect(command).toContain('claude -p');
+    expect(command).toContain('--permission-mode bypassPermissions');
+    expect(command).toContain('--mcp-config');
+    expect(command).toMatch(/--mcp-config \S+mcp\.json/);
+  });
+});

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -17,6 +17,7 @@ import type { ReviewDecision } from '../agents/agentPair.js';
 import { extractCostFromStreamJson, formatCost } from '../support/costTracker.js';
 import { extractResultFromStreamJson } from '../agents/cliStreamParser.js';
 import { t } from '../locale/index.js';
+import { writeClaudeMcpConfig } from './memoryMcp.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -47,7 +48,9 @@ export class ClaudeCliAdapter implements CliAdapter {
     const promptFile = options.prompt;
     const modelFlag = options.model ? ` --model ${options.model}` : '';
     const maxTurnsFlag = options.maxTurns ? ` --max-turns ${options.maxTurns}` : '';
-    const cmd = `echo "" | claude -p "$(cat ${promptFile})" --output-format stream-json --verbose --permission-mode bypassPermissions${modelFlag}${maxTurnsFlag}`;
+    // Register OpenSwarm's memory MCP server; bypassPermissions auto-allows its tool.
+    const mcpConfig = writeClaudeMcpConfig();
+    const cmd = `echo "" | claude -p "$(cat ${promptFile})" --output-format stream-json --verbose --permission-mode bypassPermissions --mcp-config ${mcpConfig}${modelFlag}${maxTurnsFlag}`;
     return { command: cmd, args: [] };
   }
 

--- a/src/adapters/codex.test.ts
+++ b/src/adapters/codex.test.ts
@@ -18,6 +18,9 @@ describe('CodexCliAdapter', () => {
     expect(command).not.toContain('--full-auto');
     expect(command).toContain('--skip-git-repo-check');
     expect(command).toContain("-m 'gpt-5-codex'");
+    // Memory MCP server is registered so codex can call search_memory (INT-1855)
+    expect(command).toContain("-c 'mcp_servers.openswarm_memory.command=");
+    expect(command).toContain("-c 'mcp_servers.openswarm_memory.args=[");
   });
 
   it('substitutes a claude model with the codex default and warns', () => {

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -16,6 +16,7 @@ import type {
 import { t } from '../locale/index.js';
 import { AuthProfileStore, ensureValidToken } from '../auth/index.js';
 import { getCodexModelIds } from './codexModels.js';
+import { codexMcpConfigFlags } from './memoryMcp.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -68,7 +69,8 @@ export class CodexCliAdapter implements CliAdapter {
     // `--full-auto` was deprecated in codex 0.137 (warns, still runs). Its documented
     // replacement is `--sandbox workspace-write`: same low-friction policy (writes
     // confined to the workspace, no approval prompts in non-interactive `exec`). (INT-1699)
-    const cmd = `cat ${shellEscape(promptFile)} | codex exec --json --sandbox workspace-write --skip-git-repo-check${modelFlag}`;
+    // Register OpenSwarm's memory MCP server so codex can call `search_memory`.
+    const cmd = `cat ${shellEscape(promptFile)} | codex exec --json --sandbox workspace-write --skip-git-repo-check${modelFlag} ${codexMcpConfigFlags()}`;
     return { command: cmd, args: [] };
   }
 

--- a/src/adapters/memoryMcp.test.ts
+++ b/src/adapters/memoryMcp.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+  memoryServerPath,
+  memoryServerLaunch,
+  writeClaudeMcpConfig,
+  codexMcpConfigFlags,
+  MEMORY_MCP_NAME,
+} from './memoryMcp.js';
+
+describe('memoryMcp', () => {
+  it('memoryServerPath points at the built memory server entry', () => {
+    expect(memoryServerPath().replace(/\\/g, '/')).toMatch(/\/mcp\/memoryServer\.js$/);
+  });
+
+  it('memoryServerLaunch runs the entry with the current node binary', () => {
+    const { command, args } = memoryServerLaunch();
+    expect(command).toBe(process.execPath);
+    expect(args[0]).toMatch(/memoryServer\.js$/);
+  });
+
+  it('writeClaudeMcpConfig writes a valid mcp.json registering the memory server', () => {
+    const file = writeClaudeMcpConfig();
+    const cfg = JSON.parse(readFileSync(file, 'utf-8'));
+    expect(cfg.mcpServers[MEMORY_MCP_NAME].command).toBe(process.execPath);
+    expect(cfg.mcpServers[MEMORY_MCP_NAME].args[0]).toMatch(/memoryServer\.js$/);
+  });
+
+  it('codexMcpConfigFlags emits -c overrides for command and args', () => {
+    const flags = codexMcpConfigFlags();
+    expect(flags).toContain(`-c 'mcp_servers.${MEMORY_MCP_NAME}.command=`);
+    expect(flags).toContain(`-c 'mcp_servers.${MEMORY_MCP_NAME}.args=[`);
+  });
+});

--- a/src/adapters/memoryMcp.ts
+++ b/src/adapters/memoryMcp.ts
@@ -1,0 +1,56 @@
+// ============================================
+// OpenSwarm — Memory MCP wiring for CLI-delegated adapters
+// ============================================
+//
+// Builds the launch spec + per-CLI config that points `codex exec` and
+// `claude -p` at the OpenSwarm memory MCP server (src/mcp/memoryServer.ts), so
+// those adapters get an on-demand `search_memory` tool. The native agentic loop
+// has the tool in-process and does not use this.
+
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+/** MCP server name both CLIs register the memory server under. */
+export const MEMORY_MCP_NAME = 'openswarm_memory';
+
+/** Absolute path to the built MCP memory server entry (dist/mcp/memoryServer.js). */
+export function memoryServerPath(): string {
+  // this file at runtime: dist/adapters/memoryMcp.js → ../mcp/memoryServer.js
+  return join(dirname(fileURLToPath(import.meta.url)), '..', 'mcp', 'memoryServer.js');
+}
+
+/** How to launch the memory server: the current Node binary running the entry. */
+export function memoryServerLaunch(): { command: string; args: string[] } {
+  return { command: process.execPath, args: [memoryServerPath()] };
+}
+
+/**
+ * Write a temporary MCP config JSON for `claude -p --mcp-config`. Returns the
+ * file path. `claude` is already invoked with `--permission-mode
+ * bypassPermissions`, so the MCP tool is auto-allowed.
+ */
+export function writeClaudeMcpConfig(): string {
+  const { command, args } = memoryServerLaunch();
+  const cfg = { mcpServers: { [MEMORY_MCP_NAME]: { command, args } } };
+  const dir = mkdtempSync(join(tmpdir(), 'osw-mcp-'));
+  const file = join(dir, 'mcp.json');
+  writeFileSync(file, JSON.stringify(cfg), 'utf-8');
+  return file;
+}
+
+/**
+ * Shell-ready `-c` config overrides registering the memory server for
+ * `codex exec` (TOML dotted paths; values are TOML literals — JSON quoting works).
+ */
+export function codexMcpConfigFlags(): string {
+  const { command, args } = memoryServerLaunch();
+  const argsToml = '[' + args.map((a) => JSON.stringify(a)).join(', ') + ']';
+  const overrides = [
+    `mcp_servers.${MEMORY_MCP_NAME}.command=${JSON.stringify(command)}`,
+    `mcp_servers.${MEMORY_MCP_NAME}.args=${argsToml}`,
+  ];
+  // Single-quote each override for the shell (inner double quotes are preserved).
+  return overrides.map((o) => `-c '${o}'`).join(' ');
+}

--- a/src/adapters/tools.test.ts
+++ b/src/adapters/tools.test.ts
@@ -4,17 +4,14 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { TOOL_DEFINITIONS, executeTool, createReadCache, ToolCall } from './tools.js';
 
-// search_memory loads the memory core lazily; stub it so the tool test stays fast
-// and deterministic (no LanceDB / embedding model).
-vi.mock('../memory/index.js', () => ({
-  searchMemorySafe: async (_query: string, opts: { repo?: string }) => ({
-    success: true,
-    memories: opts?.repo
-      ? [{ type: 'constraint', title: 'Avoid double migrations', content: 'two paths touched prod tables' }]
-      : [],
-  }),
+// search_memory loads the memory core lazily; stub the shared helper so the tool
+// test stays fast and deterministic (no LanceDB / embedding model).
+vi.mock('../memory/repoKnowledge.js', () => ({
+  searchRepoMemoryText: async (_cwd: string, query: string) =>
+    query.trim()
+      ? 'Repository knowledge (1):\n- [constraint] Avoid double migrations\n  two paths touched prod tables'
+      : 'A non-empty query is required.',
 }));
-vi.mock('../memory/repoKnowledge.js', () => ({ repoKey: (p: string) => p }));
 
 // Check if rg binary is available (not just a shell function wrapper)
 let hasRg = false;

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -420,27 +420,10 @@ export async function executeTool(
         try {
           // Loaded lazily: the memory core pulls in LanceDB + the embedding model,
           // which we don't want as a static dependency of every tools.ts consumer.
-          const [{ searchMemorySafe }, { repoKey }] = await Promise.all([
-            import('../memory/index.js'),
-            import('../memory/repoKnowledge.js'),
-          ]);
-          const limit = Math.min(Math.max(Number(args.limit) || 5, 1), 10);
-          const res = await searchMemorySafe(query, {
-            repo: repoKey(cwd),
-            types: ['system_pattern', 'constraint', 'fact', 'strategy', 'belief'],
-            limit,
-            minSimilarity: 0.3,
-          });
-          if (!res.success) {
-            return { tool_call_id: callId, content: `Memory unavailable (${res.errorCode ?? 'unknown'}); proceed without it.`, is_error: false };
-          }
-          if (res.memories.length === 0) {
-            return { tool_call_id: callId, content: 'No matching repo knowledge yet for this query.', is_error: false };
-          }
-          const formatted = res.memories
-            .map((m) => `- [${m.type}] ${m.title}\n  ${m.content.replace(/\s+/g, ' ').slice(0, 300)}`)
-            .join('\n');
-          return { tool_call_id: callId, content: `Repository knowledge (${res.memories.length}):\n${formatted}`, is_error: false };
+          // Same helper backs the MCP memory server so results stay identical.
+          const { searchRepoMemoryText } = await import('../memory/repoKnowledge.js');
+          const text = await searchRepoMemoryText(cwd, query, Number(args.limit) || 5);
+          return { tool_call_id: callId, content: text, is_error: false };
         } catch (err) {
           return { tool_call_id: callId, content: `search_memory failed: ${err instanceof Error ? err.message : String(err)}`, is_error: false };
         }

--- a/src/mcp/memoryServer.ts
+++ b/src/mcp/memoryServer.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// ============================================
+// OpenSwarm — Memory MCP server (stdio)
+// ============================================
+//
+// Exposes repo-scoped memory search to CLI-delegated agents (codex exec,
+// claude -p) that run their own harness and therefore can't see OpenSwarm's
+// in-loop `search_memory` tool. The native agentic loop already has the tool
+// in-process; this is the bridge for the CLI adapters.
+//
+// Launched by the codex/claude adapters (see src/adapters/memoryMcp.ts) with the
+// worker's project directory as cwd, so process.cwd() → repoKey scopes results to
+// the right repo. The embedding model loads lazily, only on the first call.
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { searchRepoMemoryText } from '../memory/repoKnowledge.js';
+
+const SEARCH_TOOL = {
+  name: 'search_memory',
+  description:
+    "Search this repository's accumulated knowledge from past tasks — successful approaches (patterns) " +
+    'and reviewer pitfalls (constraints) — by semantic query. Call this BEFORE implementing to reuse what ' +
+    'worked here and avoid known mistakes. Scoped to the current repository automatically.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: { type: 'string', description: 'What to recall, e.g. "how auth migrations were handled"' },
+      limit: { type: 'number', description: 'Max results (1-10). Default: 5' },
+    },
+    required: ['query'],
+  },
+} as const;
+
+async function main(): Promise<void> {
+  const server = new Server(
+    { name: 'openswarm-memory', version: '1.0.0' },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [SEARCH_TOOL] }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    if (req.params.name !== 'search_memory') {
+      return { content: [{ type: 'text', text: `Unknown tool: ${req.params.name}` }], isError: true };
+    }
+    const args = (req.params.arguments ?? {}) as { query?: string; limit?: number };
+    try {
+      const text = await searchRepoMemoryText(process.cwd(), String(args.query ?? ''), Number(args.limit) || 5);
+      return { content: [{ type: 'text', text }] };
+    } catch (err) {
+      return {
+        content: [{ type: 'text', text: `search_memory failed: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  });
+
+  await server.connect(new StdioServerTransport());
+}
+
+main().catch((err) => {
+  console.error('[memoryServer] fatal:', err);
+  process.exit(1);
+});

--- a/src/memory/repoKnowledge.test.ts
+++ b/src/memory/repoKnowledge.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Stub the memory core so searchRepoMemoryText is tested without LanceDB / embeddings.
+// Branch on the query string to exercise each path.
+vi.mock('./memoryCore.js', () => ({
+  saveMemory: async () => {},
+  searchMemorySafe: async (query: string) => {
+    if (query === 'fail') return { success: false, memories: [], errorCode: 'DB_INIT_FAILED' };
+    if (query === 'empty') return { success: true, memories: [] };
+    return {
+      success: true,
+      memories: [{ type: 'system_pattern', title: 'Solved: add logout', content: 'wired it into the header' }],
+    };
+  },
+}));
+
+import { searchRepoMemoryText } from './repoKnowledge.js';
+
+describe('searchRepoMemoryText', () => {
+  it('requires a non-empty query', async () => {
+    expect(await searchRepoMemoryText('/repo', '   ')).toContain('non-empty query');
+  });
+
+  it('reports gracefully when memory is unavailable', async () => {
+    const text = await searchRepoMemoryText('/repo', 'fail');
+    expect(text).toContain('Memory unavailable');
+    expect(text).toContain('DB_INIT_FAILED');
+  });
+
+  it('returns a friendly note when nothing matches', async () => {
+    expect(await searchRepoMemoryText('/repo', 'empty')).toContain('No matching repo knowledge yet');
+  });
+
+  it('formats hits with type tags and a count', async () => {
+    const text = await searchRepoMemoryText('/repo', 'logout');
+    expect(text).toContain('Repository knowledge (1):');
+    expect(text).toContain('[system_pattern] Solved: add logout');
+    expect(text).toContain('wired it into the header');
+  });
+});

--- a/src/memory/repoKnowledge.ts
+++ b/src/memory/repoKnowledge.ts
@@ -71,6 +71,32 @@ export async function recallRepoKnowledge(
   }
 }
 
+/**
+ * Free-form, repo-scoped memory search rendered as plain text. Shared by the
+ * in-loop `search_memory` tool (tools.ts) and the MCP memory server so both
+ * surface identical results. Always non-throwing — returns a human-readable line.
+ */
+export async function searchRepoMemoryText(
+  projectPath: string,
+  query: string,
+  limit = 5,
+): Promise<string> {
+  const q = (query ?? '').trim();
+  if (!q) return 'A non-empty query is required.';
+  const res = await searchMemorySafe(q, {
+    repo: repoKey(projectPath),
+    types: ['system_pattern', 'constraint', 'fact', 'strategy', 'belief'],
+    limit: Math.min(Math.max(limit, 1), 10),
+    minSimilarity: 0.3,
+  });
+  if (!res.success) return `Memory unavailable (${res.errorCode ?? 'unknown'}); proceed without it.`;
+  if (res.memories.length === 0) return 'No matching repo knowledge yet for this query.';
+  const formatted = res.memories
+    .map((m) => `- [${m.type}] ${m.title}\n  ${m.content.replace(/\s+/g, ' ').slice(0, 300)}`)
+    .join('\n');
+  return `Repository knowledge (${res.memories.length}):\n${formatted}`;
+}
+
 export interface TaskOutcomeInput {
   taskTitle: string;
   /** Provenance tracker, e.g. Linear issue ID */


### PR DESCRIPTION
## Summary

Follow-up to #85. `search_memory` was only available to the native agentic loop (codex-responses / openrouter / local). The CLI-delegated `codex exec` and `claude -p` run their own harness and couldn't call it. This bridges them with an MCP server, so all adapters can actively query repo knowledge. (Passive injection — the "Repository Knowledge" prompt block — already reached every adapter.)

- **`src/mcp/memoryServer.ts`** — stdio MCP server (low-level `Server` + raw JSON schema, no zod coupling) exposing `search_memory`, scoped by `process.cwd()` → `repoKey` (the CLI runs with the project dir as cwd)
- **Shared core** — extracted `searchRepoMemoryText(cwd, query, limit)` into `repoKnowledge.ts`; the in-loop tool (`tools.ts`) and the MCP server both use it, so results are identical
- **`src/adapters/memoryMcp.ts`** — launch spec + `claude --mcp-config` JSON + `codex -c mcp_servers.*` overrides
- **Wiring** — `codex.ts` (`-c`) and `claude.ts` (`--mcp-config`; `--permission-mode bypassPermissions` already auto-allows the tool)

## Verified live
Spawned the built server over stdio with the MCP SDK client (same protocol codex/claude use):
```
TOOLS: search_memory
RESULT: Repository knowledge (1):
- [system_pattern] Solved: feat(linear): scannable formatter ...   (repo-scoped)
```

## Cost note
The MCP server is spawned at CLI startup (handshake only — cheap). The embedding model loads lazily, only on the first `search_memory` call. The native loop is unaffected (in-process).

## Checklist
- [x] `npm run lint` / `typecheck` / `build` clean (pre-commit hook green)
- [x] `npm test` — 859 passing (memoryMcp helpers, shared text builder, codex/claude wiring)
- [x] Live stdio round-trip verified

> codex/claude end-to-end (a real model calling it through their harness) needs a live CLI run — not covered by unit tests.