### PR TITLE
feat(tui): CommandPalette 인터랙티브 선택 (INT-1959)

### DIFF
--- a/src/tui/chat.test.tsx
+++ b/src/tui/chat.test.tsx
@@ -41,6 +41,11 @@ describe('CommandPalette', () => {
     expect(render(<CommandPalette matches={matchSlash('/m')} />).lastFrame()).toContain('/model');
     expect(render(<CommandPalette matches={[]} />).lastFrame()).toBe('');
   });
+
+  it('marks the selected row with a pointer (INT-1959)', () => {
+    const f = render(<CommandPalette matches={matchSlash('/')} selectedIndex={1} />).lastFrame()!;
+    expect(f).toContain('❯');
+  });
 });
 
 describe('ChatInput', () => {
@@ -58,5 +63,30 @@ describe('ChatInput', () => {
     stdin.write('\r'); // Enter
     await tick();
     expect(onSubmit).toHaveBeenCalledWith('hi');
+  });
+
+  it('routes nav/select keys to the palette when open, not submit (INT-1959)', async () => {
+    const onSubmit = vi.fn();
+    const onPaletteMove = vi.fn();
+    const onPaletteSelect = vi.fn();
+    const { stdin } = render(
+      <ChatInput
+        value="/m"
+        active
+        busy={false}
+        onChange={() => {}}
+        onSubmit={onSubmit}
+        paletteOpen
+        onPaletteMove={onPaletteMove}
+        onPaletteSelect={onPaletteSelect}
+      />,
+    );
+    stdin.write('[B'); // down arrow
+    await tick();
+    expect(onPaletteMove).toHaveBeenCalledWith(1);
+    stdin.write('\r'); // Enter selects, does not submit
+    await tick();
+    expect(onPaletteSelect).toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/src/tui/chatModel.test.ts
+++ b/src/tui/chatModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { chatReducer, initialChatState, parseInput, matchSlash, normalizeConfirm, isActivityNoise } from './chatModel.js';
+import { chatReducer, initialChatState, parseInput, matchSlash, movePaletteSelection, normalizeConfirm, isActivityNoise } from './chatModel.js';
 
 describe('chatReducer (EPIC INT-1813 S4)', () => {
   it('appends user and system lines', () => {
@@ -78,5 +78,16 @@ describe('matchSlash', () => {
   it('does not match plain chat or once an argument is being typed', () => {
     expect(matchSlash('hello')).toEqual([]);
     expect(matchSlash('/model gpt')).toEqual([]);
+  });
+});
+
+describe('movePaletteSelection (INT-1959)', () => {
+  it('wraps around both ends', () => {
+    expect(movePaletteSelection(0, 1, 3)).toBe(1);
+    expect(movePaletteSelection(2, 1, 3)).toBe(0); // wrap forward
+    expect(movePaletteSelection(0, -1, 3)).toBe(2); // wrap backward
+  });
+  it('returns 0 for an empty list', () => {
+    expect(movePaletteSelection(0, 1, 0)).toBe(0);
   });
 });

--- a/src/tui/chatModel.ts
+++ b/src/tui/chatModel.ts
@@ -95,6 +95,12 @@ export function normalizeConfirm(input: string): 'yes' | 'no' | 'edit' {
   return 'no';
 }
 
+/** Wrap-around move of the palette selection index. Returns 0 for an empty list. (INT-1959) */
+export function movePaletteSelection(current: number, delta: number, count: number): number {
+  if (count <= 0) return 0;
+  return ((current + delta) % count + count) % count;
+}
+
 /** Slash commands whose name prefix-matches the current input (palette). */
 export function matchSlash(input: string): SlashCommand[] {
   if (!input.startsWith('/') || input.includes(' ')) return [];

--- a/src/tui/components/ChatInput.tsx
+++ b/src/tui/components/ChatInput.tsx
@@ -13,11 +13,33 @@ export interface ChatInputProps {
   busy?: boolean;
   onChange: (value: string) => void;
   onSubmit: (value: string) => void;
+  /** Command palette is open — ↑/↓ navigate, Enter/Tab select instead of submit. (INT-1959) */
+  paletteOpen?: boolean;
+  onPaletteMove?: (delta: number) => void;
+  onPaletteSelect?: () => void;
+  onPaletteClose?: () => void;
 }
 
-export function ChatInput({ value, active, busy, onChange, onSubmit }: ChatInputProps) {
+export function ChatInput({
+  value,
+  active,
+  busy,
+  onChange,
+  onSubmit,
+  paletteOpen,
+  onPaletteMove,
+  onPaletteSelect,
+  onPaletteClose,
+}: ChatInputProps) {
   useInput(
     (input, key) => {
+      // When the palette is open it claims navigation + selection keys (INT-1959).
+      if (paletteOpen) {
+        if (key.upArrow) return onPaletteMove?.(-1);
+        if (key.downArrow) return onPaletteMove?.(1);
+        if (key.tab || key.return) return onPaletteSelect?.();
+        if (key.escape) return onPaletteClose?.();
+      }
       if (key.return) {
         onSubmit(value);
         return;

--- a/src/tui/components/CommandPalette.tsx
+++ b/src/tui/components/CommandPalette.tsx
@@ -1,18 +1,22 @@
 // CommandPalette — slash-command suggestions for the current input (S4).
+// Interactive: the selected row (↑/↓) is highlighted; Enter/Tab completes it. (INT-1959)
 import { Box, Text } from 'ink';
 import type { SlashCommand } from '../chatModel.js';
 
-export function CommandPalette({ matches }: { matches: SlashCommand[] }) {
+export function CommandPalette({ matches, selectedIndex = 0 }: { matches: SlashCommand[]; selectedIndex?: number }) {
   if (matches.length === 0) return null;
   return (
     <Box flexDirection="column" marginTop={1}>
-      {matches.map((c) => (
-        <Text key={c.name}>
-          <Text color="cyan">{c.name}</Text>
-          {c.args ? <Text dimColor>{` ${c.args}`}</Text> : null}
-          <Text dimColor>{`  ${c.desc}`}</Text>
-        </Text>
-      ))}
+      {matches.map((c, i) => {
+        const selected = i === selectedIndex;
+        return (
+          <Text key={c.name} inverse={selected}>
+            <Text color="cyan">{`${selected ? '❯ ' : '  '}${c.name}`}</Text>
+            {c.args ? <Text dimColor>{` ${c.args}`}</Text> : null}
+            <Text dimColor>{`  ${c.desc}`}</Text>
+          </Text>
+        );
+      })}
     </Box>
   );
 }

--- a/src/tui/panels/ChatPanel.tsx
+++ b/src/tui/panels/ChatPanel.tsx
@@ -13,6 +13,7 @@ import {
   initialChatState,
   parseInput,
   matchSlash,
+  movePaletteSelection,
   normalizeConfirm,
   isActivityNoise,
   SLASH_COMMANDS,
@@ -37,6 +38,7 @@ export interface ChatPanelProps {
 export function ChatPanel({ active, provider: providerProp, model: modelProp, projectPath }: ChatPanelProps) {
   const [state, dispatch] = useReducer(chatReducer, initialChatState);
   const [input, setInput] = useState('');
+  const [paletteIndex, setPaletteIndex] = useState(0);
   const [busy, setBusy] = useState(false);
   const [activity, setActivity] = useState<string[]>([]);
   // When set, the next submitted line is routed here (a /plan confirm or edit)
@@ -181,11 +183,41 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
   // While a /plan confirm is pending, keep the field active even though busy.
   const inputActive = active && (!busy || pending !== null);
 
+  // Interactive command palette (INT-1959): ↑/↓ select, Enter/Tab complete.
+  const matches = matchSlash(input);
+  const paletteOpen = inputActive && pending === null && matches.length > 0;
+  const handleChange = useCallback((v: string) => {
+    setInput(v);
+    setPaletteIndex(0);
+  }, []);
+  const onPaletteSelect = useCallback(() => {
+    const cmd = matches[paletteIndex];
+    if (!cmd) return;
+    if (cmd.args) {
+      // command takes args → complete to "name " so the user can type them
+      setInput(`${cmd.name} `);
+      setPaletteIndex(0);
+    } else {
+      setInput('');
+      runCommand(cmd.name, '');
+    }
+  }, [matches, paletteIndex, runCommand]);
+
   return (
     <Box flexDirection="column">
       <ChatLog history={state.history} streaming={state.streaming} activity={activity} busy={busy && pending === null} />
-      <ChatInput value={input} active={inputActive} busy={busy && pending === null} onChange={setInput} onSubmit={submit} />
-      <CommandPalette matches={matchSlash(input)} />
+      <ChatInput
+        value={input}
+        active={inputActive}
+        busy={busy && pending === null}
+        onChange={handleChange}
+        onSubmit={submit}
+        paletteOpen={paletteOpen}
+        onPaletteMove={(delta) => setPaletteIndex((i) => movePaletteSelection(i, delta, matches.length))}
+        onPaletteSelect={onPaletteSelect}
+        onPaletteClose={() => setInput('')}
+      />
+      <CommandPalette matches={matches} selectedIndex={paletteIndex} />
     </Box>
   );
 }


### PR DESCRIPTION
## 목표 (부모 INT-1948, /provider·/model의 기반)
슬래시 팔레트를 화살표/Enter/Tab 선택 가능하게.

## 변경
- `chatModel.ts`: `movePaletteSelection`(wrap-around) 순수 헬퍼.
- `CommandPalette.tsx`: `selectedIndex` → ❯ + inverse 하이라이트.
- `ChatInput.tsx`: paletteOpen 시 ↑/↓→move, Enter/Tab→select, Esc→close (단일 useInput).
- `ChatPanel.tsx`: paletteIndex 상태 + 핸들러. args 명령은 'name '로 완성, arg-less는 즉시 실행.

## 검증
movePaletteSelection wrap + 하이라이트 렌더 + ChatInput nav/select 라우팅(Enter는 submit 아님). tsc/build clean, 전체 **1121 green**.