### PR TITLE
feat(web): hot-reload repos.json so CLI add/remove show without restart (INT-1877)

### DIFF
--- a/src/cli/projectHandler.ts
+++ b/src/cli/projectHandler.ts
@@ -91,7 +91,7 @@ export async function handleProjectAdd(rawPath: string): Promise<void> {
   // <repo>/openswarm.json) so it resolves without fuzzy name matching.
   await mapRepoToLinear(path);
 
-  console.log(c.dim('  Restart the daemon (openswarm start) to pick it up.'));
+  console.log(c.dim('  A running daemon picks this up within a few seconds — otherwise start it with `openswarm start`.'));
 }
 
 /**
@@ -162,5 +162,5 @@ export function handleProjectRm(rawPath: string): void {
   }
   saveRepos(removeProject(cfg, path));
   console.log(c.green(`✓ Removed work repo: ${path}`));
-  console.log(c.dim('  Restart the daemon to apply.'));
+  console.log(c.dim('  A running daemon applies this within a few seconds.'));
 }

--- a/src/support/web.reposReload.test.ts
+++ b/src/support/web.reposReload.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { applyReposConfig } from './web.js';
+import type { AutonomousRunner } from '../automation/autonomousRunner.js';
+
+// Minimal stub of the AutonomousRunner surface applyReposConfig touches, so we
+// can assert how a fresh repos.json is reconciled onto the runner without a
+// daemon. This is the load-bearing behavior behind "CLI `add` shows up in the
+// dashboard without a restart".
+function makeRunner(initialEnabled: string[] = [], initialAllowed: string[] = []) {
+  const enabled = new Set(initialEnabled);
+  let allowed = [...initialAllowed];
+  const registered: Record<string, string> = {};
+  return {
+    enableProject: (p: string) => { enabled.add(p); },
+    disableProject: (p: string) => { enabled.delete(p); },
+    getEnabledProjects: () => [...enabled],
+    getAllowedProjects: () => [...allowed],
+    updateAllowedProjects: (paths: string[]) => { allowed = [...paths]; },
+    registerProjectPath: (name: string, path: string) => { registered[name] = path; },
+    _enabled: enabled,
+    _allowed: () => allowed,
+    _registered: registered,
+  };
+}
+
+const cfg = (over: Partial<Record<'pinned' | 'enabled' | 'basePaths' | 'removedConfigPaths', string[]>> = {}) => ({
+  pinned: [], enabled: [], basePaths: [], removedConfigPaths: [], ...over,
+});
+
+describe('applyReposConfig — repos.json → runner reconciliation', () => {
+  let runner: ReturnType<typeof makeRunner>;
+  beforeEach(() => { runner = makeRunner(); });
+
+  it('enables a newly added repo and makes it allowed', () => {
+    applyReposConfig(runner as unknown as AutonomousRunner, cfg({ enabled: ['/dev/WAVE'] }));
+    expect(runner.getEnabledProjects()).toContain('/dev/WAVE');
+    expect(runner._allowed()).toContain('/dev/WAVE');
+  });
+
+  it('disables a repo dropped from enabled (file is authoritative)', () => {
+    runner = makeRunner(['/dev/OLD'], ['/dev/OLD']);
+    applyReposConfig(runner as unknown as AutonomousRunner, cfg({ enabled: ['/dev/NEW'] }));
+    expect(runner.getEnabledProjects()).toEqual(['/dev/NEW']);
+  });
+
+  it('never enables/allows a denylisted repo even if it lingers in enabled', () => {
+    applyReposConfig(
+      runner as unknown as AutonomousRunner,
+      cfg({ enabled: ['/dev/WAVE'], removedConfigPaths: ['/dev/WAVE'] }),
+    );
+    expect(runner.getEnabledProjects()).not.toContain('/dev/WAVE');
+    expect(runner._allowed()).not.toContain('/dev/WAVE');
+  });
+
+  it('pre-seeds the name→path cache for pinned and enabled repos', () => {
+    applyReposConfig(
+      runner as unknown as AutonomousRunner,
+      cfg({ pinned: ['/dev/OpenSwarm'], enabled: ['/dev/WAVE'] }),
+    );
+    expect(runner._registered).toMatchObject({ OpenSwarm: '/dev/OpenSwarm', WAVE: '/dev/WAVE' });
+  });
+
+  it('is idempotent — applying the same config twice changes nothing further', () => {
+    const c = cfg({ enabled: ['/dev/WAVE'] });
+    applyReposConfig(runner as unknown as AutonomousRunner, c);
+    const after1 = [...runner.getEnabledProjects()].sort();
+    applyReposConfig(runner as unknown as AutonomousRunner, c);
+    expect([...runner.getEnabledProjects()].sort()).toEqual(after1);
+  });
+});

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -3,7 +3,7 @@
 // ============================================
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
-import { writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { writeFileSync, readFileSync, existsSync, watchFile } from 'node:fs';
 import { readdir, stat } from 'node:fs/promises';
 import { join, resolve as resolvePath, dirname, basename } from 'node:path';
 import { homedir } from 'node:os';
@@ -205,33 +205,84 @@ const pinnedProjects = new Set<string>(_reposCfg.pinned);
 const customBasePaths = new Set<string>(_reposCfg.basePaths ?? []);
 const removedConfigPaths = new Set<string>(_reposCfg.removedConfigPaths ?? []);
 
+function syncSet(set: Set<string>, values: string[]): void {
+  set.clear();
+  for (const v of values) set.add(v);
+}
+
 /**
- * Set runner reference (call after autonomous runner is initialized)
+ * Re-read ~/.claude/openswarm-repos.json and apply it to the in-memory registry
+ * + runner. The file is the source of truth: the in-memory pinned/basePaths/
+ * denylist Sets are refilled in place (endpoints close over those refs), and the
+ * runner's enabled set is reconciled to file.enabled minus the denylist. Called
+ * at startup and by the file watcher, so a CLI `add`/`remove` (or a hand edit)
+ * reflects in the dashboard without a daemon restart.
  */
