### PR TITLE
feat(cli): openswarm mcp add|list|remove 커맨드 (INT-1953)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -148,6 +148,29 @@ program
     await launchChatTui();
   });
 
+// openswarm mcp add|list|remove
+
+program
+  .command('mcp')
+  .description('Manage MCP servers (~/.openswarm/mcp.json) available to the worker/CLI')
+  .argument('<action>', 'add | list | remove')
+  .argument('[name]', 'server name (for add/remove)')
+  .argument('[target...]', 'command + args, or a URL (for add)')
+  .option('--preset <preset>', 'use a built-in preset (e.g. linear) instead of a command/URL')
+  .action(async (action: string, name: string | undefined, target: string[], opts: { preset?: string }) => {
+    const { runMcpCommand } = await import('./cli/mcpCommand.js');
+    try {
+      console.log(runMcpCommand(action, name, target ?? [], { preset: opts.preset }));
+      if (action === 'add' || action === 'remove') {
+        const { resetMcpTools } = await import('./mcp/mcpClient.js');
+        resetMcpTools();
+      }
+    } catch (e) {
+      console.error(e instanceof Error ? e.message : String(e));
+      process.exitCode = 1;
+    }
+  });
+
 // openswarm exec <prompt>
 
 program

--- a/src/cli/mcpCommand.test.ts
+++ b/src/cli/mcpCommand.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  parseServerSpec,
+  addServer,
+  removeServer,
+  formatServerList,
+  runMcpCommand,
+  readMcpJson,
+  type McpJson,
+} from './mcpCommand.js';
+
+describe('parseServerSpec (INT-1953)', () => {
+  it('maps --preset to a preset spec', () => {
+    expect(parseServerSpec(undefined, [], 'linear')).toEqual({ preset: 'linear' });
+  });
+  it('maps an http(s) target to a url spec', () => {
+    expect(parseServerSpec('https://x/mcp', [])).toEqual({ url: 'https://x/mcp' });
+  });
+  it('maps a command + args to a stdio spec', () => {
+    expect(parseServerSpec('npx', ['-y', 'srv'])).toEqual({ command: 'npx', args: ['-y', 'srv'] });
+  });
+  it('omits empty args', () => {
+    expect(parseServerSpec('mybin', [])).toEqual({ command: 'mybin' });
+  });
+  it('throws when nothing usable is given', () => {
+    expect(() => parseServerSpec(undefined, [])).toThrow();
+  });
+});
+
+describe('addServer / removeServer / formatServerList', () => {
+  const base: McpJson = { mcpServers: { a: { command: 'x' } } };
+
+  it('adds and removes without mutating the input', () => {
+    const added = addServer(base, 'b', { preset: 'linear' });
+    expect(Object.keys(added.mcpServers)).toEqual(['a', 'b']);
+    expect(Object.keys(base.mcpServers)).toEqual(['a']); // pure
+
+    const removed = removeServer(added, 'a');
+    expect(Object.keys(removed.mcpServers)).toEqual(['b']);
+  });
+
+  it('formats presets, urls, and commands distinctly', () => {
+    const out = formatServerList({
+      mcpServers: { p: { preset: 'linear' }, r: { url: 'https://u/mcp' }, c: { command: 'npx', args: ['-y', 's'] } },
+    });
+    expect(out).toContain('p — preset:linear');
+    expect(out).toContain('r — https://u/mcp');
+    expect(out).toContain('c — npx -y s');
+  });
+
+  it('lists nothing helpfully when empty', () => {
+    expect(formatServerList({ mcpServers: {} })).toMatch(/No MCP servers configured/);
+  });
+});
+
+describe('runMcpCommand round-trip (INT-1953)', () => {
+  it('add → list → remove against a temp mcp.json', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mcpcmd-'));
+    const path = join(dir, 'mcp.json');
+    try {
+      expect(runMcpCommand('add', 'linear', [], { preset: 'linear', path })).toMatch(/Added MCP server "linear"/);
+      expect(readMcpJson(path).mcpServers.linear).toEqual({ preset: 'linear' });
+
+      expect(runMcpCommand('list', undefined, [], { path })).toContain('linear — preset:linear');
+
+      expect(runMcpCommand('remove', 'linear', [], { path })).toMatch(/Removed MCP server "linear"/);
+      expect(readMcpJson(path).mcpServers.linear).toBeUndefined();
+      expect(existsSync(path)).toBe(true);
+      expect(readFileSync(path, 'utf8')).toContain('mcpServers');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('remove of an unknown server is a no-op message', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mcpcmd-'));
+    try {
+      expect(runMcpCommand('remove', 'ghost', [], { path: join(dir, 'mcp.json') })).toMatch(/No MCP server named/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an unknown action', () => {
+    expect(() => runMcpCommand('frobnicate', undefined, [], { path: join(tmpdir(), 'nope.json') })).toThrow(/Unknown mcp action/);
+  });
+});

--- a/src/cli/mcpCommand.ts
+++ b/src/cli/mcpCommand.ts
@@ -1,0 +1,112 @@
+// ============================================
+// OpenSwarm - `openswarm mcp add|list|remove` (INT-1953)
+// ============================================
+//
+// Manage MCP servers in ~/.openswarm/mcp.json from the CLI instead of editing
+// the JSON by hand. The mutation helpers are pure (registry in → registry out)
+// so routing is unit-tested; runMcpCommand is the thin read→mutate→write shell.
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+import type { McpServerConfig } from '../core/types.js';
+import { BUILTIN_MCP_SERVERS } from '../mcp/mcpClient.js';
+
+export const MCP_JSON_PATH = join(homedir(), '.openswarm', 'mcp.json');
+
+export interface McpJson {
+  mcpServers: Record<string, McpServerConfig>;
+}
+
+export function readMcpJson(path = MCP_JSON_PATH): McpJson {
+  if (!existsSync(path)) return { mcpServers: {} };
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as { mcpServers?: Record<string, McpServerConfig> };
+    return { mcpServers: parsed.mcpServers ?? {} };
+  } catch {
+    return { mcpServers: {} };
+  }
+}
+
+export function writeMcpJson(json: McpJson, path = MCP_JSON_PATH): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(json, null, 2)}\n`);
+}
+
+/**
+ * Turn `add` arguments into a server spec: a `--preset`, an http(s) URL (remote),
+ * or a command + args (stdio).
+ */
+export function parseServerSpec(target: string | undefined, args: string[], preset?: string): McpServerConfig {
+  if (preset) return { preset };
+  if (target && /^https?:\/\//.test(target)) return { url: target };
+  if (target) return { command: target, ...(args.length ? { args } : {}) };
+  throw new Error('mcp add: provide a --preset, a URL, or a command');
+}
+
+export function addServer(json: McpJson, name: string, spec: McpServerConfig): McpJson {
+  return { mcpServers: { ...json.mcpServers, [name]: spec } };
+}
+
+export function removeServer(json: McpJson, name: string): McpJson {
+  const next = { ...json.mcpServers };
+  delete next[name];
+  return { mcpServers: next };
+}
+
+export function formatServerList(json: McpJson): string {
+  const names = Object.keys(json.mcpServers);
+  if (!names.length) {
+    const presets = Object.keys(BUILTIN_MCP_SERVERS).join(', ');
+    return `No MCP servers configured. Add one with \`openswarm mcp add <name> --preset <${presets}>\` or a command/URL.`;
+  }
+  return names
+    .map((n) => {
+      const s = json.mcpServers[n];
+      const detail = s.preset
+        ? `preset:${s.preset}`
+        : s.url
+          ? s.url
+          : `${s.command ?? ''} ${(s.args ?? []).join(' ')}`.trim();
+      return `  ${n} — ${detail}`;
+    })
+    .join('\n');
+}
+
+export interface McpCommandOptions {
+  preset?: string;
+  path?: string;
+}
+
+/** Thin I/O shell: read mcp.json → mutate → write. Returns the message to print. */
+export function runMcpCommand(
+  action: string,
+  name: string | undefined,
+  args: string[],
+  opts: McpCommandOptions = {},
+): string {
+  const path = opts.path ?? MCP_JSON_PATH;
+  const json = readMcpJson(path);
+
+  switch (action) {
+    case 'list':
+      return formatServerList(json);
+
+    case 'add': {
+      if (!name) throw new Error('mcp add: a server name is required');
+      const spec = parseServerSpec(args[0], args.slice(1), opts.preset);
+      writeMcpJson(addServer(json, name, spec), path);
+      return `Added MCP server "${name}". It is now available to the worker/CLI.`;
+    }
+
+    case 'remove': {
+      if (!name) throw new Error('mcp remove: a server name is required');
+      if (!json.mcpServers[name]) return `No MCP server named "${name}".`;
+      writeMcpJson(removeServer(json, name), path);
+      return `Removed MCP server "${name}".`;
+    }
+
+    default:
+      throw new Error(`Unknown mcp action "${action}" (use add|list|remove)`);
+  }
+}


### PR DESCRIPTION
## 목표 (부모 INT-1947, 마지막 서브이슈)
MCP 서버를 `~/.openswarm/mcp.json` 수동 편집 없이 CLI로 관리.

## 변경
- `cli/mcpCommand.ts`: 순수 헬퍼(parseServerSpec[preset|url|command], add/removeServer, formatServerList) + runMcpCommand(read→mutate→write).
- `cli.ts`: `openswarm mcp <action> [name] [target...] --preset`. add/remove 후 resetMcpTools().

## 사용
`openswarm mcp add linear --preset linear` · `openswarm mcp list` · `openswarm mcp remove linear`

## 검증
parseServerSpec 5분기 + add/remove 순수성 + format + runMcpCommand 라운드트립(temp). tsc/build clean, 전체 **1088 green**.