### PR TITLE
feat(mcp): Linear MCP 프리셋으로 워커/CLI Linear 접근 복원 (INT-1952)

### DIFF
--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -192,6 +192,21 @@ agents:
       expect(config.mcp?.servers.docs.url).toBe('https://example.com/mcp');
     });
 
+    it('should accept an mcp server declared via preset (INT-1952)', () => {
+      const jsonContent = JSON.stringify({
+        language: 'en',
+        linear: { apiKey: 'k', teamId: 't' },
+        agents: [{ name: 'main', projectPath: '/p', enabled: true, paused: false }],
+        mcp: { servers: { linear: { preset: 'linear' } } },
+      });
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(jsonContent);
+
+      const config = loadConfig('/tmp/config.json');
+      expect(config.mcp?.servers.linear.preset).toBe('linear');
+    });
+
     it('should reject an mcp server with neither command nor url (INT-1949)', () => {
       const jsonContent = JSON.stringify({
         language: 'en',

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -319,6 +319,8 @@ const NotificationsSchema = z.object({
 // Mirrors the ~/.openswarm/mcp.json shape so config.yaml is a single source. (INT-1949)
 const McpServerSchema = z
   .object({
+    /** Reference a built-in preset (e.g. `linear`) instead of command/url. (INT-1952) */
+    preset: z.string().optional(),
     command: z.string().optional(),
     args: z.array(z.string()).optional(),
     env: z.record(z.string(), z.string()).optional(),
@@ -326,8 +328,8 @@ const McpServerSchema = z
     headers: z.record(z.string(), z.string()).optional(),
     transport: z.enum(['stdio', 'http', 'sse']).optional(),
   })
-  .refine((s) => !!s.command || !!s.url, {
-    message: 'MCP server needs a `command` (stdio) or a `url` (remote)',
+  .refine((s) => !!s.preset || !!s.command || !!s.url, {
+    message: 'MCP server needs a `preset`, a `command` (stdio), or a `url` (remote)',
   });
 
 const McpConfigSchema = z

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -96,6 +96,8 @@ export type SwarmEvent = {
  * (`url`/`headers`). Mirrors the ~/.openswarm/mcp.json shape. (INT-1949)
  */
 export type McpServerConfig = {
+  /** Reference a built-in preset (e.g. `linear`) instead of command/url. (INT-1952) */
+  preset?: string;
   command?: string;
   args?: string[];
   env?: Record<string, string>;

--- a/src/mcp/mcpClient.test.ts
+++ b/src/mcp/mcpClient.test.ts
@@ -69,6 +69,16 @@ describe('registryFromConfigServers (INT-1949)', () => {
   it('handles undefined input', () => {
     expect(registryFromConfigServers(undefined)).toEqual({});
   });
+
+  it('expands a built-in preset (linear) and drops unknown presets (INT-1952)', () => {
+    const reg = registryFromConfigServers({
+      linear: { preset: 'linear' },
+      bogus: { preset: 'nope' },
+    });
+    expect(reg.linear).toMatchObject({ transport: 'stdio', command: 'npx' });
+    expect(reg.linear.args).toContain('https://mcp.linear.app/mcp');
+    expect(reg.bogus).toBeUndefined();
+  });
 });
 
 describe('loadEffectiveRegistry (INT-1949)', () => {

--- a/src/mcp/mcpClient.ts
+++ b/src/mcp/mcpClient.ts
@@ -31,8 +31,25 @@ interface ServerConfig {
   headers?: Record<string, string>;
 }
 
-/** A persisted entry: `{command,args,env}` (stdio) or `{url,headers,transport?}` (remote). */
+/**
+ * Built-in MCP server presets — referenced by `{ preset: '<name>' }` in
+ * config.yaml / mcp.json so common servers don't need hand-written commands.
+ * `linear` gives the worker/CLI Linear access (issue read, comment, sub-issue
+ * create) via the official remote MCP server. (INT-1952)
+ */
+export const BUILTIN_MCP_SERVERS: Record<string, ServerConfig> = {
+  linear: {
+    transport: 'stdio',
+    command: 'npx',
+    args: ['-y', 'mcp-remote', 'https://mcp.linear.app/mcp'],
+  },
+};
+
+/** A persisted entry: `{preset}`, `{command,args,env}` (stdio) or `{url,headers,transport?}` (remote). */
 function normalizeEntry(raw: Record<string, unknown>): ServerConfig | null {
+  if (typeof raw.preset === 'string' && raw.preset) {
+    return BUILTIN_MCP_SERVERS[raw.preset] ?? null;
+  }
   if (typeof raw.command === 'string' && raw.command) {
     return {
       transport: 'stdio',


### PR DESCRIPTION
## 목표 (부모 INT-1947)
워커/CLI가 작업 중 Linear 이슈를 직접 읽고 코멘트·서브이슈를 만들 수 있게. INT-1949~1951로 MCP 인프라가 완성됐으므로 Linear를 빌트인 프리셋으로 노출.

## 변경
- `mcp/mcpClient.ts`: `BUILTIN_MCP_SERVERS`(linear=mcp-remote) + `{ preset }` 항목 확장(미지 preset 드롭).
- `core/config.ts`·`types.ts`: McpServerSchema에 `preset` + refine 완화(preset|command|url).

## 사용
```yaml
mcp:
  servers:
    linear: { preset: linear }
```
→ gpt/openrouter/local 워커가 `linear__*` 도구 자동 획득(인증 mcp-remote OAuth).

## 검증
프리셋 확장+미지 preset 드롭, config preset 수용 테스트. tsc/build clean, 전체 **1077 green**.