### PR TITLE
fix(webTools): harden HTML→text sanitization — clear 4 CodeQL high alerts (INT-1931)

### DIFF
--- a/src/adapters/webTools.test.ts
+++ b/src/adapters/webTools.test.ts
@@ -43,6 +43,44 @@ describe('webFetch', () => {
   });
 });
 
+describe('webFetch — HTML sanitization hardening (INT-1931)', () => {
+  const htmlResponse = (body: string) =>
+    vi.fn(async () => new Response(body, { status: 200, headers: { 'content-type': 'text/html' } }));
+
+  it('decodes entities in a single pass — no double-unescaping (js/double-escaping)', async () => {
+    vi.stubGlobal('fetch', htmlResponse('<p>&amp;lt;tag&amp;gt;</p>'));
+    const out = await webFetch('https://example.com');
+    // "&amp;lt;" must decode once to the literal "&lt;", NOT twice into "<".
+    expect(out).toContain('&lt;tag&gt;');
+    expect(out).not.toContain('<tag>');
+  });
+
+  it('decodes numeric and hex entities', async () => {
+    vi.stubGlobal('fetch', htmlResponse('<p>caf&#233; &#x1F600;</p>'));
+    const out = await webFetch('https://example.com');
+    expect(out).toContain('café');
+    expect(out).toContain('😀');
+  });
+
+  it('removes script blocks whose closing tag carries whitespace/attributes (js/bad-tag-filter)', async () => {
+    vi.stubGlobal('fetch', htmlResponse(
+      '<body>keep1<script>evil1()</script ><script type="x">evil2()</script bar>keep2</body>',
+    ));
+    const out = await webFetch('https://example.com');
+    expect(out).toContain('keep1');
+    expect(out).toContain('keep2');
+    expect(out).not.toContain('evil1');
+    expect(out).not.toContain('evil2');
+  });
+
+  it('strips nested tags leaving clean text with no markup', async () => {
+    vi.stubGlobal('fetch', htmlResponse('<div><p><b>bold</b> &amp; <i>italic</i></p></div>'));
+    const out = await webFetch('https://example.com');
+    expect(out).toBe('bold & italic');
+    expect(out).not.toContain('<');
+  });
+});
+
 describe('webSearch — backend selection', () => {
   it('defaults to duckduckgo with no keys', () => {
     expect(searchBackend()).toBe('duckduckgo');

--- a/src/adapters/webTools.ts
+++ b/src/adapters/webTools.ts
@@ -63,31 +63,53 @@ async function fetchWithTimeout(url: string, init: RequestInit = {}): Promise<Re
   }
 }
 
+// Decode HTML entities in a SINGLE left-to-right pass. A chain of .replace()
+// calls (e.g. &amp; → & before &lt; → <) double-unescapes crafted input like
+// "&amp;lt;" → "<"; one pass over the original string never re-scans its own
+// output, so "&amp;lt;" correctly yields the literal "&lt;". (CodeQL js/double-escaping)
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',
+};
+function decodeEntities(s: string): string {
+  return s.replace(/&(#x[0-9a-f]+|#[0-9]+|[a-z][a-z0-9]*);/gi, (m, body: string) => {
+    if (body[0] === '#') {
+      const cp = body[1].toLowerCase() === 'x'
+        ? parseInt(body.slice(2), 16)
+        : parseInt(body.slice(1), 10);
+      return Number.isFinite(cp) && cp >= 1 && cp <= 0x10ffff ? String.fromCodePoint(cp) : m;
+    }
+    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
+  });
+}
+
+// Remove every HTML tag, repeating to a fixpoint. A single pass of /<[^>]*>/ can
+// leave a tag reconstructed from the removal (e.g. "<<b>script>" → "<script>"),
+// so iterate until the string stops changing. (CodeQL js/incomplete-multi-character-sanitization)
+function stripAllTags(s: string): string {
+  let prev: string;
+  let out = s;
+  do { prev = out; out = out.replace(/<[^>]*>/g, ''); } while (out !== prev);
+  return out;
+}
+
 function stripTags(s: string): string {
-  return s
-    .replace(/<[^>]+>/g, '')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#(?:39|x27);/g, "'")
-    .replace(/\s+/g, ' ')
-    .trim();
+  return decodeEntities(stripAllTags(s)).replace(/\s+/g, ' ').trim();
 }
 
 function htmlToText(html: string): string {
-  return html
-    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<!--[\s\S]*?-->/g, ' ')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#(?:39|x27);/g, "'")
+  // Drop script/style blocks and comments first, to a fixpoint. The closing-tag
+  // matcher uses \b + [^>]* so it can't be bypassed by whitespace/attributes
+  // before ">" ("</script >", "</script bar>"). (CodeQL js/bad-tag-filter)
+  let prev: string;
+  let out = html;
+  do {
+    prev = out;
+    out = out
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, ' ')
+      .replace(/<!--[\s\S]*?-->/g, ' ');
+  } while (out !== prev);
+  return decodeEntities(stripAllTags(out))
     .replace(/[ \t]+/g, ' ')
     .replace(/\n\s*\n\s*\n+/g, '\n\n')
     .trim();


### PR DESCRIPTION
Clears the 4 open **high** code-scanning (CodeQL) alerts, all in `src/adapters/webTools.ts`. `webFetch`/`webSearch` extract plaintext from fetched HTML to feed the agent (the output is never rendered as HTML), but the regex-based stripping had genuine correctness bugs:

| Alert | Rule | Fix |
|---|---|---|
| #34, #33 | `js/double-escaping` | Entity decoding via a `.replace()` chain double-unescaped crafted input (`&amp;lt;` → `<`). Now a **single left-to-right pass** over the original string (one regex + entity map); also decodes numeric/hex entities. |
| #32 | `js/incomplete-multi-character-sanitization` | Tag stripping ran once. Now iterates `/<[^>]*>/` to a **fixpoint**. |
| #35 | `js/bad-tag-filter` | Script/style remover only matched `</script>`; a spaced/attributed close (`</script >`, `</script bar>`) slipped through. Closing matcher is now `</script\b[^>]*>`, run to a fixpoint alongside comment removal. |

No new dependency — the existing regex approach was hardened (this is text extraction, not security-sanitization-for-rendering, so a full DOM parser would be overkill).

## Tests
`webTools.test.ts` gains: single-pass decode (no double-unescape), numeric/hex entity decode, spaced/attributed script-close removal, nested-tag stripping. Full vitest suite green (952), `tsc --noEmit` clean.

## Verification of intent
CodeQL re-runs on this PR; the 4 alerts should resolve on merge to `main`.