### PR TITLE
refactor(adapters): dynamic per-provider model resolution; drop hardcoded cross-provider fallbacks (INT-1860)

### DIFF
--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -54,6 +54,14 @@ export class ClaudeCliAdapter implements CliAdapter {
     return { command: cmd, args: [] };
   }
 
+  /**
+   * Version-agnostic alias — the claude CLI resolves "sonnet" to the current
+   * Sonnet, so it never goes stale the way a pinned model id would.
+   */
+  async getDefaultModel(): Promise<string> {
+    return 'sonnet';
+  }
+
   parseWorkerOutput(raw: CliRunResult): WorkerResult {
     try {
       const costInfo = extractCostFromStreamJson(raw.stdout);

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -62,6 +62,12 @@ export class CodexCliAdapter implements CliAdapter {
     return getCodexModelIds(accessToken);
   }
 
+  /** Default = the top model the account can use (live list), else the constant. */
+  async getDefaultModel(): Promise<string> {
+    const [first] = await this.listModels();
+    return first ?? CODEX_DEFAULT_MODEL;
+  }
+
   buildCommand(options: CliRunOptions): { command: string; args: string[] } {
     const promptFile = options.prompt;
     const resolvedModel = options.model ? coerceCodexModel(options.model) : undefined;

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -18,6 +18,8 @@ import { runAgenticLoop, loopResultToCliResult, type ChatMessage, type AgenticLo
 import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
 import type { ToolDefinition } from './tools.js';
 
+import { getCodexModelIds } from './codexModels.js';
+
 const CODEX_RESPONSES_URL = 'https://chatgpt.com/backend-api/codex/responses';
 const DEFAULT_MODEL = 'gpt-5.5';
 const PROFILE_KEY = 'openai-gpt:default';
@@ -240,6 +242,12 @@ export class CodexResponsesAdapter implements CliAdapter {
     return { command: 'echo', args: ['"codex-responses adapter uses run() — not shell spawn"'] };
   }
 
+  /** Default = top model from the Codex OAuth catalog (live/local), else constant. */
+  async getDefaultModel(): Promise<string> {
+    const [first] = await getCodexModelIds();
+    return first ?? DEFAULT_MODEL;
+  }
+
   async run(options: CliRunOptions): Promise<CliRunResult> {
     const store = new AuthProfileStore();
     const startTime = Date.now();
@@ -263,7 +271,7 @@ export class CodexResponsesAdapter implements CliAdapter {
       };
     }
 
-    const model = options.model ?? DEFAULT_MODEL;
+    const model = options.model ?? await this.getDefaultModel();
     const callApi = this.createApiCaller(accessToken, accountId, store, model, options.onToken, options.signal);
 
     const loopOptions: AgenticLoopOptions = {

--- a/src/adapters/getDefaultModel.test.ts
+++ b/src/adapters/getDefaultModel.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { GptCliAdapter } from './gpt.js';
+import { OpenRouterCliAdapter } from './openrouter.js';
+import { CodexResponsesAdapter } from './codexResponses.js';
+
+// Each adapter resolves its OWN provider-appropriate default — no cross-provider
+// hardcoded model ids (the regression that 400'd codex-responses with claude).
+describe('adapter.getDefaultModel', () => {
+  it('gpt → an OpenAI model', async () => {
+    expect(await new GptCliAdapter().getDefaultModel()).toMatch(/^gpt-/);
+  });
+
+  it('openrouter → a namespaced model id', async () => {
+    expect(await new OpenRouterCliAdapter().getDefaultModel()).toContain('/');
+  });
+
+  it('codex-responses → a gpt-* model, never a claude model (regression guard)', async () => {
+    const model = await new CodexResponsesAdapter().getDefaultModel();
+    expect(model).toMatch(/^gpt-/);
+    expect(model).not.toContain('claude');
+  });
+});

--- a/src/adapters/gpt.ts
+++ b/src/adapters/gpt.ts
@@ -48,6 +48,10 @@ export class GptCliAdapter implements CliAdapter {
     return { command: 'echo', args: ['"GPT adapter uses run() — not shell spawn"'] };
   }
 
+  async getDefaultModel(): Promise<string> {
+    return DEFAULT_MODEL;
+  }
+
   async run(options: CliRunOptions): Promise<CliRunResult> {
     const store = new AuthProfileStore();
     const startTime = Date.now();
@@ -65,7 +69,7 @@ export class GptCliAdapter implements CliAdapter {
       };
     }
 
-    const model = options.model ?? DEFAULT_MODEL;
+    const model = options.model ?? await this.getDefaultModel();
 
     // 2. 에이전틱 루프로 실행 (도구 사용 가능)
     const callApi = this.createApiCaller(accessToken, store, model, options.onToken, options.signal);

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -122,6 +122,12 @@ export class LocalModelAdapter implements CliAdapter {
     return { command: 'echo', args: ['"Local adapter uses run() — not shell spawn"'] };
   }
 
+  /** Default = first model the running server reports (live), else the constant. */
+  async getDefaultModel(): Promise<string> {
+    const [first] = await this.listModels();
+    return first ?? this.defaultModel;
+  }
+
   async run(options: CliRunOptions): Promise<CliRunResult> {
     const startTime = Date.now();
 
@@ -139,7 +145,7 @@ export class LocalModelAdapter implements CliAdapter {
       }
     }
 
-    const model = options.model ?? this.defaultModel;
+    const model = options.model ?? await this.getDefaultModel();
     const baseUrl = this.activeUrl!;
 
     // 도구 지원 여부 감지 (모델에 따라 다를 수 있음)

--- a/src/adapters/openrouter.ts
+++ b/src/adapters/openrouter.ts
@@ -65,6 +65,10 @@ export class OpenRouterCliAdapter implements CliAdapter {
     return { command: 'echo', args: ['"OpenRouter adapter uses run() — not shell spawn"'] };
   }
 
+  async getDefaultModel(): Promise<string> {
+    return DEFAULT_MODEL;
+  }
+
   async run(options: CliRunOptions): Promise<CliRunResult> {
     const startTime = Date.now();
 
@@ -84,7 +88,7 @@ export class OpenRouterCliAdapter implements CliAdapter {
       }
     }
 
-    const model = options.model ?? DEFAULT_MODEL;
+    const model = options.model ?? await this.getDefaultModel();
     const callApi = createApiCaller(apiKey, model, {
       disableReasoning: options.disableReasoning,
       onToken: options.onToken,

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -103,6 +103,15 @@ export interface CliAdapter {
   /** Check if the CLI tool is installed and available */
   isAvailable(): Promise<boolean>;
 
+  /**
+   * The provider's default model, resolved dynamically — from the provider's
+   * live model list where one is exposed (codex backend, local /v1/models),
+   * else the adapter's own provider-appropriate default. Used when no explicit
+   * model is configured, so callers never hardcode a (possibly wrong-provider
+   * or stale) model id.
+   */
+  getDefaultModel(): Promise<string>;
+
   /** Build the shell command and args for execution */
   buildCommand(options: CliRunOptions): { command: string; args: string[] };
 

--- a/src/agents/draftAnalyzer.ts
+++ b/src/agents/draftAnalyzer.ts
@@ -283,8 +283,9 @@ export async function runDraftAnalysis(options: DraftAnalyzerOptions): Promise<D
     onLog?.(`[Draft] Registry: ${codeContext.projectStats}`);
   }
 
-  // 3. Fast model draft analysis (~3s)
-  const model = options.model ?? 'gpt-5-codex';
+  // 3. Fast model draft analysis (~3s) — model resolves from the adapter when unset
+  const adapter = getAdapter();
+  const model = options.model ?? await adapter.getDefaultModel();
   const prompt = buildDraftPrompt(options, codeContext, impactAnalysis);
 
   let haikuResult: Partial<DraftAnalysis> = {
@@ -295,7 +296,6 @@ export async function runDraftAnalysis(options: DraftAnalyzerOptions): Promise<D
   };
 
   try {
-    const adapter = getAdapter();
     const raw = await spawnCli(adapter, {
       prompt,
       cwd: '/tmp',  // 중립 디렉토리 (Planner와 동일)

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -457,12 +457,12 @@ export class AutonomousRunner {
       return {
         worker: {
           enabled: true,
-          model: this.config.workerModel || 'claude-sonnet-4-6',
+          model: this.config.workerModel,  // unset → role adapter's getDefaultModel()
           timeoutMs: this.config.workerTimeoutMs ?? 0,
         },
         reviewer: {
           enabled: true,
-          model: this.config.reviewerModel || 'claude-haiku-4-5-20251001',
+          model: this.config.reviewerModel,  // unset → role adapter's getDefaultModel()
           timeoutMs: this.config.reviewerTimeoutMs ?? 0,
         },
       };
@@ -470,8 +470,9 @@ export class AutonomousRunner {
 
     // Apply per-project overrides
     const base = this.config.defaultRoles || {
-      worker: { enabled: true, model: 'claude-sonnet-4-6', timeoutMs: 0 },
-      reviewer: { enabled: true, model: 'claude-haiku-4-5-20251001', timeoutMs: 0 },
+      // No model → each role's adapter resolves its own default (getDefaultModel).
+      worker: { enabled: true, timeoutMs: 0 },
+      reviewer: { enabled: true, timeoutMs: 0 },
     };
 
     if (!projectConfig?.roles) {
@@ -1086,12 +1087,12 @@ export class AutonomousRunner {
       defaultAdapter,
       worker: {
         adapter: defaultRoles?.worker?.adapter ?? defaultAdapter,
-        model: defaultRoles?.worker?.model ?? this.config.workerModel ?? 'gpt-5-codex',
+        model: defaultRoles?.worker?.model ?? this.config.workerModel,
         enabled: defaultRoles?.worker?.enabled !== false,
       },
       reviewer: {
         adapter: defaultRoles?.reviewer?.adapter ?? defaultAdapter,
-        model: defaultRoles?.reviewer?.model ?? this.config.reviewerModel ?? 'gpt-5-codex',
+        model: defaultRoles?.reviewer?.model ?? this.config.reviewerModel,
         enabled: defaultRoles?.reviewer?.enabled !== false,
       },
       tester: defaultRoles?.tester ? {
@@ -1108,23 +1109,19 @@ export class AutonomousRunner {
   }
 
   switchProvider(adapter: AdapterName): void {
-    const mapModelForProvider = (model: string | undefined, role: 'worker' | 'reviewer' | 'tester' | 'documenter' | 'auditor' | 'skill-documenter'): string => {
-      const current = model || '';
-      const isClaudeModel = current.startsWith('claude-');
-      // ChatGPT 계정 Codex에서는 gpt-5.x / gpt-*-codex 계열만 지원
-      // o-series (o3, o4-mini 등)는 사용 불가
-      const isCodexCompatible = current.startsWith('gpt-');
-
+    // On a provider switch, keep the model only if it clearly belongs to the new
+    // provider; otherwise drop it (undefined) so the target adapter resolves its
+    // own default via getDefaultModel(). No hardcoded per-provider model ids.
+    const mapModelForProvider = (model: string | undefined, _role?: string): string | undefined => {
+      const current = (model || '').trim();
+      if (!current) return undefined;
       if (adapter === 'codex' || adapter === 'codex-responses') {
-        if (isCodexCompatible) return current;
-        // 비호환 모델(o-series·claude 등). codex CLI는 빈 플래그로 기본값을 위임할 수
-        // 있지만, codex-responses 어댑터는 API model 필드가 필수라 기본 모델로 채운다.
-        return adapter === 'codex-responses' ? 'gpt-5.5' : '';
+        // ChatGPT-account Codex only runs gpt-* slugs; anything else → adapter default.
+        return current.startsWith('gpt-') ? current : undefined;
       }
-
-      if (isClaudeModel) return current;
-      if (role === 'reviewer') return 'claude-sonnet-4-6';
-      return 'claude-haiku-4-5-20251001';
+      // openrouter/gpt/local/lmstudio: a namespaced id ("vendor/model") may carry
+      // over; a bare id from another provider usually won't — drop to the default.
+      return current.includes('/') ? current : undefined;
     };
 
     this.config.defaultAdapter = adapter;

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -115,7 +115,7 @@ export async function fetchLinearTasks(): Promise<{ tasks: TaskItem[]; error?: s
 
 export interface ExecutionContext {
   allowedProjects: string[];
-  /** Draft analyzer 모델 (기본: claude-haiku-4-5-20251001) */
+  /** Draft analyzer 모델. 미설정 시 어댑터의 getDefaultModel()로 동적 해석. */
   draftModel?: string;
   /** Draft analyzer 활성화 (기본: true) */
   enableDraftAnalysis?: boolean;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -112,8 +112,8 @@ const RoleConfigSchema = z.object({
   enabled: z.boolean().default(true),
   /** CLI adapter */
   adapter: AdapterNameSchema.optional(),
-  /** Model ID */
-  model: z.string(),
+  /** Model ID. Omit → resolved dynamically from the role's adapter (getDefaultModel). */
+  model: z.string().optional(),
   /** Timeout (ms), 0 = unlimited */
   timeoutMs: z.number().min(0).default(0),
   /** Model to escalate to on repeated failure */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -263,8 +263,8 @@ export type RoleConfig = {
   enabled: boolean;
   /** CLI adapter name */
   adapter?: 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter';
-  /** Model ID */
-  model: string;
+  /** Model ID. Omit → resolved dynamically from the role's adapter (getDefaultModel). */
+  model?: string;
   /** Timeout (ms), 0 = unlimited */
   timeoutMs: number;
   /** Model to escalate to on repeated failure */


### PR DESCRIPTION
## Summary

Role/draft model fallbacks were hardcoded, and the orchestrator injected **claude** models regardless of the configured adapter. So `codex-responses` (ChatGPT OAuth) 400'd on every task (`model not supported`) and the daemon could never complete work. Hardcoded ids also rot on version bumps. Found while running the daemon to watch repo-knowledge accumulate — the worker failed every task on this.

**Principle (per request):** each provider picks its own model from its model list dynamically; the orchestrator never hardcodes a (wrong-provider or pinned) model id.

- **`CliAdapter.getDefaultModel()`** — each adapter resolves its own provider-appropriate default, dynamically where the provider exposes a list:
  - codex / codex-responses → Codex OAuth catalog (`getCodexModelIds`, live + local + forward-compat)
  - local / lmstudio → server `/v1/models`
  - gpt / openrouter → provider default constant (no single canonical "default")
  - claude → version-agnostic `sonnet` alias (never stale)
  - adapters use it in `run()` instead of a constant.
- **Removed cross-provider hardcoded fallbacks**: `autonomousRunner` legacy/base roles + `getAdapterSummary` + `switchProvider` (now drops incompatible models → adapter default), `draftAnalyzer`. `RoleConfig.model` is now **optional** → unset flows through and the role's adapter picks a compatible model.

## Tests
`getDefaultModel.test.ts` — per-adapter default + a **regression guard that codex-responses never returns a claude model**. Full suite **865** green; lint/typecheck/build clean.

## Note
Kept the benchmarked openrouter defaults in `config.ts` `DefaultRolesConfigSchema` (glm-4.7-flash worker / gpt-5 reviewer) — those are deliberate, documented per-provider choices, not the fragile cross-provider injection this PR removes. They only apply when `defaultRoles` is configured.