### PR TITLE
feat(cli): /goal complexity routing (INT-1821 / S8)

### DIFF
--- a/src/support/goalCommand.test.ts
+++ b/src/support/goalCommand.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  judgeGoalComplexity,
+  buildGoalPursuitPrompt,
+  runGoalCommand,
+  type GoalCommandDeps,
+} from './goalCommand.js';
+import type { PlanIO } from './planCommand.js';
+
+const io = (lines: string[] = []): PlanIO => ({
+  print: (l) => lines.push(l),
+  confirm: async () => 'yes',
+  promptText: async () => '',
+});
+
+describe('judgeGoalComplexity (INT-1821)', () => {
+  it('classifies a single focused change as simple', () => {
+    expect(judgeGoalComplexity('fix the typo in README')).toBe('simple');
+    expect(judgeGoalComplexity('add a debug log to worker.ts')).toBe('simple');
+    expect(judgeGoalComplexity('')).toBe('simple');
+  });
+
+  it('classifies heavyweight keywords as complex', () => {
+    expect(judgeGoalComplexity('refactor the entire auth module')).toBe('complex');
+    expect(judgeGoalComplexity('migrate the build to ESM')).toBe('complex');
+  });
+
+  it('classifies enumerated / multi-deliverable goals as complex', () => {
+    expect(judgeGoalComplexity('1. add login\n2. add logout\n3. add session')).toBe('complex');
+    expect(
+      judgeGoalComplexity('Add a cache layer and wire it into the API and update the docs and tests'),
+    ).toBe('complex');
+  });
+
+  it('handles Korean complexity signals', () => {
+    expect(judgeGoalComplexity('전체 아키텍처를 재설계하고 여러 모듈을 통합')).toBe('complex');
+    expect(judgeGoalComplexity('오타 하나 고쳐줘')).toBe('simple');
+  });
+});
+
+describe('buildGoalPursuitPrompt', () => {
+  it('frames the goal as an autonomous task and embeds it verbatim', () => {
+    const p = buildGoalPursuitPrompt('  add a retry  ');
+    expect(p).toContain('autonomously');
+    expect(p).toContain('add a retry');
+  });
+});
+
+describe('runGoalCommand routing (INT-1821)', () => {
+  const mkDeps = (over: Partial<GoalCommandDeps> = {}): Required<Pick<GoalCommandDeps, 'pursue' | 'plan'>> & GoalCommandDeps => ({
+    pursue: vi.fn(async () => {}),
+    plan: vi.fn(async () => {}),
+    ...over,
+  });
+
+  it('routes a simple goal to pursue (not plan)', async () => {
+    const deps = mkDeps({ judge: () => 'simple' });
+    const lines: string[] = [];
+    const c = await runGoalCommand('do a small thing', io(lines), {}, deps);
+    expect(c).toBe('simple');
+    expect(deps.pursue).toHaveBeenCalledOnce();
+    expect(deps.plan).not.toHaveBeenCalled();
+    expect(lines.join('\n')).toMatch(/Simple goal/);
+  });
+
+  it('routes a complex goal to plan (not pursue)', async () => {
+    const deps = mkDeps({ judge: () => 'complex' });
+    const lines: string[] = [];
+    const c = await runGoalCommand('refactor everything', io(lines), {}, deps);
+    expect(c).toBe('complex');
+    expect(deps.plan).toHaveBeenCalledOnce();
+    expect(deps.pursue).not.toHaveBeenCalled();
+    expect(lines.join('\n')).toMatch(/Complex goal/);
+  });
+
+  it('uses the real heuristic when no judge is injected', async () => {
+    const deps = mkDeps();
+    expect(await runGoalCommand('migrate the entire build to ESM and update docs', io(), {}, deps)).toBe('complex');
+    expect(deps.plan).toHaveBeenCalledOnce();
+  });
+
+  it('prints usage and routes nowhere for an empty goal', async () => {
+    const deps = mkDeps();
+    const lines: string[] = [];
+    const c = await runGoalCommand('   ', io(lines), {}, deps);
+    expect(c).toBe('simple');
+    expect(deps.pursue).not.toHaveBeenCalled();
+    expect(deps.plan).not.toHaveBeenCalled();
+    expect(lines.join('\n')).toMatch(/Usage: \/goal/);
+  });
+
+  it('passes options through to the plan handler', async () => {
+    const plan = vi.fn(async () => {});
+    await runGoalCommand('refactor all the things', io(), { projectPath: '/x', model: 'm' }, { judge: () => 'complex', plan });
+    expect(plan).toHaveBeenCalledWith('refactor all the things', expect.anything(), expect.objectContaining({ projectPath: '/x', model: 'm' }));
+  });
+});

