### PR TITLE
feat(tui): monitor tabs Projects/Tasks/Stuck/Issues (INT-1939, EPIC INT-1813 S6)

### DIFF
--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -19,9 +19,9 @@ describe('Ink shell (EPIC INT-1813 S3/S4/S5)', () => {
 
   it('switches tab on a digit key (from a non-chat tab)', async () => {
     const { lastFrame, stdin } = render(<App version="1.0.0" initialTab={1} />); // start on Pipeline
-    stdin.write('4'); // 4 → Tasks (chat,pipeline,projects,tasks)
+    stdin.write('7'); // 7 → Logs (distinct placeholder text)
     await tick();
-    expect(lastFrame()).toContain('Tasks — panel');
+    expect(lastFrame()).toContain('live log lands');
   });
 
   it('renders the Pipeline panel (idle, no port) at initialTab 1', () => {
@@ -30,16 +30,21 @@ describe('Ink shell (EPIC INT-1813 S3/S4/S5)', () => {
     expect(f).toContain('daemon port unknown');
   });
 
+  it('renders a monitor panel (idle, no port) on the Projects tab', () => {
+    const f = render(<App initialTab={2} />).lastFrame()!; // Projects
+    expect(f).toContain('daemon port unknown');
+  });
+
   it('cycles forward with Tab, wrapping from the last tab back to Chat', async () => {
     const { lastFrame, stdin } = render(<App initialTab={6} />); // start at Logs
-    expect(lastFrame()).toContain('Logs — panel');
+    expect(lastFrame()).toContain('live log lands');
     stdin.write('\t'); // Tab → wrap forward to Chat
     await tick();
     expect(lastFrame()).toContain('>'); // chat prompt back
   });
 
   it('honors an initialTab', () => {
-    const { lastFrame } = render(<App initialTab={5} />); // Issues
-    expect(lastFrame()).toContain('Issues — panel');
+    const { lastFrame } = render(<App initialTab={6} />); // Logs
+    expect(lastFrame()).toContain('live log lands');
   });
 });

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -14,7 +14,16 @@ import { TabBar } from './components/TabBar.js';
 import { HelpBar } from './components/HelpBar.js';
 import { PipelinePanel } from './panels/PipelinePanel.js';
 import { ChatPanel } from './panels/ChatPanel.js';
+import { MonitorPanel } from './panels/MonitorPanel.js';
+import { fetchProjects, fetchTasks, fetchStuck, fetchIssues } from './monitorApi.js';
 import { useTerminalSize } from './hooks/useTerminalSize.js';
+
+const MONITOR_FETCHERS = {
+  projects: fetchProjects,
+  tasks: fetchTasks,
+  stuck: fetchStuck,
+  issues: fetchIssues,
+} as const;
 
 export interface AppProps {
   version?: string;
@@ -55,8 +64,10 @@ export function App({ version, provider, model, port, initialTab = 0 }: AppProps
           <ChatPanel active={chatActive} provider={provider} model={model} />
         ) : activeTab.id === 'pipeline' ? (
           <PipelinePanel port={port} />
+        ) : activeTab.id in MONITOR_FETCHERS ? (
+          <MonitorPanel port={port} fetcher={MONITOR_FETCHERS[activeTab.id as keyof typeof MONITOR_FETCHERS]} />
         ) : (
-          <Text>{`${activeTab.label} — panel arrives in a later sub-issue (S6).`}</Text>
+          <Text>{`${activeTab.label} — live log lands with the bin cutover (S9).`}</Text>
         )}
       </Box>
       <HelpBar />

--- a/src/tui/components/DataTable.tsx
+++ b/src/tui/components/DataTable.tsx
@@ -1,0 +1,26 @@
+// DataTable — minimal column-aligned table for the monitor tabs (S6).
+// Hand-rolled (no ink-table) to avoid peer-version risk on ink 7 / react 19.
+import { Box, Text } from 'ink';
+import type { Table } from '../monitorRows.js';
+
+export interface DataTableProps extends Table {
+  empty?: string;
+}
+
+export function DataTable({ columns, rows, empty }: DataTableProps) {
+  if (rows.length === 0) {
+    return <Text dimColor>{empty ?? '(no data)'}</Text>;
+  }
+  const widths = columns.map((c, i) =>
+    Math.max(c.length, ...rows.map((r) => (r[i] ?? '').length)),
+  );
+  const fmt = (cells: string[]) => cells.map((cell, i) => (cell ?? '').padEnd(widths[i])).join('  ');
+  return (
+    <Box flexDirection="column">
+      <Text bold>{fmt(columns)}</Text>
+      {rows.map((r, i) => (
+        <Text key={i}>{fmt(r)}</Text>
+      ))}
+    </Box>
+  );
+}

--- a/src/tui/dataTable.test.tsx
+++ b/src/tui/dataTable.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import { DataTable } from './components/DataTable.js';
+
+describe('DataTable (EPIC INT-1813 S6)', () => {
+  it('renders an empty state', () => {
+    expect(render(<DataTable columns={['A']} rows={[]} empty="nothing here" />).lastFrame()).toContain('nothing here');
+  });
+
+  it('renders header + column-aligned rows', () => {
+    const f = render(
+      <DataTable columns={['ID', 'NAME']} rows={[['1', 'alpha'], ['2', 'beta']]} />,
+    ).lastFrame()!;
+    expect(f).toContain('ID');
+    expect(f).toContain('NAME');
+    expect(f).toContain('alpha');
+    expect(f).toContain('beta');
+  });
+});

--- a/src/tui/hooks/useMonitor.ts
+++ b/src/tui/hooks/useMonitor.ts
@@ -1,0 +1,51 @@
+// ============================================
+// OpenSwarm - useMonitor (EPIC INT-1813 S6 / INT-1939)
+// Polls a monitor fetcher on an interval. Network/effect boundary — the mappers
+// it renders are pure + tested.
+// ============================================
+
+import { useEffect, useState } from 'react';
+import type { Table } from '../monitorRows.js';
+
+export interface MonitorResult {
+  table: Table | null;
+  error: string | null;
+  loading: boolean;
+}
+
+export function useMonitor(
+  port: number | undefined,
+  fetcher: (port: number) => Promise<Table>,
+  intervalMs = 5000,
+): MonitorResult {
+  const [table, setTable] = useState<Table | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!port) return;
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const t = await fetcher(port);
+        if (!cancelled) {
+          setTable(t);
+          setError(null);
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    void load();
+    const timer = setInterval(() => void load(), intervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [port, fetcher, intervalMs]);
+
+  return { table, error, loading };
+}

--- a/src/tui/monitorApi.ts
+++ b/src/tui/monitorApi.ts
@@ -1,0 +1,39 @@
+// ============================================
+// OpenSwarm - Monitor API client (EPIC INT-1813 S6 / INT-1939)
+// Network boundary: fetches daemon snapshots for the monitor tabs. The pure
+// mappers (monitorRows.ts) turn these into tables. Default daemon port 3847.
+// ============================================
+
+import { projectsToTable, pipelineToTable, stuckToTable, issuesToTable, type Table } from './monitorRows.js';
+
+const base = (port: number) => `http://127.0.0.1:${port}`;
+
+export async function fetchProjects(port: number): Promise<Table> {
+  const res = await fetch(`${base(port)}/api/projects`);
+  return projectsToTable(await res.json());
+}
+
+export async function fetchTasks(port: number): Promise<Table> {
+  const res = await fetch(`${base(port)}/api/pipeline`);
+  const { stages } = (await res.json()) as { stages: unknown[] };
+  return pipelineToTable((stages ?? []) as never);
+}
+
+export async function fetchStuck(port: number): Promise<Table> {
+  const res = await fetch(`${base(port)}/api/stuck-issues`);
+  const { stuckIssues, failedIssues } = (await res.json()) as { stuckIssues: never[]; failedIssues: never[] };
+  return stuckToTable(stuckIssues ?? [], failedIssues ?? []);
+}
+
+export async function fetchIssues(port: number): Promise<Table> {
+  const res = await fetch(`${base(port)}/graphql`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      query: '{ issues(filter: { limit: 50 }) { issues { id title status priority } total } }',
+    }),
+  });
+  const json = (await res.json()) as { data?: { issues?: { issues?: never[] } }; errors?: Array<{ message: string }> };
+  if (json.errors?.length) throw new Error(json.errors[0].message);
+  return issuesToTable(json.data?.issues?.issues ?? []);
+}

