### PR TITLE
feat(cli): design-pipeline — CI 워크플로 생성 (INT-1956)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,6 +171,26 @@ program
     }
   });
 
+// openswarm design-pipeline
+
+program
+  .command('design-pipeline')
+  .description('Analyze the project and generate a CI workflow (.github/workflows/ci.yml)')
+  .option('--path <path>', 'Project path (default: cwd)')
+  .option('--dry-run', 'Print the generated workflow without writing')
+  .option('--force', 'Overwrite an existing ci.yml')
+  .action(async (opts: { path?: string; dryRun?: boolean; force?: boolean }) => {
+    const { runDesignPipeline } = await import('./cli/designPipeline.js');
+    try {
+      const r = runDesignPipeline({ path: opts.path, dryRun: opts.dryRun, force: opts.force });
+      if (r.wrote) console.log(`Wrote ${r.path}`);
+      else console.log(r.yaml);
+    } catch (e) {
+      console.error(e instanceof Error ? e.message : String(e));
+      process.exitCode = 1;
+    }
+  });
+
 // openswarm review
 
 program

--- a/src/cli/designPipeline.test.ts
+++ b/src/cli/designPipeline.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { analyzePackageJson, detectStack, generateWorkflow, runDesignPipeline } from './designPipeline.js';
+
+describe('analyzePackageJson (INT-1956)', () => {
+  it('picks existing lint/build/test scripts and the package manager', () => {
+    const s = analyzePackageJson({ scripts: { test: 'vitest', build: 'tsc', start: 'node x' } }, ['pnpm-lock.yaml']);
+    expect(s).toEqual({ ecosystem: 'node', packageManager: 'pnpm', steps: ['build', 'test'] });
+  });
+  it('defaults to npm when no known lockfile', () => {
+    expect(analyzePackageJson({ scripts: { test: 'x' } }).packageManager).toBe('npm');
+  });
+});
+
+describe('detectStack (INT-1956)', () => {
+  it('detects node, python, rust, go, generic', () => {
+    expect(detectStack(['package.json'], () => ({ scripts: { test: 't' } })).ecosystem).toBe('node');
+    expect(detectStack(['pyproject.toml']).ecosystem).toBe('python');
+    expect(detectStack(['Cargo.toml']).ecosystem).toBe('rust');
+    expect(detectStack(['go.mod']).ecosystem).toBe('go');
+    expect(detectStack(['README.md']).ecosystem).toBe('generic');
+  });
+});
+
+describe('generateWorkflow (INT-1956)', () => {
+  it('emits node steps with the right package manager and scripts', () => {
+    const y = generateWorkflow({ ecosystem: 'node', packageManager: 'pnpm', steps: ['lint', 'test'] });
+    expect(y).toContain('actions/setup-node@v4');
+    expect(y).toContain('pnpm install --frozen-lockfile');
+    expect(y).toContain('pnpm lint');
+    expect(y).toContain('pnpm test');
+  });
+  it('emits python / rust / go templates', () => {
+    expect(generateWorkflow({ ecosystem: 'python', steps: ['test'] })).toContain('pytest');
+    expect(generateWorkflow({ ecosystem: 'rust', steps: [] })).toContain('cargo test');
+    expect(generateWorkflow({ ecosystem: 'go', steps: [] })).toContain('go test ./...');
+  });
+});
+
+describe('runDesignPipeline (INT-1956)', () => {
+  it('dry-run returns yaml without writing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dp-'));
+    try {
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ scripts: { test: 'vitest' } }));
+      const r = runDesignPipeline({ path: dir, dryRun: true });
+      expect(r.wrote).toBe(false);
+      expect(r.yaml).toContain('npm run test');
+      expect(existsSync(join(dir, '.github', 'workflows', 'ci.yml'))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes ci.yml and refuses to overwrite without --force', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dp-'));
+    try {
+      writeFileSync(join(dir, 'go.mod'), 'module x\n');
+      const r = runDesignPipeline({ path: dir });
+      expect(r.wrote).toBe(true);
+      expect(readFileSync(r.path, 'utf8')).toContain('go test ./...');
+      expect(() => runDesignPipeline({ path: dir })).toThrow(/already exists/);
+      expect(runDesignPipeline({ path: dir, force: true }).wrote).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/designPipeline.ts
+++ b/src/cli/designPipeline.ts
@@ -1,0 +1,127 @@
+// ============================================
+// OpenSwarm - `openswarm design-pipeline` (INT-1956)
+// ============================================
+//
+// Analyze a project and generate a CI workflow (.github/workflows/ci.yml).
+// Detection + YAML generation are pure (unit-tested); runDesignPipeline is the
+// fs shell. Node is fully supported; Python/Rust/Go are recognized and emit a
+// sensible setup+test template.
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+export type Ecosystem = 'node' | 'python' | 'rust' | 'go' | 'generic';
+
+export interface ProjectStack {
+  ecosystem: Ecosystem;
+  /** npm | pnpm | yarn (node only) */
+  packageManager?: 'npm' | 'pnpm' | 'yarn';
+  /** package.json scripts that exist, in run order. */
+  steps: Array<'lint' | 'build' | 'test'>;
+}
+
+/** Pure: derive a Node stack from a parsed package.json. */
+export function analyzePackageJson(pkg: { scripts?: Record<string, string> }, lockfiles: string[] = []): ProjectStack {
+  const scripts = pkg.scripts ?? {};
+  const steps = (['lint', 'build', 'test'] as const).filter((s) => typeof scripts[s] === 'string' && scripts[s]);
+  const packageManager = lockfiles.includes('pnpm-lock.yaml')
+    ? 'pnpm'
+    : lockfiles.includes('yarn.lock')
+      ? 'yarn'
+      : 'npm';
+  return { ecosystem: 'node', packageManager, steps: [...steps] };
+}
+
+/** Pure: detect the stack from a directory listing + optional package.json reader. */
+export function detectStack(files: string[], readPkg?: () => { scripts?: Record<string, string> } | null): ProjectStack {
+  if (files.includes('package.json')) {
+    const pkg = readPkg?.() ?? null;
+    return analyzePackageJson(pkg ?? {}, files);
+  }
+  if (files.includes('pyproject.toml') || files.includes('setup.py') || files.includes('requirements.txt')) {
+    return { ecosystem: 'python', steps: ['test'] };
+  }
+  if (files.includes('Cargo.toml')) return { ecosystem: 'rust', steps: ['build', 'test'] };
+  if (files.includes('go.mod')) return { ecosystem: 'go', steps: ['build', 'test'] };
+  return { ecosystem: 'generic', steps: [] };
+}
+
+const NODE_INSTALL: Record<NonNullable<ProjectStack['packageManager']>, string> = {
+  npm: 'npm ci',
+  pnpm: 'pnpm install --frozen-lockfile',
+  yarn: 'yarn install --frozen-lockfile',
+};
+
+function nodeRun(pm: NonNullable<ProjectStack['packageManager']>, script: string): string {
+  return pm === 'npm' ? `npm run ${script}` : `${pm} ${script}`;
+}
+
+/** Pure: render a GitHub Actions workflow for the detected stack. */
+export function generateWorkflow(stack: ProjectStack): string {
+  const head = [
+    'name: CI',
+    '',
+    'on:',
+    '  push:',
+    '    branches: [main]',
+    '  pull_request:',
+    '',
+    'jobs:',
+    '  build:',
+    '    runs-on: ubuntu-latest',
+    '    steps:',
+    '      - uses: actions/checkout@v4',
+  ];
+
+  const steps: string[] = [];
+  if (stack.ecosystem === 'node') {
+    const pm = stack.packageManager ?? 'npm';
+    steps.push('      - uses: actions/setup-node@v4', '        with:', "          node-version: '22'");
+    steps.push(`      - run: ${NODE_INSTALL[pm]}`);
+    for (const s of stack.steps) steps.push(`      - run: ${nodeRun(pm, s)}`);
+    if (!stack.steps.length) steps.push('      # no lint/build/test scripts detected — add them to package.json');
+  } else if (stack.ecosystem === 'python') {
+    steps.push('      - uses: actions/setup-python@v5', '        with:', "          python-version: '3.12'");
+    steps.push('      - run: pip install -e . || pip install -r requirements.txt', '      - run: pytest');
+  } else if (stack.ecosystem === 'rust') {
+    steps.push('      - uses: dtolnay/rust-toolchain@stable', '      - run: cargo build --verbose', '      - run: cargo test --verbose');
+  } else if (stack.ecosystem === 'go') {
+    steps.push('      - uses: actions/setup-go@v5', '        with:', "          go-version: '1.22'");
+    steps.push('      - run: go build ./...', '      - run: go test ./...');
+  } else {
+    steps.push('      # generic project — add your build/test steps here');
+  }
+
+  return `${[...head, ...steps].join('\n')}\n`;
+}
+
+export interface DesignPipelineOptions {
+  path?: string;
+  dryRun?: boolean;
+  force?: boolean;
+}
+
+/** fs shell: detect → generate → write .github/workflows/ci.yml (or print on --dry-run). */
+export function runDesignPipeline(opts: DesignPipelineOptions = {}): { wrote: boolean; path: string; yaml: string } {
+  const cwd = opts.path ?? process.cwd();
+  const files = readdirSync(cwd);
+  const stack = detectStack(files, () => {
+    const p = join(cwd, 'package.json');
+    if (!existsSync(p)) return null;
+    try {
+      return JSON.parse(readFileSync(p, 'utf8'));
+    } catch {
+      return null;
+    }
+  });
+  const yaml = generateWorkflow(stack);
+  const outPath = join(cwd, '.github', 'workflows', 'ci.yml');
+
+  if (opts.dryRun) return { wrote: false, path: outPath, yaml };
+  if (existsSync(outPath) && !opts.force) {
+    throw new Error(`${outPath} already exists — pass --force to overwrite`);
+  }
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, yaml);
+  return { wrote: true, path: outPath, yaml };
+}


### PR DESCRIPTION
## 목표 (부모 INT-1946, CI/CD 갈래)
`openswarm design-pipeline`이 프로젝트 스택을 감지해 `.github/workflows/ci.yml` 생성.

## 변경
- `cli/designPipeline.ts`: analyzePackageJson/detectStack(node/python/rust/go/generic) + generateWorkflow(스택별 GitHub Actions YAML) — 순수. runDesignPipeline은 fs 셸(--dry-run/--force).
- `cli.ts`: `openswarm design-pipeline --path --dry-run --force`.

node는 lockfile로 pm 감지 + 존재하는 lint/build/test만 단계화. py/rust/go 표준 템플릿.

## 검증
7건(analyze·detect 5스택·generate 4스택·dry-run·write/force). tsc/build clean, 전체 **1104 green**.