### PR TITLE
feat(cli): map repo→Linear project on `openswarm add` (INT-1877)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -405,7 +405,7 @@ program
   .argument('<path>', 'Path to the git repository')
   .action(async (path: string) => {
     const { handleProjectAdd } = await import('./cli/projectHandler.js');
-    handleProjectAdd(path);
+    await handleProjectAdd(path);
   });
 
 program

--- a/src/cli/initWizard.ts
+++ b/src/cli/initWizard.ts
@@ -17,8 +17,8 @@ import { writeEnvVars } from '../core/envFile.js';
 import { generateSampleConfig } from '../core/config.js';
 import { AuthProfileStore, loginAndSaveLinearProfile, ensureValidToken } from '../auth/index.js';
 import { getAdapter } from '../adapters/index.js';
-import { listTeams, listProjects, type LinearCredential } from '../linear/index.js';
-import { saveRepoMetadata } from '../support/repoMetadata.js';
+import { type LinearCredential } from '../linear/index.js';
+import { pickAndSaveLinearMapping } from './linearMapping.js';
 import { banner } from '../support/banner.js';
 
 type ProviderId = 'codex-responses' | 'openrouter' | 'gpt' | 'lmstudio' | 'local' | 'codex' | 'claude';
@@ -182,62 +182,16 @@ async function setupLinear(envVars: Record<string, string>, cwd: string): Promis
     cred = { apiKey };
   }
 
