### PR TITLE
feat(tui): restore blessed loading lines + braille spinner (INT-1945)

### DIFF
--- a/src/tui/components/ChatLog.tsx
+++ b/src/tui/components/ChatLog.tsx
@@ -8,10 +8,10 @@
 // render wipes them, so messages never accumulate. The reconciler already
 // diff-renders, so a normal (windowed) map keeps history without flicker.
 import { Box, Text } from 'ink';
-import Spinner from 'ink-spinner';
 import type { ChatLine } from '../chatModel.js';
 import { renderMarkdown } from '../markdown.js';
 import { theme, ICON } from '../theme.js';
+import { WorkingIndicator } from './WorkingIndicator.js';
 
 const ROLE_COLOR: Record<ChatLine['role'], string> = {
   user: theme.user,
@@ -67,12 +67,7 @@ export function ChatLog({ history, streaming, activity = [], busy, maxMessages =
               <Text key={i} color={theme.dim}>{`${ICON.tool} ${line}`}</Text>
             ))}
             {streaming ? <Text>{streaming}</Text> : null}
-            {busy ? (
-              <Text color={theme.dim}>
-                <Spinner type="dots" />
-                <Text>{' working…'}</Text>
-              </Text>
-            ) : null}
+            {busy ? <WorkingIndicator /> : null}
           </Box>
         </Box>
       ) : null}

--- a/src/tui/components/WorkingIndicator.tsx
+++ b/src/tui/components/WorkingIndicator.tsx
@@ -1,0 +1,32 @@
+// WorkingIndicator — animated braille spinner + cycling Warhammer-40k loading
+// line, recovered from the blessed TUI (INT-1813 follow-up). The spinner ticks
+// ~120ms; the message rotates ~2.5s. Frame/message math lives in
+// loadingMessages.ts (tested); this just drives the timer.
+import { Text } from 'ink';
+import { useState, useEffect } from 'react';
+import { spinnerFrame, loadingMessage, LOADING_MESSAGES } from '../loadingMessages.js';
+import { theme } from '../theme.js';
+
+const TICK_MS = 120;
+
+export interface WorkingIndicatorProps {
+  /** Fixed starting message index (tests). Defaults to a random line per mount. */
+  startIndex?: number;
+}
+
+export function WorkingIndicator({ startIndex }: WorkingIndicatorProps) {
+  const [base] = useState(() => startIndex ?? Math.floor(Math.random() * LOADING_MESSAGES.length));
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => setTick((t) => t + 1), TICK_MS);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <Text color={theme.dim}>
+      <Text color={theme.accent}>{spinnerFrame(tick)}</Text>
+      <Text>{` ${loadingMessage(tick, base)}…`}</Text>
+    </Text>
+  );
+}

--- a/src/tui/loadingMessages.test.ts
+++ b/src/tui/loadingMessages.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { spinnerFrame, loadingMessage, LOADING_MESSAGES, SPINNER_FRAMES } from './loadingMessages.js';
+
+describe('loading flavor (INT-1813 follow-up)', () => {
+  it('keeps the blessed-era loading lines and braille frames', () => {
+    expect(LOADING_MESSAGES[0]).toBe('Initializing cogitator arrays');
+    expect(LOADING_MESSAGES).toContain('Interfacing with the Noosphere');
+    expect(SPINNER_FRAMES[0]).toBe('⣾');
+    expect(SPINNER_FRAMES).toHaveLength(8);
+  });
+
+  it('spinnerFrame cycles through the frames', () => {
+    expect(spinnerFrame(0)).toBe('⣾');
+    expect(spinnerFrame(SPINNER_FRAMES.length)).toBe('⣾'); // wraps
+    expect(spinnerFrame(1)).toBe('⣽');
+  });
+
+  it('loadingMessage advances once per period and honors the base offset', () => {
+    expect(loadingMessage(0, 0)).toBe(LOADING_MESSAGES[0]);
+    // 2500ms / 120ms ≈ 21 ticks before the message advances.
+    expect(loadingMessage(20, 0)).toBe(LOADING_MESSAGES[0]);
+    expect(loadingMessage(21, 0)).toBe(LOADING_MESSAGES[1]);
+    expect(loadingMessage(0, 4)).toBe(LOADING_MESSAGES[4]);
+  });
+});

