### PR TITLE
feat(cli): flatten work-repo commands to top level (add/projects/remove)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -397,13 +397,9 @@ authCmd
     handleAuthLogout(opts.provider);
   });
 
-// openswarm project — manage work repos the daemon picks up
+// Work-repo management — register which repos the daemon operates on
 
-const projectCmd = program
-  .command('project')
-  .description('Manage work repositories the daemon operates on');
-
-projectCmd
+program
   .command('add')
   .description('Register a repository as a work repo (enabled + pinned)')
   .argument('<path>', 'Path to the git repository')
@@ -412,16 +408,16 @@ projectCmd
     handleProjectAdd(path);
   });
 
-projectCmd
-  .command('list')
+program
+  .command('projects')
   .description('List registered work repositories')
   .action(async () => {
     const { handleProjectList } = await import('./cli/projectHandler.js');
     handleProjectList();
   });
 
-projectCmd
-  .command('rm')
+program
+  .command('remove')
   .description('Unregister a work repository (adds it to the denylist)')
   .argument('<path>', 'Path to the repository')
   .action(async (path: string) => {

--- a/src/cli/projectHandler.ts
+++ b/src/cli/projectHandler.ts
@@ -1,5 +1,5 @@
 // ============================================
-// OpenSwarm - `openswarm project` CLI
+// OpenSwarm - work-repo CLI (`openswarm add` / `projects` / `remove`)
 // ============================================
 //
 // Manage the work-repo registry the daemon reads at startup


### PR DESCRIPTION
## What

Follow-up to #90 / INT-1877. `openswarm project add` was too verbose for the most common action, so the work-repo commands move to the top level:

| Before | After |
|---|---|
| `openswarm project add <path>` | `openswarm add <path>` |
| `openswarm project list` | `openswarm projects` |
| `openswarm project rm <path>` | `openswarm remove <path>` |

The `project` group is removed. `list`/`rm` were renamed to `projects`/`remove` because bare top-level `list`/`rm` would be ambiguous (list what?) and `rm` reads as destructive.

## Scope

Command surface only — handlers and the pure registry helpers (`addProject`/`removeProject`) are unchanged, so the existing unit tests still cover the logic.

## Verification

- `npm run typecheck` + `npm run build` clean
- `node dist/cli.js --help` shows `add`/`projects`/`remove` at top level; `project` group gone
- `npm test` — projectHandler tests pass (5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)