### PR TITLE
refactor(tui): extract UI-agnostic chat session core (INT-1935, EPIC INT-1813 S2)

### DIFF
--- a/src/support/chatSession.test.ts
+++ b/src/support/chatSession.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// callChatModel is a thin wrapper over chatBackend.runChatCompletion; mock the
+// backend so the wrapper is exercised without spawning a real provider.
+vi.mock('./chatBackend.js', () => ({
+  getDefaultChatModel: (p: string) => `default-${p}`,
+  runChatCompletion: vi.fn(async (opts: { onText?: (t: string, k: boolean) => void }) => {
+    opts.onText?.('streamed', false);
+    return { response: 'streamed', sessionId: 'sess-1', cost: 0.25, tokens: 12 };
+  }),
+}));
+
+import {
+  generateSessionId,
+  inferProvider,
+  saveSession,
+  loadSession,
+  callChatModel,
+  type Session,
+} from './chatSession.js';
+
+describe('generateSessionId', () => {
+  it('produces a YYYYMMDD-HHMM id', () => {
+    expect(generateSessionId()).toMatch(/^\d{8}-\d{4}$/);
+  });
+});
+
+describe('inferProvider', () => {
+  it('passes through a known adapter', () => {
+    expect(inferProvider('codex')).toBe('codex');
+    expect(inferProvider('openrouter')).toBe('openrouter');
+  });
+
+  it('infers codex from a gpt-/codex model when no valid provider', () => {
+    expect(inferProvider(undefined, 'gpt-4o')).toBe('codex');
+    expect(inferProvider(undefined, 'something-codex-mini')).toBe('codex');
+    // An unknown provider string is not trusted; the model still routes it.
+    expect(inferProvider('bogus' as never, 'gpt-4o')).toBe('codex');
+  });
+
+  it('falls back to the default provider for an unknown model', () => {
+    // Whatever the env default is, it must be a non-empty adapter name.
+    expect(inferProvider(undefined, 'mystery-model')).toBeTruthy();
+  });
+});
+
+describe('saveSession / loadSession (injectable dir)', () => {
+  let dir: string;
+  beforeEach(async () => { dir = await fs.mkdtemp(path.join(os.tmpdir(), 'chatsess-')); });
+  afterEach(async () => { await fs.rm(dir, { recursive: true, force: true }); });
+
+  const mk = (over: Partial<Session> = {}): Session => ({
+    id: '20260626-1200',
+    provider: 'codex',
+    model: 'gpt-5.2-codex',
+    messages: [{ role: 'user', content: 'hi' }],
+    totalCost: 0.5,
+    totalTokens: 42,
+    createdAt: '2026-06-26T12:00:00.000Z',
+    updatedAt: '2026-06-26T12:00:00.000Z',
+    ...over,
+  });
+
+  it('round-trips a session, preserving a valid provider/model', async () => {
+    await saveSession(mk(), dir);
+    const loaded = await loadSession('20260626-1200', dir);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.provider).toBe('codex');
+    expect(loaded!.model).toBe('gpt-5.2-codex');
+    expect(loaded!.messages).toEqual([{ role: 'user', content: 'hi' }]);
+    expect(loaded!.totalTokens).toBe(42);
+  });
+
+  it('returns null for a missing session', async () => {
+    expect(await loadSession('does-not-exist', dir)).toBeNull();
+  });
+
+  it('repairs an unknown persisted provider on load (default model from backend)', async () => {
+    // Hand-write a session whose provider is no longer a valid adapter.
+    await fs.writeFile(
+      path.join(dir, 'bad.json'),
+      JSON.stringify({ id: 'bad', provider: 'bogus', model: 'gpt-4o', messages: [], createdAt: '', updatedAt: '' }),
+    );
+    const loaded = await loadSession('bad', dir);
+    expect(loaded!.provider).toBe('codex'); // inferred from the gpt- model
+    expect(loaded!.model).toBe('default-codex'); // provider changed → default model
+    expect(loaded!.totalCost).toBe(0); // missing fields defaulted
+  });
+});
+
+describe('callChatModel', () => {
+  it('forwards to the backend and normalizes the result', async () => {
+    const streamed: string[] = [];
+    const out = await callChatModel('hi', 'codex', 'gpt-5.2-codex', (t) => streamed.push(t));
+    expect(out).toEqual({ response: 'streamed', sessionId: 'sess-1', cost: 0.25, tokens: 12 });
+    expect(streamed).toContain('streamed');
+  });
+});

