### PR TITLE
feat(cli): openswarm review 커맨드 (INT-1955)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,6 +171,26 @@ program
     }
   });
 
+// openswarm review
+
+program
+  .command('review')
+  .description('Review the working-tree changes; optionally file follow-ups as Linear sub-issues')
+  .option('--path <path>', 'Project path (default: cwd)')
+  .option('--file <issue>', 'Parent Linear issue id — file recommendedActions as sub-issues under it')
+  .option('--adapter <name>', 'Adapter override for the reviewer')
+  .option('--debug', 'Verbose logging')
+  .action(async (opts: { path?: string; file?: string; adapter?: string; debug?: boolean }) => {
+    const { runReviewCommand } = await import('./cli/reviewCommand.js');
+    try {
+      const result = await runReviewCommand({ path: opts.path, fileIssue: opts.file, adapter: opts.adapter, debug: opts.debug });
+      if (result && result.decision === 'reject') process.exitCode = 1;
+    } catch (e) {
+      console.error(e instanceof Error ? e.message : String(e));
+      process.exitCode = 1;
+    }
+  });
+
 // openswarm exec <prompt>
 
 program

--- a/src/cli/reviewCommand.test.ts
+++ b/src/cli/reviewCommand.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildReviewWorkerResult, formatReviewOutput, runReviewCommand } from './reviewCommand.js';
+import type { ReviewResult } from '../agents/agentPair.js';
+
+describe('buildReviewWorkerResult (INT-1955)', () => {
+  it('synthesizes a WorkerResult from changed files', () => {
+    const wr = buildReviewWorkerResult(['a.ts', 'b.ts']);
+    expect(wr).toMatchObject({ success: true, filesChanged: ['a.ts', 'b.ts'], commands: [] });
+    expect(wr.summary).toContain('2');
+  });
+});
+
+describe('formatReviewOutput (INT-1955)', () => {
+  it('renders decision, feedback, issues, suggestions, follow-ups', () => {
+    const review: ReviewResult = {
+      decision: 'approve',
+      feedback: 'looks good',
+      issues: ['minor naming'],
+      suggestions: ['add a test'],
+      recommendedActions: [{ type: 'test', title: 'cover edge case', location: 'a.ts:3' }],
+    };
+    const out = formatReviewOutput(review);
+    expect(out).toContain('Decision: APPROVE');
+    expect(out).toContain('looks good');
+    expect(out).toContain('- minor naming');
+    expect(out).toContain('- add a test');
+    expect(out).toContain('[test] cover edge case (a.ts:3)');
+  });
+});
+
+describe('runReviewCommand (INT-1955)', () => {
+  it('returns null and skips review when there are no changes', async () => {
+    const review = vi.fn();
+    const out = await runReviewCommand({}, { getChangedFiles: async () => [], review, log: () => {} });
+    expect(out).toBeNull();
+    expect(review).not.toHaveBeenCalled();
+  });
+
+  it('runs the reviewer over changed files and prints the verdict', async () => {
+    const logs: string[] = [];
+    const review = vi.fn(async () => ({ decision: 'approve', feedback: 'ok' }) as ReviewResult);
+    const out = await runReviewCommand(
+      {},
+      { getChangedFiles: async () => ['x.ts'], review, log: (l) => logs.push(l) },
+    );
+    expect(review).toHaveBeenCalledOnce();
+    expect(out?.decision).toBe('approve');
+    expect(logs.join('\n')).toContain('Decision: APPROVE');
+  });
+
+  it('files follow-ups when --file is set and the reviewer recommends actions', async () => {
+    const fileFollowups = vi.fn(async () => 2);
+    await runReviewCommand(
+      { fileIssue: 'INT-1' },
+      {
+        getChangedFiles: async () => ['x.ts'],
+        review: async () =>
+          ({ decision: 'approve', feedback: 'ok', recommendedActions: [{ type: 'test', title: 't' }] }) as ReviewResult,
+        fileFollowups,
+        log: () => {},
+      },
+    );
+    expect(fileFollowups).toHaveBeenCalledWith('INT-1', expect.objectContaining({ decision: 'approve' }));
+  });
+
+  it('does not file when there are no recommendedActions', async () => {
+    const fileFollowups = vi.fn(async () => 0);
+    await runReviewCommand(
+      { fileIssue: 'INT-1' },
+      {
+        getChangedFiles: async () => ['x.ts'],
+        review: async () => ({ decision: 'approve', feedback: 'ok' }) as ReviewResult,
+        fileFollowups,
+        log: () => {},
+      },
+    );
+    expect(fileFollowups).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/reviewCommand.ts
+++ b/src/cli/reviewCommand.ts
@@ -1,0 +1,109 @@
+// ============================================
+// OpenSwarm - `openswarm review` (INT-1955)
+// ============================================
+//
+// Run the reviewer over the working-tree changes from the CLI, print the
+// verdict, and (optionally) file its recommendedActions as Linear sub-issues
+// under a parent issue — reusing fileReviewerFollowups (INT-1704/INT-1954).
+// The formatter and synthetic-WorkerResult builder are pure (unit-tested); the
+// command shell wires git + reviewer + Linear.
+
+import type { ReviewResult, WorkerResult } from '../agents/agentPair.js';
+
+/** Synthesize a WorkerResult describing the working-tree changes for the reviewer. */
+export function buildReviewWorkerResult(changedFiles: string[], summary?: string): WorkerResult {
+  return {
+    success: true,
+    summary: summary ?? `Working-tree review of ${changedFiles.length} changed file(s)`,
+    filesChanged: changedFiles,
+    commands: [],
+    output: '',
+  };
+}
+
+/** Render a review verdict for the terminal. */
+export function formatReviewOutput(review: ReviewResult): string {
+  const lines: string[] = [];
+  const mark = review.decision === 'approve' ? '✓' : review.decision === 'reject' ? '✗' : '✎';
+  lines.push(`${mark} Decision: ${review.decision.toUpperCase()}`);
+  if (review.feedback) lines.push(`  ${review.feedback}`);
+  if (review.issues?.length) {
+    lines.push('  Issues:');
+    review.issues.forEach((i) => lines.push(`    - ${i}`));
+  }
+  if (review.suggestions?.length) {
+    lines.push('  Suggestions:');
+    review.suggestions.forEach((s) => lines.push(`    - ${s}`));
+  }
+  if (review.recommendedActions?.length) {
+    lines.push('  Recommended follow-ups:');
+    review.recommendedActions.forEach((a) =>
+      lines.push(`    - [${a.type}] ${a.title}${a.location ? ` (${a.location})` : ''}`),
+    );
+  }
+  return lines.join('\n');
+}
+
+export interface ReviewCommandOptions {
+  /** Project path (default cwd). */
+  path?: string;
+  /** Parent Linear issue id — file recommendedActions as sub-issues under it. */
+  fileIssue?: string;
+  /** Adapter override. */
+  adapter?: string;
+  /** Verbose logging. */
+  debug?: boolean;
+}
+
+/**
+ * Run the review flow. Injectable deps keep it testable without git/network.
+ */
+export async function runReviewCommand(
+  opts: ReviewCommandOptions = {},
+  deps: {
+    getChangedFiles?: (cwd: string) => Promise<string[]>;
+    review?: (wr: WorkerResult, cwd: string) => Promise<ReviewResult>;
+    fileFollowups?: (parentIssueId: string, review: ReviewResult) => Promise<number>;
+    log?: (line: string) => void;
+  } = {},
+): Promise<ReviewResult | null> {
+  const cwd = opts.path ?? process.cwd();
+  const log = deps.log ?? ((l: string) => console.log(l));
+
+  const getChangedFiles = deps.getChangedFiles ?? (async (c) => (await import('../support/gitTracker.js')).getChangedFiles(c));
+  const changed = await getChangedFiles(cwd);
+  if (!changed.length) {
+    log('No working-tree changes to review.');
+    return null;
+  }
+  if (opts.debug) log(`Reviewing ${changed.length} changed file(s): ${changed.join(', ')}`);
+
+  const review =
+    deps.review ??
+    (async (wr: WorkerResult, c: string) => {
+      const { runReviewer } = await import('../agents/reviewer.js');
+      return runReviewer({
+        taskTitle: 'CLI working-tree review',
+        taskDescription: 'Review the current working-tree changes for correctness, bugs, and follow-ups.',
+        workerResult: wr,
+        projectPath: c,
+        adapterName: opts.adapter as never,
+      });
+    });
+
+  const result = await review(buildReviewWorkerResult(changed), cwd);
+  log(formatReviewOutput(result));
+
+  if (opts.fileIssue && result.recommendedActions?.length) {
+    const fileFollowups =
+      deps.fileFollowups ??
+      (async (parent: string, r: ReviewResult) => {
+        const { fileReviewerFollowups, getTaskSource } = await import('../automation/runnerExecution.js');
+        return fileReviewerFollowups(getTaskSource(), parent, r, { autoFile: true });
+      });
+    const filed = await fileFollowups(opts.fileIssue, result);
+    log(`Filed ${filed} follow-up sub-issue(s) under ${opts.fileIssue}.`);
+  }
+
+  return result;
+}


### PR DESCRIPTION
## 목표 (부모 INT-1946, code-review 갈래)
CLI에서 워킹트리 변경을 리뷰하고 recommendedActions를 Linear 서브이슈로 파일링.

## 변경
- `cli/reviewCommand.ts`: buildReviewWorkerResult(git 변경→합성 WorkerResult), formatReviewOutput(순수), runReviewCommand(getChangedFiles→runReviewer→포맷→옵션 fileReviewerFollowups). deps 주입으로 테스트 가능.
- `cli.ts`: `openswarm review --path --file <issue> --debug --adapter`, reject 시 exit 1.

## 사용
`openswarm review --file INT-123` → 리뷰 + 후속 작업을 INT-123 하위 서브이슈로.

## 검증
6건(합성·렌더·no-change·실행·--file 파일링·미추천 미파일링). tsc/build clean, 전체 **1097 green**.