### PR TITLE
fix(tui): chat messages vanished — drop <Static> (INT-1944)

### DIFF
--- a/src/tui/chat.test.tsx
+++ b/src/tui/chat.test.tsx
@@ -19,6 +19,21 @@ describe('ChatLog', () => {
     expect(f).toContain('hi there');
     expect(f).toContain('typing…');
   });
+
+  it('accumulates every message (no <Static> — persists under full-screen)', () => {
+    // Regression: messages used to vanish because <Static> is wiped by the
+    // alt-screen full-frame redraw. They must all stay in the render tree.
+    const history: ChatLine[] = [
+      { role: 'user', content: 'first question' },
+      { role: 'assistant', content: 'first answer' },
+      { role: 'user', content: 'second question' },
+      { role: 'assistant', content: 'second answer' },
+    ];
+    const f = render(<ChatLog history={history} streaming={null} />).lastFrame()!;
+    for (const msg of ['first question', 'first answer', 'second question', 'second answer']) {
+      expect(f).toContain(msg);
+    }
+  });
 });
 
 describe('CommandPalette', () => {

--- a/src/tui/components/ChatLog.tsx
+++ b/src/tui/components/ChatLog.tsx
@@ -1,8 +1,13 @@
 // ChatLog — Claude-Code-style conversation (INT-1943).
-// Finalized messages render once in <Static> (no flicker); assistant text is
-// markdown-rendered. A live area below shows the streaming reply + inline tool
-// activity + a spinner while the agent works.
-import { Box, Text, Static } from 'ink';
+// Renders the recent message history (assistant text as markdown) plus a live
+// area with the streaming reply, inline tool activity, and a spinner.
+//
+// NOTE: this deliberately does NOT use Ink's <Static>. <Static> prints items to
+// the scrollback ABOVE the live region, which is incompatible with the
+// full-screen alternate-screen buffer (fullscreen-ink) — the next full-frame
+// render wipes them, so messages never accumulate. The reconciler already
+// diff-renders, so a normal (windowed) map keeps history without flicker.
+import { Box, Text } from 'ink';
 import Spinner from 'ink-spinner';
 import type { ChatLine } from '../chatModel.js';
 import { renderMarkdown } from '../markdown.js';
@@ -42,13 +47,18 @@ export interface ChatLogProps {
   /** Recent tool-activity lines shown under the in-flight reply. */
   activity?: string[];
   busy?: boolean;
+  /** Keep the last N messages on screen (bounds height in the full-screen layout). */
+  maxMessages?: number;
 }
 
-export function ChatLog({ history, streaming, activity = [], busy }: ChatLogProps) {
+export function ChatLog({ history, streaming, activity = [], busy, maxMessages = 40 }: ChatLogProps) {
   const live = streaming !== null || busy;
+  const shown = history.slice(-maxMessages);
   return (
     <Box flexDirection="column">
-      <Static items={history}>{(line, i) => <Message key={i} line={line} />}</Static>
+      {shown.map((line, i) => (
+        <Message key={history.length - shown.length + i} line={line} />
+      ))}
       {live ? (
         <Box flexDirection="column">
           <Text color={theme.assistant} bold>{`${ICON.assistant} ${ROLE_LABEL.assistant}`}</Text>


### PR DESCRIPTION
## 문제
Ink 채팅에서 응답이 스트리밍으로 나온 뒤 commit되면 즉시 사라지고 대화가 누적 안 됨(빈 입력 상태로 머묾). 사용자 리포트.

## 원인
`ChatLog`가 완료 메시지를 Ink `<Static>`으로 렌더. `<Static>`은 라이브 영역 위 스크롤백에 1회 출력 → fullscreen-ink **alt-screen 풀프레임 재렌더가 지워버림**. (EPIC INT-1813이 리스크로 적어둔 '풀스크린 + <Static>' 조합, S4에서 도입.)

## 해결
`<Static>` 제거, history를 일반 렌더(최근 N개 윈도잉, 기본 40). Ink reconciler diff 렌더라 플리커 없이 누적.

## 검증
다중 메시지 누적 회귀 테스트 추가, tsc/build clean, 전체 vitest **1034 green**.