--- a/src/tui/monitorRows.test.ts
+++ b/src/tui/monitorRows.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import {
+  projectsToTable,
+  pipelineToTable,
+  stuckToTable,
+  issuesToTable,
+} from './monitorRows.js';
+
+describe('monitorRows (EPIC INT-1813 S6)', () => {
+  it('projectsToTable maps enabled flag and run/queue counts', () => {
+    const t = projectsToTable([
+      { name: 'A', path: '/a', enabled: true, running: ['x'], queued: [] },
+      { name: 'B', path: '/b', enabled: false },
+    ]);
+    expect(t.columns).toEqual(['', 'PROJECT', 'RUN', 'QUEUE']);
+    expect(t.rows[0]).toEqual(['●', 'A', '1', '0']);
+    expect(t.rows[1]).toEqual(['○', 'B', '0', '0']);
+  });
+
+  it('pipelineToTable joins task:started titles to stage rows, newest first', () => {
+    const t = pipelineToTable([
+      { type: 'task:started', data: { taskId: 't1', issueIdentifier: 'INT-9' } },
+      { type: 'pipeline:stage', data: { taskId: 't1', stage: 'worker', status: 'start', model: 'gpt-5.2-codex' } },
+      { type: 'pipeline:stage', data: { taskId: 't1', stage: 'reviewer', status: 'complete' } },
+    ]);
+    expect(t.rows[0][0]).toBe('INT-9');
+    expect(t.rows[0][1]).toBe('reviewer'); // newest first
+    expect(t.rows[1][1]).toBe('worker');
+    expect(t.rows[1][2]).toBe('5.2-codex'); // model shortened
+  });
+
+  it('stuckToTable tags stuck vs failed and truncates long text', () => {
+    const t = stuckToTable(
+      [{ identifier: 'INT-1', title: 'short', reason: 'no retry', priority: 1 }],
+      [{ identifier: 'INT-2', title: 'x'.repeat(60), reason: 'boom', priority: 3 }],
+    );
+    expect(t.rows[0]).toEqual(['stuck', 'INT-1', 'short', 'urgent', 'no retry']);
+    expect(t.rows[1][0]).toBe('failed');
+    expect(t.rows[1][2].endsWith('…')).toBe(true);
+  });
+
+  it('issuesToTable maps title/status/priority', () => {
+    const t = issuesToTable([{ id: '1', title: 'fix it', status: 'open', priority: 2 }]);
+    expect(t.rows[0]).toEqual(['fix it', 'open', 'high']);
+  });
+});

