### PR TITLE
fix(pipeline): keep reviewer feedback on fresh-context worker retries (INT-1705)

### DIFF
--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -558,12 +558,16 @@ export class PairPipeline extends EventEmitter {
           }
 
           // Self-repair feedback: objective lint/test errors (reflection trail)
-          // are always carried forward — they are ground truth and survive a
-          // fresh-context reset. Subjective reviewer feedback is dropped on fresh
-          // context and only included when it was the latest revise reason.
+          // are always carried forward — ground truth that survives a fresh-context
+          // reset. The reviewer's revision prompt is ALSO preserved across fresh
+          // context (INT-1705): it carries the task requirement (e.g. "wire it into
+          // the heartbeat / add the call site"), not chat pollution — dropping it
+          // made the worker repeat the same partial impl forever. Fresh context
+          // still clears the worker's own chat history; only the reviewer's task
+          // signal is kept.
           const reflectionPart = buildReflectionFeedback(context.reflection);
           const includeReview =
-            !useFreshContext && context.feedbackSource === 'review' && !!context.reviewResult;
+            context.feedbackSource === 'review' && !!context.reviewResult;
           const reviewPart = includeReview
             ? reviewerAgent.buildRevisionPrompt(context.reviewResult!)
             : undefined;


### PR DESCRIPTION
## 문제 (INT-1702 분기 정리)
origin/main은 `includeReview = !useFreshContext && feedbackSource==='review'`로 fresh-context 리셋 시 reviewer 수정 프롬프트를 드롭 → 워커가 같은 부분 구현을 무한 반복('not wired / no call site' REVISE 매번). feat/v0.7.0은 이걸 유지하도록 학습(수정 프롬프트는 chat 오염이 아니라 작업 요구사항).

## 해결
`!useFreshContext` 조건 제거 → `includeReview = feedbackSource==='review' && reviewResult`. fresh context는 워커 자체 chat 히스토리만 비우고, reviewer의 작업 신호는 보존. reflection trail은 기존대로 유지.

## 검증
fresh-context 재시도에서도 워커 프롬프트에 reviewer 요구사항 포함. tsc/build clean, 전체 vitest **1054 green**.