### PR TITLE
feat(config): MCP 서버 설정 스키마 + mcp.json 병합 (INT-1949)

### DIFF
--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -171,6 +171,41 @@ agents:
       expect(config.autonomous?.jobProfiles?.[0]?.roles).toEqual({ worker: 'm1', reviewer: 'm2' });
     });
 
+    it('should wire mcp.servers through to runtime config (INT-1949)', () => {
+      const jsonContent = JSON.stringify({
+        language: 'en',
+        linear: { apiKey: 'k', teamId: 't' },
+        agents: [{ name: 'main', projectPath: '/p', enabled: true, paused: false }],
+        mcp: {
+          servers: {
+            linear: { command: 'npx', args: ['-y', 'mcp-remote', 'https://mcp.linear.app/mcp'] },
+            docs: { url: 'https://example.com/mcp', transport: 'http' },
+          },
+        },
+      });
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(jsonContent);
+
+      const config = loadConfig('/tmp/config.json');
+      expect(config.mcp?.servers.linear.command).toBe('npx');
+      expect(config.mcp?.servers.docs.url).toBe('https://example.com/mcp');
+    });
+
+    it('should reject an mcp server with neither command nor url (INT-1949)', () => {
+      const jsonContent = JSON.stringify({
+        language: 'en',
+        linear: { apiKey: 'k', teamId: 't' },
+        agents: [{ name: 'main', projectPath: '/p', enabled: true, paused: false }],
+        mcp: { servers: { broken: { args: ['x'] } } },
+      });
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(jsonContent);
+
+      expect(() => loadConfig('/tmp/config.json')).toThrow();
+    });
+
     it('should throw error when config file not found', () => {
       vi.mocked(existsSync).mockReturnValue(false);
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -7,7 +7,7 @@ import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { z } from 'zod';
 import YAML from 'yaml';
-import type { SwarmConfig, AgentSession, LongRunningMonitorConfig, ConflictResolverConfig } from './types.js';
+import type { SwarmConfig, AgentSession, LongRunningMonitorConfig, ConflictResolverConfig, McpConfig } from './types.js';
 import { setTimeWindowConfig, DEFAULT_TIME_WINDOW } from '../support/timeWindow.js';
 
 // Constants
@@ -315,6 +315,27 @@ const NotificationsSchema = z.object({
   webhookUrl: z.string().optional(),
 }).optional();
 
+// MCP server entry: stdio (`command`/`args`/`env`) or remote (`url`/`headers`).
+// Mirrors the ~/.openswarm/mcp.json shape so config.yaml is a single source. (INT-1949)
+const McpServerSchema = z
+  .object({
+    command: z.string().optional(),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+    url: z.string().optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    transport: z.enum(['stdio', 'http', 'sse']).optional(),
+  })
+  .refine((s) => !!s.command || !!s.url, {
+    message: 'MCP server needs a `command` (stdio) or a `url` (remote)',
+  });
+
+const McpConfigSchema = z
+  .object({
+    servers: z.record(z.string(), McpServerSchema).default({}),
+  })
+  .optional();
+
 const RawConfigSchema = z.object({
   adapter: AdapterNameSchema.default('codex'),
   language: z.enum(['en', 'ko']).default('en'),
@@ -328,6 +349,7 @@ const RawConfigSchema = z.object({
   prProcessor: PRProcessorConfigSchema,
   ciWorker: CIWorkerConfigSchema,
   monitors: z.array(LongRunningMonitorConfigSchema).optional(),
+  mcp: McpConfigSchema,
   agents: z.array(AgentSessionSchema).min(1, 'At least one agent is required'),
   defaultHeartbeatInterval: z.number().positive().default(DEFAULT_HEARTBEAT_INTERVAL),
 });
@@ -532,6 +554,7 @@ function transformConfig(raw: RawConfig): SwarmConfig {
       maxAgeDays: raw.ciWorker.maxAgeDays,
     } : undefined,
     monitors: raw.monitors as LongRunningMonitorConfig[] | undefined,
+    mcp: raw.mcp ? { servers: raw.mcp.servers as McpConfig['servers'] } : undefined,
   };
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -92,6 +92,24 @@ export type SwarmEvent = {
 };
 
 /**
+ * A single MCP server entry: stdio (`command`/`args`/`env`) or remote
+ * (`url`/`headers`). Mirrors the ~/.openswarm/mcp.json shape. (INT-1949)
+ */
+export type McpServerConfig = {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
+  transport?: 'stdio' | 'http' | 'sse';
+};
+
+/** MCP servers declared in config.yaml (merged into the mcp.json registry). */
+export type McpConfig = {
+  servers: Record<string, McpServerConfig>;
+};
+
+/**
  * Global configuration
  */
 export type SwarmConfig = {
@@ -133,6 +151,8 @@ export type SwarmConfig = {
   monitors?: LongRunningMonitorConfig[];
   /** Daily status report scheduler config */
   dailyReporter?: DailyReporterConfig;
+  /** MCP servers declared in config (merged into ~/.openswarm/mcp.json registry) — INT-1949 */
+  mcp?: McpConfig;
 };
 
 /**

--- a/src/mcp/mcpClient.test.ts
+++ b/src/mcp/mcpClient.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { loadRegistry, isMcpTool } from './mcpClient.js';
+import { loadRegistry, isMcpTool, registryFromConfigServers, loadEffectiveRegistry } from './mcpClient.js';
 
 let dir: string | null = null;
 function writeMcpJson(content: unknown): string {
@@ -48,5 +48,41 @@ describe('loadRegistry', () => {
     const p = writeMcpJson({ mcpServers: { bad: { nonsense: true } } });
     expect(loadRegistry(p)).toEqual({});
     expect(loadRegistry(join(tmpdir(), 'does-not-exist-xyz.json'))).toEqual({});
+  });
+});
+
+describe('registryFromConfigServers (INT-1949)', () => {
+  it('normalizes config.mcp.servers (stdio + remote) and drops invalid', () => {
+    const reg = registryFromConfigServers({
+      linear: { command: 'npx', args: ['-y', 'x'] },
+      docs: { url: 'https://example.com/mcp' },
+      stream: { url: 'https://example.com/sse', transport: 'sse' },
+      broken: { args: ['x'] },
+    });
+    expect(reg.linear).toMatchObject({ transport: 'stdio', command: 'npx', args: ['-y', 'x'] });
+    expect(reg.docs).toMatchObject({ transport: 'http', url: 'https://example.com/mcp' });
+    expect(reg.stream).toMatchObject({ transport: 'sse' });
+    expect(reg.broken).toBeUndefined();
+  });
+
+  it('handles undefined input', () => {
+    expect(registryFromConfigServers(undefined)).toEqual({});
+  });
+});
+
+describe('loadEffectiveRegistry (INT-1949)', () => {
+  it('merges mcp.json with config servers, config winning on collision', () => {
+    const p = writeMcpJson({ mcpServers: { fromFile: { command: 'file-cmd' }, shared: { command: 'file-shared' } } });
+    const reg = loadEffectiveRegistry(
+      { fromConfig: { url: 'https://c/mcp' }, shared: { command: 'config-shared' } },
+      p,
+    );
+    expect(reg.fromFile).toMatchObject({ command: 'file-cmd' });
+    expect(reg.fromConfig).toMatchObject({ url: 'https://c/mcp' });
+    expect(reg.shared).toMatchObject({ command: 'config-shared' });
+  });
+
+  it('returns only config servers when the mcp.json path is absent', () => {
+    expect(Object.keys(loadEffectiveRegistry({ only: { command: 'c' } }, join(tmpdir(), 'no-such-mcp.json')))).toEqual(['only']);
   });
 });

--- a/src/mcp/mcpClient.ts
+++ b/src/mcp/mcpClient.ts
@@ -66,6 +66,33 @@ export function loadRegistry(path = MCP_JSON_PATH): Record<string, ServerConfig>
   return out;
 }
 
+/**
+ * Normalize MCP servers declared in config.yaml (`mcp.servers`) into the same
+ * registry shape loadRegistry produces. Invalid entries are dropped. (INT-1949)
+ */
+export function registryFromConfigServers(
+  servers: Record<string, Record<string, unknown>> | undefined,
+): Record<string, ServerConfig> {
+  const out: Record<string, ServerConfig> = {};
+  for (const [name, raw] of Object.entries(servers ?? {})) {
+    const cfg = normalizeEntry(raw);
+    if (cfg) out[name] = cfg;
+  }
+  return out;
+}
+
+/**
+ * The effective MCP registry = ~/.openswarm/mcp.json merged with the servers
+ * declared in config.yaml. Config entries win on name collision (config.yaml is
+ * the source of truth the user edits). (INT-1949)
+ */
+export function loadEffectiveRegistry(
+  configServers?: Record<string, Record<string, unknown>>,
+  path = MCP_JSON_PATH,
+): Record<string, ServerConfig> {
+  return { ...loadRegistry(path), ...registryFromConfigServers(configServers) };
+}
+
 function makeTransport(cfg: ServerConfig) {
   if (cfg.transport === 'stdio') {
     return new StdioClientTransport({


### PR DESCRIPTION
## 목표 (부모 INT-1947)
config.yaml에서 MCP 서버를 선언할 수 있게 — 지금까지는 `~/.openswarm/mcp.json` 수동 작성만 가능. MCP 클라이언트 인프라(`src/mcp/mcpClient.ts`)는 완성돼 있어 설정 표면만 추가.

## 변경
- `core/config.ts`: `McpServerSchema`(stdio | remote, command|url refine) + `mcp.servers` 배선.
- `core/types.ts`: `McpServerConfig`/`McpConfig` + `SwarmConfig.mcp`.
- `mcp/mcpClient.ts`: `registryFromConfigServers` + `loadEffectiveRegistry`(mcp.json + config 병합, config 우선).

## 검증
config mcp.servers 라운드트립 + command/url 없는 항목 거부, registry 정규화·병합 우선순위 테스트. tsc/build clean, 전체 **1070 green**.

후속: INT-1950(worker→adapter mcpTools 전달)이 이 레지스트리를 소비.