### PR TITLE
feat(runner): file reviewer follow-up sub-issues on approve (INT-1704)

### DIFF
--- a/src/agents/agentPair.ts
+++ b/src/agents/agentPair.ts
@@ -65,12 +65,22 @@ export type ReviewDecision = 'approve' | 'revise' | 'reject';
 /**
  * Reviewer result
  */
+/** A follow-up the reviewer recommends (filed as a sub-issue when approved). INT-1611. */
+export interface RecommendedAction {
+  type: string;
+  title: string;
+  /** Optional file:line or area the follow-up concerns. */
+  location?: string;
+}
+
 export interface ReviewResult {
   decision: ReviewDecision;
   feedback: string;
   issues?: string[];
   suggestions?: string[];
   costInfo?: CostInfo;
+  /** Reviewer-recommended follow-ups, filed as sub-issues on approve (INT-1704). */
+  recommendedActions?: RecommendedAction[];
 }
 
 /**

--- a/src/automation/runnerExecution.followups.test.ts
+++ b/src/automation/runnerExecution.followups.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fileReviewerFollowups } from './runnerExecution.js';
+import type { ReviewResult } from '../agents/agentPair.js';
+import type { ITaskSource } from './taskSource.js';
+
+const mockSource = (createSubIssue = vi.fn(async () => ({}))) =>
+  ({ createSubIssue } as unknown as ITaskSource);
+
+const review = (over: Partial<ReviewResult> = {}): ReviewResult => ({
+  decision: 'approve',
+  feedback: 'lgtm',
+  recommendedActions: [
+    { type: 'test', title: 'add edge-case coverage', location: 'src/x.ts:10' },
+    { type: 'refactor', title: 'extract helper' },
+  ],
+  ...over,
+});
+
+describe('fileReviewerFollowups (INT-1704)', () => {
+  it('is OFF by default — files nothing unless autoFile is set', async () => {
+    const src = mockSource();
+    expect(await fileReviewerFollowups(src, 'INT-1', review(), {})).toBe(0);
+    expect((src.createSubIssue as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+
+  it('files each recommended action as a sub-issue when approved + enabled', async () => {
+    const create = vi.fn(async () => ({}));
+    const filed = await fileReviewerFollowups(mockSource(create), 'INT-1', review(), { autoFile: true });
+    expect(filed).toBe(2);
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(create.mock.calls[0][1]).toBe('[test] add edge-case coverage'); // title
+    expect(create.mock.calls[0][3]).toMatchObject({ priority: 3 });
+  });
+
+  it('does nothing when the reviewer did not approve', async () => {
+    const create = vi.fn(async () => ({}));
+    expect(await fileReviewerFollowups(mockSource(create), 'INT-1', review({ decision: 'reject' }), { autoFile: true })).toBe(0);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('caps at 10 actions', async () => {
+    const create = vi.fn(async () => ({}));
+    const many = Array.from({ length: 14 }, (_, i) => ({ type: 'test', title: `t${i}` }));
+    const filed = await fileReviewerFollowups(mockSource(create), 'INT-1', review({ recommendedActions: many }), { autoFile: true });
+    expect(filed).toBe(10);
+    expect(create).toHaveBeenCalledTimes(10);
+  });
+
+  it('counts only successful creates and never throws', async () => {
+    const create = vi.fn()
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('boom'));
+    const filed = await fileReviewerFollowups(mockSource(create), 'INT-1', review(), { autoFile: true });
+    expect(filed).toBe(1);
+  });
+
+  it('handles a null task source gracefully', async () => {
+    expect(await fileReviewerFollowups(null, 'INT-1', review(), { autoFile: true })).toBe(0);
+  });
+});

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -9,7 +9,7 @@ import type { ExecutorResult } from '../orchestration/workflow.js';
 import type { PipelineResult } from '../agents/pairPipeline.js';
 import type { DefaultRolesConfig, PipelineStage, JobProfile } from '../core/types.js';
 import { createPipelineFromConfig, buildTaskPrefix } from '../agents/pairPipeline.js';
-import type { WorkerResult } from '../agents/agentPair.js';
+import type { WorkerResult, ReviewResult } from '../agents/agentPair.js';
 import { buildWorkerStartComment, buildWorkerCompleteComment } from './workerAuditLog.js';
 import { formatParsedTaskSummary, loadParsedTask } from '../orchestration/taskParser.js';
 import { saveCognitiveMemory } from '../memory/index.js';
@@ -253,6 +253,37 @@ export async function isValidProjectPath(path: string): Promise<boolean> {
  * dispatch endpoint so both behave identically (no logic fork). The caller must
  * have already created the parent issue (`parentIssueId`).
  */
