### PR TITLE
feat(tui): /provider 인터랙티브 switcher (INT-1960)

### DIFF
--- a/src/tui/chatModel.ts
+++ b/src/tui/chatModel.ts
@@ -53,8 +53,8 @@ export interface SlashCommand {
 export const SLASH_COMMANDS: readonly SlashCommand[] = [
   { name: '/goal', args: '<goal>', desc: 'Set a goal & pursue it autonomously' },
   { name: '/plan', args: '<goal>', desc: 'Decompose a goal & dispatch to the loop' },
-  { name: '/model', args: '[name]', desc: 'Switch model' },
-  { name: '/provider', args: '[name]', desc: 'Switch provider' },
+  { name: '/model', args: '', desc: 'Switch model (interactive)' },
+  { name: '/provider', args: '', desc: 'Switch provider (interactive)' },
   { name: '/clear', args: '', desc: 'Clear the conversation' },
   { name: '/help', args: '', desc: 'Show all commands' },
 ];

--- a/src/tui/components/SelectList.tsx
+++ b/src/tui/components/SelectList.tsx
@@ -1,0 +1,30 @@
+// SelectList — a titled, single-select list with a highlighted row. Used by the
+// /provider and /model switchers (INT-1960/INT-1961). Key handling lives in the
+// caller (ChatInput's palette routing); this is pure presentation.
+import { Box, Text } from 'ink';
+
+export function SelectList({
+  title,
+  items,
+  selectedIndex = 0,
+}: {
+  title: string;
+  items: string[];
+  selectedIndex?: number;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text color="yellow">{title}</Text>
+      {items.map((item, i) => {
+        const selected = i === selectedIndex;
+        return (
+          <Text key={item} inverse={selected}>
+            {`${selected ? '❯ ' : '  '}${item}`}
+          </Text>
+        );
+      })}
+      <Text dimColor>{'  ↑/↓ select · Enter confirm · Esc cancel'}</Text>
+    </Box>
+  );
+}

--- a/src/tui/panels/ChatPanel.provider.test.tsx
+++ b/src/tui/panels/ChatPanel.provider.test.tsx
@@ -1,0 +1,35 @@
+// Purpose: /provider interactive switcher + direct switch (INT-1960)
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import { ChatPanel } from './ChatPanel.js';
+
+const tick = () => new Promise((r) => setTimeout(r, 60));
+
+describe('ChatPanel /provider (INT-1960)', () => {
+  it('switches provider directly with /provider <name>', async () => {
+    const { stdin, lastFrame } = render(<ChatPanel active />);
+    stdin.write('/provider gpt');
+    await tick();
+    stdin.write('\r'); // no palette (has a space) → submit
+    await tick();
+    expect(lastFrame()).toContain('Provider → gpt');
+  });
+
+  it('opens an interactive selector on bare /provider', async () => {
+    const { stdin, lastFrame } = render(<ChatPanel active />);
+    stdin.write('/provider');
+    await tick();
+    stdin.write('\r'); // palette select runs /provider → selector opens
+    await tick();
+    expect(lastFrame()).toContain('Switch provider:');
+  });
+
+  it('rejects an unknown provider', async () => {
+    const { stdin, lastFrame } = render(<ChatPanel active />);
+    stdin.write('/provider nope-xyz');
+    await tick();
+    stdin.write('\r');
+    await tick();
+    expect(lastFrame()).toContain('Unknown provider');
+  });
+});

--- a/src/tui/panels/ChatPanel.tsx
+++ b/src/tui/panels/ChatPanel.tsx
@@ -21,6 +21,8 @@ import {
 import { ChatLog } from '../components/ChatLog.js';
 import { ChatInput } from '../components/ChatInput.js';
 import { CommandPalette } from '../components/CommandPalette.js';
+import { SelectList } from '../components/SelectList.js';
+import { listAdapterNames } from '../../adapters/index.js';
 import { callChatModel, loadDefaultProvider } from '../../support/chatSession.js';
 import { getDefaultChatModel } from '../../support/chatBackend.js';
 import { runPlanCommand, type PlanIO } from '../../support/planCommand.js';
@@ -45,8 +47,12 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
   // instead of being treated as chat — the Ink analogue of blessed pendingInput.
   const [pending, setPending] = useState<{ resolve: (value: string) => void } | null>(null);
 
-  const provider = (providerProp as AdapterName | undefined) ?? loadDefaultProvider();
-  const model = modelProp ?? getDefaultChatModel(provider);
+  // provider/model are runtime-switchable via /provider and /model (INT-1960/1961).
+  const [provider, setProvider] = useState<AdapterName>((providerProp as AdapterName | undefined) ?? loadDefaultProvider());
+  const [model, setModel] = useState<string>(modelProp ?? getDefaultChatModel((providerProp as AdapterName | undefined) ?? loadDefaultProvider()));
+  // Active /provider | /model selector overlay (null = none). (INT-1960/1961)
+  const [selector, setSelector] = useState<{ kind: 'provider' | 'model'; title: string; items: string[] } | null>(null);
+  const [selectorIndex, setSelectorIndex] = useState(0);
   const cwd = projectPath ?? process.cwd();
 
   const ask = useCallback(
@@ -147,16 +153,51 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
           // complex → decompose & dispatch. Shared, UI-agnostic goalCommand.
           void runGoal(args);
           break;
+        case '/provider': {
+          // `/provider <name>` switches directly; bare `/provider` opens a selector. (INT-1960)
+          const items = listAdapterNames();
+          const target = args.trim();
+          if (target) {
+            if (!items.includes(target as AdapterName)) {
+              dispatch({ type: 'system', content: `Unknown provider "${target}". Options: ${items.join(', ')}` });
+            } else {
+              setProvider(target as AdapterName);
+              setModel(getDefaultChatModel(target as AdapterName));
+              dispatch({ type: 'system', content: `Provider → ${target} (model: ${getDefaultChatModel(target as AdapterName)})` });
+            }
+            break;
+          }
+          setSelectorIndex(Math.max(0, items.indexOf(provider)));
+          setSelector({ kind: 'provider', title: 'Switch provider:', items });
+          break;
+        }
         case '/model':
-        case '/provider':
-          dispatch({ type: 'system', content: `${name} switching from the Ink TUI is not wired yet — set it via config/flags.` });
+          dispatch({ type: 'system', content: `${name} switching is not wired yet — set it via config/flags.` });
           break;
         default:
           dispatch({ type: 'system', content: `Unknown command: ${name}` });
       }
     },
-    [runPlan, runGoal],
+    [runPlan, runGoal, provider],
   );
