### PR TITLE
feat(cli): openswarm schedule add|list|remove|pause (INT-1957)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,6 +171,24 @@ program
     }
   });
 
+// openswarm schedule add|list|remove|pause
+
+program
+  .command('schedule')
+  .description('Schedule agent tasks on a cron/interval (run by the daemon)')
+  .argument('<action>', 'add | list | remove | pause')
+  .argument('[args...]', 'add: <name> <cron|interval> <task...>; remove/pause: <name>')
+  .option('--path <path>', 'Project path for the task (default: cwd)')
+  .action(async (action: string, args: string[], opts: { path?: string }) => {
+    const { runScheduleCommand } = await import('./cli/scheduleCommand.js');
+    try {
+      console.log(await runScheduleCommand(action, args ?? [], { path: opts.path }));
+    } catch (e) {
+      console.error(e instanceof Error ? e.message : String(e));
+      process.exitCode = 1;
+    }
+  });
+
 // openswarm design-pipeline
 
 program

--- a/src/cli/scheduleCommand.test.ts
+++ b/src/cli/scheduleCommand.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { formatScheduleList, runScheduleCommand, type ScheduleDeps } from './scheduleCommand.js';
+import type { ScheduledJob } from '../automation/scheduler.js';
+
+const job = (over: Partial<ScheduledJob> = {}): ScheduledJob => ({
+  id: 'job-1',
+  name: 'nightly',
+  projectPath: '/p',
+  prompt: 'run audit',
+  schedule: '0 3 * * *',
+  enabled: true,
+  createdAt: 0,
+  ...over,
+});
+
+const mkDeps = (over: Partial<ScheduleDeps> = {}): ScheduleDeps => ({
+  add: vi.fn(async (name, projectPath, prompt, schedule) => job({ name, projectPath, prompt, schedule })),
+  list: vi.fn(async () => [job()]),
+  remove: vi.fn(async () => true),
+  toggle: vi.fn(async () => job({ enabled: false })),
+  ...over,
+});
+
+describe('formatScheduleList (INT-1957)', () => {
+  it('renders state, schedule, prompt', () => {
+    const out = formatScheduleList([job(), job({ name: 'paused', enabled: false })]);
+    expect(out).toContain('▶ nightly — 0 3 * * * — run audit');
+    expect(out).toContain('⏸ paused');
+  });
+  it('helps when empty', () => {
+    expect(formatScheduleList([])).toMatch(/No schedules/);
+  });
+});
+
+describe('runScheduleCommand (INT-1957)', () => {
+  it('add requires name + schedule + task', async () => {
+    await expect(runScheduleCommand('add', ['only-name'], {}, mkDeps())).rejects.toThrow(/usage/);
+  });
+
+  it('add registers via the scheduler', async () => {
+    const deps = mkDeps();
+    const msg = await runScheduleCommand('add', ['nightly', '0 3 * * *', 'run', 'audit'], { path: '/proj' }, deps);
+    expect(deps.add).toHaveBeenCalledWith('nightly', '/proj', 'run audit', '0 3 * * *');
+    expect(msg).toMatch(/Added schedule "nightly"/);
+  });
+
+  it('list formats the scheduler output', async () => {
+    expect(await runScheduleCommand('list', [], {}, mkDeps())).toContain('nightly');
+  });
+
+  it('remove reports found / not-found', async () => {
+    expect(await runScheduleCommand('remove', ['nightly'], {}, mkDeps())).toMatch(/Removed/);
+    expect(await runScheduleCommand('remove', ['ghost'], {}, mkDeps({ remove: async () => false }))).toMatch(/No schedule/);
+  });
+
+  it('pause toggles and reports the new state', async () => {
+    expect(await runScheduleCommand('pause', ['nightly'], {}, mkDeps())).toMatch(/Paused/);
+    expect(
+      await runScheduleCommand('pause', ['nightly'], {}, mkDeps({ toggle: async () => job({ enabled: true }) })),
+    ).toMatch(/Resumed/);
+  });
+
+  it('rejects unknown actions', async () => {
+    await expect(runScheduleCommand('frob', [], {}, mkDeps())).rejects.toThrow(/Unknown schedule action/);
+  });
+});