--- a/src/tui/monitorRows.ts
+++ b/src/tui/monitorRows.ts
@@ -1,0 +1,109 @@
+// ============================================
+// OpenSwarm - Monitor row mappers (EPIC INT-1813 S6 / INT-1939)
+// Pure daemon-JSON → table mappers for the Projects/Tasks/Stuck/Issues tabs.
+// No React/ink/network — unit-tested. DataTable renders the {columns, rows}.
+// ============================================
+
+export interface Table {
+  columns: string[];
+  rows: string[][];
+}
+
+export interface ApiProject {
+  name: string;
+  path: string;
+  enabled: boolean;
+  running?: string[];
+  queued?: string[];
+}
+
+export function projectsToTable(projects: ApiProject[]): Table {
+  return {
+    columns: ['', 'PROJECT', 'RUN', 'QUEUE'],
+    rows: projects.map((p) => [
+      p.enabled ? '●' : '○',
+      p.name,
+      String(p.running?.length ?? 0),
+      String(p.queued?.length ?? 0),
+    ]),
+  };
+}
+
+export interface ApiPipelineEvent {
+  type: string;
+  data: {
+    taskId?: string;
+    stage?: string;
+    status?: string;
+    model?: string;
+    title?: string;
+    issueIdentifier?: string;
+  };
+}
+
+const STAGE_ICON: Record<string, string> = { start: '◐', complete: '●', fail: '✗' };
+
+/** Most-recent pipeline stage events as task rows (newest first). */
+export function pipelineToTable(stages: ApiPipelineEvent[], limit = 15): Table {
+  const info = new Map<string, string>(); // taskId → identifier/title
+  const events: Array<{ taskId: string; stage: string; status: string; model?: string }> = [];
+  for (const ev of stages) {
+    if (ev.type === 'task:started' && ev.data.taskId) {
+      info.set(ev.data.taskId, ev.data.issueIdentifier || ev.data.title || ev.data.taskId);
+    } else if (ev.type === 'pipeline:stage' && ev.data.taskId && ev.data.stage) {
+      events.push({ taskId: ev.data.taskId, stage: ev.data.stage, status: ev.data.status ?? '', model: ev.data.model });
+    }
+  }
+  const recent = events.slice(-limit).reverse();
+  return {
+    columns: ['TASK', 'STAGE', 'MODEL', 'STATUS'],
+    rows: recent.map((e) => [
+      (info.get(e.taskId) ?? e.taskId).slice(0, 14),
+      e.stage,
+      e.model ? e.model.split('-').slice(-2).join('-') : '',
+      `${STAGE_ICON[e.status] ?? '○'} ${e.status}`,
+    ]),
+  };
+}
+
+export interface ApiStuckIssue {
+  identifier: string;
+  title: string;
+  reason: string;
+  priority: number;
+  project?: { name: string };
+}
+
+const PRIO = (p: number) => (p === 1 ? 'urgent' : p === 2 ? 'high' : p === 3 ? 'med' : 'low');
+
+export function stuckToTable(stuck: ApiStuckIssue[], failed: ApiStuckIssue[]): Table {
+  const row = (kind: string) => (i: ApiStuckIssue): string[] => [
+    kind,
+    i.identifier,
+    i.title.length > 40 ? `${i.title.slice(0, 39)}…` : i.title,
+    PRIO(i.priority),
+    i.reason.length > 30 ? `${i.reason.slice(0, 29)}…` : i.reason,
+  ];
+  return {
+    columns: ['KIND', 'ID', 'TITLE', 'PRIO', 'REASON'],
+    rows: [...stuck.map(row('stuck')), ...failed.map(row('failed'))],
+  };
+}
+
+export interface ApiIssue {
+  id: string;
+  title: string;
+  status: string;
+  priority: number;
+}
+
+export function issuesToTable(issues: ApiIssue[]): Table {
+  return {
+    columns: ['TITLE', 'STATUS', 'PRIO'],
+    rows: issues.map((i) => [
+      i.title.length > 50 ? `${i.title.slice(0, 49)}…` : i.title,
+      i.status,
+      PRIO(i.priority),
+    ]),
+  };
+}