+/**
+ * File the reviewer's recommendedActions as follow-up sub-issues when it
+ * approves (INT-1611 restore / INT-1704). Gated by `autoFile` (default OFF);
+ * caps at 10; each create is best-effort (failures logged, never throw).
+ * Returns the count filed.
+ */
+export async function fileReviewerFollowups(
+  source: ITaskSource | null,
+  parentIssueId: string,
+  review: ReviewResult,
+  opts: { autoFile?: boolean; projectId?: string } = {},
+): Promise<number> {
+  if (!opts.autoFile || !source || review.decision !== 'approve') return 0;
+  const actions = (review.recommendedActions ?? []).slice(0, 10);
+  let filed = 0;
+  for (const a of actions) {
+    try {
+      await source.createSubIssue(
+        parentIssueId,
+        `[${a.type}] ${a.title}`,
+        a.location ? `Follow-up from reviewer.\n\nLocation: ${a.location}` : 'Follow-up recommended by the reviewer.',
+        { priority: 3, projectId: opts.projectId },
+      );
+      filed += 1;
+    } catch (err) {
+      console.error(`[Runner] follow-up sub-issue create failed (${a.title}):`, err);
+    }
+  }
+  return filed;
+}
+
 export async function createSubIssuesWithDependencies(
   parentIssueId: string,
   task: { title: string; issueIdentifier?: string; parentId?: string; linearProject?: { id?: string; name?: string } },
@@ -717,6 +748,19 @@ export async function executePipeline(
           }));
         } catch (err) {
           console.error(`[${taskPrefix}] Worker complete audit comment failed:`, err);
+        }
+      }
+      // On reviewer approval, optionally file recommendedActions as follow-up
+      // sub-issues (gated OFF by default). INT-1611 restore (INT-1704).
+      if (stage === 'reviewer' && task.issueId && ctx.guards?.autoFileFollowups && result.result) {
+        try {
+          const filed = await fileReviewerFollowups(taskSource, task.issueId, result.result as ReviewResult, {
+            autoFile: true,
+            projectId: task.linearProject?.id,
+          });
+          if (filed > 0) console.log(`[${taskPrefix}] Filed ${filed} follow-up sub-issue(s) from reviewer.`);
+        } catch (err) {
+          console.error(`[${taskPrefix}] Follow-up sub-issue filing failed:`, err);
         }
       }
     });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -402,6 +402,11 @@ export interface PipelineGuardsConfig {
   haltToLinear: boolean;
   registryCheck: boolean;
   bsDetector: boolean;
+  /**
+   * When the reviewer approves, file its recommendedActions as follow-up
+   * sub-issues (INT-1611 / INT-1704). Optional, default OFF. (INT-1704)
+   */
+  autoFileFollowups?: boolean;
 }
 
 export type AutonomousStartupConfig = {


### PR DESCRIPTION
## 목표
origin/main vs feat 분기에서 드롭된 INT-1611 동작 복원: reviewer 승인 시 recommendedActions를 후속 sub-issue로 파일링. 기본 OFF(`guards.autoFileFollowups`), 최대 10개, best-effort. 기존 buildWorkerCompleteComment 감사 유지.

## 변경
- `agentPair.ts`: `ReviewResult.recommendedActions` + `RecommendedAction` 타입.
- `core/types.ts`: `PipelineGuardsConfig.autoFileFollowups`(optional, 기본 OFF).
- `runnerExecution.ts`: `fileReviewerFollowups` 헬퍼(export) + stage:complete reviewer 분기 배선.

## 검증
fileReviewerFollowups 테스트 6건(기본 OFF, 승인+활성 시 파일링, cap 10, 비승인 skip, 성공만 카운트, null-source 안전). 전체 vitest **1054 green**, tsc/oxlint clean.

참고: reviewer가 recommendedActions를 **생성(파싱)**하는 부분은 별도 복원 — 본 PR은 소비를 배선·게이트해 생성이 복원되면 자동 활성화.