### PR TITLE
feat(autonomy): dependency-aware ordering (unblockers first) + per-heartbeat worktree sweep (INT-1900)

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -590,6 +590,21 @@ export class AutonomousRunner {
       // 0. Knowledge graph refresh (async, service continues even on failure)
       this.refreshKnowledgeGraphs();
 
+      // 0.1 Sweep orphan worktrees every heartbeat (crashed/cancelled leftovers),
+      // never the worktree of a currently-running task. Startup does a full sweep;
+      // this keeps repos from accumulating worktree/ dirs between restarts.
+      if (this.config.worktreeMode) {
+        const activeWorktrees = new Set(
+          this.scheduler.getRunningTasks().map((r) => `${r.projectPath}/worktree/${r.task.issueId}`),
+        );
+        for (const projectPath of this.config.allowedProjects) {
+          const resolvedPath = projectPath.replace('~', process.env.HOME || '');
+          pruneWorktrees(resolvedPath, activeWorktrees).catch((e) =>
+            console.error(`[AutonomousRunner] Worktree sweep failed for ${resolvedPath}:`, e),
+          );
+        }
+      }
+
       // 0.5 Long-running monitor passive check (before time window)
       const active = getActiveMonitors().filter(m => m.state === 'pending' || m.state === 'running');
       if (active.length > 0) {

--- a/src/orchestration/decisionEngine.dependency.test.ts
+++ b/src/orchestration/decisionEngine.dependency.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { computeDownstreamCounts } from './decisionEngine.js';
+import type { TaskItem } from './decisionEngine.js';
+
+// blockedBy holds the ids of a task's blockers; computeDownstreamCounts inverts
+// that to "how many tasks (transitively) depend on me" — the unblock weight.
+const t = (id: string, blockedBy: string[] = []): TaskItem =>
+  ({ id, issueId: id, title: id, priority: 3, blockedBy } as TaskItem);
+
+describe('computeDownstreamCounts — dependency graph from blockedBy', () => {
+  it('a blocker that gates a chain scores its full transitive downstream', () => {
+    // A ← B ← C  (C blockedBy B, B blockedBy A)
+    const counts = computeDownstreamCounts([t('A'), t('B', ['A']), t('C', ['B'])]);
+    expect(counts.get('A')).toBe(2); // B and C
+    expect(counts.get('B')).toBe(1); // C
+    expect(counts.get('C')).toBe(0); // leaf
+  });
+
+  it('a standalone task with no dependents scores 0 (→ plain priority order)', () => {
+    const counts = computeDownstreamCounts([t('X'), t('Y')]);
+    expect(counts.get('X')).toBe(0);
+    expect(counts.get('Y')).toBe(0);
+  });
+
+  it('diamond deps are counted once (no double counting)', () => {
+    // A blocks B and C; both B and C block D.  A's downstream = {B,C,D} = 3
+    const counts = computeDownstreamCounts([
+      t('A'), t('B', ['A']), t('C', ['A']), t('D', ['B', 'C']),
+    ]);
+    expect(counts.get('A')).toBe(3);
+    expect(counts.get('D')).toBe(0);
+  });
+
+  it('ignores blockers not in the fetched set', () => {
+    // B is blocked by A, but A is not in the set → B has no in-set dependents counted for A
+    const counts = computeDownstreamCounts([t('B', ['A']), t('C')]);
+    expect(counts.get('B')).toBe(0);
+    expect(counts.has('A')).toBe(false);
+  });
+
+  it('is cycle-safe (A↔B) and terminates', () => {
+    const counts = computeDownstreamCounts([t('A', ['B']), t('B', ['A'])]);
+    // both reference each other; counts are finite, no throw/hang
+    expect(typeof counts.get('A')).toBe('number');
+    expect(typeof counts.get('B')).toBe('number');
+  });
+});

--- a/src/orchestration/decisionEngine.ts
+++ b/src/orchestration/decisionEngine.ts
@@ -72,6 +72,48 @@ export function isUmbrellaIssue(task: TaskItem, parentIds: Set<string>): boolean
 }
 
 /**
+ * Count, per task, how many OTHER fetched tasks (transitively) depend on it — its
+ * "downstream" / unblock weight, derived from the `blockedBy` graph (INT-1809
+ * wires blockedBy from Linear relations + description text). The readiness gate
+ * already prevents a dependent from running before its blocker; this metric lets
+ * the priority sort *prefer the unblockers* among ready tasks, so dependency
+ * chains drain instead of leaf tasks being picked first. Cycle-safe; a task with
+ * no dependents scores 0 (then ordering falls back to plain priority).
+ */
+export function computeDownstreamCounts(tasks: TaskItem[]): Map<string, number> {
+  const idOf = (t: TaskItem) => t.issueId || t.id;
+  const inSet = new Set(tasks.map(idOf));
+  // blocker id → dependents that list it in blockedBy (reverse edges, in-set only)
+  const dependents = new Map<string, string[]>();
+  for (const t of tasks) {
+    for (const blocker of t.blockedBy ?? []) {
+      if (!inSet.has(blocker)) continue;
+      const arr = dependents.get(blocker);
+      if (arr) arr.push(idOf(t));
+      else dependents.set(blocker, [idOf(t)]);
+    }
+  }
+  const memo = new Map<string, Set<string>>();
+  const descendants = (id: string, stack: Set<string>): Set<string> => {
+    const cached = memo.get(id);
+    if (cached) return cached;
+    if (stack.has(id)) return new Set(); // cycle guard
+    stack.add(id);
+    const out = new Set<string>();
+    for (const d of dependents.get(id) ?? []) {
+      out.add(d);
+      for (const x of descendants(d, stack)) out.add(x);
+    }
+    stack.delete(id);
+    memo.set(id, out);
+    return out;
+  };
+  const counts = new Map<string, number>();
+  for (const t of tasks) counts.set(idOf(t), descendants(idOf(t), new Set()).size);
+  return counts;
+}
+
+/**
  * Decision result
  */
 export interface DecisionResult {
@@ -261,8 +303,10 @@ export class DecisionEngine {
       };
     }
 
-    // 5. Priority sorting
-    const sorted = this.prioritizeTasks(executableTasks);
+    // 5. Priority sorting — dependency-aware (unblockers first), computed over the
+    // full fetched set so blocked dependents still count toward a blocker's weight.
+    const downstream = computeDownstreamCounts(tasks);
+    const sorted = this.prioritizeTasks(executableTasks, downstream);
     const selectedTask = sorted[0];
 
     // 6. Scope validation (CRITICAL)
@@ -358,8 +402,10 @@ export class DecisionEngine {
       };
     }
 
