### PR TITLE
fix(memory): normalize worktree paths in repoKey so repo knowledge accumulates (INT-1856)

### DIFF
--- a/src/memory/repoKnowledge.test.ts
+++ b/src/memory/repoKnowledge.test.ts
@@ -14,7 +14,19 @@ vi.mock('./memoryCore.js', () => ({
   },
 }));
 
-import { searchRepoMemoryText } from './repoKnowledge.js';
+import { searchRepoMemoryText, repoKey } from './repoKnowledge.js';
+
+describe('repoKey', () => {
+  it('normalizes a per-issue worktree path back to the repo', () => {
+    expect(repoKey('/Users/x/dev/vega-agent/worktree/abc-123')).toBe('/Users/x/dev/vega-agent');
+  });
+  it('leaves a plain repo path unchanged', () => {
+    expect(repoKey('/Users/x/dev/vega-agent')).toBe('/Users/x/dev/vega-agent');
+  });
+  it('strips a worktree path with a trailing slash too', () => {
+    expect(repoKey('/Users/x/dev/vega-agent/worktree/id/')).toBe('/Users/x/dev/vega-agent');
+  });
+});
 
 describe('searchRepoMemoryText', () => {
   it('requires a non-empty query', async () => {

--- a/src/memory/repoKnowledge.ts
+++ b/src/memory/repoKnowledge.ts
@@ -21,11 +21,17 @@ import type { WorkerResult } from '../agents/agentPair.js';
  */
 export function repoKey(projectPath: string): string {
   const resolved = path.resolve(projectPath);
+  let real: string;
   try {
-    return realpathSync(resolved);
+    real = realpathSync(resolved);
   } catch {
-    return resolved; // path may not exist yet (tests, dry runs) — resolve is enough
+    real = resolved; // path may not exist yet (tests, dry runs) — resolve is enough
   }
+  // Per-issue git worktrees live at `<repo>/worktree/<issueId>` (worktreeManager).
+  // Normalize them back to the repo so knowledge accumulates per-repo instead of
+  // per ephemeral worktree — each worktree is a unique key recall never revisits,
+  // which silently broke cross-task accumulation. (INT-1856)
+  return real.replace(/\/worktree\/[^/]+\/?$/, '');
 }
 
 /** Repo knowledge item injected into the worker prompt (mirrors locale WorkerContext) */


### PR DESCRIPTION
## Summary

The repo-knowledge loop wasn't accumulating across tasks. Tasks run in per-issue git worktrees (`<repo>/worktree/<issueId>`), and `recordTaskOutcome` / `recallRepoKnowledge` keyed memory by that **ephemeral worktree path**. The next task runs in a *different* worktree → recall never finds the prior knowledge. The loop worked within a single task but reset every task.

`repoKey` now strips the `/worktree/<id>` suffix back to the canonical repo, so writes and recall share one key per repo.

## Evidence (full store dump)
- 845 memories total; **98 task-outcomes scattered across worktree keys**, while canonical `vega-agent` had only **8**.
- Separately, 717/845 were regenerable `repo="cognitive"` code-analysis dumps (coverage/high-risk/churn), heavily duplicated.

## Store cleanup (operational, already applied; backup at ~/.openswarm/memory.bak-20260623)
- Pruned the 717 cognitive dumps.
- Re-keyed the 98 worktree rows to canonical → **vega-agent 8 → 90**, OpenSwarm 15, kyte-portal 2. Store 845 → 128, all canonically keyed.
- Verified: `recall(/Users/.../vega-agent)` now returns real accumulated task-outcomes (was empty-ish before).

## Checklist
- [x] `npm run lint` / `typecheck` / `build` clean
- [x] `npm test` — 862 passing (repoKey worktree→canonical + plain-path tests)

> Follow-up (separate): the `cognitive`-keyed code-analysis dumps have a live writer that will regrow them — scope that writer to the real repo or stop storing analysis snapshots as memories.