### PR TITLE
feat(worker): worker/reviewer→adapter mcpTools 전달 경로 (INT-1950)

### DIFF
--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -6,6 +6,7 @@
 import type { WorkerResult, ReviewResult } from './agentPair.js';
 import { t, getPrompts } from '../locale/index.js';
 import type { AdapterName, ProcessContext } from '../adapters/types.js';
+import type { ToolDefinition } from '../adapters/tools.js';
 import { getAdapter, spawnCli } from '../adapters/index.js';
 import { expandPath } from '../core/config.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
@@ -26,6 +27,8 @@ export interface ReviewerOptions {
   reasoningEffort?: 'low' | 'medium' | 'high';
   /** Execution-grounded definition of done to hard-gate on (INT-1914). */
   completionCriteria?: string[];
+  /** MCP tools to expose (e.g. linear__*). When unset the adapter self-sources (INT-1951). (INT-1950) */
+  mcpTools?: ToolDefinition[];
   /** Abort the run + in-flight adapter call (pipeline cancel / project disable). */
   signal?: AbortSignal;
 }
@@ -207,6 +210,7 @@ export async function runReviewer(options: ReviewerOptions): Promise<ReviewResul
       processContext: options.processContext,
       systemPrompt: getPrompts().systemPrompt,
       reasoningEffort: options.reasoningEffort,
+      mcpTools: options.mcpTools,
       signal: options.signal,
     });
 

--- a/src/agents/worker.mcptools.test.ts
+++ b/src/agents/worker.mcptools.test.ts
@@ -1,0 +1,40 @@
+// Purpose: WorkerOptions.mcpTools is forwarded to the adapter spawnCli call (INT-1950)
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ToolDefinition } from '../adapters/tools.js';
+
+const spawnCli = vi.fn(async () => 'raw');
+const parseWorkerOutput = vi.fn(() => ({
+  success: true,
+  summary: 's',
+  filesChanged: [],
+  commands: [],
+  output: 'o',
+}));
+
+vi.mock('../adapters/index.js', () => ({
+  getAdapter: () => ({ parseWorkerOutput }),
+  getDefaultAdapterName: () => 'gpt',
+  spawnCli: (...args: unknown[]) => spawnCli(...(args as [])),
+}));
+
+const { runWorker } = await import('./worker.js');
+
+describe('runWorker mcpTools pass-through (INT-1950)', () => {
+  beforeEach(() => spawnCli.mockClear());
+
+  it('forwards mcpTools to the adapter spawnCli options', async () => {
+    const mcpTools: ToolDefinition[] = [
+      { type: 'function', function: { name: 'linear__list_issues', description: '', parameters: { type: 'object', properties: {} } } },
+    ];
+    await runWorker({ taskTitle: 't', taskDescription: 'd', projectPath: '/p', adapterName: 'gpt', mcpTools });
+    expect(spawnCli).toHaveBeenCalled();
+    const opts = spawnCli.mock.calls[0][1] as { mcpTools?: ToolDefinition[] };
+    expect(opts.mcpTools).toBe(mcpTools);
+  });
+
+  it('leaves mcpTools undefined when not provided', async () => {
+    await runWorker({ taskTitle: 't', taskDescription: 'd', projectPath: '/p', adapterName: 'gpt' });
+    const opts = spawnCli.mock.calls[0][1] as { mcpTools?: ToolDefinition[] };
+    expect(opts.mcpTools).toBeUndefined();
+  });
+});

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -8,6 +8,7 @@ import * as gitTracker from '../support/gitTracker.js';
 import { t, getPrompts } from '../locale/index.js';
 import type { WorkerContext } from '../locale/types.js';
 import type { AdapterName, ProcessContext } from '../adapters/types.js';
+import type { ToolDefinition } from '../adapters/tools.js';
 import { getAdapter, getDefaultAdapterName, spawnCli } from '../adapters/index.js';
 import { expandPath } from '../core/config.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
@@ -40,6 +41,9 @@ export interface WorkerOptions {
   bashTimeoutMs?: number;
   /** Expose web_fetch + web_search tools (default true). Set false for SWE-bench integrity. */
   webTools?: boolean;
+  /** MCP tools to expose to the agentic loop (server__tool). When unset the adapter
+   * self-sources from the registry (INT-1951); set to pin a specific set. (INT-1950) */
+  mcpTools?: ToolDefinition[];
   /** Abort the run + in-flight adapter call (pipeline cancel / project disable). */
   signal?: AbortSignal;
   /**
@@ -170,6 +174,7 @@ export async function runWorker(options: WorkerOptions): Promise<WorkerResult> {
       protectedFiles: options.protectedFiles,
       bashTimeoutMs: options.bashTimeoutMs,
       webTools: options.webTools,
+      mcpTools: options.mcpTools,
       signal: options.signal,
     });
 


### PR DESCRIPTION
## 목표 (부모 INT-1947)
`CliRunOptions.mcpTools`는 어댑터/agenticLoop가 이미 소비하지만 worker/reviewer가 전달하지 않아 파이프라인 경로에서 MCP 도구가 항상 빈 배열.

## 변경
- `worker.ts`: `WorkerOptions.mcpTools` + spawnCli 전달.
- `reviewer.ts`: `ReviewerOptions.mcpTools` + runReviewer spawnCli 전달.
- 미설정 시 어댑터 자체 소싱(INT-1951), 설정 시 특정 집합 고정.

## 검증
runWorker가 mcpTools를 spawnCli 옵션으로 전달(adapters mock 테스트 2건). tsc/build clean, 전체 **1072 green**.