### PR TITLE
feat(cli): openswarm project add/list/rm — register work repos (INT-1877)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -397,6 +397,38 @@ authCmd
     handleAuthLogout(opts.provider);
   });
 
+// openswarm project — manage work repos the daemon picks up
+
+const projectCmd = program
+  .command('project')
+  .description('Manage work repositories the daemon operates on');
+
+projectCmd
+  .command('add')
+  .description('Register a repository as a work repo (enabled + pinned)')
+  .argument('<path>', 'Path to the git repository')
+  .action(async (path: string) => {
+    const { handleProjectAdd } = await import('./cli/projectHandler.js');
+    handleProjectAdd(path);
+  });
+
+projectCmd
+  .command('list')
+  .description('List registered work repositories')
+  .action(async () => {
+    const { handleProjectList } = await import('./cli/projectHandler.js');
+    handleProjectList();
+  });
+
+projectCmd
+  .command('rm')
+  .description('Unregister a work repository (adds it to the denylist)')
+  .argument('<path>', 'Path to the repository')
+  .action(async (path: string) => {
+    const { handleProjectRm } = await import('./cli/projectHandler.js');
+    handleProjectRm(path);
+  });
+
 // 서브커맨드 없이 `openswarm`만 입력 시 → TUI chat 실행 (`openswarm chat`과 동일)
 
 async function launchChatTui(): Promise<void> {

--- a/src/cli/projectHandler.test.ts
+++ b/src/cli/projectHandler.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { addProject, removeProject, loadRepos, emptyReposConfig } from './projectHandler.js';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('projectHandler registry helpers', () => {
+  it('addProject registers to enabled + pinned and lifts the denylist', () => {
+    const start = { ...emptyReposConfig(), removedConfigPaths: ['/a/repo'] };
+    const out = addProject(start, '/a/repo');
+    expect(out.enabled).toContain('/a/repo');
+    expect(out.pinned).toContain('/a/repo');
+    expect(out.removedConfigPaths).not.toContain('/a/repo'); // denylist lifted
+  });
+
+  it('addProject is idempotent (no duplicates)', () => {
+    let cfg = emptyReposConfig();
+    cfg = addProject(cfg, '/a/repo');
+    cfg = addProject(cfg, '/a/repo');
+    expect(cfg.enabled.filter((p) => p === '/a/repo')).toHaveLength(1);
+    expect(cfg.pinned.filter((p) => p === '/a/repo')).toHaveLength(1);
+  });
+
+  it('removeProject drops from enabled/pinned and adds to the denylist', () => {
+    const cfg = addProject(emptyReposConfig(), '/a/repo');
+    const out = removeProject(cfg, '/a/repo');
+    expect(out.enabled).not.toContain('/a/repo');
+    expect(out.pinned).not.toContain('/a/repo');
+    expect(out.removedConfigPaths).toContain('/a/repo'); // denylisted
+  });
+
+  it('loadRepos returns an empty config for a missing file', () => {
+    expect(loadRepos('/nonexistent/osw-repos.json')).toEqual(emptyReposConfig());
+  });
+
+  it('loadRepos round-trips a written config', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'osw-proj-'));
+    const file = join(dir, 'repos.json');
+    writeFileSync(file, JSON.stringify(addProject(emptyReposConfig(), '/x/y')));
+    expect(loadRepos(file).enabled).toContain('/x/y');
+  });
+});

