### PR TITLE
feat(worker): match edit format to model capability (INT-1676)

### DIFF
--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -9,6 +9,8 @@
 import { TOOL_DEFINITIONS, APPLY_PATCH_TOOL, executeToolCalls, createReadCache, type ToolCall, type ToolResult, type ToolDefinition } from './tools.js';
 import { WEB_TOOL_DEFINITIONS } from './webTools.js';
 import { detectRateLimit } from './rateLimitError.js';
+import { parseSearchReplaceBlocks, applyEditBlock, type EditFormat } from '../support/editParser.js';
+import path from 'node:path';
 import type { CliRunResult } from './types.js';
 
 // ============ 토큰 카운팅 (VEGA token_count.py 이식) ============
@@ -128,6 +130,14 @@ export interface AgenticLoopOptions {
   mcpTools?: ToolDefinition[];
   /** Abort the loop (checked each turn) — Esc/Ctrl+C in chat. */
   signal?: AbortSignal;
+  /**
+   * File-edit format matched to model capability (INT-1676). Default 'json'.
+   * - 'json': keep the edit_file / apply_patch tools (frontier models).
+   * - 'search-replace': hide those tools; parse Aider-style SEARCH/REPLACE blocks
+   *   from the response text and apply them (much better for weaker models).
+   * - 'whole-file': hide edit_file / apply_patch; the model rewrites via write_file.
+   */
+  editFormat?: EditFormat;
 }
 
 /** 루프 실행 결과 */
@@ -179,6 +189,7 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
     applyPatch = false,
     mcpTools,
     signal,
+    editFormat = 'json',
   } = options;
 
   const startTime = Date.now();
@@ -199,10 +210,16 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
     `or absolute paths under this root. Do NOT use "/" or a bare repo name — those are outside the project and will be rejected.\n\n`;
   messages.push({ role: 'user', content: cwdNote + prompt });
 
+  // In search-replace / whole-file mode the model edits via response-text blocks
+  // (S/R) or whole write_file calls, so the structured edit_file tool is hidden to
+  // force that path; apply_patch is likewise suppressed (it's a structured edit). (INT-1676)
+  const baseTools = editFormat === 'json'
+    ? TOOL_DEFINITIONS
+    : TOOL_DEFINITIONS.filter(t => t.function.name !== 'edit_file');
   const tools = enableTools
     ? [
-        ...TOOL_DEFINITIONS,
-        ...(applyPatch ? [APPLY_PATCH_TOOL] : []),
+        ...baseTools,
+        ...(applyPatch && editFormat === 'json' ? [APPLY_PATCH_TOOL] : []),
         ...(webTools ? WEB_TOOL_DEFINITIONS : []),
         ...(mcpTools ?? []),
       ]
