### PR TITLE
feat(tui): SSE client + Pipeline observability tab (INT-1938, EPIC INT-1813 S5)

### DIFF
--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -12,19 +12,29 @@ describe('Ink shell (EPIC INT-1813 S3)', () => {
     expect(f).toContain('OpenSwarm v9.9.9');
     expect(f).toContain('codex:gpt-5.2-codex');
     expect(f).toContain('1:Chat');
-    expect(f).toContain('6:Logs');
+    expect(f).toContain('2:Pipeline');
+    expect(f).toContain('7:Logs');
     expect(f).toContain('Chat — panel');
   });
 
   it('switches tab on a digit key', async () => {
     const { lastFrame, stdin } = render(<App version="1.0.0" />);
-    stdin.write('3');
+    stdin.write('4'); // 4 → Tasks (chat,pipeline,projects,tasks)
     await tick();
     expect(lastFrame()).toContain('Tasks — panel');
   });
 
+  it('renders the Pipeline panel (idle, no port) on tab 2', async () => {
+    const { lastFrame, stdin } = render(<App />);
+    stdin.write('2');
+    await tick();
+    const f = lastFrame()!;
+    expect(f).toContain('Pipeline stages');
+    expect(f).toContain('daemon port unknown');
+  });
+
   it('cycles forward with Tab, wrapping past the last tab', async () => {
-    const { lastFrame, stdin } = render(<App initialTab={5} />); // start at Logs
+    const { lastFrame, stdin } = render(<App initialTab={6} />); // start at Logs
     expect(lastFrame()).toContain('Logs — panel');
     stdin.write('\t'); // Tab → wrap forward to Chat
     await tick();
@@ -32,7 +42,7 @@ describe('Ink shell (EPIC INT-1813 S3)', () => {
   });
 
   it('honors an initialTab', () => {
-    const { lastFrame } = render(<App initialTab={4} />);
+    const { lastFrame } = render(<App initialTab={5} />); // Issues
     expect(lastFrame()).toContain('Issues — panel');
   });
 });

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -12,17 +12,20 @@ import { TABS, nextTab, tabFromDigit } from './tabs.js';
 import { StatusBar } from './components/StatusBar.js';
 import { TabBar } from './components/TabBar.js';
 import { HelpBar } from './components/HelpBar.js';
+import { PipelinePanel } from './panels/PipelinePanel.js';
 import { useTerminalSize } from './hooks/useTerminalSize.js';
 
 export interface AppProps {
   version?: string;
   provider?: string;
   model?: string;
+  /** Daemon HTTP port — used by the Pipeline tab's SSE connection. */
+  port?: number;
   /** Initial active tab index (deep-link / tests). Defaults to Chat. */
   initialTab?: number;
 }
 
