### PR TITLE
feat(tui): Ink shell + tab router (INT-1936, EPIC INT-1813 S3)

### DIFF
--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -2,18 +2,37 @@ import { describe, it, expect } from 'vitest';
 import { render } from 'ink-testing-library';
 import { App } from './App.js';
 
-// Proves the full JSX build chain (INT-1934 / EPIC INT-1813 S1): a .tsx component
-// compiles, Ink renders it, and ink-testing-library can assert on the output.
-describe('Ink scaffold (EPIC INT-1813 S1)', () => {
-  it('renders the OpenSwarm header with a version', () => {
-    const { lastFrame } = render(<App version="9.9.9" />);
-    expect(lastFrame()).toContain('OpenSwarm');
-    expect(lastFrame()).toContain('v9.9.9');
+// Input handling is async (ink processes stdin on the next ticks).
+const tick = () => new Promise((r) => setTimeout(r, 40));
+
+describe('Ink shell (EPIC INT-1813 S3)', () => {
+  it('renders status bar, tab strip, and the default Chat panel', () => {
+    const { lastFrame } = render(<App version="9.9.9" provider="codex" model="gpt-5.2-codex" />);
+    const f = lastFrame()!;
+    expect(f).toContain('OpenSwarm v9.9.9');
+    expect(f).toContain('codex:gpt-5.2-codex');
+    expect(f).toContain('1:Chat');
+    expect(f).toContain('6:Logs');
+    expect(f).toContain('Chat — panel');
   });
 
-  it('renders a scaffold label when no version is given', () => {
-    const { lastFrame } = render(<App />);
-    expect(lastFrame()).toContain('OpenSwarm');
-    expect(lastFrame()).toContain('scaffold');
+  it('switches tab on a digit key', async () => {
+    const { lastFrame, stdin } = render(<App version="1.0.0" />);
+    stdin.write('3');
+    await tick();
+    expect(lastFrame()).toContain('Tasks — panel');
+  });
+
+  it('cycles forward with Tab, wrapping past the last tab', async () => {
+    const { lastFrame, stdin } = render(<App initialTab={5} />); // start at Logs
+    expect(lastFrame()).toContain('Logs — panel');
+    stdin.write('\t'); // Tab → wrap forward to Chat
+    await tick();
+    expect(lastFrame()).toContain('Chat — panel');
+  });
+
+  it('honors an initialTab', () => {
+    const { lastFrame } = render(<App initialTab={4} />);
+    expect(lastFrame()).toContain('Issues — panel');
   });
 });

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,22 +1,51 @@
 // ============================================
-// OpenSwarm - Ink TUI scaffold (EPIC INT-1813 S1 / INT-1934)
-// Minimal Ink shell that proves the JSX build + render path end to end.
-// The real 6-tab cockpit (App/StatusBar/TabBar + tabs) replaces this in
-// S3 (INT-1936); kept deliberately tiny so S1 stays a pure build-chain change.
+// OpenSwarm - Ink TUI shell (EPIC INT-1813 S3 / INT-1936)
+// App composes the cockpit chrome (StatusBar / TabBar / HelpBar) around the
+// active tab panel and owns tab navigation (number keys, Tab/Shift-Tab, arrows,
+// q to quit). Tab panels are placeholders here — the real Chat (S4), Pipeline/
+// SSE (S5) and monitor (S6) panels slot into the content area next.
 // ============================================
 
-import { Box, Text } from 'ink';
+import { Box, Text, useInput, useApp } from 'ink';
+import { useState } from 'react';
+import { TABS, nextTab, tabFromDigit } from './tabs.js';
+import { StatusBar } from './components/StatusBar.js';
+import { TabBar } from './components/TabBar.js';
+import { HelpBar } from './components/HelpBar.js';
+import { useTerminalSize } from './hooks/useTerminalSize.js';
 
 export interface AppProps {
-  /** Version string shown in the header (from package.json). */
   version?: string;
+  provider?: string;
+  model?: string;
+  /** Initial active tab index (deep-link / tests). Defaults to Chat. */
+  initialTab?: number;
 }
 
-export function App({ version }: AppProps) {
+export function App({ version, provider, model, initialTab = 0 }: AppProps) {
+  const [active, setActive] = useState(initialTab);
+  const { columns, rows } = useTerminalSize();
+  const { exit } = useApp();
+
+  useInput((input, key) => {
+    if (input === 'q') return exit();
+    if (key.tab) return setActive((a) => nextTab(a, key.shift ? -1 : +1));
+    if (key.leftArrow) return setActive((a) => nextTab(a, -1));
+    if (key.rightArrow) return setActive((a) => nextTab(a, +1));
+    const digit = tabFromDigit(input);
+    if (digit !== null) setActive(digit);
+  });
+
+  const activeTab = TABS[active];
+
   return (
-    <Box flexDirection="column" padding={1}>
-      <Text color="cyan" bold>OpenSwarm</Text>
-      <Text dimColor>{version ? `v${version}` : 'Ink TUI scaffold'}</Text>
+    <Box flexDirection="column" width={columns}>
+      <StatusBar version={version} provider={provider} model={model} />
+      <TabBar active={active} />
+      <Box flexDirection="column" paddingY={1} minHeight={Math.max(1, rows - 4)}>
+        <Text>{`${activeTab.label} — panel arrives in a later sub-issue (S4–S6).`}</Text>
+      </Box>
+      <HelpBar />
     </Box>
   );
 }

--- a/src/tui/components/HelpBar.tsx
+++ b/src/tui/components/HelpBar.tsx
@@ -1,0 +1,10 @@
+// HelpBar — bottom keybinding hint strip (EPIC INT-1813 S3).
+import { Box, Text } from 'ink';
+
+export function HelpBar() {
+  return (
+    <Box>
+      <Text dimColor>1-6 switch tab · Tab/Shift-Tab cycle · ←/→ move · q quit</Text>
+    </Box>
+  );
+}

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -1,0 +1,18 @@
+// StatusBar — top bar: app identity + active provider/model (EPIC INT-1813 S3).
+import { Box, Text } from 'ink';
+
+export interface StatusBarProps {
+  version?: string;
+  provider?: string;
+  model?: string;
+}
+
+export function StatusBar({ version, provider, model }: StatusBarProps) {
+  const right = provider ? (model ? `${provider}:${model}` : provider) : '';
+  return (
+    <Box justifyContent="space-between">
+      <Text color="cyan" bold>{`OpenSwarm${version ? ` v${version}` : ''}`}</Text>
+      {right ? <Text dimColor>{right}</Text> : null}
+    </Box>
+  );
+}

--- a/src/tui/components/TabBar.tsx
+++ b/src/tui/components/TabBar.tsx
@@ -1,0 +1,21 @@
+// TabBar — the 6-tab strip; highlights the active tab (EPIC INT-1813 S3).
+import { Box, Text } from 'ink';
+import { TABS } from '../tabs.js';
+
+export interface TabBarProps {
+  active: number;
+}
+
+export function TabBar({ active }: TabBarProps) {
+  return (
+    <Box>
+      {TABS.map((tab, i) => (
+        <Box key={tab.id} marginRight={1}>
+          <Text inverse={i === active} color={i === active ? 'cyan' : undefined}>
+            {` ${i + 1}:${tab.label} `}
+          </Text>
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/src/tui/hooks/useTerminalSize.ts
+++ b/src/tui/hooks/useTerminalSize.ts
@@ -1,0 +1,33 @@
+// ============================================
+// OpenSwarm - useTerminalSize (EPIC INT-1813 S3 / INT-1936)
+// Portable terminal-size hook: reads stdout columns/rows and tracks 'resize'.
+// Works under both withFullScreen (prod) and ink-testing-library (tests),
+// unlike fullscreen-ink's useScreenSize which needs its provider context.
+// ============================================
+
+import { useStdout } from 'ink';
+import { useEffect, useState } from 'react';
+
+export interface TerminalSize {
+  columns: number;
+  rows: number;
+}
+
+export function useTerminalSize(): TerminalSize {
+  const { stdout } = useStdout();
+  const [size, setSize] = useState<TerminalSize>({
+    columns: stdout?.columns ?? 80,
+    rows: stdout?.rows ?? 24,
+  });
+
+  useEffect(() => {
+    if (!stdout) return;
+    const onResize = () => setSize({ columns: stdout.columns ?? 80, rows: stdout.rows ?? 24 });
+    stdout.on('resize', onResize);
+    return () => {
+      stdout.off('resize', onResize);
+    };
+  }, [stdout]);
+
+  return size;
+}

--- a/src/tui/tabs.test.ts
+++ b/src/tui/tabs.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { TABS, nextTab, tabFromDigit } from './tabs.js';
+
+describe('tabs (EPIC INT-1813 S3)', () => {
+  it('exposes the 6 cockpit tabs in order', () => {
+    expect(TABS.map((t) => t.id)).toEqual(['chat', 'projects', 'tasks', 'stuck', 'issues', 'logs']);
+  });
+
+  it('nextTab wraps both directions', () => {
+    expect(nextTab(0, 1)).toBe(1);
+    expect(nextTab(5, 1)).toBe(0); // forward wrap
+    expect(nextTab(0, -1)).toBe(5); // backward wrap
+    expect(nextTab(2, -1)).toBe(1);
+  });
+
+  it('tabFromDigit maps 1-based digits and rejects out-of-range / non-digits', () => {
+    expect(tabFromDigit('1')).toBe(0);
+    expect(tabFromDigit('6')).toBe(5);
+    expect(tabFromDigit('7')).toBeNull();
+    expect(tabFromDigit('0')).toBeNull();
+    expect(tabFromDigit('x')).toBeNull();
+    expect(tabFromDigit('')).toBeNull();
+  });
+});

--- a/src/tui/tabs.ts
+++ b/src/tui/tabs.ts
@@ -1,0 +1,31 @@
+// ============================================
+// OpenSwarm - TUI tab registry (EPIC INT-1813 S3 / INT-1936)
+// Pure tab definitions + navigation math — no React/ink, unit-testable.
+// Mirrors the 6 panels of the blessed cockpit (chatTui createUI).
+// ============================================
+
+export interface TabDef {
+  id: 'chat' | 'projects' | 'tasks' | 'stuck' | 'issues' | 'logs';
+  label: string;
+}
+
+export const TABS: readonly TabDef[] = [
+  { id: 'chat', label: 'Chat' },
+  { id: 'projects', label: 'Projects' },
+  { id: 'tasks', label: 'Tasks' },
+  { id: 'stuck', label: 'Stuck' },
+  { id: 'issues', label: 'Issues' },
+  { id: 'logs', label: 'Logs' },
+];
+
+/** Move `current` by `delta` with wraparound across the tab count. */
+export function nextTab(current: number, delta: number, total: number = TABS.length): number {
+  return (((current + delta) % total) + total) % total;
+}
+
+/** Map a 1-based digit key to a 0-based tab index, or null if out of range. */
+export function tabFromDigit(input: string): number | null {
+  const n = Number(input);
+  if (!Number.isInteger(n) || n < 1 || n > TABS.length) return null;
+  return n - 1;
+}


### PR DESCRIPTION
EPIC **INT-1813** S3. S1 스캐폴드 위에 콕핏 chrome을 세워 탭 패널(S4~S6)이 들어갈 골격 마련.

## 해결
- **tabs.ts**: 순수 6탭 레지스트리(Chat/Projects/Tasks/Stuck/Issues/Logs) + nextTab wraparound + tabFromDigit (React 무관, 단위테스트).
- **components/{StatusBar,TabBar,HelpBar}**: 상단 identity+provider, 활성 탭 strip, 하단 키바인딩 힌트.
- **hooks/useTerminalSize**: 이식성 stdout columns/rows + resize 추적(withFullScreen·ink-testing-library 양쪽 동작; fullscreen-ink useScreenSize는 provider 의존이라 테스트 불가).
- **App.tsx**: chrome 합성 + useInput 네비(1-6, Tab/Shift-Tab, ←/→, q quit) + useApp().exit. 패널은 S4~S6까지 placeholder. **openswarm bin 미배선**(콕핏 사용가능 전까지 blessed 유지 — strangler).

## 검증
- tabs.test + App.test(chrome 렌더, digit 전환, Tab wrap, initialTab). tsc/oxlint clean, 전체 vitest **985 green**, 빌드 emit 정상.

의존: S1(✓). 다음: S4(Chat 탭, S2 chatSession+이 셸 위), S5(Pipeline/SSE).