--- a/src/cli/scheduleCommand.ts
+++ b/src/cli/scheduleCommand.ts
@@ -1,0 +1,87 @@
+// ============================================
+// OpenSwarm - `openswarm schedule add|list|remove|pause` (INT-1957)
+// ============================================
+//
+// CLI surface over the existing scheduler (src/automation/scheduler.ts): register
+// agent tasks on a cron/interval, persisted to ~/.openswarm/schedules.json and
+// run by the daemon (startAllSchedules). The formatter is pure; routing delegates
+// to the scheduler via injectable deps (testable without fs/cron).
+
+import type { ScheduledJob } from '../automation/scheduler.js';
+
+/** Render the schedule list for the terminal. */
+export function formatScheduleList(jobs: ScheduledJob[]): string {
+  if (!jobs.length) {
+    return 'No schedules. Add one: openswarm schedule add <name> <cron|interval> <task>';
+  }
+  return jobs
+    .map((j) => {
+      const state = j.enabled ? '▶' : '⏸';
+      const last = j.lastRun ? ` (last: ${new Date(j.lastRun).toISOString()})` : '';
+      return `  ${state} ${j.name} — ${j.schedule} — ${j.prompt}${last}`;
+    })
+    .join('\n');
+}
+
+export interface ScheduleDeps {
+  add: (name: string, projectPath: string, prompt: string, schedule: string) => Promise<ScheduledJob>;
+  list: () => Promise<ScheduledJob[]>;
+  remove: (nameOrId: string) => Promise<boolean>;
+  toggle: (nameOrId: string) => Promise<ScheduledJob | null>;
+}
+
+async function defaultDeps(): Promise<ScheduleDeps> {
+  const s = await import('../automation/scheduler.js');
+  return {
+    add: (name, projectPath, prompt, schedule) => s.addSchedule(name, projectPath, prompt, schedule),
+    list: () => s.listSchedules(),
+    remove: (nameOrId) => s.removeSchedule(nameOrId),
+    toggle: (nameOrId) => s.toggleSchedule(nameOrId),
+  };
+}
+
+export interface ScheduleCommandOptions {
+  path?: string;
+}
+
+/** Route a `schedule` subcommand. Returns the message to print. */
+export async function runScheduleCommand(
+  action: string,
+  args: string[],
+  opts: ScheduleCommandOptions = {},
+  deps?: ScheduleDeps,
+): Promise<string> {
+  const d = deps ?? (await defaultDeps());
+
+  switch (action) {
+    case 'add': {
+      const [name, schedule, ...rest] = args;
+      if (!name || !schedule || !rest.length) {
+        throw new Error('usage: openswarm schedule add <name> <cron|interval> <task...>');
+      }
+      const job = await d.add(name, opts.path ?? process.cwd(), rest.join(' '), schedule);
+      return `Added schedule "${job.name}" (${job.schedule}). The daemon runs it on schedule.`;
+    }
+
+    case 'list':
+      return formatScheduleList(await d.list());
+
+    case 'remove': {
+      const name = args[0];
+      if (!name) throw new Error('usage: openswarm schedule remove <name>');
+      return (await d.remove(name)) ? `Removed schedule "${name}".` : `No schedule named "${name}".`;
+    }
+
+    case 'pause':
+    case 'toggle': {
+      const name = args[0];
+      if (!name) throw new Error('usage: openswarm schedule pause <name>');
+      const job = await d.toggle(name);
+      if (!job) return `No schedule named "${name}".`;
+      return `${job.enabled ? 'Resumed' : 'Paused'} schedule "${name}".`;
+    }
+
+    default:
+      throw new Error(`Unknown schedule action "${action}" (use add|list|remove|pause)`);
+  }
+}


### PR DESCRIPTION
## 목표 (부모 INT-1946, cron 갈래)
임의 에이전트 작업을 cron/interval로 등록하는 CLI. 백엔드 스케쥴러(`src/automation/scheduler.ts`)는 이미 완비 — CLI 노출.

## 변경
- `cli/scheduleCommand.ts`: formatScheduleList(순수) + runScheduleCommand(add/list/remove/pause, scheduler deps 주입).
- `cli.ts`: `openswarm schedule <action> [args...] --path`.

## 사용
`openswarm schedule add nightly '0 3 * * *' run audit` · `list` · `remove <name>` · `pause <name>`

## 검증
8건(포맷 + 라우팅 5분기 + usage/unknown). tsc/build clean, 전체 **1112 green**.