### PR TITLE
docs(draftAnalyzer): de-Haiku stale comments (INT-1909)

### DIFF
--- a/src/agents/draftAnalyzer.ts
+++ b/src/agents/draftAnalyzer.ts
@@ -1,7 +1,7 @@
 // ============================================
 // OpenSwarm - Draft Analyzer
 // Created: 2026-04-11
-// Purpose: Haiku 기반 사전 분석 — 이슈 의도 파악 + 코드베이스 상태 수집
+// Purpose: drafter 모델 기반 사전 분석 — 이슈 의도 파악 + 코드베이스 상태 수집
 //          Planner/Worker에 enriched context를 제공하여 첫 시도 정확도 향상
 // ============================================
 
@@ -73,11 +73,11 @@ export interface DraftAnalysis {
    * more specific label than the common bugfix/feature/refactor/docs/test/config.
    */
   taskType: string;
-  /** Haiku가 요약한 핵심 의도 (1-2문장) */
+  /** drafter가 요약한 핵심 의도 (1-2문장) */
   intentSummary: string;
-  /** Haiku가 식별한 관련 파일/모듈 목록 */
+  /** drafter가 식별한 관련 파일/모듈 목록 */
   relevantFiles: string[];
-  /** Haiku가 제안한 접근 방식 (1-3문장) */
+  /** drafter가 제안한 접근 방식 (1-3문장) */
   suggestedApproach: string;
   /**
    * Execution-grounded definition of done (INT-1914). Each item must be
@@ -124,7 +124,7 @@ export interface DraftAnalyzerOptions {
   projectId?: string;
   /** Fast model for draft analysis (default: gpt-5-codex) */
   model?: string;
-  /** 타임아웃 (기본: 30초 — Haiku는 빠름) */
+  /** 타임아웃 (기본: 30초 — drafter는 빠름) */
   timeoutMs?: number;
   onLog?: (line: string) => void;
 }
@@ -211,10 +211,10 @@ function collectCodebaseState(
   return { registrySnapshot, projectStats };
 }
 
-// ============ Haiku 의도 분석 ============
+// ============ drafter 의도 분석 ============
 
 /**
- * Haiku에게 이슈 의도를 분석시키는 프롬프트 구성
+ * drafter에게 이슈 의도를 분석시키는 프롬프트 구성
  * 코드베이스 상태를 컨텍스트로 제공하여 더 정확한 분류 유도
  */
 function buildDraftPrompt(
@@ -297,7 +297,7 @@ Each criterion must be a runtime/observable fact, NOT mere existence of code:
 }
 
 /**
- * Haiku 응답 파싱
+ * drafter 응답 파싱
  */
 function parseDraftResponse(output: string): Partial<DraftAnalysis> {
   // JSON 블록 추출
@@ -388,7 +388,7 @@ function isProviderQuotaError(message?: string): boolean {
  * 흐름:
  * 1. Knowledge Graph impact analysis (로컬)
  * 2. Code Registry 상태 수집 (로컬)
- * 3. Haiku에게 의도 분석 (API, ~3초)
+ * 3. drafter에게 의도 분석 (API, ~3초)
  * 4. 결과 병합
  */
 export async function runDraftAnalysis(options: DraftAnalyzerOptions): Promise<DraftAnalysis> {


### PR DESCRIPTION
## 문제
draftAnalyzer의 drafter는 더 이상 Haiku로 동작하지 않고 `DRAFT_MODELS`로 provider별 모델을 해석한다(claude→sonnet, openrouter→qwen3-235b, 그 외 adapter default). 그러나 헤더·주석 9곳이 여전히 'Haiku'라고 적혀 stale했다 — INT-1909 항목1(문서가 Haiku 중심 → 변경 필요)의 마지막 미해결 부분.

## 해결
주석 9곳의 'Haiku' → provider-neutral 'drafter'로 정정. 주석 전용, 동작 변경 없음.

## 검증
- `grep Haiku src/agents/draftAnalyzer.ts` → 0
- `tsc --noEmit` clean
- `vitest run draftAnalyzer.test.ts` → 9/9 green

INT-1909의 실질 작업(항목1~5 + drafter hard gate)은 이미 #102로 main에 머지됨. 이 PR이 마지막 문서 잔여를 닫는다. 항목6(KG/registry stale)은 이슈 본문에서 범위 밖으로 분리됨.