### PR TITLE
fix(tui): hide 'API call #N' loop chatter from chat activity

### DIFF
--- a/src/tui/chatModel.test.ts
+++ b/src/tui/chatModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { chatReducer, initialChatState, parseInput, matchSlash, normalizeConfirm } from './chatModel.js';
+import { chatReducer, initialChatState, parseInput, matchSlash, normalizeConfirm, isActivityNoise } from './chatModel.js';
 
 describe('chatReducer (EPIC INT-1813 S4)', () => {
   it('appends user and system lines', () => {
@@ -54,6 +54,19 @@ describe('normalizeConfirm', () => {
     expect(normalizeConfirm('edit')).toBe('edit');
     expect(normalizeConfirm('n')).toBe('no');
     expect(normalizeConfirm('whatever')).toBe('no');
+  });
+});
+
+describe('isActivityNoise', () => {
+  it('hides API-call loop chatter', () => {
+    expect(isActivityNoise('▸ API call #1')).toBe(true);
+    expect(isActivityNoise('▸ API call #2 (tool turn 1)')).toBe(true);
+    expect(isActivityNoise('[GPT] 3 API calls, 2 tool uses, 1200 tokens')).toBe(true);
+  });
+  it('keeps real tool activity and results', () => {
+    expect(isActivityNoise('🔧 read_file: src/auth.ts')).toBe(false);
+    expect(isActivityNoise('📝 SEARCH/REPLACE: applied 1/1 block(s)')).toBe(false);
+    expect(isActivityNoise('edit_file auth.ts')).toBe(false);
   });
 });
 

--- a/src/tui/chatModel.ts
+++ b/src/tui/chatModel.ts
@@ -76,6 +76,17 @@ export function parseInput(raw: string): ParsedInput | null {
   return { kind: 'chat', text: t };
 }
 
+/**
+ * Whether an adapter log line is internal loop chatter that shouldn't surface in
+ * the chat activity feed. Hides the "▸ API call #N" turns and the per-adapter
+ * "[GPT] N API calls, …" summary; real tool activity (🔧 read_file, edit
+ * results, errors) still shows. (INT-1813 follow-up)
+ */
+export function isActivityNoise(line: string): boolean {
+  const t = line.trim();
+  return /^▸\s*API call/i.test(t) || /\bAPI calls?\b,/i.test(t);
+}
+
 /** Normalize a typed confirm answer to the PlanIO decision vocabulary. */
 export function normalizeConfirm(input: string): 'yes' | 'no' | 'edit' {
   const t = input.trim().toLowerCase();

--- a/src/tui/panels/ChatPanel.tsx
+++ b/src/tui/panels/ChatPanel.tsx
@@ -14,6 +14,7 @@ import {
   parseInput,
   matchSlash,
   normalizeConfirm,
+  isActivityNoise,
   SLASH_COMMANDS,
 } from '../chatModel.js';
 import { ChatLog } from '../components/ChatLog.js';
@@ -130,7 +131,10 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
           provider,
           model,
           (t) => dispatch({ type: 'stream', chunk: t }),
-          (line) => setActivity((a) => [...a, line].slice(-10)),
+          (line) => {
+            if (isActivityNoise(line)) return;
+            setActivity((a) => [...a, line].slice(-10));
+          },
         );
       } catch (e) {
         dispatch({ type: 'stream', chunk: `\n[error] ${e instanceof Error ? e.message : String(e)}` });


### PR DESCRIPTION
## 문제
에이전틱 루프가 `▸ API call #N`(+ 어댑터 'N API calls…' 요약)을 onLog로 흘려 채팅 활동 피드에 `⦿ ▸ API call #1`처럼 노출됨. 잡음.

## 해결
`isActivityNoise()` 순수 필터로 API-call 라인을 거름. 실제 도구 활동(read_file/edit, SEARCH/REPLACE 결과, 에러)은 그대로 표시.

## 검증
isActivityNoise 단위테스트(API-call 숨김 / 도구 라인 유지). tsc/oxlint clean, 전체 vitest **1040 green**.