### PR TITLE
feat(tui): Chat tab — streaming, slash palette, Static log (INT-1937, EPIC INT-1813 S4)

### DIFF
--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -5,7 +5,7 @@ import { App } from './App.js';
 // Input handling is async (ink processes stdin on the next ticks).
 const tick = () => new Promise((r) => setTimeout(r, 40));
 
-describe('Ink shell (EPIC INT-1813 S3)', () => {
+describe('Ink shell (EPIC INT-1813 S3/S4/S5)', () => {
   it('renders status bar, tab strip, and the default Chat panel', () => {
     const { lastFrame } = render(<App version="9.9.9" provider="codex" model="gpt-5.2-codex" />);
     const f = lastFrame()!;
@@ -14,31 +14,28 @@ describe('Ink shell (EPIC INT-1813 S3)', () => {
     expect(f).toContain('1:Chat');
     expect(f).toContain('2:Pipeline');
     expect(f).toContain('7:Logs');
-    expect(f).toContain('Chat — panel');
+    expect(f).toContain('>'); // chat input prompt
   });
 
-  it('switches tab on a digit key', async () => {
-    const { lastFrame, stdin } = render(<App version="1.0.0" />);
+  it('switches tab on a digit key (from a non-chat tab)', async () => {
+    const { lastFrame, stdin } = render(<App version="1.0.0" initialTab={1} />); // start on Pipeline
     stdin.write('4'); // 4 → Tasks (chat,pipeline,projects,tasks)
     await tick();
     expect(lastFrame()).toContain('Tasks — panel');
   });
 
-  it('renders the Pipeline panel (idle, no port) on tab 2', async () => {
-    const { lastFrame, stdin } = render(<App />);
-    stdin.write('2');
-    await tick();
-    const f = lastFrame()!;
+  it('renders the Pipeline panel (idle, no port) at initialTab 1', () => {
+    const f = render(<App initialTab={1} />).lastFrame()!;
     expect(f).toContain('Pipeline stages');
     expect(f).toContain('daemon port unknown');
   });
 
-  it('cycles forward with Tab, wrapping past the last tab', async () => {
+  it('cycles forward with Tab, wrapping from the last tab back to Chat', async () => {
     const { lastFrame, stdin } = render(<App initialTab={6} />); // start at Logs
     expect(lastFrame()).toContain('Logs — panel');
     stdin.write('\t'); // Tab → wrap forward to Chat
     await tick();
-    expect(lastFrame()).toContain('Chat — panel');
+    expect(lastFrame()).toContain('>'); // chat prompt back
   });
 
   it('honors an initialTab', () => {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -13,6 +13,7 @@ import { StatusBar } from './components/StatusBar.js';
 import { TabBar } from './components/TabBar.js';
 import { HelpBar } from './components/HelpBar.js';
 import { PipelinePanel } from './panels/PipelinePanel.js';
+import { ChatPanel } from './panels/ChatPanel.js';
 import { useTerminalSize } from './hooks/useTerminalSize.js';
 
 export interface AppProps {
@@ -30,26 +31,32 @@ export function App({ version, provider, model, port, initialTab = 0 }: AppProps
   const { columns, rows } = useTerminalSize();
   const { exit } = useApp();
 
+  const activeTab = TABS[active];
+  const chatActive = activeTab.id === 'chat';
+
   useInput((input, key) => {
-    if (input === 'q') return exit();
+    // Tab always cycles — the way to leave the chat input.
     if (key.tab) return setActive((a) => nextTab(a, key.shift ? -1 : +1));
+    // On the Chat tab the input field owns every other key (incl. digits/q).
+    if (chatActive) return;
+    if (input === 'q') return exit();
     if (key.leftArrow) return setActive((a) => nextTab(a, -1));
     if (key.rightArrow) return setActive((a) => nextTab(a, +1));
     const digit = tabFromDigit(input);
     if (digit !== null) setActive(digit);
   });
 
-  const activeTab = TABS[active];
-
   return (
     <Box flexDirection="column" width={columns}>
       <StatusBar version={version} provider={provider} model={model} />
       <TabBar active={active} />
       <Box flexDirection="column" paddingY={1} minHeight={Math.max(1, rows - 4)}>
-        {activeTab.id === 'pipeline' ? (
+        {activeTab.id === 'chat' ? (
+          <ChatPanel active={chatActive} provider={provider} model={model} />
+        ) : activeTab.id === 'pipeline' ? (
           <PipelinePanel port={port} />
         ) : (
-          <Text>{`${activeTab.label} — panel arrives in a later sub-issue (S4, S6).`}</Text>
+          <Text>{`${activeTab.label} — panel arrives in a later sub-issue (S6).`}</Text>
         )}
       </Box>
       <HelpBar />

--- a/src/tui/chat.test.tsx
+++ b/src/tui/chat.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
+import { render } from 'ink-testing-library';
+import { ChatLog } from './components/ChatLog.js';
+import { CommandPalette } from './components/CommandPalette.js';
+import { ChatInput } from './components/ChatInput.js';
+import { matchSlash, type ChatLine } from './chatModel.js';
+
+const tick = () => new Promise((r) => setTimeout(r, 40));
+
+describe('ChatLog', () => {
+  it('renders finalized history and the live streaming line', () => {
+    const history: ChatLine[] = [
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi there' },
+    ];
+    const f = render(<ChatLog history={history} streaming={'typing…'} />).lastFrame()!;
+    expect(f).toContain('hello');
+    expect(f).toContain('hi there');
+    expect(f).toContain('typing…');
+  });
+});
+
+describe('CommandPalette', () => {
+  it('lists matching commands and nothing when empty', () => {
+    expect(render(<CommandPalette matches={matchSlash('/m')} />).lastFrame()).toContain('/model');
+    expect(render(<CommandPalette matches={[]} />).lastFrame()).toBe('');
+  });
+});
+
+describe('ChatInput', () => {
+  function Harness({ onSubmit }: { onSubmit: (v: string) => void }) {
+    const [v, setV] = useState('');
+    return <ChatInput value={v} active busy={false} onChange={setV} onSubmit={onSubmit} />;
+  }
+
+  it('echoes typed characters and submits on Enter', async () => {
+    const onSubmit = vi.fn();
+    const { lastFrame, stdin } = render(<Harness onSubmit={onSubmit} />);
+    stdin.write('hi'); // ink delivers the chunk as one input event
+    await tick();
+    expect(lastFrame()).toContain('hi');
+    stdin.write('\r'); // Enter
+    await tick();
+    expect(onSubmit).toHaveBeenCalledWith('hi');
+  });
+});

--- a/src/tui/chatModel.test.ts
+++ b/src/tui/chatModel.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { chatReducer, initialChatState, parseInput, matchSlash } from './chatModel.js';
+
+describe('chatReducer (EPIC INT-1813 S4)', () => {
+  it('appends user and system lines', () => {
+    let s = chatReducer(initialChatState, { type: 'user', content: 'hi' });
+    s = chatReducer(s, { type: 'system', content: 'note' });
+    expect(s.history).toEqual([
+      { role: 'user', content: 'hi' },
+      { role: 'system', content: 'note' },
+    ]);
+  });
+
+  it('accumulates streaming chunks then commits to an assistant line', () => {
+    let s = chatReducer(initialChatState, { type: 'stream', chunk: 'he' });
+    s = chatReducer(s, { type: 'stream', chunk: 'llo' });
+    expect(s.streaming).toBe('hello');
+    s = chatReducer(s, { type: 'commit' });
+    expect(s.streaming).toBeNull();
+    expect(s.history.at(-1)).toEqual({ role: 'assistant', content: 'hello' });
+  });
+
+  it('commit with nothing streaming is a no-op', () => {
+    const s = chatReducer(initialChatState, { type: 'commit' });
+    expect(s).toBe(initialChatState);
+  });
+
+  it('clear resets to the initial state', () => {
+    const s = chatReducer({ history: [{ role: 'user', content: 'x' }], streaming: 'y' }, { type: 'clear' });
+    expect(s).toEqual(initialChatState);
+  });
+});
+
+describe('parseInput', () => {
+  it('classifies free chat', () => {
+    expect(parseInput('  hello world ')).toEqual({ kind: 'chat', text: 'hello world' });
+  });
+  it('classifies a bare command', () => {
+    expect(parseInput('/clear')).toEqual({ kind: 'command', name: '/clear', args: '' });
+  });
+  it('classifies a command with args', () => {
+    expect(parseInput('/model gpt-5.2')).toEqual({ kind: 'command', name: '/model', args: 'gpt-5.2' });
+  });
+  it('returns null for empty input', () => {
+    expect(parseInput('   ')).toBeNull();
+  });
+});
+
+describe('matchSlash', () => {
+  it('prefix-matches command names', () => {
+    expect(matchSlash('/m').map((c) => c.name)).toEqual(['/model']);
+    expect(matchSlash('/').length).toBeGreaterThan(1);
+  });
+  it('does not match plain chat or once an argument is being typed', () => {
+    expect(matchSlash('hello')).toEqual([]);
+    expect(matchSlash('/model gpt')).toEqual([]);
+  });
+});

--- a/src/tui/chatModel.ts
+++ b/src/tui/chatModel.ts
@@ -1,0 +1,84 @@
+// ============================================
+// OpenSwarm - Chat model (EPIC INT-1813 S4 / INT-1937)
+// Pure chat state + input parsing for the Ink Chat tab. No React/ink/network —
+// the streaming reducer and slash parser are unit-tested; ChatPanel wires them
+// to chatSession.callChatModel.
+// ============================================
+
+export interface ChatLine {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+export interface ChatState {
+  /** Finalized lines — rendered in <Static> (no re-render, no flicker). */
+  history: ChatLine[];
+  /** In-flight assistant text being streamed, or null when idle. */
+  streaming: string | null;
+}
+
+export const initialChatState: ChatState = { history: [], streaming: null };
+
+export type ChatAction =
+  | { type: 'user'; content: string }
+  | { type: 'system'; content: string }
+  | { type: 'stream'; chunk: string }
+  | { type: 'commit' }
+  | { type: 'clear' };
+
+export function chatReducer(state: ChatState, action: ChatAction): ChatState {
+  switch (action.type) {
+    case 'user':
+      return { ...state, history: [...state.history, { role: 'user', content: action.content }] };
+    case 'system':
+      return { ...state, history: [...state.history, { role: 'system', content: action.content }] };
+    case 'stream':
+      return { ...state, streaming: (state.streaming ?? '') + action.chunk };
+    case 'commit':
+      return state.streaming === null
+        ? state
+        : { history: [...state.history, { role: 'assistant', content: state.streaming }], streaming: null };
+    case 'clear':
+      return initialChatState;
+  }
+}
+
+export interface SlashCommand {
+  name: string;
+  args: string;
+  desc: string;
+}
+
+/** Slash commands offered in the Ink palette (mirrors the blessed TUI). */
+export const SLASH_COMMANDS: readonly SlashCommand[] = [
+  { name: '/goal', args: '<goal>', desc: 'Set a goal & pursue it autonomously' },
+  { name: '/plan', args: '<goal>', desc: 'Decompose a goal & dispatch to the loop' },
+  { name: '/model', args: '[name]', desc: 'Switch model' },
+  { name: '/provider', args: '[name]', desc: 'Switch provider' },
+  { name: '/clear', args: '', desc: 'Clear the conversation' },
+  { name: '/help', args: '', desc: 'Show all commands' },
+];
+
+export type ParsedInput =
+  | { kind: 'chat'; text: string }
+  | { kind: 'command'; name: string; args: string };
+
+/** Classify a submitted input line as free chat or a slash command. */
+export function parseInput(raw: string): ParsedInput | null {
+  const t = raw.trim();
+  if (!t) return null;
+  if (t.startsWith('/')) {
+    const sp = t.indexOf(' ');
+    return sp === -1
+      ? { kind: 'command', name: t, args: '' }
+      : { kind: 'command', name: t.slice(0, sp), args: t.slice(sp + 1).trim() };
+  }
+  return { kind: 'chat', text: t };
+}
+
+/** Slash commands whose name prefix-matches the current input (palette). */
+export function matchSlash(input: string): SlashCommand[] {
+  if (!input.startsWith('/') || input.includes(' ')) return [];
+  const q = input.slice(1).toLowerCase();
+  return SLASH_COMMANDS.filter((c) => c.name.slice(1).toLowerCase().startsWith(q));
+}

--- a/src/tui/components/ChatInput.tsx
+++ b/src/tui/components/ChatInput.tsx
@@ -1,0 +1,41 @@
+// ChatInput — controlled single-line input driven by useInput (S4).
+// Korean/IME caveat: terminals deliver committed code points to useInput, so
+// typed/pasted Hangul appends fine; in-progress IME composition is terminal-
+// dependent and not echoed mid-composition. Nav keys (Tab/arrows) are left for
+// the App router; Enter submits, Backspace deletes.
+import { Box, Text, useInput } from 'ink';
+
+export interface ChatInputProps {
+  value: string;
+  active: boolean;
+  busy?: boolean;
+  onChange: (value: string) => void;
+  onSubmit: (value: string) => void;
+}
+
+export function ChatInput({ value, active, busy, onChange, onSubmit }: ChatInputProps) {
+  useInput(
+    (input, key) => {
+      if (key.return) {
+        onSubmit(value);
+        return;
+      }
+      if (key.backspace || key.delete) {
+        onChange(value.slice(0, -1));
+        return;
+      }
+      // Leave navigation keys to the App-level router.
+      if (key.tab || key.leftArrow || key.rightArrow || key.upArrow || key.downArrow || key.escape) return;
+      if (input && !key.ctrl && !key.meta) onChange(value + input);
+    },
+    { isActive: active && !busy },
+  );
+
+  return (
+    <Box>
+      <Text color="cyan">{'> '}</Text>
+      <Text>{value}</Text>
+      {busy ? <Text dimColor> …working (Esc to leave)</Text> : <Text inverse> </Text>}
+    </Box>
+  );
+}

--- a/src/tui/components/ChatLog.tsx
+++ b/src/tui/components/ChatLog.tsx
@@ -1,0 +1,34 @@
+// ChatLog — completed messages in <Static> (rendered once, no flicker) plus a
+// live streaming area below (EPIC INT-1813 S4). This is the direct fix for the
+// blessed flicker: React/Ink never redraws the settled history.
+import { Box, Text, Static } from 'ink';
+import type { ChatLine } from '../chatModel.js';
+
+const ROLE_COLOR: Record<ChatLine['role'], string> = { user: 'cyan', assistant: 'white', system: 'yellow' };
+const ROLE_LABEL: Record<ChatLine['role'], string> = { user: 'you', assistant: 'ai', system: 'sys' };
+
+export interface ChatLogProps {
+  history: ChatLine[];
+  streaming: string | null;
+}
+
+export function ChatLog({ history, streaming }: ChatLogProps) {
+  return (
+    <Box flexDirection="column">
+      <Static items={history}>
+        {(line, i) => (
+          <Box key={i} flexDirection="column" marginBottom={1}>
+            <Text color={ROLE_COLOR[line.role]} bold>{ROLE_LABEL[line.role]}</Text>
+            <Text>{line.content}</Text>
+          </Box>
+        )}
+      </Static>
+      {streaming !== null ? (
+        <Box flexDirection="column">
+          <Text color="white" bold>ai</Text>
+          <Text>{streaming.length > 0 ? streaming : '…'}</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/src/tui/components/CommandPalette.tsx
+++ b/src/tui/components/CommandPalette.tsx
@@ -1,0 +1,18 @@
+// CommandPalette — slash-command suggestions for the current input (S4).
+import { Box, Text } from 'ink';
+import type { SlashCommand } from '../chatModel.js';
+
+export function CommandPalette({ matches }: { matches: SlashCommand[] }) {
+  if (matches.length === 0) return null;
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      {matches.map((c) => (
+        <Text key={c.name}>
+          <Text color="cyan">{c.name}</Text>
+          {c.args ? <Text dimColor>{` ${c.args}`}</Text> : null}
+          <Text dimColor>{`  ${c.desc}`}</Text>
+        </Text>
+      ))}
+    </Box>
+  );
+}

--- a/src/tui/panels/ChatPanel.tsx
+++ b/src/tui/panels/ChatPanel.tsx
@@ -1,0 +1,84 @@
+// ============================================
+// OpenSwarm - Chat tab panel (EPIC INT-1813 S4 / INT-1937)
+// Wires the pure chat model (chatModel.ts) to the input/log components and to
+// chatSession.callChatModel (streaming). Network/effect boundary — the reducer,
+// parser and presentational components carry the tested logic.
+// ============================================
+
+import { Box } from 'ink';
+import { useReducer, useState, useCallback } from 'react';
+import { chatReducer, initialChatState, parseInput, matchSlash, SLASH_COMMANDS, type ChatAction } from '../chatModel.js';
+import { ChatLog } from '../components/ChatLog.js';
+import { ChatInput } from '../components/ChatInput.js';
+import { CommandPalette } from '../components/CommandPalette.js';
+import { callChatModel, loadDefaultProvider } from '../../support/chatSession.js';
+import { getDefaultChatModel } from '../../support/chatBackend.js';
+import type { AdapterName } from '../../adapters/types.js';
+
+export interface ChatPanelProps {
+  active: boolean;
+  provider?: string;
+  model?: string;
+}
+
+function runLocalCommand(name: string, dispatch: (a: ChatAction) => void): void {
+  switch (name) {
+    case '/clear':
+      dispatch({ type: 'clear' });
+      break;
+    case '/help':
+      dispatch({ type: 'system', content: SLASH_COMMANDS.map((c) => `${c.name} ${c.args} — ${c.desc}`).join('\n') });
+      break;
+    case '/goal':
+    case '/plan':
+      dispatch({ type: 'system', content: `${name} dispatch lands in S8 (INT-1941) — use the dashboard/daemon for now.` });
+      break;
+    case '/model':
+    case '/provider':
+      dispatch({ type: 'system', content: `${name} switching from the Ink TUI lands in S8 (INT-1941).` });
+      break;
+    default:
+      dispatch({ type: 'system', content: `Unknown command: ${name}` });
+  }
+}
+
+export function ChatPanel({ active, provider: providerProp, model: modelProp }: ChatPanelProps) {
+  const [state, dispatch] = useReducer(chatReducer, initialChatState);
+  const [input, setInput] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const provider = (providerProp as AdapterName | undefined) ?? loadDefaultProvider();
+  const model = modelProp ?? getDefaultChatModel(provider);
+
+  const submit = useCallback(
+    async (raw: string) => {
+      const parsed = parseInput(raw);
+      setInput('');
+      if (!parsed) return;
+      if (parsed.kind === 'command') {
+        runLocalCommand(parsed.name, dispatch);
+        return;
+      }
+      dispatch({ type: 'user', content: parsed.text });
+      dispatch({ type: 'stream', chunk: '' });
+      setBusy(true);
+      try {
+        await callChatModel(parsed.text, provider, model, (t) => dispatch({ type: 'stream', chunk: t }));
+      } catch (e) {
+        dispatch({ type: 'stream', chunk: `\n[error] ${e instanceof Error ? e.message : String(e)}` });
+      } finally {
+        dispatch({ type: 'commit' });
+        setBusy(false);
+      }
+    },
+    [provider, model],
+  );
+
+  return (
+    <Box flexDirection="column">
+      <ChatLog history={state.history} streaming={state.streaming} />
+      <ChatInput value={input} active={active} busy={busy} onChange={setInput} onSubmit={submit} />
+      <CommandPalette matches={matchSlash(input)} />
+    </Box>
+  );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -88,6 +88,7 @@ const integrationBoundaryCoverageExcludes = [
   'src/tui/sse.ts',
   'src/tui/hooks/usePipelineEvents.ts',
   'src/tui/hooks/useTerminalSize.ts',
+  'src/tui/panels/ChatPanel.tsx',
 ];
 
 export default defineConfig({


### PR DESCRIPTION
EPIC **INT-1813** S4. S3 셸 + S2 chatSession 위에 Chat 탭 구현.

## 해결
- **chatModel.ts**: 순수 reducer(user/system/stream/commit/clear) + parseInput(chat/슬래시) + matchSlash. 단위테스트.
- **ChatLog**: 완료 메시지는 **Static**(1회 렌더 → 플리커 없음, blessed 플리커 직격 해결) + 라이브 스트리밍 영역.
- **ChatInput**: controlled useInput(Enter 제출, Backspace 삭제; Tab/arrow는 라우터로). 한국어/IME: 커밋된 코드포인트는 정상 append, 조합중은 터미널 의존(스파이크 결과 문서화).
- **CommandPalette**: 실시간 슬래시 제안.
- **ChatPanel**: reducer↔chatSession.callChatModel(onText 델타 스트리밍) 연결 + 로컬 /clear,/help; /goal·/plan·/model·/provider는 S8로 stub.
- **App**: Chat 탭에 ChatPanel 렌더 + useInput 게이팅(Chat에선 입력 필드가 Tab 제외 모든 키 소유). Chat이 기본 탭.

## 검증
- chatModel(reducer/parse/match), ChatLog/CommandPalette/ChatInput 렌더+타이핑+제출, App 기본 Chat/네비. ChatPanel은 네트워크 경계(커버리지 제외). tsc/oxlint clean, 전체 **1010 green**.

의존: S2·S3(✓). 아직 bin 미배선(S9). IME 멀티라인 완전 검증은 실 터미널 스파이크 후속.