--- a/src/support/goalCommand.ts
+++ b/src/support/goalCommand.ts
@@ -1,0 +1,148 @@
+// ============================================
+// OpenSwarm - Shared `/goal` orchestration (INT-1821 / S8)
+// ============================================
+//
+// `/goal <goal>` routes by complexity, in one UI-agnostic place so every chat
+// front-end behaves identically (mirrors planCommand.ts / PlanIO — INT-1441):
+//
+//   • simple goal  → pursue it autonomously in-session via the agentic chat loop
+//                    (raised maxTurns), no decomposition, no daemon round-trip.
+//   • complex goal → hand off to the `/plan` flow (decompose → approve → dispatch
+//                    to the daemon loop) — runPlanCommand.
+//
+// The feat/v0.7.0 `chatBackend.judgeGoalComplexity/runGoalPipeline` pair never
+// landed on main; this is the reconciled implementation. judgeGoalComplexity is
+// a pure, testable heuristic so routing is deterministic (no extra model call).
+
+import { runPlanCommand, type PlanIO, type PlanCommandOptions } from './planCommand.js';
+import { callChatModel, loadDefaultProvider } from './chatSession.js';
+import { getDefaultChatModel } from './chatBackend.js';
+import type { AdapterName } from '../adapters/index.js';
+
+export type GoalComplexity = 'simple' | 'complex';
+
+/** Turn budget for autonomous simple-goal pursuit (higher than a normal chat turn). */
+export const GOAL_PURSUIT_MAX_TURNS = 60;
+
+// Signals that a goal is more than a single, local change. Each is intentionally
+// coarse — the score threshold (2) is what decides, not any one keyword. Erring
+// toward 'complex' is cheap (the planner may still say "no decomposition needed"
+// and dispatch a single task); erring toward 'simple' risks one over-long pursuit.
+const COMPLEX_KEYWORDS = [
+  // English
+  'refactor', 'migrate', 'migration', 'epic', 'redesign', 'rewrite', 'architecture',
+  'entire', 'across', 'multiple', 'end-to-end', 'pipeline', 'integrate', 'overhaul',
+  // Korean
+  '전부', '모두', '전체', '리팩터', '마이그레이', '재설계', '아키텍처', '여러', '통합', '전반',
+];
+
+/**
+ * Classify a goal as 'simple' (one focused change → pursue in-session) or
+ * 'complex' (multiple steps/deliverables → decompose & dispatch). Pure heuristic
+ * — deterministic and unit-tested, so /goal routing never needs a model call.
+ */
+export function judgeGoalComplexity(goal: string): GoalComplexity {
+  const g = goal.trim();
+  if (!g) return 'simple';
+  const lower = g.toLowerCase();
+  let score = 0;
+
+  // Length: long asks tend to bundle work.
+  const words = g.split(/\s+/).length;
+  if (words > 25) score += 2;
+  else if (words > 12) score += 1;
+
+  // Multiple sentences / enumerations → multiple deliverables.
+  const sentences = g.split(/[.!?。\n]+/).filter((s) => s.trim().length > 0).length;
+  if (sentences >= 3) score += 2;
+  else if (sentences === 2) score += 1;
+  if (/(^|\s)(\d+\.|[-*])\s/m.test(g)) score += 2; // numbered or bulleted list
+
+  // Conjunctions joining tasks.
+  const conj =
+    (lower.match(/\b(and|then|also|plus)\b/g) || []).length +
+    (g.match(/그리고|또한|및|,|、/g) || []).length;
+  if (conj >= 2) score += 2;
+  else if (conj === 1) score += 1;
+
+  // Heavyweight keywords.
+  if (COMPLEX_KEYWORDS.some((k) => lower.includes(k))) score += 2;
+
+  return score >= 2 ? 'complex' : 'simple';
+}
+
+/** Frame a goal as an autonomous task for the in-session agentic loop. */
+export function buildGoalPursuitPrompt(goal: string): string {
+  return [
+    `Pursue this goal autonomously to completion, using the available tools:`,
+    ``,
+    goal.trim(),
+    ``,
+    `Work step by step, make the edits yourself, and verify the result. ` +
+      `Stop when the goal is met or you are genuinely blocked (say why).`,
+  ].join('\n');
+}
+
+export interface GoalCommandOptions extends PlanCommandOptions {
+  /** Adapter for simple-goal pursuit (defaults to the configured provider). */
+  provider?: AdapterName;
+  /** Turn budget for pursuit (default GOAL_PURSUIT_MAX_TURNS). */
+  maxTurns?: number;
+  /** Abort the pursuit (Esc/Ctrl+C). */
+  signal?: AbortSignal;
+}
+
+/** Injectable seams so routing is unit-testable without a model/daemon. */
+export interface GoalCommandDeps {
+  judge?: (goal: string) => GoalComplexity;
+  /** Simple-goal pursuit. Front-ends override this to stream into their own UI. */
+  pursue?: (goal: string, io: PlanIO, opts: GoalCommandOptions) => Promise<void>;
+  /** Complex-goal handoff. Defaults to runPlanCommand. */
+  plan?: (goal: string, io: PlanIO, opts: PlanCommandOptions) => Promise<void>;
+}
+
+/** Default simple-goal pursuit: run the agentic chat loop and print the result. */
+async function defaultPursue(goal: string, io: PlanIO, opts: GoalCommandOptions): Promise<void> {
+  const provider = opts.provider ?? loadDefaultProvider();
+  const model = opts.model ?? getDefaultChatModel(provider);
+  let out = '';
+  await callChatModel(
+    buildGoalPursuitPrompt(goal),
+    provider,
+    model,
+    (text) => {
+      out += text;
+    },
+    (line) => io.print(line),
+    opts.maxTurns ?? GOAL_PURSUIT_MAX_TURNS,
+    opts.signal,
+  );
+  if (out.trim()) io.print(out.trim());
+}
+
+/**
+ * Run the `/goal <goal>` flow: judge complexity, then route.
+ * Returns the chosen complexity (handy for tests / callers).
+ */
+export async function runGoalCommand(
+  goal: string,
+  io: PlanIO,
+  opts: GoalCommandOptions = {},
+  deps: GoalCommandDeps = {},
+): Promise<GoalComplexity> {
+  const trimmed = goal.trim();
+  if (!trimmed) {
+    io.print('Usage: /goal <goal>');
+    return 'simple';
+  }
+
+  const complexity = (deps.judge ?? judgeGoalComplexity)(trimmed);
+  if (complexity === 'complex') {
+    io.print(`🎯 Complex goal — decomposing & dispatching: ${trimmed}`);
+    await (deps.plan ?? runPlanCommand)(trimmed, io, opts);
+  } else {
+    io.print(`🎯 Simple goal — pursuing autonomously: ${trimmed}`);
+    await (deps.pursue ?? defaultPursue)(trimmed, io, opts);
+  }
+  return complexity;
+}

