### PR TITLE
fix(adapters): codex-responses live model catalog + 400 fallback (INT-1872)

### DIFF
--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -302,7 +302,17 @@ export class CodexResponsesAdapter implements CliAdapter {
     // matches no jobProfile) would silently pick the one broken model. Exclude it and
     // prefer the cheapest capable model. Roles/profiles that pass an explicit model
     // are unaffected.
-    const ids = (await getCodexModelIds()).filter((m) => m !== SPARK_MODEL);
+    // Resolve the LIVE catalog with the account's OAuth token (INT-1872): the
+    // curated offline list is account-stale (e.g. gpt-5-codex 400s
+    // "model is not supported … with a ChatGPT account"). With a token,
+    // getCodexModelIds returns what this account actually supports.
+    let token: string | undefined;
+    try {
+      token = await ensureValidToken(new AuthProfileStore(), PROFILE_KEY);
+    } catch {
+      // no/expired auth → getCodexModelIds falls back to the offline curated list
+    }
+    const ids = (await getCodexModelIds(token)).filter((m) => m !== SPARK_MODEL);
     return ids.find((m) => m === SAFE_CHEAP_MODEL) ?? ids[0] ?? DEFAULT_MODEL;
   }
 
@@ -402,6 +412,7 @@ export class CodexResponsesAdapter implements CliAdapter {
   ) {
     let token = initialToken;
     let retried = false;
+    let modelRetried = false;
 
     return async (messages: ChatMessage[], tools: ToolDefinition[]): Promise<ChatLikeResponse> => {
       const { instructions, input } = chatToResponsesInput(messages);
@@ -445,6 +456,18 @@ export class CodexResponsesAdapter implements CliAdapter {
             retried = true;
             token = await refreshAndRetry(store);
             return doCall(token);
+          }
+          // 400 "model is not supported" — this account can't use body.model.
+          // Fall forward to the next live-catalog model once (INT-1872): account
+          // model availability varies, so adapt instead of failing the task.
+          if (res.status === 400 && /not supported/i.test(errText) && !modelRetried) {
+            modelRetried = true;
+            const alt = (await getCodexModelIds(token)).find((m) => m !== SPARK_MODEL && m !== body.model);
+            if (alt) {
+              onReasoning?.(`model ${String(body.model)} not supported on this account — retrying with ${alt}`);
+              body.model = alt;
+              return doCall(token);
+            }
           }
           throw new Error(`Codex responses error (${res.status}): ${errText.slice(0, 500)}`);
         }


### PR DESCRIPTION
## 문제
`codexResponses.getDefaultModel()`이 `getCodexModelIds()`를 **토큰 없이** 호출 → 오프라인 [0]=gpt-5-codex 반환. 일부 ChatGPT 계정은 이를 HTTP 400('model is not supported … with a ChatGPT account')으로 거부.

## 해결
- `codex.ts`처럼 토큰을 먼저 해석(`ensureValidToken`) → `getCodexModelIds(token)` → **계정이 실제 지원하는 live 카탈로그**의 top. 무인증이면 오프라인 fallback.
- (견고) Responses 호출이 400 'not supported'면 live 카탈로그의 **다음 모델로 1회 fall-forward** → 계정별 가용성 차이에 자동 적응.

## 검증
codex-responses는 auth/network 경계 — tsc/build + 전체 vitest **1048 green**. 인증 계정 실워커 검증은 데몬 런으로 후속(계정 의존).