### PR TITLE
fix(autonomy): resolve repos to Linear by openswarm.json projectId, not repo name (INT-1902)

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -43,6 +43,7 @@ import { reportToDiscord, fetchLinearTasks, getTaskSource } from './runnerExecut
 import { t } from '../locale/index.js';
 import { broadcastEvent, type SwarmStats } from '../core/eventHub.js';
 import { pruneWorktrees } from '../support/worktreeManager.js';
+import { loadRepoMetadata } from '../support/repoMetadata.js';
 import { refreshGraph, toProjectSlug } from '../knowledge/index.js';
 import { checkAllMonitors, getActiveMonitors } from './longRunningMonitor.js';
 import { detectFileConflicts } from '../orchestration/conflictDetector.js';
@@ -721,14 +722,33 @@ export class AutonomousRunner {
 
     let tasksForEngine = executableTasks;
     if (this.enabledProjects.size > 0) {
+      // Explicit repo↔Linear mapping — match fetched issues to repos by the Linear
+      // projectId the user picked in `openswarm add` (written to <repo>/openswarm.json),
+      // NOT by guessing from the repo directory name. Built fresh each cycle so a
+      // newly-mapped repo is picked up without a restart. Name matching stays only as
+      // a best-effort fallback for repos that never ran the picker.
+      const byProjectId = new Map<string, string>();
+      for (const repoPath of this.enabledProjects) {
+        try {
+          const meta = await loadRepoMetadata(repoPath);
+          if (meta?.linear?.projectId) byProjectId.set(meta.linear.projectId, repoPath);
+        } catch (e) {
+          this.syslog(`  ⚠ openswarm.json unreadable for ${repoPath.split('/').pop()}: ${(e as Error).message}`);
+        }
+      }
+
       tasksForEngine = executableTasks.filter(task => {
         const projName = task.linearProject?.name;
-        if (!projName) return false;
-        const cachedPath = this.projectPathCache.get(projName)
-          ?? this.projectPathCache.get(projName.toLowerCase())
-          ?? this.projectPathCache.get(projName.replace(/-/g, ' '));
+        const projId = task.linearProject?.id;
+        // 1) Explicit projectId mapping (openswarm.json) wins.
+        const mappedPath = projId ? byProjectId.get(projId) : undefined;
+        // 2) Fallback: repo-name path cache (only for repos without an explicit mapping).
+        const cachedPath = mappedPath
+          ?? (projName && (this.projectPathCache.get(projName)
+            ?? this.projectPathCache.get(projName.toLowerCase())
+            ?? this.projectPathCache.get(projName.replace(/-/g, ' '))));
         if (!cachedPath) {
-          this.syslog(`  ⚠ No path cache for project "${projName}" — skipping ${task.issueIdentifier}`);
+          this.syslog(`  ⚠ No repo mapped to Linear project "${projName ?? projId}" — run \`openswarm add\` and pick it. Skipping ${task.issueIdentifier}`);
           return false;
         }
         const enabled = this.isProjectEnabled(cachedPath);

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -32,6 +32,7 @@ import {
   removeWorktree,
 } from '../support/worktreeManager.js';
 import type { WorktreeInfo } from '../support/worktreeManager.js';
+import { loadRepoMetadata } from '../support/repoMetadata.js';
 import {
   getDecompositionDepth,
   getChildrenCount,
@@ -154,6 +155,22 @@ export async function resolveProjectPath(
   if (!projectId || !projectName) {
     console.error(`[AutonomousRunner] Task "${task.title}" has no Linear project info - SKIP`);
     return null;
+  }
+
+  // 0순위: explicit openswarm.json mapping — the Linear projectId the user picked
+  // in `openswarm add` (written to <repo>/openswarm.json). Highest confidence, no
+  // name guessing; this is the source of truth for repo↔Linear connection.
+  for (const allowed of ctx.allowedProjects) {
+    const expanded = allowed.replace('~', process.env.HOME || '');
+    try {
+      const meta = await loadRepoMetadata(expanded);
+      if (meta?.linear?.projectId === projectId && (await isValidProjectPath(expanded))) {
+        console.log(`[AutonomousRunner] openswarm.json mapping: ${projectName} → ${expanded}`);
+        return expanded;
+      }
+    } catch (e) {
+      console.warn(`[AutonomousRunner] openswarm.json unreadable at ${expanded}: ${(e as Error).message}`);
+    }
   }
 
   // 1순위: allowedProjects에서 정확한 basename 매칭 (fuzzy보다 신뢰도 높음)


### PR DESCRIPTION
Fixes INT-1902. A registered repo (vega-agent) never picked up its Linear issues.

The Linear project is "VEGA Agent" (space, caps) but the repo dir is "vega-agent" (hyphen, lowercase). Both the heartbeat pre-filter and `resolveProjectPath` matched by guessing from the name (exact / lowercase / hyphen→space / `~/dev/{name}` / fuzzy) — none bridge "VEGA Agent" ↔ "vega-agent", so every VEGA issue was dropped with `No path cache for project` (confirmed in the daemon log).

## Changes
Use the explicit mapping the user picks in `openswarm add` — the Linear `projectId` in `<repo>/openswarm.json`:
- **heartbeatParallel**: build a `projectId → repoPath` index from each enabled repo's `openswarm.json` (fresh per cycle), match fetched issues by `task.linearProject.id`. Repo-name matching stays only as a fallback for repos without an explicit mapping; the skip message now points at `openswarm add`.
- **resolveProjectPath**: add a 0th-priority `openswarm.json` projectId match over `allowedProjects`, above the name-guessing tiers.

A malformed `openswarm.json` is logged and skipped (falls through to the name tiers). No behavior change for repos whose dir name already matches the Linear project name.

## Verification
- typecheck / build / lint clean · `npm test` 887 passed
- Live: after deploy VEGA now passes the pre-filter (engine selected 2 tasks); the resolveProjectPath 0th-priority confirms on the next successful fetch (transient Linear fetch failures delayed live observation). vega-agent's `openswarm.json` mapping was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)