### PR TITLE
feat(tui): /plan + /goal orchestration in the Chat tab (INT-1941, EPIC INT-1813 S8)

### DIFF
--- a/src/tui/chatModel.test.ts
+++ b/src/tui/chatModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { chatReducer, initialChatState, parseInput, matchSlash } from './chatModel.js';
+import { chatReducer, initialChatState, parseInput, matchSlash, normalizeConfirm } from './chatModel.js';
 
 describe('chatReducer (EPIC INT-1813 S4)', () => {
   it('appends user and system lines', () => {
@@ -43,6 +43,17 @@ describe('parseInput', () => {
   });
   it('returns null for empty input', () => {
     expect(parseInput('   ')).toBeNull();
+  });
+});
+
+describe('normalizeConfirm', () => {
+  it('maps y/yes → yes, e/edit → edit, everything else → no', () => {
+    expect(normalizeConfirm('y')).toBe('yes');
+    expect(normalizeConfirm('YES')).toBe('yes');
+    expect(normalizeConfirm(' e ')).toBe('edit');
+    expect(normalizeConfirm('edit')).toBe('edit');
+    expect(normalizeConfirm('n')).toBe('no');
+    expect(normalizeConfirm('whatever')).toBe('no');
   });
 });
 

--- a/src/tui/chatModel.ts
+++ b/src/tui/chatModel.ts
@@ -76,6 +76,14 @@ export function parseInput(raw: string): ParsedInput | null {
   return { kind: 'chat', text: t };
 }
 
+/** Normalize a typed confirm answer to the PlanIO decision vocabulary. */
+export function normalizeConfirm(input: string): 'yes' | 'no' | 'edit' {
+  const t = input.trim().toLowerCase();
+  if (t === 'y' || t === 'yes') return 'yes';
+  if (t === 'e' || t === 'edit') return 'edit';
+  return 'no';
+}
+
 /** Slash commands whose name prefix-matches the current input (palette). */
 export function matchSlash(input: string): SlashCommand[] {
   if (!input.startsWith('/') || input.includes(' ')) return [];

--- a/src/tui/panels/ChatPanel.tsx
+++ b/src/tui/panels/ChatPanel.tsx
@@ -1,62 +1,122 @@
 // ============================================
-// OpenSwarm - Chat tab panel (EPIC INT-1813 S4 / INT-1937)
-// Wires the pure chat model (chatModel.ts) to the input/log components and to
-// chatSession.callChatModel (streaming). Network/effect boundary — the reducer,
-// parser and presentational components carry the tested logic.
+// OpenSwarm - Chat tab panel (EPIC INT-1813 S4 + S8 / INT-1937, INT-1941)
+// Wires the pure chat model to the input/log components and to
+// chatSession.callChatModel (streaming). S8 adds /plan + /goal orchestration via
+// planCommand.runPlanCommand, with confirms routed through a pending-input flow
+// (the Ink PlanIO implementation). Network/effect boundary.
 // ============================================
 
 import { Box } from 'ink';
 import { useReducer, useState, useCallback } from 'react';
-import { chatReducer, initialChatState, parseInput, matchSlash, SLASH_COMMANDS, type ChatAction } from '../chatModel.js';
+import {
+  chatReducer,
+  initialChatState,
+  parseInput,
+  matchSlash,
+  normalizeConfirm,
+  SLASH_COMMANDS,
+} from '../chatModel.js';
 import { ChatLog } from '../components/ChatLog.js';
 import { ChatInput } from '../components/ChatInput.js';
 import { CommandPalette } from '../components/CommandPalette.js';
 import { callChatModel, loadDefaultProvider } from '../../support/chatSession.js';
 import { getDefaultChatModel } from '../../support/chatBackend.js';
+import { runPlanCommand, type PlanIO } from '../../support/planCommand.js';
 import type { AdapterName } from '../../adapters/types.js';
 
 export interface ChatPanelProps {
   active: boolean;
   provider?: string;
   model?: string;
+  /** Project root for /plan + /goal dispatch (defaults to cwd). */
+  projectPath?: string;
 }
 
-function runLocalCommand(name: string, dispatch: (a: ChatAction) => void): void {
-  switch (name) {
-    case '/clear':
-      dispatch({ type: 'clear' });
-      break;
-    case '/help':
-      dispatch({ type: 'system', content: SLASH_COMMANDS.map((c) => `${c.name} ${c.args} — ${c.desc}`).join('\n') });
-      break;
-    case '/goal':
-    case '/plan':
-      dispatch({ type: 'system', content: `${name} dispatch lands in S8 (INT-1941) — use the dashboard/daemon for now.` });
-      break;
-    case '/model':
-    case '/provider':
-      dispatch({ type: 'system', content: `${name} switching from the Ink TUI lands in S8 (INT-1941).` });
-      break;
-    default:
-      dispatch({ type: 'system', content: `Unknown command: ${name}` });
-  }
-}
-
-export function ChatPanel({ active, provider: providerProp, model: modelProp }: ChatPanelProps) {
+export function ChatPanel({ active, provider: providerProp, model: modelProp, projectPath }: ChatPanelProps) {
   const [state, dispatch] = useReducer(chatReducer, initialChatState);
   const [input, setInput] = useState('');
   const [busy, setBusy] = useState(false);
+  // When set, the next submitted line is routed here (a /plan confirm or edit)
+  // instead of being treated as chat — the Ink analogue of blessed pendingInput.
+  const [pending, setPending] = useState<{ resolve: (value: string) => void } | null>(null);
 
   const provider = (providerProp as AdapterName | undefined) ?? loadDefaultProvider();
   const model = modelProp ?? getDefaultChatModel(provider);
+  const cwd = projectPath ?? process.cwd();
+
+  const ask = useCallback(
+    (prompt: string) =>
+      new Promise<string>((resolve) => {
+        dispatch({ type: 'system', content: prompt });
+        setPending({ resolve });
+      }),
+    [],
+  );
+
+  const planIO: PlanIO = {
+    print: (line) => dispatch({ type: 'system', content: line }),
+    confirm: async (prompt) => normalizeConfirm(await ask(prompt)),
+    promptText: (prompt) => ask(prompt),
+  };
+
+  const runPlan = useCallback(
+    async (goal: string) => {
+      setBusy(true);
+      try {
+        await runPlanCommand(goal, planIO, { projectPath: cwd, model });
+      } catch (e) {
+        dispatch({ type: 'system', content: `✖ plan failed: ${e instanceof Error ? e.message : String(e)}` });
+      } finally {
+        setBusy(false);
+      }
+    },
+    // planIO is rebuilt each render but only closes over stable dispatch/ask.
+    [cwd, model], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
+  const runCommand = useCallback(
+    (name: string, args: string) => {
+      switch (name) {
+        case '/clear':
+          dispatch({ type: 'clear' });
+          break;
+        case '/help':
+          dispatch({ type: 'system', content: SLASH_COMMANDS.map((c) => `${c.name} ${c.args} — ${c.desc}`).join('\n') });
+          break;
+        case '/plan':
+          void runPlan(args);
+          break;
+        case '/goal':
+          // /goal reuses the plan→dispatch path so it works in main (the feat-only
+          // runGoalPipeline never landed); decompose the goal and dispatch it.
+          dispatch({ type: 'system', content: `🎯 Goal set: ${args}` });
+          void runPlan(args);
+          break;
+        case '/model':
+        case '/provider':
+          dispatch({ type: 'system', content: `${name} switching from the Ink TUI is not wired yet — set it via config/flags.` });
+          break;
+        default:
+          dispatch({ type: 'system', content: `Unknown command: ${name}` });
+      }
+    },
+    [runPlan],
+  );
 
   const submit = useCallback(
     async (raw: string) => {
-      const parsed = parseInput(raw);
       setInput('');
+      // A pending /plan confirm/edit consumes the next line verbatim.
+      if (pending) {
+        const { resolve } = pending;
+        setPending(null);
+        resolve(raw);
+        return;
+      }
+      const parsed = parseInput(raw);
       if (!parsed) return;
       if (parsed.kind === 'command') {
-        runLocalCommand(parsed.name, dispatch);
+        runCommand(parsed.name, parsed.args);
         return;
       }
       dispatch({ type: 'user', content: parsed.text });
@@ -71,13 +131,16 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp }: 
         setBusy(false);
       }
     },
-    [provider, model],
+    [pending, runCommand, provider, model],
   );
+
+  // While a /plan confirm is pending, keep the field active even though busy.
+  const inputActive = active && (!busy || pending !== null);
 
   return (
     <Box flexDirection="column">
       <ChatLog history={state.history} streaming={state.streaming} />
-      <ChatInput value={input} active={active} busy={busy} onChange={setInput} onSubmit={submit} />
+      <ChatInput value={input} active={inputActive} busy={busy && pending === null} onChange={setInput} onSubmit={submit} />
       <CommandPalette matches={matchSlash(input)} />
     </Box>
   );


### PR DESCRIPTION
EPIC **INT-1813** S8. Ink 채팅에서 /plan·/goal을 planCommand.runPlanCommand로 연결.

## 해결
- **chatModel.ts**: 순수 normalizeConfirm(y/yes→yes, e/edit→edit, else no) — PlanIO confirm 어휘. 단위테스트.
- **ChatPanel**: Ink PlanIO 구현(print→system 라인; confirm/promptText→**pending-input 흐름**으로 다음 제출 라인을 resolver로 라우팅 — blessed pendingInput의 Ink 대응). pending confirm 중엔 busy여도 입력 유지.
- **/plan <goal>**: planner→렌더→승인/편집→dispatch 루프.
- **/goal <goal>**: feat 전용 runGoalPipeline이 main에 없으므로 **동일 plan→dispatch 경로 재사용으로 main에 반영** — 두 명령이 dispatch 일관.

## 검증
- normalizeConfirm. ChatPanel·planCommand은 네트워크 경계(커버리지 제외). tsc/oxlint clean, 전체 **1023 green**.

의존: S4(✓). 다음: S9(정리 — blessed 제거, bin cutover, console-mute 핵 제거).