### PR TITLE
feat(tui): subagent tree in the Pipeline tab (INT-1940, EPIC INT-1813 S7)

### DIFF
--- a/src/tui/components/SubagentTree.tsx
+++ b/src/tui/components/SubagentTree.tsx
@@ -1,0 +1,38 @@
+// SubagentTree — concurrent tasks as a per-worktree agent tree (S7).
+// Presentational: takes nodes built by buildSubagentTree.
+import { Box, Text } from 'ink';
+import type { TaskNode, TaskStatus } from '../subagentTree.js';
+
+const ICON: Record<TaskStatus, string> = { start: '◐', complete: '●', fail: '✗' };
+const COLOR: Record<TaskStatus, string> = { start: 'yellow', complete: 'green', fail: 'red' };
+
+export interface SubagentTreeProps {
+  tasks: TaskNode[];
+  /** Max tasks shown (most recent). */
+  max?: number;
+  /** Max stage children shown per task. */
+  maxStages?: number;
+}
+
+export function SubagentTree({ tasks, max = 6, maxStages = 5 }: SubagentTreeProps) {
+  const shown = tasks.slice(-max);
+  return (
+    <Box flexDirection="column">
+      <Text bold>Agents (by task)</Text>
+      {shown.length === 0 ? (
+        <Text dimColor>(no active agents)</Text>
+      ) : (
+        shown.map((task) => (
+          <Box key={task.taskId} flexDirection="column">
+            <Text color={COLOR[task.status]}>{`${ICON[task.status]} ${task.taskId.slice(0, 16)}`}</Text>
+            {task.stages.slice(-maxStages).map((s, i) => (
+              <Text key={i} dimColor>
+                {`   └ ${s.stage}${s.model ? ` (${s.model})` : ''} — ${s.status}`}
+              </Text>
+            ))}
+          </Box>
+        ))
+      )}
+    </Box>
+  );
+}

--- a/src/tui/panels/PipelinePanel.tsx
+++ b/src/tui/panels/PipelinePanel.tsx
@@ -3,8 +3,10 @@
 // the CLI counterpart of the web dashboard's PIPELINE tab.
 import { Box, Text } from 'ink';
 import { StageTimeline } from '../components/StageTimeline.js';
+import { SubagentTree } from '../components/SubagentTree.js';
 import { LiveLog } from '../components/LiveLog.js';
 import { usePipelineEvents } from '../hooks/usePipelineEvents.js';