@@ -306,17 +323,52 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
 
     // 도구 호출이 없으면 최종 응답
     if (!assistantMsg.tool_calls || assistantMsg.tool_calls.length === 0) {
+      // SEARCH/REPLACE 모드 — 도구 호출이 아니라 응답 본문의 S/R 블록으로 편집한다.
+      // 블록이 있으면 직접 적용하고(보호 파일은 거부) 결과를 되돌려 루프를 잇는다. (INT-1676)
+      if (editFormat === 'search-replace' && assistantMsg.content) {
+        const parsed = parseSearchReplaceBlocks(assistantMsg.content);
+        if (parsed.blocks.length > 0) {
+          const resultLines = await Promise.all(parsed.blocks.map(async (block) => {
+            const resolved = path.isAbsolute(block.filePath) ? block.filePath : path.join(cwd, block.filePath);
+            // protectedFiles enforcement — applyEditBlock bypasses tools.ts guards.
+            if (protectedFiles?.some(p => resolved === p || resolved.endsWith(`/${p}`) || resolved.endsWith(path.sep + p))) {
+              return `✗ ${block.filePath} — PROTECTED harness file, cannot modify`;
+            }
+            const r = await applyEditBlock(block, cwd);
+            if (r.success) editToolCount++;
+            return r.success ? `✓ Applied: ${block.filePath}` : `✗ Failed: ${block.filePath} — ${r.error}`;
+          }));
+          const failed = resultLines.filter(l => l.startsWith('✗')).length;
+          onLog?.(`📝 SEARCH/REPLACE: applied ${parsed.blocks.length - failed}/${parsed.blocks.length} block(s)`);
+          messages.push({ role: 'assistant', content: assistantMsg.content });
+          messages.push({
+            role: 'user',
+            content: `Edit results:\n${resultLines.join('\n')}\n\n${
+              failed > 0
+                ? 'Some edits failed — fix the SEARCH text to match the file exactly and retry.'
+                : 'All edits applied. Verify the changes and finish when done.'
+            }`,
+          });
+          continue;
+        }
+      }
+
       // no-edit 종료 가드 — 수정 필수 작업인데 edit/write를 한 번도 안 하고 끝내려 하면
       // 되밀어 계속하게 한다(경량 모델의 조기 결론 패턴 차단).
       if (editToolCount === 0 && noEditNudgesUsed < nudgeMaxOnNoEdit) {
         noEditNudgesUsed++;
         onLog?.(`↩ No-edit guard: model tried to finish without editing (nudge ${noEditNudgesUsed}/${nudgeMaxOnNoEdit})`);
+        const howToEdit = editFormat === 'search-replace'
+          ? 'Apply the fix now using SEARCH/REPLACE blocks, then verify.'
+          : editFormat === 'whole-file'
+          ? 'Apply the fix now by rewriting the file with write_file, then verify.'
+          : 'Apply the fix now with edit_file, then verify.';
         messages.push({ role: 'assistant', content: assistantMsg.content ?? '' });
         messages.push({
           role: 'user',
           content:
             'You have not modified any files yet, but this task REQUIRES code changes. ' +
-            'Do not conclude with analysis only. Apply the fix now with edit_file, then verify. ' +
+            `Do not conclude with analysis only. ${howToEdit} ` +
             'Continue working.',
         });
         continue;

--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -6,11 +6,10 @@
 //          VEGA token_count.py 패턴 이식 — 토큰 기반 히스토리 압축.
 // ============================================
 
-import { TOOL_DEFINITIONS, APPLY_PATCH_TOOL, executeToolCalls, createReadCache, type ToolCall, type ToolResult, type ToolDefinition } from './tools.js';
+import { TOOL_DEFINITIONS, APPLY_PATCH_TOOL, executeToolCalls, createReadCache, validatePath, type ToolCall, type ToolResult, type ToolDefinition } from './tools.js';
 import { WEB_TOOL_DEFINITIONS } from './webTools.js';
 import { detectRateLimit } from './rateLimitError.js';
 import { parseSearchReplaceBlocks, applyEditBlock, type EditFormat } from '../support/editParser.js';
-import path from 'node:path';
 import type { CliRunResult } from './types.js';
 
 // ============ 토큰 카운팅 (VEGA token_count.py 이식) ============
@@ -239,6 +238,11 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
   // could exhaust it and then slip past the guard, ending analysis-only. (INT-1925)
   let noEditNudgesUsed = 0;
   let readLoopNudgesUsed = 0;
+  // search-replace stall guard: consecutive finish-turns where S/R blocks were
+  // present but ALL failed to apply. A model can re-emit the same non-matching
+  // block forever, burning turns at full API cost — bail after a couple. (INT-1676)
+  let srFailedTurns = 0;
+  const SR_FAILED_LIMIT = 2;
   let apiCallCount = 0;
   let totalTokens = 0;
   let cachedTokens = 0;
@@ -329,9 +333,16 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
         const parsed = parseSearchReplaceBlocks(assistantMsg.content);
         if (parsed.blocks.length > 0) {
           const resultLines = await Promise.all(parsed.blocks.map(async (block) => {
-            const resolved = path.isAbsolute(block.filePath) ? block.filePath : path.join(cwd, block.filePath);
-            // protectedFiles enforcement — applyEditBlock bypasses tools.ts guards.
-            if (protectedFiles?.some(p => resolved === p || resolved.endsWith(`/${p}`) || resolved.endsWith(path.sep + p))) {
+            // Containment + protection. applyEditBlock bypasses tools.ts guards, so
+            // run the same cwd-containment check (rejects ../ escapes) and the
+            // protectedFiles check here before touching disk.
+            let resolved: string;
+            try {
+              resolved = validatePath(block.filePath, cwd);
+            } catch {
+              return `✗ ${block.filePath} — outside project root, rejected`;
+            }
+            if (protectedFiles?.some(p => resolved === p || resolved.endsWith(`/${p}`))) {
               return `✗ ${block.filePath} — PROTECTED harness file, cannot modify`;
             }
             const r = await applyEditBlock(block, cwd);
@@ -339,13 +350,24 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
             return r.success ? `✓ Applied: ${block.filePath}` : `✗ Failed: ${block.filePath} — ${r.error}`;
           }));
           const failed = resultLines.filter(l => l.startsWith('✗')).length;
+          const allFailed = failed === parsed.blocks.length;
           onLog?.(`📝 SEARCH/REPLACE: applied ${parsed.blocks.length - failed}/${parsed.blocks.length} block(s)`);
+
+          // Stall guard: if every block failed for SR_FAILED_LIMIT turns running,
+          // the model is stuck re-emitting non-matching blocks — stop. (INT-1676)
+          srFailedTurns = allFailed ? srFailedTurns + 1 : 0;
+          if (srFailedTurns >= SR_FAILED_LIMIT) {
+            onLog?.(`■ SEARCH/REPLACE stalled: ${srFailedTurns} turns with no block applied — stopping`);
+            finalText = assistantMsg.content;
+            break;
+          }
+
           messages.push({ role: 'assistant', content: assistantMsg.content });
           messages.push({
             role: 'user',
             content: `Edit results:\n${resultLines.join('\n')}\n\n${
               failed > 0
-                ? 'Some edits failed — fix the SEARCH text to match the file exactly and retry.'
+                ? 'Some edits failed — copy the SEARCH text VERBATIM from the file (exact whitespace) and retry.'
                 : 'All edits applied. Verify the changes and finish when done.'
             }`,
           });

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -365,6 +365,7 @@ export class CodexResponsesAdapter implements CliAdapter {
       // emits clean V4A here, whereas non-codex adapters keep edit_file only.
       applyPatch: true,
       signal: options.signal,
+      editFormat: options.editFormat,
     };
 
     try {

--- a/src/adapters/editFormat.test.ts
+++ b/src/adapters/editFormat.test.ts
@@ -99,6 +99,55 @@ describe('agenticLoop edit-format wiring (INT-1676)', () => {
     expect(call).toBe(2); // looped once after applying, then finished
   });
 
+  it('rejects a SEARCH/REPLACE block whose path escapes the project root', async () => {
+    const srBlock =
+      '../../escape.ts\n```ts\n<<<<<<< SEARCH\nx\n=======\ny\n>>>>>>> REPLACE\n```\n';
+    let call = 0;
+    const callApi = async () => { call++; return call === 1 ? finalResp(srBlock) : finalResp('stopped'); };
+
+    await runAgenticLoop({
+      prompt: 'escape', cwd: tmp, model: 't', callApi,
+      webTools: false, maxTurns: 5, editFormat: 'search-replace',
+    });
+
+    // No file created outside the sandbox root.
+    await expect(fs.access(path.join(tmp, '..', '..', 'escape.ts'))).rejects.toThrow();
+  });
+
+  it('stops after consecutive turns where every SEARCH/REPLACE block fails (stall guard)', async () => {
+    await fs.writeFile(path.join(tmp, 'a.ts'), 'real content\n', 'utf-8');
+    // SEARCH text never matches → every turn fails to apply.
+    const badBlock =
+      'a.ts\n```ts\n<<<<<<< SEARCH\nDOES NOT EXIST\n=======\nnope\n>>>>>>> REPLACE\n```\n';
+    let call = 0;
+    const callApi = async () => { call++; return finalResp(badBlock); };
+
+    const res = await runAgenticLoop({
+      prompt: 'loop', cwd: tmp, model: 't', callApi,
+      webTools: false, maxTurns: 20, editFormat: 'search-replace',
+    });
+
+    // Bailed at the stall limit (2), not after maxTurns (20).
+    expect(call).toBeLessThanOrEqual(3);
+    expect(res.text).toContain('DOES NOT EXIST');
+    expect(await fs.readFile(path.join(tmp, 'a.ts'), 'utf-8')).toBe('real content\n');
+  });
+
+  it('whole-file mode hides edit_file/apply_patch but keeps write_file', async () => {
+    let seen: string[] = [];
+    const callApi = async (_m: ChatMessage[], tools: ToolDefinition[]) => {
+      seen = toolNames(tools);
+      return finalResp('done');
+    };
+    await runAgenticLoop({
+      prompt: 'x', cwd: tmp, model: 't', callApi,
+      webTools: false, maxTurns: 2, editFormat: 'whole-file', applyPatch: true,
+    });
+    expect(seen).not.toContain('edit_file');
+    expect(seen).not.toContain('apply_patch');
+    expect(seen).toContain('write_file');
+  });
+
   it('refuses to apply a SEARCH/REPLACE block targeting a protected file', async () => {
     const guard = path.join(tmp, 'guard.test.ts');
     await fs.writeFile(guard, 'keep me', 'utf-8');

--- a/src/adapters/editFormat.test.ts
+++ b/src/adapters/editFormat.test.ts
@@ -1,0 +1,121 @@
+// ============================================
+// OpenSwarm - Edit-format matching tests (INT-1676)
+// Covers the capability resolver + the agentic loop's SEARCH/REPLACE path:
+// edit_file/apply_patch hidden for weak models, S/R blocks parsed & applied.
+// ============================================
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runAgenticLoop, type ChatMessage } from './agenticLoop.js';
+import type { ToolDefinition } from './tools.js';
+import { resolveEditFormat } from '../support/editParser.js';
+
+const finalResp = (content: string) => ({
+  choices: [{ message: { role: 'assistant', content }, finish_reason: 'stop' }],
+});
+
+describe('resolveEditFormat (INT-1676)', () => {
+  afterEach(() => { delete process.env.OPENSWARM_EDIT_FORMAT; });
+
+  it('routes weak in-process adapters to search-replace', () => {
+    expect(resolveEditFormat('local')).toBe('search-replace');
+    expect(resolveEditFormat('lmstudio')).toBe('search-replace');
+    expect(resolveEditFormat('openrouter')).toBe('search-replace');
+  });
+
+  it('keeps capable adapters on json', () => {
+    expect(resolveEditFormat('claude')).toBe('json');
+    expect(resolveEditFormat('codex')).toBe('json');
+    expect(resolveEditFormat('codex-responses')).toBe('json');
+    expect(resolveEditFormat('gpt')).toBe('json');
+    expect(resolveEditFormat(undefined)).toBe('json');
+  });
+
+  it('OPENSWARM_EDIT_FORMAT overrides per-adapter routing (rollback lever)', () => {
+    process.env.OPENSWARM_EDIT_FORMAT = 'json';
+    expect(resolveEditFormat('local')).toBe('json');
+    process.env.OPENSWARM_EDIT_FORMAT = 'search-replace';
+    expect(resolveEditFormat('claude')).toBe('search-replace');
+  });
+
+  it('ignores a bogus env value and falls back to per-adapter routing', () => {
+    process.env.OPENSWARM_EDIT_FORMAT = 'nonsense';
+    expect(resolveEditFormat('local')).toBe('search-replace');
+    expect(resolveEditFormat('claude')).toBe('json');
+  });
+});
+
+describe('agenticLoop edit-format wiring (INT-1676)', () => {
+  let tmp: string;
+  beforeEach(async () => { tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'editfmt-')); });
+  afterEach(async () => { await fs.rm(tmp, { recursive: true, force: true }); });
+
+  const toolNames = (tools: ToolDefinition[]) => tools.map(t => t.function.name);
+
+  it('hides edit_file in search-replace mode and keeps it in json mode', async () => {
+    let seen: string[] = [];
+    const callApi = async (_m: ChatMessage[], tools: ToolDefinition[]) => {
+      seen = toolNames(tools);
+      return finalResp('done');
+    };
+
+    await runAgenticLoop({ prompt: 'x', cwd: tmp, model: 't', callApi, webTools: false, maxTurns: 2, editFormat: 'json' });
+    expect(seen).toContain('edit_file');
+
+    await runAgenticLoop({ prompt: 'x', cwd: tmp, model: 't', callApi, webTools: false, maxTurns: 2, editFormat: 'search-replace' });
+    expect(seen).not.toContain('edit_file');
+  });
+
+  it('parses a SEARCH/REPLACE block from the response and applies it to disk', async () => {
+    await fs.writeFile(path.join(tmp, 'a.ts'), 'const v = 1;\n', 'utf-8');
+
+    const srBlock =
+      'Here is the fix:\n\n' +
+      'a.ts\n' +
+      '```typescript\n' +
+      '<<<<<<< SEARCH\n' +
+      'const v = 1;\n' +
+      '=======\n' +
+      'const v = 2;\n' +
+      '>>>>>>> REPLACE\n' +
+      '```\n';
+
+    let call = 0;
+    const callApi = async () => {
+      call++;
+      // 1st turn: emit the S/R block; 2nd turn: finish (no block).
+      return call === 1 ? finalResp(srBlock) : finalResp('all done');
+    };
+
+    const res = await runAgenticLoop({
+      prompt: 'change v to 2', cwd: tmp, model: 't', callApi,
+      webTools: false, maxTurns: 5, editFormat: 'search-replace',
+    });
+
+    expect(res.text).toBe('all done');
+    expect(await fs.readFile(path.join(tmp, 'a.ts'), 'utf-8')).toBe('const v = 2;\n');
+    expect(call).toBe(2); // looped once after applying, then finished
+  });
+
+  it('refuses to apply a SEARCH/REPLACE block targeting a protected file', async () => {
+    const guard = path.join(tmp, 'guard.test.ts');
+    await fs.writeFile(guard, 'keep me', 'utf-8');
+
+    const srBlock =
+      'guard.test.ts\n```ts\n<<<<<<< SEARCH\nkeep me\n=======\nhacked\n>>>>>>> REPLACE\n```\n';
+
+    let call = 0;
+    const callApi = async () => { call++; return call === 1 ? finalResp(srBlock) : finalResp('stopped'); };
+
+    await runAgenticLoop({
+      prompt: 'edit guard', cwd: tmp, model: 't', callApi,
+      webTools: false, maxTurns: 5, editFormat: 'search-replace',
+      protectedFiles: [guard],
+    });
+
+    // Untouched — protected-file guard rejected the block before applying.
+    expect(await fs.readFile(guard, 'utf-8')).toBe('keep me');
+  });
+});

--- a/src/adapters/gpt.ts
+++ b/src/adapters/gpt.ts
@@ -91,6 +91,7 @@ export class GptCliAdapter implements CliAdapter {
       webTools: options.webTools,
       mcpTools: options.mcpTools,
       signal: options.signal,
+      editFormat: options.editFormat,
     };
 
     try {

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -171,6 +171,7 @@ export class LocalModelAdapter implements CliAdapter {
       webTools: options.webTools,
       mcpTools: options.mcpTools,
       signal: options.signal,
+      editFormat: options.editFormat,
     };
 
     try {

--- a/src/adapters/openrouter.ts
+++ b/src/adapters/openrouter.ts
@@ -112,6 +112,7 @@ export class OpenRouterCliAdapter implements CliAdapter {
       webTools: options.webTools,
       mcpTools: options.mcpTools,
       signal: options.signal,
+      editFormat: options.editFormat,
     };
 
     try {

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -265,7 +265,7 @@ function isProtected(resolved: string, protectedFiles?: string[]): boolean {
 }
 
 /** 프로젝트 경로 내로 접근을 제한하는 경로 검증 */
-function validatePath(filePath: string, cwd: string): string {
+export function validatePath(filePath: string, cwd: string): string {
   const resolved = path.resolve(cwd, filePath);
   // cwd 하위이거나, /tmp 하위만 허용
   if (!resolved.startsWith(cwd) && !resolved.startsWith('/tmp')) {

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -86,6 +86,15 @@ export interface CliRunOptions {
   mcpTools?: ToolDefinition[];
   /** Abort the run (and in-flight API/stream) — e.g. Esc/Ctrl+C in chat. */
   signal?: AbortSignal;
+  /**
+   * File-edit format matched to model capability (INT-1676). Only the in-process
+   * adapters (gpt/local/openrouter/codex-responses) act on it via the agentic
+   * loop; the external-CLI adapters (claude/codex) ignore it. Defaults to 'json'.
+   * - 'json': edit_file / apply_patch tool calls.
+   * - 'search-replace': Aider-style blocks in response text (weaker models).
+   * - 'whole-file': write_file rewrites only.
+   */
+  editFormat?: 'json' | 'search-replace' | 'whole-file';
 }
 
 /**

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -11,6 +11,7 @@ import type { AdapterName, ProcessContext } from '../adapters/types.js';
 import { getAdapter, getDefaultAdapterName, spawnCli } from '../adapters/index.js';
 import { expandPath } from '../core/config.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
+import { resolveEditFormat, SEARCH_REPLACE_PROMPT, WHOLE_FILE_PROMPT, type EditFormat } from '../support/editParser.js';
 
 // Types
 
@@ -41,6 +42,12 @@ export interface WorkerOptions {
   webTools?: boolean;
   /** Abort the run + in-flight adapter call (pipeline cancel / project disable). */
   signal?: AbortSignal;
+  /**
+   * File-edit format (INT-1676). When unset it is resolved per adapter from model
+   * capability (resolveEditFormat) — weaker in-process adapters get SEARCH/REPLACE.
+   * Set explicitly to pin a format (e.g. roll back a regressing model to 'json').
+   */
+  editFormat?: EditFormat;
 }
 
 // Prompts
@@ -134,6 +141,16 @@ export async function runWorker(options: WorkerOptions): Promise<WorkerResult> {
     // default resolve the model to avoid provider/model mismatch.
     const model = isFallbackAttempt ? undefined : options.model;
 
+    // Edit format matched to THIS adapter's capability (INT-1676): a primary
+    // openrouter/local attempt edits via SEARCH/REPLACE, while a claude/codex
+    // fallback uses JSON tools — the format follows the adapter. The matching S/R
+    // or whole-file instruction is appended to the worker's system prompt so the
+    // model emits the format the agentic loop expects.
+    const editFormat = options.editFormat ?? resolveEditFormat(adapterName);
+    let systemPrompt = getPrompts().systemPrompt;
+    if (editFormat === 'search-replace') systemPrompt += SEARCH_REPLACE_PROMPT;
+    else if (editFormat === 'whole-file') systemPrompt += WHOLE_FILE_PROMPT;
+
     const raw = await spawnCli(adapter, {
       prompt,
       cwd,
@@ -142,7 +159,8 @@ export async function runWorker(options: WorkerOptions): Promise<WorkerResult> {
       maxTurns: options.maxTurns,
       onLog: options.onLog,
       processContext: options.processContext,
-      systemPrompt: getPrompts().systemPrompt,
+      systemPrompt,
+      editFormat,
       // Worker is a mechanical execution role — file edits, not deep reasoning.
       // Disable reasoning tokens to cut cost/latency (no-op on non-thinking models).
       // BUT when a jobProfile sets an effort (e.g. heavy tasks), reason at that effort.

--- a/src/support/editParser.ts
+++ b/src/support/editParser.ts
@@ -3,6 +3,42 @@
 // Aider-style SEARCH/REPLACE block parsing
 // ============================================
 
+/**
+ * File-edit format handed to a worker, matched to model capability (INT-1676).
+ * - 'json'          : structured edit_file / apply_patch tool calls — frontier models.
+ * - 'search-replace': Aider-style SEARCH/REPLACE blocks in the response text —
+ *   far higher edit success on weaker/untrained models.
+ * - 'whole-file'    : rewrite the whole file via write_file — weakest fallback.
+ */
+export type EditFormat = 'json' | 'search-replace' | 'whole-file';
+
+/**
+ * Pick an edit format by model capability (INT-1676). The structured JSON
+ * edit_file / apply_patch tools are the format frontier models are trained on,
+ * but weaker/untrained models botch them — Aider measured the SAME GPT-4-Turbo
+ * jump from 20% (JSON) to 61% (diff blocks). We route per ADAPTER, the same
+ * granularity the rest of the harness uses (getDefaultAdapterName, DRAFT_MODELS):
+ * the in-process small/non-frontier adapters (local/lmstudio, OpenRouter pool)
+ * get SEARCH/REPLACE; the capable paths (claude/codex/gpt) keep JSON.
+ *
+ * Rollback levers (issue requirement): an explicit `editFormat` on the call wins,
+ * and `OPENSWARM_EDIT_FORMAT` forces a format globally if a model regresses.
+ */
+export function resolveEditFormat(adapterName: string | undefined): EditFormat {
+  const env = process.env.OPENSWARM_EDIT_FORMAT;
+  if (env === 'json' || env === 'search-replace' || env === 'whole-file') return env;
+
+  switch (adapterName) {
+    case 'local':
+    case 'lmstudio':
+    case 'openrouter':
+      return 'search-replace';
+    default:
+      // claude / codex / codex-responses / gpt — capable with the JSON tools.
+      return 'json';
+  }
+}
+
 export interface EditBlock {
   filePath: string;
   search: string;
@@ -436,4 +472,22 @@ Rules:
 - SEARCH section must exactly match existing code in the file
 - When modifying multiple files, use separate blocks for each
 - Leave SEARCH section empty when creating a new file
+`;
+
+/**
+ * System-prompt injection for whole-file rewrite mode (editFormat === 'whole-file').
+ * edit_file / apply_patch are hidden; the model must rewrite entire files.
+ */
+export const WHOLE_FILE_PROMPT = `
+## Code Edit Format (Whole-File Rewrite)
+
+When you must change a file, rewrite it IN FULL with the \`write_file\` tool.
+The \`edit_file\` and \`apply_patch\` tools are not available in this mode.
+
+Steps:
+1. Read the current file with \`read_file\`.
+2. Produce the complete new contents.
+3. Write them with \`write_file\` (the whole file, not a fragment).
+
+Only rewrite files you actually need to change; leave the rest untouched.
 `;


### PR DESCRIPTION
## 문제
worker가 JSON `edit_file`/`apply_patch` 도구만 제공 → 미훈련/약 모델이 그 포맷을 망침(Aider: 동일 GPT-4-Turbo가 JSON 20% → diff 61%). `editParser.ts`에 SEARCH/REPLACE 파서가 있었으나 **루프가 안 써서 dead lever**였고, 이전 worktree 작업은 **capability 매칭·엔드투엔드 배선이 빠져** main 미반영(재오픈 사유).

## 해결
- `editParser.ts`: **`resolveEditFormat(adapter)` — 누락됐던 capability 매칭.** local/lmstudio/openrouter → `search-replace`, claude/codex/gpt → `json`. `OPENSWARM_EDIT_FORMAT` env + 명시 옵션 = 롤백 레버. `WHOLE_FILE_PROMPT` 추가.
- `agenticLoop`: `editFormat` 옵션. search-replace/whole-file 모드에서 `edit_file`(+`apply_patch`) 숨김, 응답 본문의 SEARCH/REPLACE 블록 파싱·적용(보호 파일 가드 복제 — applyEditBlock은 tools.ts 가드 우회), no-edit nudge 문구 포맷 인지.
- `worker`: 미지정 시 어댑터별로 editFormat 해석 + 시스템 프롬프트에 포맷 지침 주입 — **이전 시도가 놓친 엔드투엔드 배선**. `CliRunOptions` + gpt/local/openrouter/codex-responses에 관통.

## 검증
- `editFormat.test.ts` 7건 — resolver 라우팅+env 오버라이드, S/R 모드 edit_file 숨김, S/R 블록 디스크 적용, 보호 파일 거부.
- 전체 vitest **959 green**, tsc clean, oxlint 0.

재오픈 요구(2026-06-25) 충족: (1) agenticLoop editFormat 옵션 (2) capability 분기 (3) editParser 실제 배선. L0~L5 ladder 재측정은 벤치 인프라가 필요해 후속(별도 벤치 런)으로 분리.