### PR TITLE
fix(runner): pause on 429 rate limit instead of failing/spamming (INT-1906)

### DIFF
--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -8,6 +8,7 @@
 
 import { TOOL_DEFINITIONS, APPLY_PATCH_TOOL, executeToolCalls, createReadCache, type ToolCall, type ToolResult, type ToolDefinition } from './tools.js';
 import { WEB_TOOL_DEFINITIONS } from './webTools.js';
+import { detectRateLimit } from './rateLimitError.js';
 import type { CliRunResult } from './types.js';
 
 // ============ 토큰 카운팅 (VEGA token_count.py 이식) ============
@@ -274,6 +275,16 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
         break;
       }
       const msg = err instanceof Error ? err.message : String(err);
+      // A 429/usage-limit raised by the in-process API caller (gpt/local/
+      // openrouter/codex-responses) would otherwise be swallowed into finalText
+      // here and returned as a normal result — the scheduler never learns it was
+      // rate-limited. Re-throw it as a typed RateLimitError so it propagates up to
+      // the pipeline, which pauses instead of failing/spamming. (INT-1906)
+      const rl = detectRateLimit('', msg);
+      if (rl) {
+        onLog?.(`■ ${rl.message}`);
+        throw rl;
+      }
       onLog?.(`✖ API error: ${msg}`);
       finalText = `API error: ${msg}`;
       break;

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -9,6 +9,7 @@ import type { CliAdapter, CliRunOptions, CliRunResult } from './types.js';
 import { parseCliStreamChunk } from '../agents/cliStreamParser.js';
 import { registerProcess } from './processRegistry.js';
 import { buildWorkerEnv } from './envPath.js';
