### PR TITLE
fix(autonomy): cancel in-flight pipelines on disable + show in-process tasks in dashboard (INT-1898)

### DIFF
--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -188,10 +188,25 @@ export type PipelineEventType =
 
 // Pair Pipeline
 
+/** Thrown when the pipeline is cancelled mid-run (project disable / manual stop). */
+export class PipelineCancelledError extends Error {
+  constructor() {
+    super('Pipeline cancelled');
+    this.name = 'PipelineCancelledError';
+  }
+}
+
 export class PairPipeline extends EventEmitter {
   private config: PipelineConfig;
   private stuckDetector: StuckDetector;
   private jobProfiles: JobProfile[];
+  /** Set per run() — aborts the pipeline + in-flight adapter call on cancel/disable. */
+  private abortSignal?: AbortSignal;
+
+  /** Throw if this run has been cancelled. Called at iteration/stage boundaries. */
+  private throwIfAborted(): void {
+    if (this.abortSignal?.aborted) throw new PipelineCancelledError();
+  }
 
   constructor(config: PipelineConfig) {
     super();
@@ -238,10 +253,11 @@ export class PairPipeline extends EventEmitter {
    * 1 iteration = full pass through Worker → Reviewer → Tester
    * On failure at any stage, returns to Worker (up to maxIterations)
    */
-  async run(task: TaskItem, projectPath: string): Promise<PipelineResult> {
+  async run(task: TaskItem, projectPath: string, opts?: { signal?: AbortSignal }): Promise<PipelineResult> {
     const startTime = Date.now();
     const stages: StageResult[] = [];
     const maxIterations = this.config.maxIterations ?? 3;
+    this.abortSignal = opts?.signal;
 
     // Reset stuck detector (new pipeline run)
     this.stuckDetector.reset();
@@ -328,13 +344,20 @@ export class PairPipeline extends EventEmitter {
       return this.buildResult(context, stages, startTime);
 
     } catch (error) {
-      console.error('[%s] Error:', context.taskPrefix, error);
+      // Cancellation (project disable / manual stop) is not a failure — surface it
+      // as 'cancelled' so the scheduler doesn't count it failed or trigger a retry.
+      const cancelled = error instanceof PipelineCancelledError || !!this.abortSignal?.aborted;
+      if (cancelled) {
+        console.log(`[${context.taskPrefix}] Pipeline cancelled`);
+      } else {
+        console.error('[%s] Error:', context.taskPrefix, error);
+      }
       agentPair.updateSessionStatus(session.id, 'failed');
       return {
         success: false,
         sessionId: session.id,
         stages,
-        finalStatus: 'failed',
+        finalStatus: cancelled ? 'cancelled' : 'failed',
         totalDuration: Date.now() - startTime,
         iterations: context.currentIteration,
         workerResult: context.workerResult,
@@ -540,6 +563,7 @@ export class PairPipeline extends EventEmitter {
             onLog,
             processContext: { taskId: context.task.id, stage: 'worker' },
             workerContext,
+            signal: this.abortSignal,
           });
           agentPair.saveWorkerResult(context.session.id, result as WorkerResult);
           context.workerResult = result as WorkerResult;
@@ -602,6 +626,7 @@ export class PairPipeline extends EventEmitter {
             maxTurns: reviewerMaxTurns,
             adapterName: this.config.roles?.reviewer?.adapter,
             processContext: { taskId: context.task.id, stage: 'reviewer' },
+            signal: this.abortSignal,
           });
 
           agentPair.saveReviewerResult(context.session.id, result as ReviewResult);
@@ -840,6 +865,7 @@ export class PairPipeline extends EventEmitter {
     }
 
     while (context.currentIteration < maxIterations) {
+      this.throwIfAborted(); // bail before starting another iteration
       context.currentIteration++;
 
       // Stuck detection check (before iteration starts)

--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -21,6 +21,8 @@ export interface ReviewerOptions {
   maxTurns?: number;           // Max agentic turns per CLI invocation
   adapterName?: AdapterName;
   processContext?: ProcessContext;
+  /** Abort the run + in-flight adapter call (pipeline cancel / project disable). */
+  signal?: AbortSignal;
 }
 
 export interface PreCheckResult {
@@ -122,6 +124,7 @@ export async function runPreCheck(options: ReviewerOptions): Promise<PreCheckRes
       model: options.model,
       maxTurns: options.maxTurns,
       processContext: options.processContext,
+      signal: options.signal,
     });
 
     // DEBUG: Log raw Haiku output for troubleshooting
@@ -194,6 +197,7 @@ export async function runReviewer(options: ReviewerOptions): Promise<ReviewResul
       maxTurns: options.maxTurns,
       processContext: options.processContext,
       systemPrompt: getPrompts().systemPrompt,
+      signal: options.signal,
     });
 
     // Parse result via adapter

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -36,6 +36,8 @@ export interface WorkerOptions {
   bashTimeoutMs?: number;
   /** Expose web_fetch + web_search tools (default true). Set false for SWE-bench integrity. */
   webTools?: boolean;
+  /** Abort the run + in-flight adapter call (pipeline cancel / project disable). */
+  signal?: AbortSignal;
 }
 
 // Prompts
@@ -89,6 +91,7 @@ export async function runWorker(options: WorkerOptions): Promise<WorkerResult> {
       protectedFiles: options.protectedFiles,
       bashTimeoutMs: options.bashTimeoutMs,
       webTools: options.webTools,
+      signal: options.signal,
     });
 
     // Parse result via adapter

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -441,8 +441,8 @@ export class AutonomousRunner {
       return; // Parallel processing disabled
     }
 
-    await this.scheduler.runAvailable(async (task, projectPath) => {
-      return this.executePipeline(task, projectPath);
+    await this.scheduler.runAvailable(async (task, projectPath, signal) => {
+      return this.executePipeline(task, projectPath, signal);
     });
   }
 
@@ -991,8 +991,8 @@ export class AutonomousRunner {
     return execution.decomposeTask(this.getExecCtx(), task, projectPath, targetMinutes);
   }
 
-  private async executePipeline(task: TaskItem, projectPath: string): Promise<PipelineResult> {
-    return execution.executePipeline(this.getExecCtx(), task, projectPath);
+  private async executePipeline(task: TaskItem, projectPath: string, signal?: AbortSignal): Promise<PipelineResult> {
+    return execution.executePipeline(this.getExecCtx(), task, projectPath, signal);
   }
 
   private async requestApproval(decision: DecisionResult): Promise<void> {
@@ -1202,6 +1202,12 @@ export class AutonomousRunner {
   disableProject(projectPath: string): void {
     this.enabledProjects.delete(projectPath);
     console.log(`[AutonomousRunner] Project disabled: ${projectPath}`);
+    // Disabling gates new selection AND cancels any in-flight pipeline for this
+    // project — otherwise a running task keeps working a now-disabled repo.
+    const cancelled = this.scheduler.cancelProjectTasks(projectPath);
+    if (cancelled > 0) {
+      this.syslog(`⏹ Cancelled ${cancelled} in-flight task(s) for disabled project ${projectPath.split('/').pop()}`);
+    }
   }
 
   enableProject(projectPath: string): void {
@@ -1212,6 +1218,31 @@ export class AutonomousRunner {
   /** Get all currently enabled project paths */
   getEnabledProjects(): string[] {
     return Array.from(this.enabledProjects);
+  }
+
+  /**
+   * Running pipeline tasks for the dashboard process view. With native in-process
+   * adapters (codex-responses/openrouter/local) there is no child PID to show in
+   * the OS process registry, so the dashboard reads these instead.
+   */
+  getRunningPipelines(): Array<{
+    id: string; issue?: string; title: string; project: string;
+    projectPath: string; startedAt: number; stage?: string;
+  }> {
+    return this.scheduler.getRunningTasks().map((r) => ({
+      id: r.task.id,
+      issue: r.task.issueIdentifier,
+      title: r.task.title,
+      project: r.task.linearProject?.name ?? r.projectPath.split('/').pop() ?? r.projectPath,
+      projectPath: r.projectPath,
+      startedAt: r.startedAt,
+      stage: r.stage,
+    }));
+  }
+
+  /** Cancel a running pipeline task by id (manual stop from the dashboard). */
+  cancelTask(taskId: string): boolean {
+    return this.scheduler.cancelTask(taskId);
   }
 
   /** Pre-register project path in cache (name → path) */

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -550,6 +550,7 @@ export async function executePipeline(
   ctx: ExecutionContext,
   task: TaskItem,
   projectPath: string,
+  signal?: AbortSignal,
 ): Promise<PipelineResult> {
   console.log(`[AutonomousRunner] executePipeline: ${task.title}`);
 
@@ -774,8 +775,9 @@ export async function executePipeline(
       }
     }
 
-    // Run pipeline in worktree path
-    const result = await pipeline.run(task, actualPath);
+    // Run pipeline in worktree path. The signal aborts the pipeline + in-flight
+    // adapter call on cancel/disable; the finally below removes the worktree.
+    const result = await pipeline.run(task, actualPath, { signal });
 
     // Create PR (worktree mode + pipeline success = finalStatus 'approved')
     if (worktreeInfo && result.success && result.finalStatus === 'approved') {

--- a/src/orchestration/taskScheduler.cancel.test.ts
+++ b/src/orchestration/taskScheduler.cancel.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TaskScheduler } from './taskScheduler.js';
+import type { TaskItem } from './decisionEngine.js';
+import type { PipelineResult } from '../agents/pairPipeline.js';
+
+const task = (id: string): TaskItem => ({ id, title: id, priority: 3 } as TaskItem);
+const cancelledResult = () => ({ success: false, finalStatus: 'cancelled' } as PipelineResult);
+const okResult = () => ({ success: true, finalStatus: 'approved' } as PipelineResult);
+
+// A controllable executor: resolves only when we tell it to, and records whether
+// its abort signal fired — that's how we assert cancellation actually propagates.
+function deferredExecutor() {
+  let resolve!: (r: PipelineResult) => void;
+  const done = new Promise<PipelineResult>((r) => { resolve = r; });
+  let abortedSignal: AbortSignal | undefined;
+  const exec = (signal: AbortSignal) => { abortedSignal = signal; return done; };
+  return { exec, resolve, wasAborted: () => !!abortedSignal?.aborted };
+}
+
+describe('TaskScheduler cancellation', () => {
+  let sched: TaskScheduler;
+  beforeEach(() => { sched = new TaskScheduler({ maxConcurrent: 4, worktreeMode: true }); });
+
+  it('cancelTask aborts the signal handed to the executor', () => {
+    const d = deferredExecutor();
+    sched.startTask(task('t1'), '/repo', d.exec);
+    expect(d.wasAborted()).toBe(false);
+    expect(sched.cancelTask('t1')).toBe(true);
+    expect(d.wasAborted()).toBe(true);
+  });
+
+  it('cancelTask returns false for an unknown task', () => {
+    expect(sched.cancelTask('nope')).toBe(false);
+  });
+
+  it('cancelProjectTasks aborts every task on the project (repo + worktree paths)', () => {
+    const a = deferredExecutor();
+    const b = deferredExecutor();
+    const c = deferredExecutor();
+    sched.startTask(task('a'), '/dev/WAVE', a.exec);
+    sched.startTask(task('b'), '/dev/WAVE/worktree/abc', b.exec); // worktree under repo
+    sched.startTask(task('c'), '/dev/other', c.exec);
+    const n = sched.cancelProjectTasks('/dev/WAVE');
+    expect(n).toBe(2);
+    expect(a.wasAborted()).toBe(true);
+    expect(b.wasAborted()).toBe(true);
+    expect(c.wasAborted()).toBe(false);
+  });
+
+  it("a cancelled result is not counted as failed", async () => {
+    const d = deferredExecutor();
+    const events: string[] = [];
+    sched.on('cancelled', () => events.push('cancelled'));
+    sched.on('failed', () => events.push('failed'));
+    sched.startTask(task('t'), '/repo', d.exec);
+    d.resolve(cancelledResult());
+    await new Promise((r) => setTimeout(r, 0));
+    expect(events).toEqual(['cancelled']);
+    expect(sched.getStats().failed).toBe(0);
+    expect(sched.getStats().completed).toBe(0);
+    expect(sched.isTaskRunning('t')).toBe(false);
+  });
+
+  it('a normal success still completes (cancellation path is additive)', async () => {
+    const d = deferredExecutor();
+    sched.startTask(task('t'), '/repo', d.exec);
+    d.resolve(okResult());
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sched.getStats().completed).toBe(1);
+  });
+
+  it('setTaskStage updates the running task for the dashboard view', () => {
+    sched.startTask(task('t'), '/repo', deferredExecutor().exec);
+    sched.setTaskStage('t', 'reviewer');
+    expect(sched.getRunningTasks().find((r) => r.task.id === 't')?.stage).toBe('reviewer');
+  });
+});

--- a/src/orchestration/taskScheduler.ts
+++ b/src/orchestration/taskScheduler.ts
@@ -21,6 +21,10 @@ export interface RunningTask {
   projectPath: string;
   startedAt: number;
   promise: Promise<PipelineResult>;
+  /** Aborts this task's pipeline + in-flight adapter call (cancel / project disable). */
+  abortController: AbortController;
+  /** Current pipeline stage (worker/reviewer/…), for the dashboard process view. */
+  stage?: string;
 }
 
 export interface SchedulerConfig {
@@ -210,13 +214,15 @@ export class TaskScheduler extends EventEmitter {
   startTask(
     task: TaskItem,
     projectPath: string,
-    executor: () => Promise<PipelineResult>
+    executor: (signal: AbortSignal) => Promise<PipelineResult>
   ): void {
+    const abortController = new AbortController();
     const runningTask: RunningTask = {
       task,
       projectPath,
       startedAt: Date.now(),
-      promise: executor(),
+      abortController,
+      promise: executor(abortController.signal),
     };
 
     this.runningTasks.set(task.id, runningTask);
@@ -242,7 +248,12 @@ export class TaskScheduler extends EventEmitter {
 
     this.runningTasks.delete(taskId);
 
-    if (result.success) {
+    if (result.finalStatus === 'cancelled') {
+      // A cancelled task is neither a success nor a failure — don't bump counts
+      // or trigger the failure/retry path. Just free the slot.
+      console.log(`[Scheduler] Task cancelled: ${running.task.title}`);
+      this.emit('cancelled', { task: running.task, result });
+    } else if (result.success) {
       this.completedCount++;
       console.log(`[Scheduler] Task completed: ${running.task.title}`);
       this.emit('completed', { task: running.task, result });
@@ -276,7 +287,7 @@ export class TaskScheduler extends EventEmitter {
    * @param executor Task execution function
    */
   async runAvailable(
-    executor: (task: TaskItem, projectPath: string) => Promise<PipelineResult>
+    executor: (task: TaskItem, projectPath: string, signal: AbortSignal) => Promise<PipelineResult>
   ): Promise<number> {
     let started = 0;
 
@@ -289,14 +300,50 @@ export class TaskScheduler extends EventEmitter {
         break;
       }
 
-      this.startTask(next.task, next.projectPath, () =>
-        executor(next.task, next.projectPath)
+      this.startTask(next.task, next.projectPath, (signal) =>
+        executor(next.task, next.projectPath, signal)
       );
       started++;
     }
 
     console.log(`[Scheduler] runAvailable: started ${started} tasks`);
     return started;
+  }
+
+  /** Record the current pipeline stage of a running task (dashboard process view). */
+  setTaskStage(taskId: string, stage: string): void {
+    const running = this.runningTasks.get(taskId);
+    if (running) running.stage = stage;
+  }
+
+  /**
+   * Cancel one running task — aborts its pipeline + in-flight adapter call. The
+   * pipeline returns a 'cancelled' result and its worktree is cleaned up by the
+   * executor's finally block. Returns true if the task was running.
+   */
+  cancelTask(taskId: string): boolean {
+    const running = this.runningTasks.get(taskId);
+    if (!running) return false;
+    console.log(`[Scheduler] Cancelling task: ${running.task.title}`);
+    running.abortController.abort();
+    return true;
+  }
+
+  /**
+   * Cancel every running task belonging to a project (e.g. when the project is
+   * disabled). Matches by repo path or worktree-path prefix. Returns the count.
+   */
+  cancelProjectTasks(projectPath: string): number {
+    let n = 0;
+    for (const running of this.runningTasks.values()) {
+      const p = running.projectPath;
+      if (p === projectPath || p.startsWith(projectPath) || projectPath.startsWith(p)) {
+        running.abortController.abort();
+        n++;
+      }
+    }
+    if (n > 0) console.log(`[Scheduler] Cancelled ${n} running task(s) for ${projectPath}`);
+    return n;
   }
 
   /**

--- a/src/support/dashboardHtml.ts
+++ b/src/support/dashboardHtml.ts
@@ -2102,14 +2102,15 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
         if (res.ok) { processesData = await res.json(); renderMonitorsAndProcesses(); }
       } catch {}
     }
-    async function killProcess(pid) {
-      if (!confirm("Kill process PID " + pid + "?")) return;
+    async function stopProcess(id, isPipeline) {
+      var verb = isPipeline ? "Cancel task" : "Kill process";
+      if (!confirm(verb + " " + id + "?")) return;
       try {
-        await fetch("/api/processes/" + pid, { method: "DELETE" });
-        processesData = processesData.filter(p => p.pid !== pid);
+        await fetch("/api/processes/" + encodeURIComponent(id), { method: "DELETE" });
+        processesData = processesData.filter(p => String(p.id) !== String(id));
         renderMonitorsAndProcesses();
       } catch(e) {
-        addLogLine({ taskId: "system", stage: "error", line: "Kill failed: " + e.message });
+        addLogLine({ taskId: "system", stage: "error", line: "Stop failed: " + e.message });
       }
     }
     function procActivityIcon(lastActivityAt) {
@@ -2140,17 +2141,24 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
         html += "<div class=\\"issue-sec-label\\">processes</div>";
         html += processesData.map(function(p) {
           var dur = fmtDur(Date.now() - p.spawnedAt);
-          var act = procActivityIcon(p.lastActivityAt);
+          var isPipeline = p.kind === "pipeline";
+          var act = isPipeline ? "\\u2699" : procActivityIcon(p.lastActivityAt);
           var modelStr = p.model ? shortModel(p.model) : "";
-          var projName = p.projectPath ? p.projectPath.split("/").pop() : "";
+          var projName = p.project || (p.projectPath ? p.projectPath.split("/").pop() : "");
+          // In-process pipeline tasks have no OS PID — show the issue id instead, and
+          // a CANCEL button (aborts the pipeline + its in-flight adapter call).
+          var lead = isPipeline ? escapeHtml(p.taskId || "task") : p.pid;
+          var btn = isPipeline
+            ? '<button class="proc-kill" onclick="stopProcess(\\'' + escapeAttr(String(p.id)) + '\\', true)">CANCEL</button>'
+            : '<button class="proc-kill" onclick="stopProcess(\\'' + escapeAttr(String(p.id)) + '\\', false)">KILL</button>';
           return '<div class="proc-row">' +
-            '<span class="proc-pid">' + p.pid + '</span>' +
+            '<span class="proc-pid">' + lead + '</span>' +
             '<span class="proc-stage">' + escapeHtml(p.stage) + '</span>' +
             '<span class="proc-model">' + escapeHtml(modelStr) + '</span>' +
             '<span style="color:var(--dim);font-size:9px;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="' + escapeAttr(p.projectPath || "") + '">' + escapeHtml(projName) + '</span>' +
             '<span class="proc-activity">' + act + '</span>' +
             '<span class="proc-dur">' + dur + '</span>' +
-            '<button class="proc-kill" onclick="killProcess(' + p.pid + ')">KILL</button>' +
+            btn +
           '</div>';
         }).join("");
       }

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -943,20 +943,38 @@ export async function startWebServer(port: number = 3847): Promise<void> {
 
       // ---- Processes: list ----
       } else if (url === '/api/processes' && req.method === 'GET') {
+        // Spawned CLI subprocesses (PID-tracked) + in-process pipeline tasks. Native
+        // adapters (codex-responses/openrouter/local) run the worker/reviewer in-process
+        // with no child PID, so without the pipeline entries the panel looks empty even
+        // while tasks are actively running.
+        const subprocs = getAllProcesses().map((p) => ({ ...p, kind: 'subprocess', id: String(p.pid) }));
+        const pipelines = (runnerRef?.getRunningPipelines() ?? []).map((t) => ({
+          kind: 'pipeline',
+          id: t.id,
+          pid: null,
+          taskId: t.issue ?? t.title,
+          project: t.project,
+          stage: t.stage ?? 'running',
+          projectPath: t.projectPath,
+          spawnedAt: t.startedAt,
+          lastActivityAt: t.startedAt,
+        }));
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify(getAllProcesses()));
+        res.end(JSON.stringify([...pipelines, ...subprocs]));
 
-      // ---- Processes: kill ----
+      // ---- Processes: kill (PID) or cancel (pipeline task id) ----
       } else if (url.startsWith('/api/processes/') && req.method === 'DELETE') {
-        const pidStr = url.replace('/api/processes/', '');
-        const pid = parseInt(pidStr, 10);
-        if (isNaN(pid)) {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid PID' }));
-        } else {
+        const idStr = decodeURIComponent(url.replace('/api/processes/', ''));
+        const pid = parseInt(idStr, 10);
+        if (!isNaN(pid) && String(pid) === idStr) {
           const killed = await killProcess(pid);
           res.writeHead(killed ? 200 : 404, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ ok: killed }));
+        } else {
+          // Non-numeric id → in-process pipeline task: abort it (and its adapter call).
+          const cancelled = runnerRef?.cancelTask(idStr) ?? false;
+          res.writeHead(cancelled ? 200 : 404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: cancelled }));
         }
 
       // ---- Scan Paths: list ----


### PR DESCRIPTION
Fixes INT-1898. Reported: "a disabled project keeps working, and MONITOR & PROCESSES shows nothing."

## Root cause (one, two symptoms)

Pipeline tasks run **in-process** under native adapters (`codex-responses`/openrouter/local) — worker/reviewer execute inside the daemon with no child PID. The daemon only gated and visualized work that spawned a subprocess.

1. **Disable kept working.** `disableProject` only removed the repo from the enabled set, gating *new* selection. A pipeline already running (observed: de-artifact INT-1753, `worktree/c9994fbc`, worker↔reviewer iter 3/3) ran to completion with no way to stop it (scheduler had no cancel; `PairPipeline` took no `AbortSignal`).
2. **MONITOR & PROCESSES empty.** `/api/processes` = `getAllProcesses()` tracks only spawned CLI subprocesses (`adapters/base.ts`), so in-process runs registered nothing — empty list (`[]`) even mid-task. Work was only visible as `running:N` in the PROJECTS panel.

## Changes

- **TaskScheduler** — an `AbortController` per running task; `cancelTask(id)` / `cancelProjectTasks(path)` abort it; a `'cancelled'` result is emitted as such (not failed → no retry); `setTaskStage`.
- **Abort signal threaded** scheduler → executor → `runnerExecution.executePipeline` → `PairPipeline.run({signal})` → worker/reviewer → `spawnCli`. Adapters already abort the in-flight API/stream on `signal` (the chat Esc path), so cancellation is **immediate**, not just at the next stage boundary. `PairPipeline` checks the signal at each iteration boundary and maps an abort to `finalStatus: 'cancelled'`; the worktree is removed by the existing `executePipeline` finally.
- **`disableProject` → `cancelProjectTasks(path)`** — disabling now stops in-flight work for that repo.
- **`/api/processes`** merges in-process pipeline tasks (no PID) with the subprocess registry; `DELETE` handles a numeric PID (kill) or a task id (cancel).
- **Dashboard** renders pipeline tasks in MONITOR & PROCESSES with a CANCEL button.

## Verification

- 6 scheduler-cancel unit tests: abort propagation, project match (repo + worktree paths), cancelled≠failed (no count/retry), stage set
- `npm test` 881 passed · typecheck / build / lint clean
- Live daemon verification to follow after deploy

## Deploy note

Needs one daemon restart to load the new code. The currently-running de-artifact INT-1753 (on a now-disabled project) is interrupted by the restart — which is the desired outcome here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)