--- a/src/support/chatSession.ts
+++ b/src/support/chatSession.ts
@@ -1,0 +1,116 @@
+// ============================================
+// OpenSwarm - Chat session core (UI-agnostic)
+// Extracted from chatTui.ts (EPIC INT-1813 S2 / INT-1935): session persistence,
+// provider/model resolution, and the model-call wrapper — none of which touch
+// blessed or ink. The Ink front-end (S4) and the existing blessed TUI both build
+// on this. The session directory is injectable (PlanIO-style) so the logic is
+// testable without writing to the real home directory.
+// ============================================
+
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { loadConfig } from '../core/config.js';
+import { getDefaultAdapterName, isKnownAdapter, type AdapterName } from '../adapters/index.js';
+import { getDefaultChatModel, runChatCompletion } from './chatBackend.js';
+
+/** Default on-disk location for persisted chat sessions. */
+export const CHAT_DIR = resolve(homedir(), '.openswarm', 'chat');
+
+export type Message = { role: 'user' | 'assistant'; content: string; cost?: number };
+
+export type Session = {
+  id: string;
+  provider: AdapterName;
+  model: string;
+  messages: Message[];
+  totalCost: number;
+  totalTokens: number;
+  createdAt: string;
+  updatedAt: string;
+  /** Session goal set via /goal; the agent pursues it autonomously. */
+  goal?: string;
+};
+
+// Session persistence
+
+export async function ensureChatDir(dir: string = CHAT_DIR): Promise<void> {
+  await mkdir(dir, { recursive: true });
+}
+
+export async function saveSession(session: Session, dir: string = CHAT_DIR): Promise<void> {
+  await ensureChatDir(dir);
+  session.updatedAt = new Date().toISOString();
+  await writeFile(resolve(dir, `${session.id}.json`), JSON.stringify(session, null, 2));
+}
+
+export async function loadSession(id: string, dir: string = CHAT_DIR): Promise<Session | null> {
+  const path = resolve(dir, `${id}.json`);
+  if (!existsSync(path)) return null;
+  const data = JSON.parse(await readFile(path, 'utf-8'));
+  // Validate the persisted provider — a stale/removed adapter (e.g. `claude`)
+  // must not pass through, or downstream model lookups crash. If it's replaced,
+  // its model no longer applies → use the provider's default.
+  const provider = inferProvider(data.provider, data.model);
+  const model = data.provider === provider && data.model ? data.model : getDefaultChatModel(provider);
+  return {
+    ...data,
+    provider,
+    model,
+    totalCost: data.totalCost ?? 0,
+    totalTokens: data.totalTokens ?? 0,
+  };
+}
+
+export function generateSessionId(): string {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}`;
+}
+
+// Provider / model resolution
+
+export function inferProvider(provider?: AdapterName, model?: string): AdapterName {
+  if (provider && isKnownAdapter(provider)) return provider;
+  if (model?.startsWith('gpt-') || model?.includes('codex')) return 'codex';
+  return loadDefaultProvider();
+}
+
+export function loadDefaultProvider(): AdapterName {
+  try {
+    return loadConfig().adapter ?? getDefaultAdapterName();
+  } catch {
+    return getDefaultAdapterName();
+  }
+}
+
+// Model call wrapper
+
+export async function callChatModel(
+  prompt: string,
+  provider: AdapterName,
+  model: string,
+  onStream: (text: string, isThinking: boolean) => void,
+  onToolLog?: (line: string) => void,
+  maxTurns?: number,
+  signal?: AbortSignal,
+): Promise<{ response: string; sessionId: string; cost: number; tokens: number }> {
+  const result = await runChatCompletion({
+    prompt,
+    provider,
+    model,
+    timeoutMs: 300000,
+    onText: onStream,
+    onLog: onToolLog,
+    maxTurns,
+    signal,
+  });
+
+  return {
+    response: result.response,
+    sessionId: result.sessionId ?? '',
+    cost: result.cost ?? 0,
+    tokens: result.tokens ?? 0,
+  };
+}

--- a/src/support/chatTui.ts
+++ b/src/support/chatTui.ts
@@ -3,16 +3,20 @@
 // OpenSwarm - Rich TUI Chat Interface
 // Claude Code style tabbed interface with real-time updates
 import blessed from 'blessed';
-import { homedir } from 'node:os';
 import { resolve } from 'node:path';
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
-import { loadConfig, expandPath } from '../core/config.js';
-import { getDefaultAdapterName, isKnownAdapter, type AdapterName } from '../adapters/index.js';
-import { getDefaultChatModel, resolveChatModel, runChatCompletion, shortenChatModel } from './chatBackend.js';
+import { writeFile } from 'node:fs/promises';
+import { expandPath } from '../core/config.js';
+import { type AdapterName } from '../adapters/index.js';
+import { getDefaultChatModel, resolveChatModel, shortenChatModel } from './chatBackend.js';
 import { runPlanCommand, type PlanIO } from './planCommand.js';
-// Constants
-const CHAT_DIR = resolve(homedir(), '.openswarm', 'chat');
+import {
+  type Session,
+  saveSession,
+  loadSession,
+  generateSessionId,
+  loadDefaultProvider,
+  callChatModel,
+} from './chatSession.js';
 
 // Render guard: blessed는 동시 render() 호출 시 화면이 검은색으로 깨질 수 있음
 let renderScheduled = false;
@@ -36,22 +40,7 @@ function safeRender() {
     }
   });
 }
-// Types
-type Message = { role: 'user' | 'assistant'; content: string; cost?: number };
-
-type Session = {
-  id: string;
-  provider: AdapterName;
-  model: string;
-  messages: Message[];
-  totalCost: number;
-  totalTokens: number;
-  createdAt: string;
-  updatedAt: string;
-  /** Session goal set via /goal; the agent pursues it autonomously. */
-  goal?: string;
-};
-
+// Types — Session/Message live in chatSession.ts (UI-agnostic, INT-1935)
 type AppState = {
   session: Session;
   currentTab: number;
@@ -68,84 +57,9 @@ type AppState = {
   /** Set while an agent run is in flight; Esc/Ctrl+C aborts it. */
   activeRun?: AbortController;
 };
-// Session Management
-async function ensureChatDir(): Promise<void> {
-  await mkdir(CHAT_DIR, { recursive: true });
-}
+// Session management, provider resolution, and the model-call wrapper now live
+// in chatSession.ts (UI-agnostic, INT-1935) and are imported above.
 
-async function saveSession(session: Session): Promise<void> {
-  await ensureChatDir();
-  session.updatedAt = new Date().toISOString();
-  const path = resolve(CHAT_DIR, `${session.id}.json`);
-  await writeFile(path, JSON.stringify(session, null, 2));
-}
-
-async function loadSession(id: string): Promise<Session | null> {
-  const path = resolve(CHAT_DIR, `${id}.json`);
-  if (!existsSync(path)) return null;
-  const data = JSON.parse(await readFile(path, 'utf-8'));
-  // Validate the persisted provider — a stale/removed adapter (e.g. `claude`)
-  // must not pass through, or downstream model lookups crash. If it's replaced,
-  // its model no longer applies → use the provider's default.
-  const provider = inferProvider(data.provider, data.model);
-  const model = data.provider === provider && data.model ? data.model : getDefaultChatModel(provider);
-  return {
-    ...data,
-    provider,
-    model,
-    totalCost: data.totalCost ?? 0,
-    totalTokens: data.totalTokens ?? 0,
-  };
-}
-
-function generateSessionId(): string {
-  const now = new Date();
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}`;
-}
-
-function inferProvider(provider?: AdapterName, model?: string): AdapterName {
-  if (provider && isKnownAdapter(provider)) return provider;
-  if (model?.startsWith('gpt-') || model?.includes('codex')) return 'codex';
-  return loadDefaultProvider();
-}
-
-function loadDefaultProvider(): AdapterName {
-  try {
-    return loadConfig().adapter ?? getDefaultAdapterName();
-  } catch {
-    return getDefaultAdapterName();
-  }
-}
-
-// Shared chat backend
-async function callChatModel(
-  prompt: string,
-  provider: AdapterName,
-  model: string,
-  onStream: (text: string, isThinking: boolean) => void,
-  onToolLog?: (line: string) => void,
-  maxTurns?: number,
-  signal?: AbortSignal,
-): Promise<{ response: string; sessionId: string; cost: number; tokens: number }> {
-  const result = await runChatCompletion({
-    prompt,
-    provider,
-    model,
-    timeoutMs: 300000,
-    onText: onStream,
-    onLog: onToolLog,
-    maxTurns,
-    signal,
-  });
-
-  return {
-    response: result.response,
-    sessionId: result.sessionId ?? '',
-    cost: result.cost ?? 0,
-    tokens: result.tokens ?? 0,
-  };
-}
 // Warhammer 40k Loading Messages
 const LOADING_MESSAGES = [
   'Initializing cogitator arrays',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -76,6 +76,7 @@ const integrationBoundaryCoverageExcludes = [
   'src/support/projectMapper.ts',
   'src/support/promptHelper.ts',
   'src/support/planCommand.ts',
+  'src/support/chatSession.ts',
   'src/support/rateLimiter.ts',
   'src/support/repoMetadata.ts',
   'src/support/timeWindow.ts',


### PR DESCRIPTION
EPIC **INT-1813** S2. session/provider/model 로직을 `chatTui.ts`(1,474 LOC, blessed+로직 혼재)에서 UI-agnostic 모듈로 분리 — 기존 blessed TUI와 향후 Ink(S4)가 공유.

## 해결
- **`src/support/chatSession.ts`(신규)**: Session/Message 타입, 세션 영속화(ensureChatDir/saveSession/loadSession/generateSessionId), provider+model 해석(inferProvider/loadDefaultProvider), callChatModel 래퍼. **blessed/ink import 0.** 세션 dir 주입형(PlanIO식)이라 홈 디렉터리 안 건드리고 테스트 가능.
- **chatTui.ts**: chatSession에서 import, 이동된 정의(~110줄) + 미사용 import 제거. 동작 불변(1473→1387줄).
- **chatSession.test.ts**: 8건(id 포맷, provider 추론, temp dir roundtrip, missing→null, stale provider 복구, 목 백엔드로 callChatModel).

## 검증
- tsc clean, oxlint clean, 전체 vitest **978 green**.
- chatSession.ts를 커버리지 integration-boundary에 추가(callChatModel/loadDefaultProvider가 provider·config 경계 래핑) — planCommand.ts 관례 일치.

S1(INT-1934)과 독립. S4(Chat 탭)가 이 모듈을 소비.