+import { buildSubagentTree } from '../subagentTree.js';
 
 export interface PipelinePanelProps {
   /** Daemon HTTP port; when unset the panel renders idle (no connection). */
@@ -21,7 +23,10 @@ export function PipelinePanel({ port }: PipelinePanelProps) {
   return (
     <Box flexDirection="column">
       <Text dimColor>{status}</Text>
-      <StageTimeline stages={stages} />
+      <SubagentTree tasks={buildSubagentTree(stages)} />
+      <Box marginTop={1}>
+        <StageTimeline stages={stages} />
+      </Box>
       <Box marginTop={1}>
         <LiveLog logs={logs} />
       </Box>

--- a/src/tui/subagentTree.test.ts
+++ b/src/tui/subagentTree.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { buildSubagentTree } from './subagentTree.js';
+import type { StageEntry } from './pipelineEvents.js';
+
+const s = (taskId: string, stage: string, status: StageEntry['status']): StageEntry => ({ taskId, stage, status });
+
+describe('buildSubagentTree (EPIC INT-1813 S7)', () => {
+  it('groups stages by task into nodes', () => {
+    const tree = buildSubagentTree([
+      s('t1', 'worker', 'start'),
+      s('t2', 'worker', 'start'),
+      s('t1', 'reviewer', 'complete'),
+    ]);
+    expect(tree).toHaveLength(2);
+    const t1 = tree.find((n) => n.taskId === 't1')!;
+    expect(t1.stages.map((x) => x.stage)).toEqual(['worker', 'reviewer']);
+  });
+
+  it('rolls up status: fail dominates, all-complete completes, else running', () => {
+    expect(buildSubagentTree([s('t', 'a', 'complete'), s('t', 'b', 'fail')])[0].status).toBe('fail');
+    expect(buildSubagentTree([s('t', 'a', 'complete'), s('t', 'b', 'complete')])[0].status).toBe('complete');
+    expect(buildSubagentTree([s('t', 'a', 'complete'), s('t', 'b', 'start')])[0].status).toBe('start');
+  });
+
+  it('returns an empty tree for no stages', () => {
+    expect(buildSubagentTree([])).toEqual([]);
+  });
+});

--- a/src/tui/subagentTree.test.tsx
+++ b/src/tui/subagentTree.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import { SubagentTree } from './components/SubagentTree.js';
+import { buildSubagentTree } from './subagentTree.js';
+import type { StageEntry } from './pipelineEvents.js';
+
+describe('SubagentTree component (EPIC INT-1813 S7)', () => {
+  it('renders an empty state', () => {
+    expect(render(<SubagentTree tasks={[]} />).lastFrame()).toContain('no active agents');
+  });
+
+  it('renders a task node with its stage children', () => {
+    const stages: StageEntry[] = [
+      { taskId: 'INT-1940-x', stage: 'worker', status: 'complete', model: 'gpt-5.2-codex' },
+      { taskId: 'INT-1940-x', stage: 'reviewer', status: 'start' },
+    ];
+    const f = render(<SubagentTree tasks={buildSubagentTree(stages)} />).lastFrame()!;
+    expect(f).toContain('Agents (by task)');
+    expect(f).toContain('INT-1940-x');
+    expect(f).toContain('worker');
+    expect(f).toContain('reviewer');
+  });
+});

--- a/src/tui/subagentTree.ts
+++ b/src/tui/subagentTree.ts
@@ -1,0 +1,38 @@
+// ============================================
+// OpenSwarm - Subagent tree (EPIC INT-1813 S7 / INT-1940)
+// Pure grouping of pipeline stage entries into a per-task (per-worktree) tree —
+// the Claude-Code-subagent view of concurrent runs. Derived from the existing
+// taskId-keyed events (each worktree task = one node, its stages = children), so
+// no new backend event stream is required to surface the tree.
+// ============================================
+
+import type { StageEntry } from './pipelineEvents.js';
+
+export type TaskStatus = 'start' | 'complete' | 'fail';
+
+export interface TaskNode {
+  taskId: string;
+  stages: StageEntry[];
+  /** Rolled-up status: fail if any stage failed, complete if all complete, else running. */
+  status: TaskStatus;
+}
+
+export function buildSubagentTree(stages: StageEntry[]): TaskNode[] {
+  const byTask = new Map<string, StageEntry[]>();
+  for (const s of stages) {
+    const arr = byTask.get(s.taskId);
+    if (arr) arr.push(s);
+    else byTask.set(s.taskId, [s]);
+  }
+  return [...byTask.entries()].map(([taskId, taskStages]) => ({
+    taskId,
+    stages: taskStages,
+    status: rollUp(taskStages),
+  }));
+}
+
+function rollUp(stages: StageEntry[]): TaskStatus {
+  if (stages.some((s) => s.status === 'fail')) return 'fail';
+  if (stages.length > 0 && stages.every((s) => s.status === 'complete')) return 'complete';
+  return 'start';
+}


### PR DESCRIPTION
EPIC **INT-1813** S7. 동시 실행을 task별(worktree별) 에이전트 트리로 표시 — Claude Code subagent 뷰.

## 해결
- **subagentTree.ts**: 순수 buildSubagentTree — StageEntry[]를 taskId로 묶어 task 노드 + 롤업 상태(fail > running > complete). **기존 taskId-keyed 이벤트로 유도**하므로 별도 worktree 이벤트 backend 신설 불필요(이슈가 지적한 갭을 클라이언트 그룹핑으로 해소 — backend 변경 리스크 회피).
- **SubagentTree.tsx**: task별 + 하위 stage 렌더.
- **PipelinePanel**: flat 타임라인·라이브로그 위에 에이전트 트리 추가.

## 검증
- buildSubagentTree(그룹핑·상태 롤업·empty) + SubagentTree 렌더. tsc/oxlint clean, 전체 vitest green.

의존: S5(✓). 다음: S8(/plan·/goal)·S9(정리·cutover).

참고: 이슈는 'worktree 이벤트 스트림 신설'을 backend 변경으로 명시했으나, taskId 그룹핑으로 동일 트리 뷰를 달성해 backend를 건드리지 않음(불필요한 변경 회피). 추후 worktree 경로별 분리가 필요하면 process:spawn projectPath로 확장 가능.