--- a/src/tui/loadingMessages.ts
+++ b/src/tui/loadingMessages.ts
@@ -1,0 +1,43 @@
+// ============================================
+// OpenSwarm - Loading flavor (INT-1813 follow-up)
+// The Warhammer-40k loading lines + braille spinner from the blessed TUI,
+// recovered for the Ink cockpit. Pure data + frame/message derivation so the
+// animation logic is unit-testable; WorkingIndicator wires the timer.
+// ============================================
+
+export const LOADING_MESSAGES = [
+  'Initializing cogitator arrays',
+  'Querying data-vault archives',
+  'Accessing servitor protocols',
+  'Compiling neural responses',
+  'Interfacing with the Noosphere',
+  'Scanning data-streams',
+  'Calibrating logic engines',
+  'Decoding transmission packets',
+  'Loading archive databases',
+  'Synchronizing machine protocols',
+  'Analyzing pattern matrices',
+  'Establishing neural link',
+  'Processing data-core output',
+  'Running diagnostics sequence',
+  'Activating response circuits',
+] as const;
+
+export const SPINNER_FRAMES = ['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷'] as const;
+
+const mod = (n: number, m: number) => ((n % m) + m) % m;
+
+/** Braille spinner glyph for the given tick. */
+export function spinnerFrame(tick: number): string {
+  return SPINNER_FRAMES[mod(tick, SPINNER_FRAMES.length)];
+}
+
+/**
+ * Loading line for a given tick. The message advances once per `periodMs`
+ * (spinner ticks every `tickMs`); `base` offsets the starting line so each run
+ * opens on a different message.
+ */
+export function loadingMessage(tick: number, base = 0, periodMs = 2500, tickMs = 120): string {
+  const idx = base + Math.floor((tick * tickMs) / periodMs);
+  return LOADING_MESSAGES[mod(idx, LOADING_MESSAGES.length)];
+}

--- a/src/tui/polish.test.tsx
+++ b/src/tui/polish.test.tsx
@@ -38,9 +38,9 @@ describe('ChatLog (INT-1943)', () => {
     expect(f).toContain('openswarm');
     expect(f).toContain('bold');
   });
-  it('shows tool activity + working while busy', () => {
+  it('shows tool activity + an animated loading line while busy', () => {
     const f = render(<ChatLog history={[]} streaming={''} activity={['read_file auth.ts']} busy />).lastFrame()!;
     expect(f).toContain('read_file auth.ts');
-    expect(f).toContain('working');
+    expect(f).toMatch(/…/); // WorkingIndicator's cycling loading line
   });
 });

--- a/src/tui/workingIndicator.test.tsx
+++ b/src/tui/workingIndicator.test.tsx
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import { WorkingIndicator } from './components/WorkingIndicator.js';
+
+describe('WorkingIndicator (INT-1813 follow-up)', () => {
+  it('renders a braille frame + the starting loading line', () => {
+    const f = render(<WorkingIndicator startIndex={4} />).lastFrame()!;
+    expect(f).toContain('Interfacing with the Noosphere'); // LOADING_MESSAGES[4]
+    expect(f).toMatch(/[⣾⣽⣻⢿⡿⣟⣯⣷]/); // a braille spinner glyph
+    expect(f).toContain('…');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -88,6 +88,7 @@ const integrationBoundaryCoverageExcludes = [
   'src/tui/sse.ts',
   'src/tui/hooks/usePipelineEvents.ts',
   'src/tui/hooks/useTerminalSize.ts',
+  'src/tui/components/WorkingIndicator.tsx',
   'src/tui/panels/ChatPanel.tsx',
   'src/tui/monitorApi.ts',
   'src/tui/hooks/useMonitor.ts',


### PR DESCRIPTION
blessed 시절의 Warhammer 40k 로딩 문구 + 브라유 스피너(⣾⣽⣻⢿⡿⣟⣯⣷)가 S9에서 chatTui.ts와 함께 사라졌던 걸 Ink 콕핏에 복원. (사용자 요청)

## 해결
- **loadingMessages.ts**: 로딩 문구 15종 + 브라유 프레임 8종 + 순수 `spinnerFrame(tick)`/`loadingMessage(tick, base)` 파생. 단위테스트.
- **WorkingIndicator**: 브라유 스피너(~120ms 회전) + 로딩 문구(~2.5s 순환, 매 실행 랜덤 시작). ChatLog busy 영역의 밋밋한 'working…' 대체.

## 검증
- loadingMessages 파생 + WorkingIndicator 렌더 테스트. tsc/oxlint clean, 전체 vitest **1038 green**.

INT-1813 EPIC 후속.