--- a/src/tui/panels/ChatPanel.tsx
+++ b/src/tui/panels/ChatPanel.tsx
@@ -23,6 +23,7 @@ import { CommandPalette } from '../components/CommandPalette.js';
 import { callChatModel, loadDefaultProvider } from '../../support/chatSession.js';
 import { getDefaultChatModel } from '../../support/chatBackend.js';
 import { runPlanCommand, type PlanIO } from '../../support/planCommand.js';
+import { runGoalCommand, buildGoalPursuitPrompt, GOAL_PURSUIT_MAX_TURNS } from '../../support/goalCommand.js';
 import type { AdapterName } from '../../adapters/types.js';
 
 export interface ChatPanelProps {
@@ -76,6 +77,57 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
     [cwd, model], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
+  // Stream an agentic chat turn into the reducer. Shared by free chat and simple
+  // /goal pursuit (the latter raises maxTurns). (INT-1821)
+  const streamChat = useCallback(
+    async (prompt: string, maxTurns?: number) => {
+      dispatch({ type: 'stream', chunk: '' });
+      setActivity([]);
+      setBusy(true);
+      try {
+        await callChatModel(
+          prompt,
+          provider,
+          model,
+          (t) => dispatch({ type: 'stream', chunk: t }),
+          (line) => {
+            if (isActivityNoise(line)) return;
+            setActivity((a) => [...a, line].slice(-10));
+          },
+          maxTurns,
+        );
+      } catch (e) {
+        dispatch({ type: 'stream', chunk: `\n[error] ${e instanceof Error ? e.message : String(e)}` });
+      } finally {
+        dispatch({ type: 'commit' });
+        setActivity([]);
+        setBusy(false);
+      }
+    },
+    [provider, model],
+  );
+
+  // /goal routes by complexity: simple → pursue in-session (streamed), complex →
+  // decompose & dispatch via the /plan flow. (INT-1821 / S8)
+  const runGoal = useCallback(
+    async (goal: string) => {
+      setBusy(true);
+      try {
+        await runGoalCommand(
+          goal,
+          planIO,
+          { projectPath: cwd, model, provider },
+          { pursue: (g) => streamChat(buildGoalPursuitPrompt(g), GOAL_PURSUIT_MAX_TURNS) },
+        );
+      } catch (e) {
+        dispatch({ type: 'system', content: `✖ goal failed: ${e instanceof Error ? e.message : String(e)}` });
+      } finally {
+        setBusy(false);
+      }
+    },
+    [cwd, model, provider, streamChat], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
   const runCommand = useCallback(
     (name: string, args: string) => {
       switch (name) {
@@ -89,10 +141,9 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
           void runPlan(args);
           break;
         case '/goal':
-          // /goal reuses the plan→dispatch path so it works in main (the feat-only
-          // runGoalPipeline never landed); decompose the goal and dispatch it.
-          dispatch({ type: 'system', content: `🎯 Goal set: ${args}` });
-          void runPlan(args);
+          // /goal routes by complexity (INT-1821): simple → pursue in-session,
+          // complex → decompose & dispatch. Shared, UI-agnostic goalCommand.
+          void runGoal(args);
           break;
         case '/model':
         case '/provider':
@@ -102,7 +153,7 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
           dispatch({ type: 'system', content: `Unknown command: ${name}` });
       }
     },
-    [runPlan],
+    [runPlan, runGoal],
   );
 
   const submit = useCallback(
@@ -122,29 +173,9 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
         return;
       }
       dispatch({ type: 'user', content: parsed.text });
-      dispatch({ type: 'stream', chunk: '' });
-      setActivity([]);
-      setBusy(true);
-      try {
-        await callChatModel(
-          parsed.text,
-          provider,
-          model,
-          (t) => dispatch({ type: 'stream', chunk: t }),
-          (line) => {
-            if (isActivityNoise(line)) return;
-            setActivity((a) => [...a, line].slice(-10));
-          },
-        );
-      } catch (e) {
-        dispatch({ type: 'stream', chunk: `\n[error] ${e instanceof Error ? e.message : String(e)}` });
-      } finally {
-        dispatch({ type: 'commit' });
-        setActivity([]);
-        setBusy(false);
-      }
+      await streamChat(parsed.text);
     },
-    [pending, runCommand, provider, model],
+    [pending, runCommand, streamChat],
   );
 
   // While a /plan confirm is pending, keep the field active even though busy.


