### PR TITLE
feat(adapters): CLI 어댑터 standalone MCP 초기화 (INT-1951)

### DIFF
--- a/src/adapters/gpt.ts
+++ b/src/adapters/gpt.ts
@@ -14,6 +14,7 @@ import type {
 } from './types.js';
 import { AuthProfileStore, ensureValidToken } from '../auth/index.js';
 import { runAgenticLoop, loopResultToCliResult, type ChatMessage, type AgenticLoopOptions } from './agenticLoop.js';
+import { resolveMcpTools } from '../mcp/mcpClient.js';
 import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
 import { consumeChatCompletionsStream } from './chatStream.js';
 import type { ToolDefinition } from './tools.js';
@@ -75,6 +76,11 @@ export class GptCliAdapter implements CliAdapter {
     // 2. 에이전틱 루프로 실행 (도구 사용 가능)
     const callApi = this.createApiCaller(accessToken, store, model, options.onToken, options.signal);
 
+    // MCP tools: caller-provided, else self-source from the registry
+    // (mcp.json + config.mcp.servers) so standalone chat/exec and the worker
+    // path all get MCP without each caller threading them. (INT-1951)
+    const mcpTools = await resolveMcpTools(options.mcpTools);
+
     const loopOptions: AgenticLoopOptions = {
       systemPrompt: options.systemPrompt,
       prompt: options.prompt,
@@ -89,7 +95,7 @@ export class GptCliAdapter implements CliAdapter {
       protectedFiles: options.protectedFiles,
       bashTimeoutMs: options.bashTimeoutMs,
       webTools: options.webTools,
-      mcpTools: options.mcpTools,
+      mcpTools,
       signal: options.signal,
       editFormat: options.editFormat,
     };

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -13,6 +13,7 @@ import type {
   ReviewResult,
 } from './types.js';
 import { runAgenticLoop, loopResultToCliResult, type ChatMessage, type AgenticLoopOptions } from './agenticLoop.js';
+import { resolveMcpTools } from '../mcp/mcpClient.js';
 import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
 import { consumeChatCompletionsStream } from './chatStream.js';
 import type { ToolDefinition } from './tools.js';
@@ -155,6 +156,9 @@ export class LocalModelAdapter implements CliAdapter {
     // 에이전틱 루프로 실행
     const callApi = this.createApiCaller(baseUrl, model, options.onToken, options.signal);
 
+    // MCP tools: caller-provided, else self-source from the registry. (INT-1951)
+    const mcpTools = await resolveMcpTools(options.mcpTools);
+
     const loopOptions: AgenticLoopOptions = {
       systemPrompt: options.systemPrompt,
       prompt: options.prompt,
@@ -169,7 +173,7 @@ export class LocalModelAdapter implements CliAdapter {
       protectedFiles: options.protectedFiles,
       bashTimeoutMs: options.bashTimeoutMs,
       webTools: options.webTools,
-      mcpTools: options.mcpTools,
+      mcpTools,
       signal: options.signal,
       editFormat: options.editFormat,
     };

--- a/src/adapters/openrouter.ts
+++ b/src/adapters/openrouter.ts
@@ -19,6 +19,7 @@ import {
   type ChatMessage,
   type AgenticLoopOptions,
 } from './agenticLoop.js';
+import { resolveMcpTools } from '../mcp/mcpClient.js';
 import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
 import { RateLimitError } from './rateLimitError.js';
 import { consumeChatCompletionsStream } from './chatStream.js';
@@ -96,6 +97,9 @@ export class OpenRouterCliAdapter implements CliAdapter {
       signal: options.signal,
     });
 
+    // MCP tools: caller-provided, else self-source from the registry. (INT-1951)
+    const mcpTools = await resolveMcpTools(options.mcpTools);
+
     const loopOptions: AgenticLoopOptions = {
       systemPrompt: options.systemPrompt,
       prompt: options.prompt,
@@ -110,7 +114,7 @@ export class OpenRouterCliAdapter implements CliAdapter {
       protectedFiles: options.protectedFiles,
       bashTimeoutMs: options.bashTimeoutMs,
       webTools: options.webTools,
-      mcpTools: options.mcpTools,
+      mcpTools,
       signal: options.signal,
       editFormat: options.editFormat,
     };

--- a/src/mcp/mcpClient.test.ts
+++ b/src/mcp/mcpClient.test.ts
@@ -2,7 +2,8 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { loadRegistry, isMcpTool, registryFromConfigServers, loadEffectiveRegistry } from './mcpClient.js';
+import { loadRegistry, isMcpTool, registryFromConfigServers, loadEffectiveRegistry, resolveMcpTools } from './mcpClient.js';
+import type { ToolDefinition } from '../adapters/tools.js';
 
 let dir: string | null = null;
 function writeMcpJson(content: unknown): string {
@@ -84,5 +85,34 @@ describe('loadEffectiveRegistry (INT-1949)', () => {
 
   it('returns only config servers when the mcp.json path is absent', () => {
     expect(Object.keys(loadEffectiveRegistry({ only: { command: 'c' } }, join(tmpdir(), 'no-such-mcp.json')))).toEqual(['only']);
+  });
+});
+
+describe('resolveMcpTools (INT-1951)', () => {
+  const tool: ToolDefinition = {
+    type: 'function',
+    function: { name: 'srv__t', description: '', parameters: { type: 'object', properties: {} } },
+  };
+
+  it('returns the caller-provided set without sourcing', async () => {
+    let sourced = false;
+    const out = await resolveMcpTools([tool], async () => {
+      sourced = true;
+      return [];
+    });
+    expect(out).toEqual([tool]);
+    expect(sourced).toBe(false);
+  });
+
+  it('self-sources when none provided', async () => {
+    expect(await resolveMcpTools(undefined, async () => [tool])).toEqual([tool]);
+  });
+
+  it('degrades to [] when the source throws', async () => {
+    expect(
+      await resolveMcpTools(undefined, async () => {
+        throw new Error('unreachable');
+      }),
+    ).toEqual([]);
   });
 });

--- a/src/mcp/mcpClient.ts
+++ b/src/mcp/mcpClient.ts
@@ -163,16 +163,52 @@ export async function initMcpTools(registry = loadRegistry()): Promise<ToolDefin
 // Cache the discovered tools so chat doesn't re-list every message.
 let cachedTools: ToolDefinition[] | null = null;
 
-/** Discovered MCP tools (cached). Empty when no mcp.json / no reachable servers. */
+/**
+ * The effective registry for auto-discovery: mcp.json merged with the servers
+ * declared in config.yaml (`mcp.servers`, INT-1949). config is loaded lazily so
+ * mcpClient stays free of a static dependency on core/config. (INT-1951)
+ */
+async function loadConfiguredRegistry(): Promise<Record<string, ServerConfig>> {
+  let configServers: Record<string, Record<string, unknown>> | undefined;
+  try {
+    const { loadConfig } = await import('../core/config.js');
+    configServers = loadConfig().mcp?.servers as Record<string, Record<string, unknown>> | undefined;
+  } catch {
+    // No/invalid config → fall back to mcp.json only.
+  }
+  return loadEffectiveRegistry(configServers);
+}
+
+/**
+ * Discovered MCP tools (cached). Sources from mcp.json + config.yaml mcp.servers.
+ * Empty when nothing is configured / no reachable servers. (INT-1951)
+ */
 export async function getMcpTools(): Promise<ToolDefinition[]> {
   if (cachedTools) return cachedTools;
-  cachedTools = await initMcpTools();
+  cachedTools = await initMcpTools(await loadConfiguredRegistry());
   return cachedTools;
 }
 
 /** Drop the cache (after editing mcp.json). */
 export function resetMcpTools(): void {
   cachedTools = null;
+}
+
+/**
+ * Resolve the MCP tools for an adapter run: use the caller-provided set if any,
+ * otherwise self-source from the registry. A failing source degrades to no
+ * tools (never blocks the run). `source` is injectable for tests. (INT-1951)
+ */
+export async function resolveMcpTools(
+  provided?: ToolDefinition[],
+  source: () => Promise<ToolDefinition[]> = getMcpTools,
+): Promise<ToolDefinition[]> {
+  if (provided) return provided;
+  try {
+    return await source();
+  } catch {
+    return [];
+  }
 }
 
 /** Execute a `server__tool` call against its MCP server. Returns text content. */


### PR DESCRIPTION
## 목표 (부모 INT-1947)
데몬 없이 `openswarm chat`/`exec`/worker 경로에서도 MCP 도구 사용 가능하게 어댑터가 self-source.

## 변경
- `mcp/mcpClient.ts`: `getMcpTools()` config-aware(mcp.json + config.mcp.servers 병합, config는 lazy import) + `resolveMcpTools(provided, source)` 헬퍼.
- `adapters/gpt|openrouter|local`: run()에서 `resolveMcpTools(options.mcpTools)` → agenticLoop. caller 미설정 시 자체 소싱.

## 검증
resolveMcpTools 3분기 테스트(provided 우선·self-source·throw→[]). tsc/build clean, 전체 **1075 green**.