### PR TITLE
feat(reviewer): emit + parse recommendedActions (INT-1954)

### DIFF
--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -466,6 +466,16 @@ function normalizeReviewResult(parsed: Record<string, unknown>): ReviewResult {
     suggestions: Array.isArray(parsed.suggestions)
       ? parsed.suggestions.filter((v): v is string => typeof v === 'string')
       : [],
+    recommendedActions: Array.isArray(parsed.recommendedActions)
+      ? parsed.recommendedActions
+          .filter((a): a is Record<string, unknown> => !!a && typeof a === 'object')
+          .map((a) => ({
+            type: typeof a.type === 'string' && a.type ? a.type : 'follow-up',
+            title: typeof a.title === 'string' ? a.title.trim() : '',
+            location: typeof a.location === 'string' ? a.location : undefined,
+          }))
+          .filter((a) => a.title.length > 0)
+      : undefined,
   };
 }
 

--- a/src/adapters/resultParsing.test.ts
+++ b/src/adapters/resultParsing.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { parseReviewerResult } from './resultParsing.js';
+
+const wrap = (obj: unknown) => '```json\n' + JSON.stringify(obj) + '\n```';
+
+describe('parseReviewerResult recommendedActions (INT-1954)', () => {
+  it('parses structured recommendedActions on approve', () => {
+    const r = parseReviewerResult(
+      wrap({
+        decision: 'approve',
+        feedback: 'lgtm',
+        issues: [],
+        suggestions: [],
+        recommendedActions: [
+          { type: 'test', title: 'add edge-case coverage', location: 'src/x.ts:10' },
+          { type: 'refactor', title: 'extract helper' },
+        ],
+      }),
+    );
+    expect(r.decision).toBe('approve');
+    expect(r.recommendedActions).toEqual([
+      { type: 'test', title: 'add edge-case coverage', location: 'src/x.ts:10' },
+      { type: 'refactor', title: 'extract helper', location: undefined },
+    ]);
+  });
+
+  it('defaults a missing type to follow-up and drops title-less entries', () => {
+    const r = parseReviewerResult(
+      wrap({ decision: 'approve', feedback: 'ok', recommendedActions: [{ title: 'do x' }, { type: 'bug' }] }),
+    );
+    expect(r.recommendedActions).toEqual([{ type: 'follow-up', title: 'do x', location: undefined }]);
+  });
+
+  it('is undefined when absent or empty', () => {
+    expect(parseReviewerResult(wrap({ decision: 'approve', feedback: 'ok' })).recommendedActions).toBeUndefined();
+    expect(
+      parseReviewerResult(wrap({ decision: 'approve', feedback: 'ok', recommendedActions: [] })).recommendedActions,
+    ).toBeUndefined();
+  });
+});

--- a/src/adapters/resultParsing.ts
+++ b/src/adapters/resultParsing.ts
@@ -74,10 +74,28 @@ function extractReviewerResultJson(text: string): ReviewResult | null {
       suggestions: Array.isArray(parsed.suggestions)
         ? parsed.suggestions.filter((v: unknown): v is string => typeof v === 'string')
         : [],
+      recommendedActions: parseRecommendedActions(parsed.recommendedActions),
     };
   } catch {
     return null;
   }
+}
+
+/**
+ * Parse the reviewer's `recommendedActions` into structured follow-ups. Filed as
+ * sub-issues on approve by fileReviewerFollowups (INT-1704). (INT-1954)
+ */
+function parseRecommendedActions(raw: unknown): ReviewResult['recommendedActions'] {
+  if (!Array.isArray(raw)) return undefined;
+  const actions = raw
+    .filter((a): a is Record<string, unknown> => !!a && typeof a === 'object')
+    .map((a) => ({
+      type: typeof a.type === 'string' && a.type ? a.type : 'follow-up',
+      title: typeof a.title === 'string' ? a.title.trim() : '',
+      location: typeof a.location === 'string' ? a.location : undefined,
+    }))
+    .filter((a) => a.title.length > 0);
+  return actions.length ? actions : undefined;
 }
 
 /** Text fallback when no JSON reviewer result is present. */

--- a/src/locale/prompts/en.ts
+++ b/src/locale/prompts/en.ts
@@ -200,9 +200,12 @@ After review, output results in the following JSON format:
   "decision": "approve" | "revise" | "reject",
   "feedback": "Overall feedback (1-3 sentences)",
   "issues": ["List of found issues (empty array if none)"],
-  "suggestions": ["List of improvement suggestions (empty array if none)"]
+  "suggestions": ["List of improvement suggestions (empty array if none)"],
+  "recommendedActions": [{ "type": "test|refactor|bug|docs|perf", "title": "Short follow-up to file as its own issue", "location": "file:line (optional)" }]
 }
 \`\`\`
+
+\`recommendedActions\` are concrete follow-ups worth tracking as separate issues (NOT blockers for this change). Use an empty array if none.
 
 `;
   },

--- a/src/locale/prompts/ko.ts
+++ b/src/locale/prompts/ko.ts
@@ -200,9 +200,12 @@ ${workerReport}
   "decision": "approve" | "revise" | "reject",
   "feedback": "전체적인 피드백 (1-3문장)",
   "issues": ["발견된 문제점 목록 (없으면 빈 배열)"],
-  "suggestions": ["개선 제안 목록 (없으면 빈 배열)"]
+  "suggestions": ["개선 제안 목록 (없으면 빈 배열)"],
+  "recommendedActions": [{ "type": "test|refactor|bug|docs|perf", "title": "별도 이슈로 등록할 후속 작업", "location": "file:line (선택)" }]
 }
 \`\`\`
+
+\`recommendedActions\`는 이번 변경의 blocker가 아니라 별도 이슈로 추적할 만한 구체적 후속 작업이다. 없으면 빈 배열.
 
 `;
   },


### PR DESCRIPTION
## 목표 (부모 INT-1946, code-review 갈래 기반)
INT-1704가 `fileReviewerFollowups` 소비를 배선했으나 reviewer가 recommendedActions를 생성·파싱하지 않아 no-op였다. 생성+파싱 추가로 활성화.

## 변경
- `locale/prompts/en.ts·ko.ts`: reviewer JSON에 `recommendedActions [{type,title,location?}]` + 'blocker 아님' 설명.
- `adapters/resultParsing.ts`: 공통 파서가 recommendedActions 파싱(type 기본 follow-up, title 없으면 드롭, 빈→undefined) → gpt/openrouter/local/codexResponses/claude 커버.
- `adapters/codex.ts`: 자체 normalizeReviewResult에도 동일.

## 검증
parseReviewerResult 3분기 + 프롬프트 포맷 테스트. tsc/build clean, 전체 **1091 green**.
이제 reviewer 승인 시 recommendedActions가 채워지고 fileReviewerFollowups(INT-1704)가 서브이슈 생성(autoFile ON).