-  let teams: Awaited<ReturnType<typeof listTeams>> = [];
-  try {
-    teams = await listTeams(cred);
-  } catch (err) { // cxt-ignore: error_swallow,exception_hiding — surfaced to the user + manual team-id fallback
-    console.log(`   ⚠ Could not fetch teams (${(err as Error).message}). Enter the team id manually.`);
-  }
-
-  if (teams.length === 0) {
+  // Team→project picker + openswarm.json write is shared with `openswarm add`.
+  const result = await pickAndSaveLinearMapping(cwd, cred);
+  if (result.kind === 'no-teams') {
+    // Manual team-id fallback keeps init usable when the Linear API is unreachable.
     const tid = (await input({ message: '   LINEAR_TEAM_ID:' })).trim();
     if (tid) envVars.LINEAR_TEAM_ID = tid;
     return;
   }
-
-  // One repo = one team. (Multi-team daemon watch lives in the main
-  // ~/.config/openswarm config, not per-repo init — keeps this picker simple.)
-  const mapTeamId = await select({
-    message: `   Linear team for "${basename(cwd)}":`,
-    choices: teams.map((t) => ({ name: `${t.key} — ${t.name}`, value: t.id })),
-  });
-  envVars.LINEAR_TEAM_ID = mapTeamId;
-
-  let projects: Awaited<ReturnType<typeof listProjects>> = [];
-  try {
-    projects = await listProjects(mapTeamId, cred);
-  } catch (err) { // cxt-ignore: error_swallow,exception_hiding — surfaced to the user; repo mapping skipped
-    console.log(`   ⚠ Could not fetch projects (${(err as Error).message}).`);
-    return;
-  }
-  if (projects.length === 0) {
-    console.log('   No projects in that team — skipping repo mapping.');
-    return;
-  }
-
-  const repoName = basename(cwd);
-  const projectId = await select({
-    message: `   Linear project for "${repoName}":`,
-    choices: [
-      { name: '(skip — no repo mapping)', value: '' },
-      ...projects.map((p) => ({ name: p.name, value: p.id })),
-    ],
-  });
-  if (!projectId) return;
-
-  const proj = projects.find((p) => p.id === projectId);
-  const team = teams.find((t) => t.id === mapTeamId);
-  const filePath = await saveRepoMetadata(cwd, {
-    schemaVersion: 1,
-    projectName: proj?.name,
-    linear: {
-      teamId: mapTeamId,
-      teamKey: team?.key,
-      projectId,
-      projectName: proj?.name,
-    },
-  });
-  console.log(`   Wrote ${filePath} → ${team?.key ?? '?'}/${proj?.name ?? projectId}`);
+  // Record the selected team for the daemon even if the project pick was skipped.
+  if (result.teamId) envVars.LINEAR_TEAM_ID = result.teamId;
 }
 
 export async function runInitWizard(opts: InitWizardOptions = {}): Promise<void> {

--- a/src/cli/linearMapping.ts
+++ b/src/cli/linearMapping.ts
@@ -1,0 +1,102 @@
+// ============================================
+// OpenSwarm - Linear repo→project mapping picker
+// ============================================
+//
+// Shared by `openswarm init` (setupLinear) and `openswarm add`: given a Linear
+// credential, interactively pick a team + project and persist the repo↔Linear
+// mapping into <repo>/openswarm.json. The daemon then resolves this repo by its
+// explicit mapping instead of fuzzy name matching (src/support/projectMapper.ts).
+
+import { basename } from 'node:path';
+import { select } from '@inquirer/prompts';
+import { listTeams, listProjects, type LinearCredential } from '../linear/index.js';
+import { saveRepoMetadata, type LinearRepoMapping } from '../support/repoMetadata.js';
+import { AuthProfileStore, ensureValidToken } from '../auth/index.js';
+
+/**
+ * Resolve a Linear credential for non-interactive use (no auth prompt):
+ *  1. linear:default OAuth profile (refreshed via ensureValidToken), then
+ *  2. LINEAR_API_KEY env var.
+ * Returns null when neither is present — the caller should hint at `auth login`.
+ */
+export async function resolveLinearCredential(): Promise<LinearCredential | null> {
+  try {
+    const store = new AuthProfileStore();
+    if (store.getProfile('linear:default')) {
+      const token = await ensureValidToken(store, 'linear:default');
+      return { accessToken: token };
+    }
+  } catch { // cxt-ignore: error_swallow,exception_hiding — profile unreadable → try API key next
+    /* fall through to API key */
+  }
+  const apiKey = process.env.LINEAR_API_KEY?.trim();
+  if (apiKey) return { apiKey };
+  return null;
+}
+
+export type MappingPickResult =
+  | { kind: 'saved'; teamId: string; mapping: LinearRepoMapping }
+  | { kind: 'skipped'; teamId?: string } // user skipped the project / team has none
+  | { kind: 'no-teams' }; // teams unfetchable or empty
+
+/**
+ * Interactive team→project picker that writes <repoPath>/openswarm.json.
+ * Logs its own progress. Does NOT prompt for auth — pass a resolved credential.
+ * Throws @inquirer's ExitPromptError on Ctrl-C (callers handle it as a skip).
+ */
+export async function pickAndSaveLinearMapping(
+  repoPath: string,
+  cred: LinearCredential,
+): Promise<MappingPickResult> {
+  let teams: Awaited<ReturnType<typeof listTeams>> = [];
+  try {
+    teams = await listTeams(cred);
+  } catch (err) { // cxt-ignore: error_swallow,exception_hiding — surfaced to the user; mapping skipped
+    console.log(`   ⚠ Could not fetch Linear teams (${(err as Error).message}).`);
+    return { kind: 'no-teams' };
+  }
+  if (teams.length === 0) return { kind: 'no-teams' };
+
+  const repoName = basename(repoPath);
+  const teamId = await select({
+    message: `   Linear team for "${repoName}":`,
+    choices: teams.map((t) => ({ name: `${t.key} — ${t.name}`, value: t.id })),
+  });
+
+  let projects: Awaited<ReturnType<typeof listProjects>> = [];
+  try {
+    projects = await listProjects(teamId, cred);
+  } catch (err) { // cxt-ignore: error_swallow,exception_hiding — surfaced to the user; mapping skipped
+    console.log(`   ⚠ Could not fetch projects (${(err as Error).message}).`);
+    return { kind: 'skipped', teamId };
+  }
+  if (projects.length === 0) {
+    console.log('   No projects in that team — skipping repo mapping.');
+    return { kind: 'skipped', teamId };
+  }
+
+  const projectId = await select({
+    message: `   Linear project for "${repoName}":`,
+    choices: [
+      { name: '(skip — no repo mapping)', value: '' },
+      ...projects.map((p) => ({ name: p.name, value: p.id })),
+    ],
+  });
+  if (!projectId) return { kind: 'skipped', teamId };
+
+  const proj = projects.find((p) => p.id === projectId);
+  const team = teams.find((t) => t.id === teamId);
+  const mapping: LinearRepoMapping = {
+    teamId,
+    teamKey: team?.key,
+    projectId,
+    projectName: proj?.name,
+  };
+  const filePath = await saveRepoMetadata(repoPath, {
+    schemaVersion: 1,
+    projectName: proj?.name,
+    linear: mapping,
+  });
+  console.log(`   Wrote ${filePath} → ${team?.key ?? '?'}/${proj?.name ?? projectId}`);
+  return { kind: 'saved', teamId, mapping };
+}

--- a/src/cli/projectHandler.ts
+++ b/src/cli/projectHandler.ts
@@ -6,12 +6,18 @@
 // (~/.claude/openswarm-repos.json — the same file the web dashboard writes).
 // `setWebRunner` (src/support/web.ts) merges `enabled` into both the runner's
 // enabled set AND its allowedProjects, so a repo added here is actually worked.
+//
+// `add` also offers a Linear team/project picker (shared with `openswarm init`
+// via ./linearMapping) and writes the repo↔Linear mapping into the repo's
+// openswarm.json — registering a path alone wouldn't tell the daemon which
+// Linear project's issues belong to it.
 
 import { existsSync, readFileSync, writeFileSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { expandPath } from '../core/config.js';
 import { c } from '../support/colors.js';
+import { loadRepoMetadata, RepoMetadataError } from '../support/repoMetadata.js';
 
 /** Persisted dashboard/CLI repo registry. Mirrors web.ts ReposConfig. */
 export interface ReposConfig {
@@ -68,7 +74,7 @@ export function removeProject(cfg: ReposConfig, path: string): ReposConfig {
   };
 }
 
-export function handleProjectAdd(rawPath: string): void {
+export async function handleProjectAdd(rawPath: string): Promise<void> {
   const path = expandPath(rawPath, true);
   if (!existsSync(path) || !statSync(path).isDirectory()) {
     console.error(c.red(`✗ Not a directory: ${path}`));
@@ -79,7 +85,62 @@ export function handleProjectAdd(rawPath: string): void {
   }
   saveRepos(addProject(loadRepos(), path));
   console.log(c.green(`✓ Added work repo: ${path}`));
+
+  // Registering the path is not enough: the daemon works Linear issues, which
+  // belong to a Linear project. Map this repo to a team/project (written into
+  // <repo>/openswarm.json) so it resolves without fuzzy name matching.
+  await mapRepoToLinear(path);
+
   console.log(c.dim('  Restart the daemon (openswarm start) to pick it up.'));
+}
+
+/**
+ * Best-effort interactive Linear mapping for a freshly added repo. Never throws:
+ * the path is registered regardless. Skips silently when already mapped, when
+ * stdin is not a TTY (scripted/CI), or when Linear isn't configured.
+ */
+async function mapRepoToLinear(path: string): Promise<void> {
+  try {
+    const meta = await loadRepoMetadata(path);
+    if (meta?.linear?.projectId) {
+      const label = meta.linear.projectName ?? meta.linear.projectId;
+      console.log(c.dim(`  Linear: already mapped → ${meta.linear.teamKey ?? '?'}/${label}`));
+      return;
+    }
+  } catch (err) {
+    if (err instanceof RepoMetadataError) {
+      console.error(c.yellow(`  ⚠ ${err.message} — re-mapping.`));
+    }
+  }
+
+  if (!process.stdin.isTTY) {
+    console.log(c.dim('  Linear mapping skipped (non-interactive) — run `openswarm add` in a terminal, or add openswarm.json manually.'));
+    return;
+  }
+
+  const { resolveLinearCredential, pickAndSaveLinearMapping } = await import('./linearMapping.js');
+  const cred = await resolveLinearCredential();
+  if (!cred) {
+    console.log(c.dim('  Linear not configured — run `openswarm auth login --provider linear` to map this repo, or add openswarm.json manually.'));
+    return;
+  }
+
+  console.log(c.bold('  Map this repo to a Linear project:'));
+  try {
+    const result = await pickAndSaveLinearMapping(path, cred);
+    if (result.kind === 'no-teams') {
+      console.log(c.dim('  No Linear teams visible — skipped. Add openswarm.json manually if needed.'));
+    } else if (result.kind === 'skipped') {
+      console.log(c.dim('  Repo mapping skipped — add openswarm.json later to pin the Linear project.'));
+    }
+  } catch (err) {
+    // @inquirer throws ExitPromptError on Ctrl-C — treat as a skip, not a crash.
+    if (err instanceof Error && err.name === 'ExitPromptError') {
+      console.log(c.dim('  Linear mapping skipped.'));
+      return;
+    }
+    throw err;
+  }
 }
 
 export function handleProjectList(): void {


### PR DESCRIPTION
## Why

`openswarm add <path>` registered the repo path but stopped there. The daemon works **Linear issues**, which belong to a Linear **project** — so a path with no project mapping fell back to fuzzy name matching (`src/support/projectMapper.ts`), which silently breaks on renames or ambiguous names. As @unohee put it: after `add`, it should show the Linear teams/projects and let you map which project this repo is.

## What

`add` now runs the **same team/project picker `openswarm init` uses** and writes the repo↔Linear mapping into `<repo>/openswarm.json`. `projectMapper` reads that explicit mapping first, before any fuzzy match.

- **`src/cli/linearMapping.ts`** (new) — extracts `pickAndSaveLinearMapping(repoPath, cred)` (team → project → `saveRepoMetadata`) plus `resolveLinearCredential()` (`linear:default` OAuth profile → `LINEAR_API_KEY`). `initWizard`'s `setupLinear` now reuses it, dropping the duplicated block.
- **`projectHandler.ts`** — `handleProjectAdd` is async and calls a best-effort `mapRepoToLinear(path)`:
  - already mapped → prints `already mapped → KEY/Project`, skips the picker
  - non-TTY (scripted/CI) → registers + prints a hint, no prompt
  - Linear not configured → registers + hints `auth login --provider linear`
  - Ctrl-C in the picker → treated as a skip, not a crash

Registration always succeeds regardless of the mapping outcome.

## Verification

- Non-interactive `add <tmp repo>` → path registered, mapping skipped with hint
- Repo with a valid `openswarm.json` → `Linear: already mapped → INT/OpenSwarm`, picker skipped
- Malformed `openswarm.json` → warns and proceeds to re-map
- `npm test` 870 passed (init refactor preserves behavior) · typecheck/build/lint clean

The interactive picker path is the exact code `init` already ships, now shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)