### PR TITLE
fix(adapters): re-register claude provider + registry-based provider validation (INT-1901)

### DIFF
--- a/src/adapters/index.test.ts
+++ b/src/adapters/index.test.ts
@@ -1,19 +1,25 @@
 import { describe, it, expect } from 'vitest';
-import { isKnownAdapter } from './index.js';
+import { isKnownAdapter, listAdapterNames } from './index.js';
 
 describe('isKnownAdapter', () => {
-  it('accepts currently-registered adapters', () => {
-    for (const name of ['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter']) {
+  it('accepts currently-registered adapters (incl. claude, the opt-in claude -p delegate)', () => {
+    for (const name of ['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter', 'claude']) {
       expect(isKnownAdapter(name)).toBe(true);
     }
   });
 
-  it('rejects removed/unknown providers (e.g. a stale `claude` chat session)', () => {
-    expect(isKnownAdapter('claude')).toBe(false);
+  it('rejects unknown providers', () => {
     expect(isKnownAdapter('')).toBe(false);
     expect(isKnownAdapter('anthropic')).toBe(false);
+    expect(isKnownAdapter('gpt5')).toBe(false);
     // must not be fooled by Object.prototype members
     expect(isKnownAdapter('toString')).toBe(false);
     expect(isKnownAdapter('constructor')).toBe(false);
+  });
+
+  it('listAdapterNames returns every registered adapter', () => {
+    expect([...listAdapterNames()].sort()).toEqual(
+      ['claude', 'codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter'].sort(),
+    );
   });
 });

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -21,6 +21,7 @@ export { GptCliAdapter } from './gpt.js';
 export { LocalModelAdapter } from './local.js';
 export { LmStudioAdapter } from './lmstudio.js';
 export { OpenRouterCliAdapter } from './openrouter.js';
+export { ClaudeCliAdapter } from './claude.js';
 export { registerProcess, getProcess, getAllProcesses, killProcess, startHealthChecker, stopHealthChecker } from './processRegistry.js';
 
 import { CodexCliAdapter } from './codex.js';
@@ -29,6 +30,7 @@ import { GptCliAdapter } from './gpt.js';
 import { LocalModelAdapter } from './local.js';
 import { LmStudioAdapter } from './lmstudio.js';
 import { OpenRouterCliAdapter } from './openrouter.js';
+import { ClaudeCliAdapter } from './claude.js';
 import type { AdapterName, CliAdapter } from './types.js';
 
 const adapters: Record<string, CliAdapter> = {
@@ -38,6 +40,9 @@ const adapters: Record<string, CliAdapter> = {
   local: new LocalModelAdapter(),
   lmstudio: new LmStudioAdapter(),
   openrouter: new OpenRouterCliAdapter(),
+  // claude -p CLI delegate — opt-in fallback (Anthropic hasn't blocked it). Offered
+  // by `openswarm init` and the dashboard provider switch, so it must be registered.
+  claude: new ClaudeCliAdapter(),
 };
 
 let defaultAdapter: AdapterName = 'codex';
@@ -65,12 +70,16 @@ export function getDefaultAdapterName(): AdapterName {
 }
 
 /**
- * True if `name` is a currently-registered adapter. Used to reject stale
- * persisted provider names (e.g. an old chat session saved `claude` before the
- * adapter was removed) instead of crashing downstream.
+ * True if `name` is a currently-registered adapter. Used to reject stale or
+ * unknown persisted provider names instead of crashing downstream.
  */
 export function isKnownAdapter(name: string): name is AdapterName {
   return Object.prototype.hasOwnProperty.call(adapters, name);
+}
+
+/** Names of every registered adapter (for validation messages / UI). */
+export function listAdapterNames(): AdapterName[] {
+  return Object.keys(adapters) as AdapterName[];
 }
 
 /**

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -9,7 +9,7 @@ import type { ToolDefinition } from './tools.js';
 // Re-export for convenience
 export type { WorkerResult, ReviewResult };
 
-export type AdapterName = 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter';
+export type AdapterName = 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter' | 'claude';
 
 /**
  * Raw result from a CLI process execution

--- a/src/automation/runnerTypes.ts
+++ b/src/automation/runnerTypes.ts
@@ -7,7 +7,7 @@ import type { ExecutorResult } from '../orchestration/workflow.js';
 import type { DefaultRolesConfig, ProjectAgentConfig, JobProfile } from '../core/types.js';
 
 export interface AutonomousConfig {
-  defaultAdapter?: 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter';
+  defaultAdapter?: 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter' | 'claude';
   linearTeamId: string;
   allowedProjects: string[];
   heartbeatSchedule: string;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -96,7 +96,7 @@ export type SwarmEvent = {
  */
 export type SwarmConfig = {
   /** Default CLI adapter */
-  adapter?: 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter';
+  adapter?: 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter' | 'claude';
   /** UI language: 'en' | 'ko' (default: 'en') */
   language: 'en' | 'ko';
   /** Discord bot token */
@@ -262,7 +262,7 @@ export type RoleConfig = {
   /** Whether role is enabled */
   enabled: boolean;
   /** CLI adapter name */
-  adapter?: 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter';
+  adapter?: 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter' | 'claude';
   /** Model ID. Omit → resolved dynamically from the role's adapter (getDefaultModel). */
   model?: string;
   /** Timeout (ms), 0 = unlimited */

--- a/src/support/chatBackend.ts
+++ b/src/support/chatBackend.ts
@@ -77,6 +77,12 @@ export const CHAT_MODEL_ALIASES: Record<AdapterName, Record<string, string>> = {
     kimi: 'moonshotai/kimi-k2',
     glm: 'z-ai/glm-4.6',
   },
+  claude: {
+    // `claude -p --model <alias>` takes version-robust aliases directly.
+    sonnet: 'sonnet',
+    opus: 'opus',
+    haiku: 'haiku',
+  },
 };
 
 export function inferProviderFromModel(model?: string): AdapterName {

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -20,7 +20,7 @@ import { getProjectGitInfo, startGitStatusPoller } from './gitStatus.js';
 import { getActiveMonitors, registerMonitor, unregisterMonitor } from '../automation/longRunningMonitor.js';
 import type { LongRunningMonitorConfig } from '../core/types.js';
 import { getAllProcesses, killProcess, startHealthChecker } from '../adapters/processRegistry.js';
-import { setDefaultAdapter } from '../adapters/index.js';
+import { setDefaultAdapter, isKnownAdapter, listAdapterNames } from '../adapters/index.js';
 import * as memory from '../memory/index.js';
 import { fetchQuota } from './quotaTracker.js';
 import { PairPipeline, type PipelineResult } from '../agents/pairPipeline.js';
@@ -530,16 +530,17 @@ export async function startWebServer(port: number = 3847): Promise<void> {
         const body = await readBody(req);
         try {
           const { provider } = JSON.parse(body) as { provider: string };
-          const VALID_PROVIDERS = ['codex', 'gpt', 'local', 'lmstudio', 'openrouter'] as const;
-          if (!VALID_PROVIDERS.includes(provider as typeof VALID_PROVIDERS[number])) {
+          // Validate against the live adapter registry rather than a hardcoded list,
+          // so the dashboard's provider buttons (incl. claude / codex-responses) never
+          // drift out of sync with what's actually registered.
+          if (!isKnownAdapter(provider)) {
             res.writeHead(400, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ error: `Invalid provider. Valid: ${VALID_PROVIDERS.join(', ')}` }));
+            res.end(JSON.stringify({ error: `Invalid provider "${provider}". Valid: ${listAdapterNames().join(', ')}` }));
             return;
           }
 
-          const validProvider = provider as typeof VALID_PROVIDERS[number];
-          setDefaultAdapter(validProvider);
-          runnerRef?.switchProvider(validProvider);
+          setDefaultAdapter(provider);
+          runnerRef?.switchProvider(provider);
           broadcastEvent({
             type: 'log',
             data: { taskId: 'system', stage: 'provider', line: `Provider switched to ${provider}` },


### PR DESCRIPTION
Fixes INT-1901. Dashboard: switching to Claude failed with `Invalid provider. Valid: codex, gpt, local, lmstudio, openrouter`.

The dashboard has a Claude button (`switchProvider('claude')`) and `openswarm init` offers claude, but claude had been dropped from the adapter registry + `AdapterName`, so `/api/provider` rejected it. The valid list was hardcoded and had drifted (also missing `codex-responses`).

## Changes
- Register `ClaudeCliAdapter` (the opt-in `claude -p` delegate — the class was still present) in the adapters map; add `'claude'` to `AdapterName` and the two config adapter unions; add a `CHAT_MODEL_ALIASES` entry (sonnet/opus/haiku — `claude -p --model` takes version-robust aliases).
- `/api/provider` now validates against the **live registry** (`isKnownAdapter` + `listAdapterNames`) instead of a hardcoded list — the dashboard buttons can't drift from what's registered again. `claude` and `codex-responses` are both switchable now.

## Verification
- `src/adapters/index.test.ts` updated to current behavior (claude is known; `listAdapterNames` covers all 7)
- `npm test` 887 passed · typecheck / build clean · runtime `getAdapter('claude')` → `ClaudeCliAdapter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)