+import { detectRateLimit } from './rateLimitError.js';
 
 /**
  * Spawn a CLI process using the given adapter and options.
@@ -105,6 +106,14 @@ export async function spawnCli(
           console.error(`[${adapter.name}] stderr: ${stderrSnippet || '(empty)'}`);
           console.error(`[${adapter.name}] stdout (first 300): ${stdoutSnippet || '(empty)'}`);
           console.error(`[${adapter.name}] Duration: ${durationMs}ms, CWD: ${options.cwd}`);
+
+          const rateLimitErr = detectRateLimit(stdout, stderr);
+          if (rateLimitErr) {
+            console.error(`[${adapter.name}] Rate limit detected: ${rateLimitErr.message}`);
+            reject(rateLimitErr);
+            return;
+          }
+
           reject(new Error(`${adapter.name} CLI failed with code ${code}: ${stderrSnippet.slice(0, 200)}`));
           return;
         }

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -17,6 +17,7 @@ import { AuthProfileStore, ensureValidToken } from '../auth/index.js';
 import { runAgenticLoop, loopResultToCliResult, type ChatMessage, type AgenticLoopOptions } from './agenticLoop.js';
 import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
 import type { ToolDefinition } from './tools.js';
+import { RateLimitError } from './rateLimitError.js';
 
 import { getCodexModelIds } from './codexModels.js';
 
@@ -374,6 +375,8 @@ export class CodexResponsesAdapter implements CliAdapter {
       }
       return loopResultToCliResult(result);
     } catch (err) {
+      // Rate-limit must propagate so the scheduler pauses (INT-1906).
+      if (err instanceof RateLimitError) throw err;
       return {
         exitCode: 1,
         stdout: '',

--- a/src/adapters/gpt.ts
+++ b/src/adapters/gpt.ts
@@ -17,6 +17,7 @@ import { runAgenticLoop, loopResultToCliResult, type ChatMessage, type AgenticLo
 import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
 import { consumeChatCompletionsStream } from './chatStream.js';
 import type { ToolDefinition } from './tools.js';
+import { RateLimitError } from './rateLimitError.js';
 
 const OPENAI_API_BASE = 'https://api.openai.com/v1';
 const DEFAULT_MODEL = 'gpt-4o';
@@ -99,6 +100,9 @@ export class GptCliAdapter implements CliAdapter {
       }
       return loopResultToCliResult(result);
     } catch (err) {
+      // Rate-limit must propagate so the scheduler pauses (INT-1906) — don't bury
+      // it in a failed CliRunResult.
+      if (err instanceof RateLimitError) throw err;
       return {
         exitCode: 1,
         stdout: '',

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -16,6 +16,7 @@ import { runAgenticLoop, loopResultToCliResult, type ChatMessage, type AgenticLo
 import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
 import { consumeChatCompletionsStream } from './chatStream.js';
 import type { ToolDefinition } from './tools.js';
+import { RateLimitError } from './rateLimitError.js';
 
 // 로컬 프로바이더 기본 URL 후보 (우선순위 순)
 const DEFAULT_ENDPOINTS = [
@@ -180,6 +181,8 @@ export class LocalModelAdapter implements CliAdapter {
       }
       return loopResultToCliResult(result);
     } catch (err) {
+      // Rate-limit must propagate so the scheduler pauses (INT-1906).
+      if (err instanceof RateLimitError) throw err;
       const message = err instanceof Error ? err.message : String(err);
       const isTimeout = message.includes('abort') || message.includes('timeout');
 

--- a/src/adapters/openrouter.ts
+++ b/src/adapters/openrouter.ts
@@ -20,6 +20,7 @@ import {
   type AgenticLoopOptions,
 } from './agenticLoop.js';
 import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
+import { RateLimitError } from './rateLimitError.js';
 import { consumeChatCompletionsStream } from './chatStream.js';
 import type { ToolDefinition } from './tools.js';
 
@@ -120,6 +121,8 @@ export class OpenRouterCliAdapter implements CliAdapter {
       );
       return loopResultToCliResult(result);
     } catch (err) {
+      // Rate-limit must propagate so the scheduler pauses (INT-1906).
+      if (err instanceof RateLimitError) throw err;
       return {
         exitCode: 1,
         stdout: '',

--- a/src/adapters/rateLimitError.test.ts
+++ b/src/adapters/rateLimitError.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { detectRateLimit, RateLimitError } from './rateLimitError.js';
+import { runAgenticLoop } from './agenticLoop.js';
 
 describe('detectRateLimit (INT-1906)', () => {
   it('detects a Codex usage_limit_reached payload and parses resets_at', () => {
@@ -37,5 +38,25 @@ describe('detectRateLimit (INT-1906)', () => {
     const err = detectRateLimit('partial output', 'error: usage_limit_reached "resets_at": 1782343811');
     expect(err).toBeInstanceOf(RateLimitError);
     expect(err?.resetsAt).toBe(1782343811);
+  });
+});
+
+describe('runAgenticLoop rate-limit propagation (INT-1906 blocker)', () => {
+  it('re-throws a 429 raised by callApi as a RateLimitError', async () => {
+    // The in-process adapters surface a 429 by throwing from callApi. The loop
+    // used to swallow it into finalText; it must now propagate so the pipeline
+    // pauses instead of returning a normal failed result.
+    const callApi = async () => {
+      throw new Error('OpenRouter API error (429): {"error":{"message":"Rate limit exceeded"}}');
+    };
+    await expect(
+      runAgenticLoop({ prompt: 'x', cwd: process.cwd(), model: 't', callApi, webTools: false, maxTurns: 2 }),
+    ).rejects.toBeInstanceOf(RateLimitError);
+  });
+
+  it('does NOT re-throw an ordinary (non-rate-limit) API error', async () => {
+    const callApi = async () => { throw new Error('500 Internal Server Error'); };
+    const res = await runAgenticLoop({ prompt: 'x', cwd: process.cwd(), model: 't', callApi, webTools: false, maxTurns: 2 });
+    expect(res.text).toContain('API error');
   });
 });

--- a/src/adapters/rateLimitError.test.ts
+++ b/src/adapters/rateLimitError.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { detectRateLimit, RateLimitError } from './rateLimitError.js';
+
+describe('detectRateLimit (INT-1906)', () => {
+  it('detects a Codex usage_limit_reached payload and parses resets_at', () => {
+    const stdout =
+      'API error: Codex responses error (429): {"error":{"type":"usage_limit_reached",' +
+      '"message":"The usage limit has been reached","plan_type":"prolite","resets_at":1782343811}}';
+    const err = detectRateLimit(stdout, '');
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err?.resetsAt).toBe(1782343811);
+    // The label embeds the ISO reset time for operator-facing logs.
+    expect(err?.message).toContain('2026'); // 1782343811 → 2026-06-…
+  });
+
+  it('detects a rate_limit_error type without resets_at (resetsAt undefined)', () => {
+    const err = detectRateLimit('{"type":"rate_limit_error","message":"slow down"}', '');
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err?.resetsAt).toBeUndefined();
+  });
+
+  it('detects a 429 paired with rate-limit wording in stderr', () => {
+    const err = detectRateLimit('', 'HTTP 429 — rate limit exceeded, retry later');
+    expect(err).toBeInstanceOf(RateLimitError);
+  });
+
+  it('returns null for ordinary CLI failures (no false positive)', () => {
+    expect(detectRateLimit('TypeError: x is not a function', 'exit code 1')).toBeNull();
+  });
+
+  it('does not treat a bare "429" without rate-limit wording as a rate limit', () => {
+    // e.g. a diff line, a port number, or unrelated numeric output.
+    expect(detectRateLimit('listening on port 4290; processed 429 rows', '')).toBeNull();
+  });
+
+  it('scans both stdout and stderr (signal split across streams)', () => {
+    const err = detectRateLimit('partial output', 'error: usage_limit_reached "resets_at": 1782343811');
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err?.resetsAt).toBe(1782343811);
+  });
+});

--- a/src/adapters/rateLimitError.ts
+++ b/src/adapters/rateLimitError.ts
@@ -1,0 +1,42 @@
+// ============================================
+// OpenSwarm - Rate Limit Error
+// Typed error for 429 / usage_limit_reached from CLI adapters
+// ============================================
+
+export class RateLimitError extends Error {
+  constructor(
+    /** Unix timestamp (seconds) when the quota resets, if provided by the API */
+    public readonly resetsAt?: number,
+    message?: string,
+  ) {
+    super(message ?? 'Rate limit reached');
+    this.name = 'RateLimitError';
+  }
+}
+
+/**
+ * Scan combined stdout+stderr output for rate-limit signals.
+ * Handles Codex format: JSON stream event with type=error carrying a message
+ * that embeds the usage_limit_reached JSON (with resets_at timestamp).
+ * Returns a RateLimitError if a rate-limit pattern is found, null otherwise.
+ */
+export function detectRateLimit(stdout: string, stderr: string): RateLimitError | null {
+  const combined = stdout + '\n' + stderr;
+
+  const hasSignal =
+    combined.includes('usage_limit_reached') ||
+    combined.includes('rate_limit_exceeded') ||
+    combined.includes('"rate_limit_error"') ||
+    (combined.includes('429') && /rate.{0,15}limit/i.test(combined));
+
+  if (!hasSignal) return null;
+
+  const resetsAtMatch = combined.match(/"resets_at"\s*:\s*(\d+)/);
+  const resetsAt = resetsAtMatch ? parseInt(resetsAtMatch[1], 10) : undefined;
+
+  const label = resetsAt
+    ? `Rate limit reached (resets at ${new Date(resetsAt * 1000).toISOString()})`
+    : 'Rate limit reached';
+
+  return new RateLimitError(resetsAt, label);
+}