--- a/src/tui/panels/MonitorPanel.tsx
+++ b/src/tui/panels/MonitorPanel.tsx
@@ -1,0 +1,21 @@
+// MonitorPanel — generic daemon-data tab (EPIC INT-1813 S6 / INT-1939).
+// Polls a fetcher and renders the resulting table; used by Projects/Tasks/
+// Stuck/Issues. Boundary (useMonitor); DataTable + mappers carry tested logic.
+import { Text } from 'ink';
+import { DataTable } from '../components/DataTable.js';
+import { useMonitor } from '../hooks/useMonitor.js';
+import type { Table } from '../monitorRows.js';
+
+export interface MonitorPanelProps {
+  port?: number;
+  fetcher: (port: number) => Promise<Table>;
+  empty?: string;
+}
+
+export function MonitorPanel({ port, fetcher, empty }: MonitorPanelProps) {
+  const { table, error, loading } = useMonitor(port, fetcher);
+  if (!port) return <Text dimColor>○ daemon port unknown</Text>;
+  if (error) return <Text color="red">{`load failed: ${error}`}</Text>;
+  if (!table) return <Text dimColor>{loading ? 'loading…' : '(no data)'}</Text>;
+  return <DataTable columns={table.columns} rows={table.rows} empty={empty} />;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -89,6 +89,9 @@ const integrationBoundaryCoverageExcludes = [
   'src/tui/hooks/usePipelineEvents.ts',
   'src/tui/hooks/useTerminalSize.ts',
   'src/tui/panels/ChatPanel.tsx',
+  'src/tui/monitorApi.ts',
+  'src/tui/hooks/useMonitor.ts',
+  'src/tui/panels/MonitorPanel.tsx',
 ];
 
 export default defineConfig({


### PR DESCRIPTION
EPIC **INT-1813** S6. blessed 모니터 패널을 Ink 데이터 테이블로 포팅.

## 해결
- **monitorRows.ts**: 순수 데몬 JSON → {columns, rows} 매퍼(projects, pipeline 태스크행, stuck+failed, 로컬 issues). 단위테스트.
- **DataTable**: 직접 구현한 컬럼 정렬 테이블(ink-table 미사용 — ink7/react19 peer 리스크 회피).
- **monitorApi.ts**: 데몬 fetcher(/api/projects·/api/pipeline·/api/stuck-issues·/graphql).
- **useMonitor**: 5초 폴링 + loading/error.
- **MonitorPanel**: 제네릭 fetch→table 패널. App이 4개 모니터 탭에 배선. Logs 탭은 S9 cutover까지 placeholder.

## 검증
- monitorRows 매퍼 + DataTable 렌더 + App 모니터/네비. 네트워크/effect 경계 커버리지 제외. tsc/oxlint clean, 전체 **1017 green**.

의존: S3·S5(✓). 다음: S7(subagent tree)·S8(/plan·/goal).