### PR DESCRIPTION
## S8 통합 (INT-1702 분기 정리, INT-1813 자식)
feat 전용 `chatBackend.judgeGoalComplexity/runGoalPipeline`이 main에 never landed → `/goal`이 `/plan` 경로만 재사용(단순/복합 라우팅 없음). UI-agnostic `goalCommand`(planCommand/PlanIO 미러)로 모든 chat 프론트엔드가 동일하게 라우팅.

## 변경
- `judgeGoalComplexity(goal)`: 순수·결정적 휴리스틱(길이·문장수·열거·접속사·EN/KO 키워드, 임계 2) — 추가 모델 호출 없음.
- `runGoalCommand`: 단순 → in-session 자율 추구(callChatModel + 상향된 턴 예산 GOAL_PURSUIT_MAX_TURNS); 복합 → runPlanCommand(분해→승인→dispatch). judge/pursue/plan 주입 seam.
- `ChatPanel`: `/goal` → runGoalCommand; `streamChat()` 추출(자유 채팅 + 단순 목표 추구 공유, reducer로 스트리밍). `/plan` dispatch 불변.

## 검증
goalCommand 테스트 10건(EN/KO 휴리스틱 + 라우팅 단순→pursue·복합→plan·빈값→usage·opts 전달). tsc/build clean, 전체 vitest **1064 green**.

blessed/readline 프론트엔드는 Ink로 이미 마이그레이션됨 → 라우팅을 support 모듈에 둬 '일관성' 충족(향후 프론트엔드도 동일 함수 재사용).