--- a/src/agents/auditor.ts
+++ b/src/agents/auditor.ts
@@ -8,6 +8,7 @@ import type { AdapterName } from '../adapters/types.js';
 import { getAdapter, spawnCli } from '../adapters/index.js';
 import { type CostInfo, extractCostFromStreamJson, formatCost } from '../support/costTracker.js';
 import { expandPath } from '../core/config.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
 
 // Types
 
@@ -100,6 +101,7 @@ export async function runAuditor(options: AuditorOptions): Promise<AuditorResult
     });
     return parseAuditorOutput(raw.stdout);
   } catch (error) {
+    if (error instanceof RateLimitError) throw error;
     return {
       success: false,
       criticalCount: 0,

--- a/src/agents/documenter.ts
+++ b/src/agents/documenter.ts
@@ -8,6 +8,7 @@ import type { AdapterName } from '../adapters/types.js';
 import { getAdapter, spawnCli } from '../adapters/index.js';
 import { type CostInfo, extractCostFromStreamJson, formatCost } from '../support/costTracker.js';
 import { expandPath } from '../core/config.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
 
 // Types
 
@@ -124,6 +125,7 @@ export async function runDocumenter(options: DocumenterOptions): Promise<Documen
 
     return parseDocumenterOutput(raw.stdout);
   } catch (error) {
+    if (error instanceof RateLimitError) throw error;
     return {
       success: false,
       updatedFiles: [],

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -37,6 +37,7 @@ import * as documenterAgent from './documenter.js';
 import * as auditorAgent from './auditor.js';
 import * as skillDocumenterAgent from './skillDocumenter.js';
 import { StuckDetector, createStuckDetector } from '../support/stuckDetector.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
 
 // Types
 
@@ -104,7 +105,9 @@ export interface PipelineResult {
   success: boolean;
   sessionId: string;
   stages: StageResult[];
-  finalStatus: 'approved' | 'rejected' | 'failed' | 'cancelled' | 'decomposed';
+  finalStatus: 'approved' | 'rejected' | 'failed' | 'cancelled' | 'decomposed' | 'rate_limited';
+  /** Unix timestamp (ms) when the rate-limit quota resets — set when finalStatus is 'rate_limited'. */
+  rateLimitResetsAt?: number;
   totalDuration: number;
   /** Total number of completed iterations */
   iterations: number;
@@ -354,8 +357,14 @@ export class PairPipeline extends EventEmitter {
       // Cancellation (project disable / manual stop) is not a failure — surface it
       // as 'cancelled' so the scheduler doesn't count it failed or trigger a retry.
       const cancelled = error instanceof PipelineCancelledError || !!this.abortSignal?.aborted;
+      // A 429/usage-limit propagates up here from any stage (worker/reviewer/…).
+      // Surface it as its own finalStatus so the runner pauses until quota resets
+      // instead of counting a failure and spamming Linear comments. (INT-1906)
+      const rateLimited = !cancelled && error instanceof RateLimitError;
       if (cancelled) {
         console.log(`[${context.taskPrefix}] Pipeline cancelled`);
+      } else if (rateLimited) {
+        console.warn(`[${context.taskPrefix}] Pipeline rate-limited: ${(error as RateLimitError).message}`);
       } else {
         console.error('[%s] Error:', context.taskPrefix, error);
       }
@@ -364,7 +373,10 @@ export class PairPipeline extends EventEmitter {
         success: false,
         sessionId: session.id,
         stages,
-        finalStatus: cancelled ? 'cancelled' : 'failed',
+        finalStatus: cancelled ? 'cancelled' : rateLimited ? 'rate_limited' : 'failed',
+        rateLimitResetsAt: rateLimited && (error as RateLimitError).resetsAt
+          ? (error as RateLimitError).resetsAt! * 1000
+          : undefined,
         totalDuration: Date.now() - startTime,
         iterations: context.currentIteration,
         workerResult: context.workerResult,

--- a/src/agents/pipelineFormat.ts
+++ b/src/agents/pipelineFormat.ts
@@ -23,6 +23,7 @@ export function formatPipelineResult(result: PipelineResult): string {
     failed: '💥',
     cancelled: '🚫',
     decomposed: '🔀',
+    rate_limited: '⏸',
   }[result.finalStatus];
 
   const lines: string[] = [];
@@ -78,6 +79,7 @@ export function formatPipelineResultEmbed(result: PipelineResult): EmbedBuilder 
     failed: { emoji: '💥', color: 0xFF6B6B, label: 'FAILED' },
     cancelled: { emoji: '🚫', color: 0xFFAA00, label: 'CANCELLED' },
     decomposed: { emoji: '🔀', color: 0x00AAFF, label: 'DECOMPOSED' },
+    rate_limited: { emoji: '⏸', color: 0xFFAA00, label: 'RATE LIMITED' },
   }[result.finalStatus] || { emoji: '❓', color: 0x808080, label: 'UNKNOWN' };
 
   const embed = new EmbedBuilder()

--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -8,6 +8,7 @@ import { t, getPrompts } from '../locale/index.js';
 import type { AdapterName, ProcessContext } from '../adapters/types.js';
 import { getAdapter, spawnCli } from '../adapters/index.js';
 import { expandPath } from '../core/config.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
 
 // Types
 
@@ -172,6 +173,9 @@ export async function runPreCheck(options: ReviewerOptions): Promise<PreCheckRes
       confidence: Math.min(3, Math.max(0, confidence)),
     };
   } catch (error) {
+    // Rate limit errors must propagate so the scheduler can pause — pre-check
+    // failure otherwise just passes through to the full review.
+    if (error instanceof RateLimitError) throw error;
     // If pre-check fails, allow proceeding to full review
     console.warn('[Reviewer] Pre-check failed, proceeding to full review:', error);
     return {
@@ -209,6 +213,8 @@ export async function runReviewer(options: ReviewerOptions): Promise<ReviewResul
     // Parse result via adapter
     return adapter.parseReviewerOutput(raw);
   } catch (error) {
+    // Rate limit errors must propagate so the scheduler can pause.
+    if (error instanceof RateLimitError) throw error;
     return {
       decision: 'reject',
       feedback: `Reviewer execution failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/agents/skillDocumenter.ts
+++ b/src/agents/skillDocumenter.ts
@@ -8,6 +8,7 @@ import type { AdapterName } from '../adapters/types.js';
 import { getAdapter, spawnCli } from '../adapters/index.js';
 import { type CostInfo, extractCostFromStreamJson, formatCost } from '../support/costTracker.js';
 import { expandPath } from '../core/config.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
 
 // Types
 
@@ -98,6 +99,7 @@ export async function runSkillDocumenter(options: SkillDocumenterOptions): Promi
     });
     return parseSkillDocumenterOutput(raw.stdout);
   } catch (error) {
+    if (error instanceof RateLimitError) throw error;
     return {
       success: false,
       updatedFiles: [],

--- a/src/agents/tester.ts
+++ b/src/agents/tester.ts
@@ -8,6 +8,7 @@ import type { AdapterName } from '../adapters/types.js';
 import { getAdapter, spawnCli } from '../adapters/index.js';
 import { type CostInfo, extractCostFromStreamJson, formatCost } from '../support/costTracker.js';
 import { expandPath } from '../core/config.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
 
 // Types
 
@@ -118,6 +119,7 @@ export async function runTester(options: TesterOptions): Promise<TesterResult> {
 
     return parseTesterOutput(raw.stdout);
   } catch (error) {
+    if (error instanceof RateLimitError) throw error;
     return {
       success: false,
       testsPassed: 0,

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -10,6 +10,7 @@ import type { WorkerContext } from '../locale/types.js';
 import type { AdapterName, ProcessContext } from '../adapters/types.js';
 import { getAdapter, getDefaultAdapterName, spawnCli } from '../adapters/index.js';
 import { expandPath } from '../core/config.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
 
 // Types
 
@@ -214,6 +215,11 @@ export async function runWorker(options: WorkerOptions): Promise<WorkerResult> {
       }
       return result;
     } catch (error) {
+      // A 429/usage-limit must STOP the run and propagate so the scheduler can
+      // pause — never fall back to another adapter (it shares the same quota
+      // window) and never get swallowed as a generic worker failure. (INT-1906)
+      if (error instanceof RateLimitError) throw error;
+
       const errMsg = error instanceof Error ? error.message : String(error);
       console.error(`[Worker] Execution failed (${adapterName}): ${errMsg}`);
       if (error instanceof Error && error.message.includes('code')) {

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -1018,6 +1018,20 @@ export class AutonomousRunner {
 
     // Single execution (legacy)
     const result = await this.executePipeline(task, projectPath);
+
+    // Rate-limited: pause until quota resets. Return before any Discord/Linear
+    // reporting or state change — no failure count, no card spam. Same as the
+    // scheduler 'failed' handler's rate_limited branch. (INT-1906)
+    if (result.finalStatus === 'rate_limited') {
+      const resetsAt = result.rateLimitResetsAt ?? Date.now() + 60_000;
+      this.rateLimitUntil = resetsAt;
+      const waitSec = Math.max(0, Math.ceil((resetsAt - Date.now()) / 1000));
+      const resetsLabel = new Date(resetsAt).toISOString();
+      console.warn(`[AutonomousRunner] Rate limit hit for ${this.formatTaskContext(task)} — pausing until ${resetsLabel} (~${waitSec}s)`);
+      broadcastEvent({ type: 'log', data: { taskId: task.issueId || task.id, stage: 'rate_limit', line: `⏸ Rate limited — pausing ~${waitSec}s (until ${resetsLabel})` } });
+      return;
+    }
+
     await reportToDiscord(formatPipelineResultEmbed(result));
 
     // Update Linear issue state

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -121,6 +121,10 @@ export class AutonomousRunner {
   private failedTaskRetryTimes = new Map<string, number>(); // issueId → next retry timestamp (ms)
   private static readonly MAX_RETRY_COUNT = 4; // Increased from 2 to allow more retries with backoff
 
+  // Rate-limit hold: epoch ms until which all task execution is paused.
+  // Set when any adapter returns a 429 / usage_limit_reached response (INT-1906).
+  private rateLimitUntil = 0;
+
   private get taskStateRef(): TaskState {
     return {
       completedTaskIds: this.completedTaskIds,
@@ -255,6 +259,23 @@ export class AutonomousRunner {
 
     this.scheduler.on('failed', async ({ task, result }) => {
       const taskCtx = this.formatTaskContext(task);
+
+      // Rate-limited: pause execution until the quota resets. Do NOT count it as a
+      // task failure, run the rejection/block path, or post a Linear comment —
+      // that is exactly the retry-spam this issue fixes. (INT-1906)
+      if (result.finalStatus === 'rate_limited') {
+        const resetsAt = result.rateLimitResetsAt ?? Date.now() + 60_000;
+        this.rateLimitUntil = resetsAt;
+        const waitSec = Math.max(0, Math.ceil((resetsAt - Date.now()) / 1000));
+        const resetsLabel = new Date(resetsAt).toISOString();
+        console.warn(`[Scheduler] Rate limit hit for ${taskCtx} — pausing until ${resetsLabel} (~${waitSec}s)`);
+        broadcastEvent({
+          type: 'log',
+          data: { taskId: task.issueId || task.id, stage: 'rate_limit', line: `⏸ Rate limited — pausing ~${waitSec}s (until ${resetsLabel})` },
+        });
+        return;
+      }
+
       console.log(`[Scheduler] Task failed: ${taskCtx} ${task.title}`);
       broadcastEvent({ type: 'task:completed', data: { taskId: task.id, success: false, duration: result.totalDuration } });
       this.recordPipelineHistory(task, result);
@@ -663,6 +684,17 @@ export class AutonomousRunner {
         return;
       }
       this.syslog('✓ Time window: allowed');
+
+      // 1.2 Rate-limit hold — skip the heartbeat while a 429 pause is still active.
+      // Cleared implicitly once the clock passes rateLimitUntil. (INT-1906)
+      if (Date.now() < this.rateLimitUntil) {
+        const remainSec = Math.max(0, Math.ceil((this.rateLimitUntil - Date.now()) / 1000));
+        const resetsLabel = new Date(this.rateLimitUntil).toISOString();
+        console.log(`[AutonomousRunner] Rate limit hold active — ${remainSec}s remaining (until ${resetsLabel})`);
+        this.syslog(`⏸ Rate limit hold: ~${remainSec}s remaining`);
+        broadcastEvent({ type: 'log', data: { taskId: 'system', stage: 'rate_limit', line: `⏸ Rate limit hold: ~${remainSec}s remaining` } });
+        return;
+      }
 
       // 1.5 Quota gate — skip heartbeat if Claude Max quota is too high
       const quotaCheck = await checkQuotaAllowance(80);


### PR DESCRIPTION
## 문제
429 / `usage_limit_reached`가 일반 worker/reviewer 실패로 처리되어 스케줄러가 retry 예산을 소모하고 Linear에 실패 카드를 반복 게시 → 쿼터 소진 중 카드 스팸. 핵심 요구(resets_at까지 대기)는 main에 미구현 상태였음(이전 worktree 작업이 머지 안 됨).

## 해결
- `rateLimitError.ts`: `RateLimitError` + `detectRateLimit()` — stdout+stderr에서 `usage_limit_reached`/`rate_limit_exceeded`/429 스캔, `resets_at` 파싱.
- `base.ts spawnCli`: 비정상 종료 시 감지되면 `RateLimitError` throw.
- worker/reviewer(+auditor/documenter/tester/skillDocumenter): `RateLimitError`를 삼키지 않고 재전파. **worker는 어댑터 폴백 이전에** 전파(폴백 어댑터도 같은 쿼터 창 공유 → 무의미).
- `pairPipeline`: 전용 `finalStatus: 'rate_limited'` + `rateLimitResetsAt`(ms).
- `autonomousRunner`: rate_limited 시 `rateLimitUntil` hold 설정 + 실패/Linear 경로 skip. heartbeat이 hold 만료까지 tick을 건너뛰고 cron이 이후 재개 — quota gate와 동일 패턴.

## 검증
- `rateLimitError.test.ts` 6건 — resets_at 파싱, 스트림 분할 신호, bare '429' false-positive 차단.
- 전체 vitest **958 green**, tsc clean, oxlint 0.

재오픈(2026-06-25) 요구 3건 모두 충족: (1) resets_at 파싱 (2) reset까지 대기 후 재개 (3) 대기 중 카드 스팸 차단.