### PR TITLE
fix(knowledge): scope + dedup graph insights so they don't bloat memory (INT-1857)

### DIFF
--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -9,7 +9,8 @@ import { saveGraph, loadGraph, listGraphs } from './store.js';
 import { enrichWithGitInfo, getRecentlyChangedFiles } from './gitInfo.js';
 import { analyzeIssueImpact, getProjectHealth, suggestReviewFocus, getModuleHealth } from './analyzer.js';
 import type { ImpactAnalysis, ProjectSummary } from './types.js';
-import { saveCognitiveMemory } from '../memory/index.js';
+import { saveCognitiveMemory, deleteMemoriesByDerivedFrom } from '../memory/index.js';
+import { repoKey } from '../memory/repoKnowledge.js';
 import { exportRepoGraph, hasRepoSnapshot, loadRepoSnapshot, snapshotAgeMinutes } from './graphqlExporter.js';
 
 // Re-exports
@@ -224,13 +225,23 @@ export async function saveGraphInsights(projectPath: string): Promise<void> {
 
   const { summary, riskModules } = getProjectHealth(graph);
 
+  // Scope insights to the canonical repo (not the default 'cognitive' bucket) and
+  // tag them with a stable per-repo key so each scan REFRESHES them in place
+  // instead of appending duplicates every run. (INT-1857)
+  const repo = repoKey(projectPath);
+  const insightKey = `knowledge-graph:${repo}`;
+  await deleteMemoriesByDerivedFrom(insightKey).catch((err) =>
+    console.warn('[Knowledge] insight refresh delete failed:', err instanceof Error ? err.message : err));
+  const insightOpts = (importance: number, confidence: number) =>
+    ({ confidence, importance, derivedFrom: insightKey, repo });
+
   // Hot modules insight
   if (summary.hotModules.length > 0) {
     const hotList = summary.hotModules.slice(0, 3).join(', ');
     try {
       await saveCognitiveMemory('system_pattern',
         `[${slug}] Frequently changed modules: ${hotList}. Watch for change impact.`,
-        { confidence: 0.8, importance: 0.6, derivedFrom: `knowledge-graph:${slug}` }
+        insightOpts(0.6, 0.8)
       );
     } catch (err) {
       console.warn(`[Knowledge] 메모리 저장 실패 (hot modules):`, err instanceof Error ? err.message : err);
@@ -244,7 +255,7 @@ export async function saveGraphInsights(projectPath: string): Promise<void> {
     try {
       await saveCognitiveMemory('system_pattern',
         `[${slug}] High-risk modules (no tests + high churn): ${riskList}. Adding tests recommended.`,
-        { confidence: 0.85, importance: 0.7, derivedFrom: `knowledge-graph:${slug}` }
+        insightOpts(0.7, 0.85)
       );
     } catch (err) {
       console.warn(`[Knowledge] 메모리 저장 실패 (high risk):`, err instanceof Error ? err.message : err);
@@ -257,7 +268,7 @@ export async function saveGraphInsights(projectPath: string): Promise<void> {
     try {
       await saveCognitiveMemory('system_pattern',
         `[${slug}] Test coverage: ${coverage}% (${summary.totalTestFiles} tests / ${summary.totalModules} modules). ${summary.untestedModules.length} untested.`,
-        { confidence: 0.9, importance: 0.5, derivedFrom: `knowledge-graph:${slug}` }
+        insightOpts(0.5, 0.9)
       );
     } catch (err) {
       console.warn(`[Knowledge] 메모리 저장 실패 (coverage):`, err instanceof Error ? err.message : err);

--- a/src/memory/memoryCore.ts
+++ b/src/memory/memoryCore.ts
@@ -616,6 +616,8 @@ export async function saveCognitiveMemory(
     derivedFrom?: string;
     supports?: string[];
     contradicts?: string[];
+    /** Repo scope for the record. Defaults to 'cognitive' (unscoped) for back-compat. */
+    repo?: string;
   }
 ): Promise<string | null> {
   await initDatabase();
@@ -646,7 +648,7 @@ export async function saveCognitiveMemory(
     derivedFrom: options?.derivedFrom || 'unknown',
 
     // Legacy fields (minimal)
-    repo: 'cognitive',
+    repo: options?.repo ?? 'cognitive',
     title: content.slice(0, 100),
     metadata: '{}',
     trust: options?.confidence ?? 0.7,
@@ -656,6 +658,25 @@ export async function saveCognitiveMemory(
   await table.add([record]);
   console.log(`[Memory] Saved cognitive ${type} (importance: ${importance.toFixed(2)}): ${content.slice(0, 50)}...`);
   return id;
+}
+
+/**
+ * Delete all memories tagged with a given `derivedFrom` value. Used to
+ * refresh regenerable insights (e.g. knowledge-graph health) in place instead of
+ * appending a new row every scan. Best-effort — returns false if no table.
+ */
+export async function deleteMemoriesByDerivedFrom(derivedFrom: string): Promise<number> {
+  await initDatabase();
+  if (!table) return 0;
+  // Resolve matching ids in JS, then delete by the lowercase `id` column. A direct
+  // predicate on the camelCase `derivedFrom` column is unreliable — datafusion
+  // lowercases unquoted identifiers and the quoted form matched nothing here.
+  const rows = (await table.query().limit(100_000).toArray()) as unknown as CognitiveMemoryRecord[];
+  const ids = rows.filter((r) => r.derivedFrom === derivedFrom).map((r) => String(r.id));
+  if (ids.length === 0) return 0;
+  const list = ids.map((id) => `'${id.replace(/'/g, "''")}'`).join(', ');
+  await table.delete(`id IN (${list})`);
+  return ids.length;
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #87. `saveGraphInsights` saved coverage/high-risk/churn insights with **no repo** (default `cognitive`) and **appended a fresh row every scan** — 717/845 stored memories were these duplicated, unscoped dumps, unreachable by repo-scoped recall.

- `saveCognitiveMemory`: add a `repo` option (was hardcoded `'cognitive'`)
- `memoryCore`: add `deleteMemoriesByDerivedFrom` — resolves matching ids then deletes by the lowercase `id` column (a predicate on the camelCase `derivedFrom` column is unreliable: datafusion lowercases unquoted identifiers, and the quoted form deleted nothing)
- `saveGraphInsights`: scope to `repoKey(projectPath)` and tag with a stable per-repo key, deleting the prior scan's insights first → **refresh-in-place** instead of append

## Verified live
Two simulated scans of the same repo:
```
after 2 scans: 2 rows (not 4)  → dedup works
repo scope:    /Users/.../OpenSwarm (not 'cognitive')  → scoped
cleanup:       deleted 2, remaining 0  → delete works
```

## Checklist
- [x] `npm run lint` / `typecheck` / `build` clean (pre-commit green)
- [x] `npm test` — 862 passing
- [x] Live scope+dedup verification (memory layer is DB+embedding coupled — not in the fast CI suite)