--- a/src/cli/projectHandler.ts
+++ b/src/cli/projectHandler.ts
@@ -1,0 +1,105 @@
+// ============================================
+// OpenSwarm - `openswarm project` CLI
+// ============================================
+//
+// Manage the work-repo registry the daemon reads at startup
+// (~/.claude/openswarm-repos.json — the same file the web dashboard writes).
+// `setWebRunner` (src/support/web.ts) merges `enabled` into both the runner's
+// enabled set AND its allowedProjects, so a repo added here is actually worked.
+
+import { existsSync, readFileSync, writeFileSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { expandPath } from '../core/config.js';
+import { c } from '../support/colors.js';
+
+/** Persisted dashboard/CLI repo registry. Mirrors web.ts ReposConfig. */
+export interface ReposConfig {
+  pinned: string[];
+  enabled: string[];
+  basePaths: string[];
+  removedConfigPaths: string[];
+}
+
+export const REPOS_FILE = join(homedir(), '.claude', 'openswarm-repos.json');
+
+export function emptyReposConfig(): ReposConfig {
+  return { pinned: [], enabled: [], basePaths: [], removedConfigPaths: [] };
+}
+
+export function loadRepos(file: string = REPOS_FILE): ReposConfig {
+  if (!existsSync(file)) return emptyReposConfig();
+  try {
+    const raw = JSON.parse(readFileSync(file, 'utf-8')) as Partial<ReposConfig>;
+    return {
+      pinned: raw.pinned ?? [],
+      enabled: raw.enabled ?? [],
+      basePaths: raw.basePaths ?? [],
+      removedConfigPaths: raw.removedConfigPaths ?? [],
+    };
+  } catch {
+    return emptyReposConfig();
+  }
+}
+
+function saveRepos(cfg: ReposConfig, file: string = REPOS_FILE): void {
+  writeFileSync(file, JSON.stringify(cfg, null, 2) + '\n', 'utf-8');
+}
+
+const uniq = (a: string[]): string[] => [...new Set(a)];
+
+/** Pure: register a repo (pinned + enabled) and lift it from the denylist. */
+export function addProject(cfg: ReposConfig, path: string): ReposConfig {
+  return {
+    ...cfg,
+    pinned: uniq([...cfg.pinned, path]),
+    enabled: uniq([...cfg.enabled, path]),
+    removedConfigPaths: cfg.removedConfigPaths.filter((p) => p !== path),
+  };
+}
+
+/** Pure: unregister a repo and add it to the denylist (matches the dashboard unpin). */
+export function removeProject(cfg: ReposConfig, path: string): ReposConfig {
+  return {
+    ...cfg,
+    pinned: cfg.pinned.filter((p) => p !== path),
+    enabled: cfg.enabled.filter((p) => p !== path),
+    removedConfigPaths: uniq([...cfg.removedConfigPaths, path]),
+  };
+}
+
+export function handleProjectAdd(rawPath: string): void {
+  const path = expandPath(rawPath, true);
+  if (!existsSync(path) || !statSync(path).isDirectory()) {
+    console.error(c.red(`✗ Not a directory: ${path}`));
+    process.exit(1);
+  }
+  if (!existsSync(join(path, '.git'))) {
+    console.error(c.yellow(`⚠ ${path} is not a git repo — workers run in git worktrees and need one.`));
+  }
+  saveRepos(addProject(loadRepos(), path));
+  console.log(c.green(`✓ Added work repo: ${path}`));
+  console.log(c.dim('  Restart the daemon (openswarm start) to pick it up.'));
+}
+
+export function handleProjectList(): void {
+  const cfg = loadRepos();
+  console.log(c.bold('Work repos (enabled):'));
+  if (cfg.enabled.length === 0) console.log('  (none)');
+  for (const p of cfg.enabled) console.log(`  ${c.green('✓')} ${p}${cfg.pinned.includes(p) ? c.dim(' (pinned)') : ''}`);
+  if (cfg.removedConfigPaths.length > 0) {
+    console.log(c.dim('\nExcluded (denylist):'));
+    for (const p of cfg.removedConfigPaths) console.log(c.dim(`  ✗ ${p}`));
+  }
+}
+
+export function handleProjectRm(rawPath: string): void {
+  const path = expandPath(rawPath, true);
+  const cfg = loadRepos();
+  if (!cfg.enabled.includes(path) && !cfg.pinned.includes(path)) {
+    console.error(c.yellow(`⚠ Not a registered work repo: ${path} (removing anyway / denylisting)`));
+  }
+  saveRepos(removeProject(cfg, path));
+  console.log(c.green(`✓ Removed work repo: ${path}`));
+  console.log(c.dim('  Restart the daemon to apply.'));
+}

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -213,17 +213,18 @@ export function setWebRunner(runner: AutonomousRunner): void {
   // Restore persisted enabled state. INT-1810 R6: removedConfigPaths is a HARD denylist —
   // never re-enable a removed/isolated repo, even if it lingers in the persisted enabled list
   // (auto-rediscovery used to re-add isolated repos and silently un-isolate them).
-  for (const path of _reposCfg.enabled) {
-    if (removedConfigPaths.has(path)) continue;
+  const enabledNow = _reposCfg.enabled.filter((p) => !removedConfigPaths.has(p));
+  for (const path of enabledNow) {
     runner.enableProject(path);
   }
-  // 대시보드에서 제거된 config 경로를 runner의 allowedProjects에서도 제거
-  if (removedConfigPaths.size > 0) {
-    const current = runner.getAllowedProjects();
-    const filtered = current.filter(p => !removedConfigPaths.has(p));
-    if (filtered.length !== current.length) {
-      runner.updateAllowedProjects(filtered);
-    }
+  // INT-1877: a CLI/dashboard-registered repo (repos.json `enabled`) must also be
+  // ALLOWED — otherwise the DecisionEngine allowedProjects filter drops it. Merge the
+  // enabled set into allowedProjects, then strip the denylist (INT-1810 R6: a removed
+  // path never returns, even if it lingers in the persisted enabled list).
+  const current = runner.getAllowedProjects();
+  const merged = [...new Set([...current, ...enabledNow])].filter((p) => !removedConfigPaths.has(p));
+  if (merged.length !== current.length || merged.some((p) => !current.includes(p))) {
+    runner.updateAllowedProjects(merged);
   }
   // Pre-seed path cache from pinned + enabled projects so tasks without execution history are still matched
   const allSeeded = new Set([...pinnedProjects, ..._reposCfg.enabled]);


### PR DESCRIPTION
## What

Adds an `openswarm project` command group so the CLI can register which repos the daemon works on. Until now that lived only in the web dashboard's `~/.claude/openswarm-repos.json` (or hand-edited config) — there was no terminal path to add a work repo.

| Command | Effect |
|---|---|
| `openswarm project add <path>` | enabled + pinned; lifts the INT-1810 denylist |
| `openswarm project list` | enabled repos (pinned marked) + denylist |
| `openswarm project rm <path>` | drops from enabled/pinned; adds to denylist |

## Why the `setWebRunner` change

The daemon gates work on **both** the config `allowedProjects` filter (DecisionEngine) **and** repos.json `enabled` (runtime). `setWebRunner` already restored `enabled` into the runner's enabled set but **not** into `allowedProjects` — so a freshly added repo was silently dropped by the DecisionEngine and never worked. The merge fixes that while keeping `removedConfigPaths` a hard denylist (INT-1810 R6).

## Design

- `projectHandler.ts` keeps registry mutations as **pure** functions (`addProject`/`removeProject`) for unit testing; handlers wrap them with path validation (must be a directory; warns if no `.git`) and file I/O.
- The registry file and pin/enable/denylist semantics mirror the dashboard exactly, so CLI and dashboard stay consistent.

## Verification

- `npm test` — 870 passed (incl. 5 new `projectHandler` tests: add/remove/idempotency/denylist/load round-trip)
- `npm run typecheck` — clean
- `npm run build` + `node dist/cli.js project --help` — subcommands present and working

🤖 Generated with [Claude Code](https://claude.com/claude-code)