-export function setWebRunner(runner: AutonomousRunner): void {
-  runnerRef = runner;
-  // Restore persisted enabled state. INT-1810 R6: removedConfigPaths is a HARD denylist —
-  // never re-enable a removed/isolated repo, even if it lingers in the persisted enabled list
-  // (auto-rediscovery used to re-add isolated repos and silently un-isolate them).
-  const enabledNow = _reposCfg.enabled.filter((p) => !removedConfigPaths.has(p));
-  for (const path of enabledNow) {
-    runner.enableProject(path);
+export function applyReposConfig(runner: AutonomousRunner, cfg: ReposConfig = loadReposConfig()): void {
+  syncSet(pinnedProjects, cfg.pinned ?? []);
+  syncSet(customBasePaths, cfg.basePaths ?? []);
+  // INT-1810 R6: removedConfigPaths is a HARD denylist — a removed/isolated repo
+  // never returns, even if it lingers in the persisted enabled list.
+  syncSet(removedConfigPaths, cfg.removedConfigPaths ?? []);
+
+  // Reconcile the runner's enabled set to the file (authoritative): enable every
+  // file-enabled, non-denylisted repo; disable anything no longer listed. enabled
+  // is only ever set from here or the dashboard toggle, so this can't fight the
+  // autonomous loop.
+  const enabledNow = (cfg.enabled ?? []).filter((p) => !removedConfigPaths.has(p));
+  const desired = new Set(enabledNow);
+  for (const path of desired) runner.enableProject(path);
+  for (const path of runner.getEnabledProjects()) {
+    if (!desired.has(path)) runner.disableProject(path);
   }
-  // INT-1877: a CLI/dashboard-registered repo (repos.json `enabled`) must also be
-  // ALLOWED — otherwise the DecisionEngine allowedProjects filter drops it. Merge the
-  // enabled set into allowedProjects, then strip the denylist (INT-1810 R6: a removed
-  // path never returns, even if it lingers in the persisted enabled list).
+
+  // INT-1877: an enabled repo must also be ALLOWED — otherwise the DecisionEngine
+  // allowedProjects filter drops it. Merge enabled into allowedProjects, strip the
+  // denylist.
   const current = runner.getAllowedProjects();
   const merged = [...new Set([...current, ...enabledNow])].filter((p) => !removedConfigPaths.has(p));
   if (merged.length !== current.length || merged.some((p) => !current.includes(p))) {
     runner.updateAllowedProjects(merged);
   }
-  // Pre-seed path cache from pinned + enabled projects so tasks without execution history are still matched
-  const allSeeded = new Set([...pinnedProjects, ..._reposCfg.enabled]);
-  for (const path of allSeeded) {
+
+  // Pre-seed name→path cache so tasks without execution history are still matched.
+  for (const path of new Set([...pinnedProjects, ...enabledNow])) {
     const name = path.split('/').pop();
     if (name) runner.registerProjectPath(name, path);
   }
+}
+
+let reposWatcherStarted = false;
+/**
+ * Poll the repo registry file and reload when it changes, so external writers
+ * (CLI `openswarm add`/`remove`, hand edits) show up in the dashboard within a
+ * few seconds — no restart. Dashboard writes (saveReposConfig) also trip this,
+ * but reload is a no-op when memory already matches the file. applyReposConfig
+ * never writes, so there is no feedback loop.
+ */
+function startReposWatcher(): void {
+  if (reposWatcherStarted) return;
+  reposWatcherStarted = true;
+  watchFile(REPOS_FILE, { interval: 3000 }, (curr, prev) => {
+    if (curr.mtimeMs === prev.mtimeMs) return;
+    const runner = runnerRef;
+    if (!runner) return;
+    console.log('[Web] repos config changed on disk — reloading project registry');
+    try {
+      applyReposConfig(runner);
+    } catch (e) {
+      console.warn('[Web] repos reload failed:', e instanceof Error ? e.message : e);
+    }
+  });
+}
+
+/**
+ * Set runner reference (call after autonomous runner is initialized)
+ */
+export function setWebRunner(runner: AutonomousRunner): void {
+  runnerRef = runner;
+  applyReposConfig(runner);
+  startReposWatcher();
 }
 
 // Read POST body helper


### PR DESCRIPTION
## Why

`openswarm add <path>` wrote the work-repo registry (`~/.claude/openswarm-repos.json`), but a **running** daemon had read that file once at startup into in-memory Sets + the runner's enabled/allowed sets. So an added repo (e.g. WAVE) didn't appear in the dashboard until a restart — confirmed live: WAVE was `pinned`+`enabled` in the file yet absent from `/api/projects`.

@unohee's ask: don't require a restart — reload on a heartbeat/interval, or when `add` happens.

## What

A poll-based file watcher (`watchFile`, 3s interval) reloads the registry whenever it changes on disk. One mechanism covers **all** external writers — CLI `add`/`remove` and hand edits — without coupling the CLI to the daemon.

- **`applyReposConfig(runner, cfg)`** — the file is authoritative. Refills the pinned/basePaths/denylist Sets in place (endpoints close over those refs) and reconciles the runner's enabled set to `file.enabled` (enable new, disable dropped), then re-merges enabled into `allowedProjects` minus the denylist (INT-1810 R6). `setWebRunner` calls it at startup; the watcher calls it on change.
- `enableProject` is only ever driven from here or the dashboard toggle, so a file-authoritative reconcile can't fight the autonomous loop.
- Dashboard writes (`saveReposConfig`) also trip the watcher, but reload is a no-op when memory already matches; `applyReposConfig` never writes → no feedback loop.
- CLI hints updated: a running daemon now picks up `add`/`remove` in seconds.

## Verification

- `applyReposConfig` reconciliation unit tests — enable / disable-on-drop / denylist / name-cache seed / idempotent (5 cases)
- Live `watchFile`→reload e2e — wrote a temp `enabled` entry to the real file, the stub runner reflected it within the poll interval, file restored byte-for-byte
- `npm test` 875 passed · typecheck/build/lint clean

## Note

Loading the watcher needs **one** daemon restart (it ships in the new code); after that, no restarts are needed for future `add`/`remove`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)