-export function App({ version, provider, model, initialTab = 0 }: AppProps) {
+export function App({ version, provider, model, port, initialTab = 0 }: AppProps) {
   const [active, setActive] = useState(initialTab);
   const { columns, rows } = useTerminalSize();
   const { exit } = useApp();
@@ -43,7 +46,11 @@ export function App({ version, provider, model, initialTab = 0 }: AppProps) {
       <StatusBar version={version} provider={provider} model={model} />
       <TabBar active={active} />
       <Box flexDirection="column" paddingY={1} minHeight={Math.max(1, rows - 4)}>
-        <Text>{`${activeTab.label} — panel arrives in a later sub-issue (S4–S6).`}</Text>
+        {activeTab.id === 'pipeline' ? (
+          <PipelinePanel port={port} />
+        ) : (
+          <Text>{`${activeTab.label} — panel arrives in a later sub-issue (S4, S6).`}</Text>
+        )}
       </Box>
       <HelpBar />
     </Box>

--- a/src/tui/components/LiveLog.tsx
+++ b/src/tui/components/LiveLog.tsx
@@ -1,0 +1,24 @@
+// LiveLog — recent daemon log lines (EPIC INT-1813 S5). Presentational; parity
+// with the dashboard's renderLog.
+import { Box, Text } from 'ink';
+
+export interface LiveLogProps {
+  logs: string[];
+  max?: number;
+}
+
+export function LiveLog({ logs, max = 12 }: LiveLogProps) {
+  const shown = logs.slice(-max);
+  return (
+    <Box flexDirection="column">
+      <Text bold>Live log</Text>
+      {shown.length === 0 ? (
+        <Text dimColor>(no log output yet)</Text>
+      ) : (
+        shown.map((line, i) => (
+          <Text key={i} dimColor>{line}</Text>
+        ))
+      )}
+    </Box>
+  );
+}

--- a/src/tui/components/StageTimeline.tsx
+++ b/src/tui/components/StageTimeline.tsx
@@ -1,0 +1,36 @@
+// StageTimeline — pipeline:stage events as a timeline (EPIC INT-1813 S5).
+// Presentational: takes already-reduced stage entries (parity with the
+// dashboard's renderStages).
+import { Box, Text } from 'ink';
+import type { StageEntry } from '../pipelineEvents.js';
+
+const ICON: Record<StageEntry['status'], string> = { start: '▶', complete: '✓', fail: '✗' };
+const COLOR: Record<StageEntry['status'], string> = { start: 'yellow', complete: 'green', fail: 'red' };
+
+export interface StageTimelineProps {
+  stages: StageEntry[];
+  max?: number;
+}
+
+export function StageTimeline({ stages, max = 12 }: StageTimelineProps) {
+  const shown = stages.slice(-max);
+  return (
+    <Box flexDirection="column">
+      <Text bold>Pipeline stages</Text>
+      {shown.length === 0 ? (
+        <Text dimColor>(no stage activity yet)</Text>
+      ) : (
+        shown.map((s, i) => {
+          const dur = s.durationMs ? ` ${Math.round(s.durationMs / 1000)}s` : '';
+          const model = s.model ? ` (${s.model})` : '';
+          const decision = s.decision ? ` → ${s.decision}` : '';
+          return (
+            <Text key={i} color={COLOR[s.status]}>
+              {`${ICON[s.status]} ${s.stage}${model}${dur}${decision}`}
+            </Text>
+          );
+        })
+      )}
+    </Box>
+  );
+}

--- a/src/tui/hooks/usePipelineEvents.ts
+++ b/src/tui/hooks/usePipelineEvents.ts
@@ -1,0 +1,27 @@
+// ============================================
+// OpenSwarm - usePipelineEvents (EPIC INT-1813 S5 / INT-1938)
+// Connects to the daemon SSE stream and reduces events into pipeline state.
+// Network/effect boundary — the pure reducer (pipelineEvents.ts) and parser
+// (sse.ts parseSseFrames) carry the tested logic.
+// ============================================
+
+import { useEffect, useReducer, useState } from 'react';
+import { connectEventStream } from '../sse.js';
+import { reducePipelineEvent, initialPipelineState, type PipelineState } from '../pipelineEvents.js';
+
+export interface PipelineEventsResult extends PipelineState {
+  connected: boolean;
+}
+
+export function usePipelineEvents(port: number | undefined): PipelineEventsResult {
+  const [state, dispatch] = useReducer(reducePipelineEvent, initialPipelineState);
+  const [connected, setConnected] = useState(false);
+
+  useEffect(() => {
+    if (!port) return;
+    const handle = connectEventStream({ port, onEvent: dispatch, onStatus: setConnected });
+    return () => handle.close();
+  }, [port]);
+
+  return { ...state, connected };
+}

--- a/src/tui/panels/PipelinePanel.tsx
+++ b/src/tui/panels/PipelinePanel.tsx
@@ -1,0 +1,30 @@
+// PipelinePanel — the Pipeline observability tab (EPIC INT-1813 S5 / INT-1938).
+// Subscribes to the daemon SSE stream and shows the stage timeline + live log,
+// the CLI counterpart of the web dashboard's PIPELINE tab.
+import { Box, Text } from 'ink';
+import { StageTimeline } from '../components/StageTimeline.js';
+import { LiveLog } from '../components/LiveLog.js';
+import { usePipelineEvents } from '../hooks/usePipelineEvents.js';
+
+export interface PipelinePanelProps {
+  /** Daemon HTTP port; when unset the panel renders idle (no connection). */
+  port?: number;
+}
+
+export function PipelinePanel({ port }: PipelinePanelProps) {
+  const { stages, logs, connected } = usePipelineEvents(port);
+  const status = !port
+    ? '○ daemon port unknown'
+    : connected
+    ? `● live (:${port})`
+    : `○ connecting :${port}…`;
+  return (
+    <Box flexDirection="column">
+      <Text dimColor>{status}</Text>
+      <StageTimeline stages={stages} />
+      <Box marginTop={1}>
+        <LiveLog logs={logs} />
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/pipelineEvents.test.ts
+++ b/src/tui/pipelineEvents.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { reducePipelineEvent, initialPipelineState, MAX_STAGES, MAX_LOGS } from './pipelineEvents.js';
+import type { HubEvent } from '../core/eventHub.js';
+
+const stage = (over: Record<string, unknown> = {}): HubEvent => ({
+  type: 'pipeline:stage',
+  data: { taskId: 't1', stage: 'worker', status: 'start', ...over },
+}) as HubEvent;
+const log = (line: string): HubEvent => ({ type: 'log', data: { taskId: 't1', stage: 'worker', line } });
+
+describe('reducePipelineEvent (EPIC INT-1813 S5)', () => {
+  it('appends pipeline:stage entries with their fields', () => {
+    let s = initialPipelineState;
+    s = reducePipelineEvent(s, stage({ status: 'start' }));
+    s = reducePipelineEvent(s, stage({ status: 'complete', model: 'gpt', durationMs: 3000, decision: 'approve' }));
+    expect(s.stages).toHaveLength(2);
+    expect(s.stages[1]).toMatchObject({ status: 'complete', model: 'gpt', decision: 'approve' });
+  });
+
+  it('appends log lines with a stage prefix', () => {
+    const s = reducePipelineEvent(initialPipelineState, log('hello'));
+    expect(s.logs).toEqual(['[worker] hello']);
+  });
+
+  it('ignores unrelated events (returns the same state)', () => {
+    const s = reducePipelineEvent(initialPipelineState, { type: 'heartbeat' } as HubEvent);
+    expect(s).toBe(initialPipelineState);
+  });
+
+  it('caps stages and logs at their maxima', () => {
+    let s = initialPipelineState;
+    for (let i = 0; i < MAX_STAGES + 10; i++) s = reducePipelineEvent(s, stage());
+    expect(s.stages).toHaveLength(MAX_STAGES);
+
+    let t = initialPipelineState;
+    for (let i = 0; i < MAX_LOGS + 10; i++) t = reducePipelineEvent(t, log(`l${i}`));
+    expect(t.logs).toHaveLength(MAX_LOGS);
+    expect(t.logs[t.logs.length - 1]).toBe(`[worker] l${MAX_LOGS + 9}`);
+  });
+});

--- a/src/tui/pipelineEvents.ts
+++ b/src/tui/pipelineEvents.ts
@@ -1,0 +1,50 @@
+// ============================================
+// OpenSwarm - Pipeline event reducer (EPIC INT-1813 S5 / INT-1938)
+// Pure reduction of HubEvents into the state the Pipeline tab renders — stage
+// timeline + live log. No React/ink/network; unit-testable.
+// ============================================
+
+import type { HubEvent } from '../core/eventHub.js';
+
+export interface StageEntry {
+  taskId: string;
+  stage: string;
+  status: 'start' | 'complete' | 'fail';
+  model?: string;
+  durationMs?: number;
+  costUsd?: number;
+  decision?: 'approve' | 'revise' | 'reject';
+  summary?: string;
+}
+
+export interface PipelineState {
+  stages: StageEntry[]; // chronological, capped at MAX_STAGES
+  logs: string[];       // recent log lines, capped at MAX_LOGS
+}
+
+export const MAX_STAGES = 100;
+export const MAX_LOGS = 200;
+
+export const initialPipelineState: PipelineState = { stages: [], logs: [] };
+
+/** Fold one HubEvent into pipeline state (reducer shape: (state, action)). */
+export function reducePipelineEvent(state: PipelineState, ev: HubEvent): PipelineState {
+  if (ev.type === 'pipeline:stage') {
+    const d = ev.data;
+    const entry: StageEntry = {
+      taskId: d.taskId,
+      stage: d.stage,
+      status: d.status,
+      model: d.model,
+      durationMs: d.durationMs,
+      costUsd: d.costUsd,
+      decision: d.decision,
+      summary: d.summary,
+    };
+    return { ...state, stages: [...state.stages, entry].slice(-MAX_STAGES) };
+  }
+  if (ev.type === 'log') {
+    return { ...state, logs: [...state.logs, `[${ev.data.stage}] ${ev.data.line}`].slice(-MAX_LOGS) };
+  }
+  return state;
+}

--- a/src/tui/pipelinePanel.test.tsx
+++ b/src/tui/pipelinePanel.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import { StageTimeline } from './components/StageTimeline.js';
+import { LiveLog } from './components/LiveLog.js';
+import { PipelinePanel } from './panels/PipelinePanel.js';
+import type { StageEntry } from './pipelineEvents.js';
+
+describe('StageTimeline', () => {
+  it('shows an empty state', () => {
+    expect(render(<StageTimeline stages={[]} />).lastFrame()).toContain('no stage activity');
+  });
+
+  it('renders a stage with model, duration and decision', () => {
+    const stages: StageEntry[] = [
+      { taskId: 't', stage: 'reviewer', status: 'complete', model: 'sonnet', durationMs: 5000, decision: 'approve' },
+    ];
+    const f = render(<StageTimeline stages={stages} />).lastFrame()!;
+    expect(f).toContain('reviewer');
+    expect(f).toContain('sonnet');
+    expect(f).toContain('5s');
+    expect(f).toContain('approve');
+  });
+});
+
+describe('LiveLog', () => {
+  it('shows an empty state and then lines', () => {
+    expect(render(<LiveLog logs={[]} />).lastFrame()).toContain('no log output');
+    expect(render(<LiveLog logs={['[worker] hi']} />).lastFrame()).toContain('[worker] hi');
+  });
+});
+
+describe('PipelinePanel', () => {
+  it('renders idle (no port) with both sections', () => {
+    const f = render(<PipelinePanel />).lastFrame()!;
+    expect(f).toContain('daemon port unknown');
+    expect(f).toContain('Pipeline stages');
+    expect(f).toContain('Live log');
+  });
+});

--- a/src/tui/sse.test.ts
+++ b/src/tui/sse.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { parseSseFrames } from './sse.js';
+
+describe('parseSseFrames (EPIC INT-1813 S5)', () => {
+  it('parses complete frames and returns the incomplete tail', () => {
+    const buf =
+      'data: {"type":"heartbeat"}\n\n' +
+      'data: {"type":"log","data":{"taskId":"t","stage":"s","line":"hi"}}\n\n' +
+      'data: {"type":"hea';
+    const { events, rest } = parseSseFrames(buf);
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe('heartbeat');
+    expect(events[1].type).toBe('log');
+    expect(rest).toBe('data: {"type":"hea');
+  });
+
+  it('skips a malformed frame without throwing', () => {
+    const { events } = parseSseFrames('data: not json\n\ndata: {"type":"heartbeat"}\n\n');
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('heartbeat');
+  });
+
+  it('ignores non-data lines (SSE comments / keepalive)', () => {
+    const { events, rest } = parseSseFrames(': keepalive\n\ndata: {"type":"heartbeat"}\n\n');
+    expect(events).toHaveLength(1);
+    expect(rest).toBe('');
+  });
+});

--- a/src/tui/sse.ts
+++ b/src/tui/sse.ts
@@ -1,0 +1,94 @@
+// ============================================
+// OpenSwarm - SSE client for the daemon event stream (EPIC INT-1813 S5)
+// parseSseFrames is pure (unit-tested); connectEventStream is the network
+// boundary that GETs /api/events and feeds parsed HubEvents to a callback,
+// replacing the old 5-second poll in the TUI.
+// ============================================
+
+import http from 'node:http';
+import type { HubEvent } from '../core/eventHub.js';
+
+/**
+ * Parse accumulated SSE text into events + the leftover (incomplete) tail.
+ * Wire format (eventHub): `data: <json>\n\n` per event. Malformed frames are
+ * skipped rather than throwing, so one bad frame can't kill the stream.
+ */
+export function parseSseFrames(buffer: string): { events: HubEvent[]; rest: string } {
+  const events: HubEvent[] = [];
+  let rest = buffer;
+  let idx: number;
+  while ((idx = rest.indexOf('\n\n')) !== -1) {
+    const frame = rest.slice(0, idx);
+    rest = rest.slice(idx + 2);
+    for (const line of frame.split('\n')) {
+      const trimmed = line.trimStart();
+      if (!trimmed.startsWith('data:')) continue;
+      const json = trimmed.slice(5).trim();
+      if (!json) continue;
+      try {
+        events.push(JSON.parse(json) as HubEvent);
+      } catch {
+        // skip a malformed frame
+      }
+    }
+  }
+  return { events, rest };
+}
+
+export interface EventStreamHandle {
+  close: () => void;
+}
+
+export interface EventStreamOptions {
+  port: number;
+  host?: string;
+  onEvent: (event: HubEvent) => void;
+  onStatus?: (connected: boolean) => void;
+  /** Reconnect delay in ms after a drop/error (default 2000). */
+  reconnectMs?: number;
+}
+
+/** Subscribe to the daemon's /api/events SSE stream, auto-reconnecting on drop. */
+export function connectEventStream(opts: EventStreamOptions): EventStreamHandle {
+  const host = opts.host ?? '127.0.0.1';
+  const reconnectMs = opts.reconnectMs ?? 2000;
+  let buffer = '';
+  let closed = false;
+  let req: http.ClientRequest | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const scheduleReconnect = () => {
+    opts.onStatus?.(false);
+    if (closed) return;
+    timer = setTimeout(connect, reconnectMs);
+  };
+
+  function connect() {
+    if (closed) return;
+    req = http.get(
+      { host, port: opts.port, path: '/api/events', headers: { Accept: 'text/event-stream' } },
+      (res) => {
+        opts.onStatus?.(true);
+        res.setEncoding('utf-8');
+        res.on('data', (chunk: string) => {
+          buffer += chunk;
+          const { events, rest } = parseSseFrames(buffer);
+          buffer = rest;
+          for (const e of events) opts.onEvent(e);
+        });
+        res.on('end', scheduleReconnect);
+      },
+    );
+    req.on('error', scheduleReconnect);
+  }
+
+  connect();
+
+  return {
+    close: () => {
+      closed = true;
+      if (timer) clearTimeout(timer);
+      req?.destroy();
+    },
+  };
+}

--- a/src/tui/tabs.test.ts
+++ b/src/tui/tabs.test.ts
@@ -2,21 +2,22 @@ import { describe, it, expect } from 'vitest';
 import { TABS, nextTab, tabFromDigit } from './tabs.js';
 
 describe('tabs (EPIC INT-1813 S3)', () => {
-  it('exposes the 6 cockpit tabs in order', () => {
-    expect(TABS.map((t) => t.id)).toEqual(['chat', 'projects', 'tasks', 'stuck', 'issues', 'logs']);
+  it('exposes the cockpit tabs in order (Pipeline added in S5)', () => {
+    expect(TABS.map((t) => t.id)).toEqual(['chat', 'pipeline', 'projects', 'tasks', 'stuck', 'issues', 'logs']);
   });
 
   it('nextTab wraps both directions', () => {
+    const last = TABS.length - 1;
     expect(nextTab(0, 1)).toBe(1);
-    expect(nextTab(5, 1)).toBe(0); // forward wrap
-    expect(nextTab(0, -1)).toBe(5); // backward wrap
+    expect(nextTab(last, 1)).toBe(0); // forward wrap
+    expect(nextTab(0, -1)).toBe(last); // backward wrap
     expect(nextTab(2, -1)).toBe(1);
   });
 
   it('tabFromDigit maps 1-based digits and rejects out-of-range / non-digits', () => {
     expect(tabFromDigit('1')).toBe(0);
-    expect(tabFromDigit('6')).toBe(5);
-    expect(tabFromDigit('7')).toBeNull();
+    expect(tabFromDigit('7')).toBe(6);
+    expect(tabFromDigit('8')).toBeNull();
     expect(tabFromDigit('0')).toBeNull();
     expect(tabFromDigit('x')).toBeNull();
     expect(tabFromDigit('')).toBeNull();

--- a/src/tui/tabs.ts
+++ b/src/tui/tabs.ts
@@ -5,12 +5,13 @@
 // ============================================
 
 export interface TabDef {
-  id: 'chat' | 'projects' | 'tasks' | 'stuck' | 'issues' | 'logs';
+  id: 'chat' | 'pipeline' | 'projects' | 'tasks' | 'stuck' | 'issues' | 'logs';
   label: string;
 }
 
 export const TABS: readonly TabDef[] = [
   { id: 'chat', label: 'Chat' },
+  { id: 'pipeline', label: 'Pipeline' },
   { id: 'projects', label: 'Projects' },
   { id: 'tasks', label: 'Tasks' },
   { id: 'stuck', label: 'Stuck' },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -82,8 +82,12 @@ const integrationBoundaryCoverageExcludes = [
   'src/support/timeWindow.ts',
   'src/taskState/store.ts',
 
-  // Ink TUI alt-screen render entry (needs a real TTY) — EPIC INT-1813.
+  // Ink TUI boundaries — alt-screen entry, network SSE, and effect hooks
+  // (real TTY / sockets); the pure parser+reducer carry the tested logic. EPIC INT-1813.
   'src/tui/index.tsx',
+  'src/tui/sse.ts',
+  'src/tui/hooks/usePipelineEvents.ts',
+  'src/tui/hooks/useTerminalSize.ts',
 ];
 
 export default defineConfig({


### PR DESCRIPTION
EPIC **INT-1813** S5. web 대시보드의 PIPELINE 패리티를 CLI로: 데몬 /api/events SSE 구독(폴링 대체) + 라이브 stage timeline·log.

## 해결
- **sse.ts**: parseSseFrames(순수, 테스트) + connectEventStream(http /api/events, 자동 재연결) — Ink 프론트의 5초 폴링 대체.
- **pipelineEvents.ts**: pipeline:stage / log HubEvent를 { stages, logs }로 접는 순수 reducer(상한 적용). 대시보드 renderStages/renderLog 패리티.
- **components/{StageTimeline,LiveLog}**: 프레젠테이션. usePipelineEvents 훅이 stream→reducer 연결. panels/PipelinePanel 합성.
- **tabs.ts**: Pipeline 탭 추가(7탭). App이 해당 탭에 PipelinePanel 렌더 + 데몬 포트 전달. 나머지 패널은 S4/S6까지 placeholder.

## 검증
- sse(프레임 파싱·malformed·keepalive), pipelineEvents(reduce·상한), StageTimeline/LiveLog/PipelinePanel 렌더, App pipeline 탭. 네트워크/effect 경계는 커버리지 제외. tsc/oxlint clean, 전체 vitest **997 green**.

아직 openswarm bin 미배선(S9 cutover까지 blessed 유지). 의존: S3(✓). 다음: S6(모니터 탭, S3+S5)·S7(subagent, S5).