-    // 5. Priority sorting
-    const sorted = this.prioritizeTasks(executableTasks);
+    // 5. Priority sorting — dependency-aware (unblockers first), computed over the
+    // full fetched set so blocked dependents still count toward a blocker's weight.
+    const downstream = computeDownstreamCounts(tasks);
+    const sorted = this.prioritizeTasks(executableTasks, downstream);
 
     // 6. Select multiple tasks (max maxTasks, blocker-based filtering only)
     const selectedTasks: Array<{ task: TaskItem; workflow: WorkflowConfig }> = [];
@@ -476,8 +522,18 @@ export class DecisionEngine {
   /**
    * Priority sorting
    */
-  private prioritizeTasks(tasks: TaskItem[]): TaskItem[] {
+  private prioritizeTasks(tasks: TaskItem[], downstream?: Map<string, number>): TaskItem[] {
+    const dsOf = (t: TaskItem) => downstream?.get(t.issueId || t.id) ?? 0;
     return [...tasks].sort((a, b) => {
+      // 0. Dependency order: prefer tasks that unblock the most pending work, so
+      // chains drain instead of leaf tasks first. When nothing depends on either
+      // (the common case), both score 0 and this is a no-op → plain priority order.
+      const dsA = dsOf(a);
+      const dsB = dsOf(b);
+      if (dsA !== dsB) {
+        return dsB - dsA;
+      }
+
       const topoA = a.topoRank ?? Number.MAX_SAFE_INTEGER;
       const topoB = b.topoRank ?? Number.MAX_SAFE_INTEGER;
       if (topoA !== topoB) {

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -192,13 +192,17 @@ export async function removeWorktree(info: WorktreeInfo): Promise<void> {
   }
 }
 
-/** Clean up dangling worktrees on service start.
+/** Clean up dangling worktrees.
  *
  * `git worktree prune` only drops metadata for worktrees whose directory is already gone. A
  * daemon that was hard-killed or crashed mid-run never ran the `finally` cleanup, so its
  * `{repo}/worktree/<issueId>` directories survive as orphans (INT-1810 R4). On start nothing
- * is in flight, so force-remove every one of our own worktree dirs. */
-export async function pruneWorktrees(repoPath: string): Promise<void> {
+ * is in flight, so force-remove every one of our own worktree dirs.
+ *
+ * `activeWorktreePaths` are the worktrees of currently-running tasks — never swept. Pass an
+ * empty set at startup (remove all); pass the live set when sweeping per-heartbeat so an
+ * in-flight task's worktree is preserved. */
+export async function pruneWorktrees(repoPath: string, activeWorktreePaths: Set<string> = new Set()): Promise<void> {
   await git(repoPath, 'worktree', 'prune').catch((e) => console.warn(`[Worktree] Prune failed for ${repoPath}:`, e));
   try {
     const out = await git(repoPath, 'worktree', 'list', '--porcelain');
@@ -207,7 +211,8 @@ export async function pruneWorktrees(repoPath: string): Promise<void> {
       .split('\n')
       .filter((l) => l.startsWith('worktree '))
       .map((l) => l.slice('worktree '.length).trim())
-      .filter((p) => p.startsWith(prefix));
+      .filter((p) => p.startsWith(prefix))
+      .filter((p) => !activeWorktreePaths.has(p)); // keep worktrees of running tasks
     for (const p of orphans) {
       await git(repoPath, 'worktree', 'remove', '--force', p)
         .then(() => console.log(`[Worktree] Swept orphan worktree: ${p}`))


### PR DESCRIPTION
Fixes INT-1900. Follow-up to the DecisionEngine review and INT-1898.

## Ordering — read dependency order, prefer unblockers

The readiness gate (INT-1809) already prevents a dependent from running before its blocker (`blockedBy` populated from Linear "blocks" relations + description text). But among **ready** tasks the sort was priority-only, so a leaf task could be picked ahead of the prerequisites of still-blocked work.

`computeDownstreamCounts()` walks the `blockedBy` graph over the full fetched set and counts each task's transitive dependents (cycle-safe, diamond-safe, in-set only). `prioritizeTasks` now prefers the bigger **unblockers** first, so dependency chains drain instead of leaves first.

When nothing depends on a task (the common case), the score is 0 and ordering falls back to the existing priority → topoRank → dueDate → createdAt keys — **no behavior change for independent backlogs.** Backlog-parked blockers stay out of scope (consistent with the readiness gate's active-set semantics).

## Worktrees — stop the sprawl

`pruneWorktrees` ran only at startup (full sweep, safe because nothing is in flight). A crashed/cancelled task between restarts left `{repo}/worktree/<id>` dirs lying around.

- `pruneWorktrees(repoPath, activeWorktreePaths)` now skips the worktrees of currently-running tasks.
- The heartbeat sweeps **every cycle** (computing the live set from the scheduler), so leftovers are reaped without a restart and live work is never touched.
- `maxConcurrentTasks` lowered 4 → 2 (runtime config) so fewer worktrees exist at once.

## Verification

- 5 `computeDownstreamCounts` unit tests: chain / standalone / diamond (no double-count) / out-of-set / cycle-safe
- `npm test` 886 passed · typecheck / build / lint clean
- Live daemon observation to follow after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)