+
+  // Apply the highlighted choice in the /provider | /model selector. (INT-1960/1961)
+  const applySelector = useCallback(() => {
+    if (!selector) return;
+    const choice = selector.items[selectorIndex];
+    if (choice) {
+      if (selector.kind === 'provider') {
+        setProvider(choice as AdapterName);
+        setModel(getDefaultChatModel(choice as AdapterName));
+        dispatch({ type: 'system', content: `Provider → ${choice} (model: ${getDefaultChatModel(choice as AdapterName)})` });
+      } else {
+        setModel(choice);
+        dispatch({ type: 'system', content: `Model → ${choice}` });
+      }
+    }
+    setSelector(null);
+    setSelectorIndex(0);
+  }, [selector, selectorIndex]);
 
   const submit = useCallback(
     async (raw: string) => {
@@ -184,13 +225,16 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
   const inputActive = active && (!busy || pending !== null);
 
   // Interactive command palette (INT-1959): ↑/↓ select, Enter/Tab complete.
+  // A /provider|/model selector (INT-1960/1961) takes precedence when open.
   const matches = matchSlash(input);
-  const paletteOpen = inputActive && pending === null && matches.length > 0;
+  const selectorOpen = inputActive && selector !== null;
+  const slashOpen = inputActive && pending === null && selector === null && matches.length > 0;
+  const menuOpen = selectorOpen || slashOpen;
   const handleChange = useCallback((v: string) => {
     setInput(v);
     setPaletteIndex(0);
   }, []);
-  const onPaletteSelect = useCallback(() => {
+  const onSlashSelect = useCallback(() => {
     const cmd = matches[paletteIndex];
     if (!cmd) return;
     if (cmd.args) {
@@ -212,12 +256,27 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
         busy={busy && pending === null}
         onChange={handleChange}
         onSubmit={submit}
-        paletteOpen={paletteOpen}
-        onPaletteMove={(delta) => setPaletteIndex((i) => movePaletteSelection(i, delta, matches.length))}
-        onPaletteSelect={onPaletteSelect}
-        onPaletteClose={() => setInput('')}
+        paletteOpen={menuOpen}
+        onPaletteMove={(delta) =>
+          selectorOpen
+            ? setSelectorIndex((i) => movePaletteSelection(i, delta, selector!.items.length))
+            : setPaletteIndex((i) => movePaletteSelection(i, delta, matches.length))
+        }
+        onPaletteSelect={() => (selectorOpen ? applySelector() : onSlashSelect())}
+        onPaletteClose={() => {
+          if (selectorOpen) {
+            setSelector(null);
+            setSelectorIndex(0);
+          } else {
+            setInput('');
+          }
+        }}
       />
-      <CommandPalette matches={matches} selectedIndex={paletteIndex} />
+      {selectorOpen ? (
+        <SelectList title={selector!.title} items={selector!.items} selectedIndex={selectorIndex} />
+      ) : (
+        <CommandPalette matches={matches} selectedIndex={paletteIndex} />
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
## 목표 (부모 INT-1948)
ChatPanel에서 provider를 런타임 전환.

## 변경
- `SelectList.tsx`: 타이틀+하이라이트 단일선택 리스트(재사용 — /model도 사용 예정).
- `ChatPanel.tsx`: provider/model 상태 승격 + selector 오버레이. `/provider`(bare)→selector(listAdapterNames), `/provider <name>`→직접 전환(+검증). selector가 슬래시 팔레트보다 우선(↑↓/Enter/Esc). 전환 시 모델을 provider 기본값으로.
- `chatModel.ts`: /provider·/model arg-less화(팔레트 선택 즉시 실행).

## 검증
3건(직접 전환·bare selector·미지 거부) + 기존 팔레트 테스트. tsc/build clean, 전체 **1124 green**.