### PR TITLE
feat(scheduler): 스케줄 실패 추적·자동 일시정지 (INT-1958)

### DIFF
--- a/src/automation/scheduler.test.ts
+++ b/src/automation/scheduler.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { nextFailureState, MAX_CONSECUTIVE_FAILURES } from './scheduler.js';
+
+describe('nextFailureState (INT-1958)', () => {
+  it('resets the counter on success', () => {
+    expect(nextFailureState(2, true)).toEqual({ consecutiveFailures: 0, autoPause: false });
+  });
+
+  it('increments on failure without pausing below the threshold', () => {
+    expect(nextFailureState(0, false)).toEqual({ consecutiveFailures: 1, autoPause: false });
+    expect(nextFailureState(1, false)).toEqual({ consecutiveFailures: 2, autoPause: false });
+  });
+
+  it('auto-pauses once the threshold is reached', () => {
+    expect(nextFailureState(MAX_CONSECUTIVE_FAILURES - 1, false)).toEqual({
+      consecutiveFailures: MAX_CONSECUTIVE_FAILURES,
+      autoPause: true,
+    });
+  });
+
+  it('honors a custom threshold', () => {
+    expect(nextFailureState(0, false, 1)).toEqual({ consecutiveFailures: 1, autoPause: true });
+  });
+});

--- a/src/automation/scheduler.ts
+++ b/src/automation/scheduler.ts
@@ -27,6 +27,25 @@ export interface ScheduledJob {
   createdAt: number;
   lastRun?: number;
   createdBy?: string; // Discord user
+  /** Consecutive failed runs; reset on success. Auto-paused at the threshold. (INT-1958) */
+  consecutiveFailures?: number;
+}
+
+/** Consecutive failures before a schedule auto-pauses itself. (INT-1958) */
+export const MAX_CONSECUTIVE_FAILURES = 3;
+
+/**
+ * Pure: next failure state for a run. Success resets the counter; failures
+ * increment and trigger auto-pause once the threshold is reached. (INT-1958)
+ */
+export function nextFailureState(
+  current: number,
+  success: boolean,
+  threshold = MAX_CONSECUTIVE_FAILURES,
+): { consecutiveFailures: number; autoPause: boolean } {
+  if (success) return { consecutiveFailures: 0, autoPause: false };
+  const consecutiveFailures = current + 1;
+  return { consecutiveFailures, autoPause: consecutiveFailures >= threshold };
 }
 
 // Job result interface
@@ -244,12 +263,28 @@ async function runScheduledJob(job: ScheduledJob): Promise<void> {
       resultListener(result);
     }
 
-    // Update last run time
+    // Update last run + consecutive-failure tracking; auto-pause on repeated failure.
+    const fs = nextFailureState(job.consecutiveFailures ?? 0, success);
     const schedules = await loadSchedules();
     const updated = schedules.map((s) =>
-      s.id === job.id ? { ...s, lastRun: Date.now() } : s
+      s.id === job.id
+        ? {
+            ...s,
+            lastRun: Date.now(),
+            consecutiveFailures: fs.consecutiveFailures,
+            enabled: fs.autoPause ? false : s.enabled,
+          }
+        : s
     );
     await saveSchedules(updated);
+
+    if (fs.autoPause) {
+      activeJobs.get(job.id)?.stop();
+      activeJobs.delete(job.id);
+      const msg = `[Scheduler] Job "${job.name}" auto-paused after ${fs.consecutiveFailures} consecutive failures — fix it and re-enable with \`openswarm schedule pause ${job.name}\``;
+      console.warn(msg);
+      resultListener?.({ ...result, output: `${result.output}\n${msg}`.trim() });
+    }
 
     console.log(
       `[Scheduler] Job ${job.name} ${success ? 'completed' : 'failed'} (${Math.round((result.finishedAt - startedAt) / 1000)}s)`

--- a/src/cli/scheduleCommand.test.ts
+++ b/src/cli/scheduleCommand.test.ts
@@ -30,6 +30,11 @@ describe('formatScheduleList (INT-1957)', () => {
   it('helps when empty', () => {
     expect(formatScheduleList([])).toMatch(/No schedules/);
   });
+
+  it('flags consecutive failures and auto-pause (INT-1958)', () => {
+    expect(formatScheduleList([job({ consecutiveFailures: 2 })])).toContain('⚠ 2 consecutive failure(s)');
+    expect(formatScheduleList([job({ enabled: false, consecutiveFailures: 3 })])).toContain('auto-paused');
+  });
 });
 
 describe('runScheduleCommand (INT-1957)', () => {

--- a/src/cli/scheduleCommand.ts
+++ b/src/cli/scheduleCommand.ts
@@ -18,7 +18,10 @@ export function formatScheduleList(jobs: ScheduledJob[]): string {
     .map((j) => {
       const state = j.enabled ? '▶' : '⏸';
       const last = j.lastRun ? ` (last: ${new Date(j.lastRun).toISOString()})` : '';
-      return `  ${state} ${j.name} — ${j.schedule} — ${j.prompt}${last}`;
+      const fails = j.consecutiveFailures
+        ? ` ⚠ ${j.consecutiveFailures} consecutive failure(s)${j.enabled ? '' : ' — auto-paused'}`
+        : '';
+      return `  ${state} ${j.name} — ${j.schedule} — ${j.prompt}${last}${fails}`;
     })
     .join('\n');
 }


### PR DESCRIPTION
## 목표 (부모 INT-1946, cron 갈래, 마지막 서브이슈)
스케줄 작업이 연속 실패하면 자동으로 멈추고 알린다.

## 변경
- `automation/scheduler.ts`: `ScheduledJob.consecutiveFailures` + `nextFailureState`(순수: 성공→0, 실패→+1, 임계 도달→autoPause), MAX_CONSECUTIVE_FAILURES=3. runScheduledJob이 카운트 갱신·영속화, 임계 시 cron stop + enabled=false + resultListener 알림.
- `cli/scheduleCommand.ts`: list에 ⚠ 실패 횟수/auto-paused 표시.

## 검증
nextFailureState 4분기 + list 실패 표시. tsc/build clean, 전체 **1117 green**.