### PR TITLE
feat(tui): /model 인터랙티브 switcher (INT-1961)

### DIFF
--- a/src/support/chatBackend.test.ts
+++ b/src/support/chatBackend.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { curatedModels, getDefaultChatModel } from './chatBackend.js';
+
+describe('curatedModels (INT-1961)', () => {
+  it('includes the provider default first and dedupes', () => {
+    const m = curatedModels('openrouter');
+    expect(m[0]).toBe(getDefaultChatModel('openrouter'));
+    expect(new Set(m).size).toBe(m.length); // no dupes
+    expect(m.length).toBeGreaterThan(1); // alias-derived options present
+  });
+
+  it('always yields at least the default for every provider', () => {
+    for (const p of ['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter'] as const) {
+      const m = curatedModels(p);
+      expect(m).toContain(getDefaultChatModel(p));
+    }
+  });
+});

--- a/src/support/chatBackend.ts
+++ b/src/support/chatBackend.ts
@@ -111,6 +111,31 @@ export function resolveChatModel(input: string | undefined, provider: AdapterNam
   return alias || input;
 }
 
+/** Curated model ids for a provider, derived from CHAT_MODEL_ALIASES. Pure. (INT-1961) */
+export function curatedModels(provider: AdapterName): string[] {
+  const fromAliases = Array.from(new Set(Object.values(CHAT_MODEL_ALIASES[provider] ?? {})));
+  const def = getDefaultChatModel(provider);
+  return Array.from(new Set([def, ...fromAliases]));
+}
+
+/**
+ * Models offered by the /model switcher: the adapter's live catalog when it
+ * exposes listModels(), else the curated list. Network failures fall back to
+ * curated. (INT-1961)
+ */
+export async function listChatModels(provider: AdapterName): Promise<string[]> {
+  try {
+    const adapter = getAdapter(provider) as { listModels?: () => Promise<string[]> };
+    if (typeof adapter.listModels === 'function') {
+      const live = await adapter.listModels();
+      if (live?.length) return Array.from(new Set(live));
+    }
+  } catch {
+    // fall through to curated
+  }
+  return curatedModels(provider);
+}
+
 export function shortenChatModel(model: string): string {
   // OpenRouter: "anthropic/claude-sonnet-4" → "claude-sonnet-4"
   if (model.includes('/')) return model.split('/').pop() ?? model;

--- a/src/tui/panels/ChatPanel.model.test.tsx
+++ b/src/tui/panels/ChatPanel.model.test.tsx
@@ -1,0 +1,18 @@
+// Purpose: /model direct switch (INT-1961). The bare-/model async selector reuses
+// the selector path covered by ChatPanel.provider.test.tsx.
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import { ChatPanel } from './ChatPanel.js';
+
+const tick = () => new Promise((r) => setTimeout(r, 60));
+
+describe('ChatPanel /model (INT-1961)', () => {
+  it('switches model directly with /model <name>', async () => {
+    const { stdin, lastFrame } = render(<ChatPanel active />);
+    stdin.write('/model my-cool-model');
+    await tick();
+    stdin.write('\r'); // has a space → submit (no palette)
+    await tick();
+    expect(lastFrame()).toContain('Model → my-cool-model');
+  });
+});

--- a/src/tui/panels/ChatPanel.tsx
+++ b/src/tui/panels/ChatPanel.tsx
@@ -24,7 +24,7 @@ import { CommandPalette } from '../components/CommandPalette.js';
 import { SelectList } from '../components/SelectList.js';
 import { listAdapterNames } from '../../adapters/index.js';
 import { callChatModel, loadDefaultProvider } from '../../support/chatSession.js';
-import { getDefaultChatModel } from '../../support/chatBackend.js';
+import { getDefaultChatModel, listChatModels } from '../../support/chatBackend.js';
 import { runPlanCommand, type PlanIO } from '../../support/planCommand.js';
 import { runGoalCommand, buildGoalPursuitPrompt, GOAL_PURSUIT_MAX_TURNS } from '../../support/goalCommand.js';
 import type { AdapterName } from '../../adapters/types.js';
@@ -136,6 +136,22 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
     [cwd, model, provider, streamChat], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
+  // Open the /model selector for the current provider (async catalog). (INT-1961)
+  const openModelSelector = useCallback(async () => {
+    dispatch({ type: 'system', content: `Fetching models for ${provider}…` });
+    try {
+      const models = await listChatModels(provider);
+      if (!models.length) {
+        dispatch({ type: 'system', content: `No models listed for ${provider}. Use /model <name>.` });
+        return;
+      }
+      setSelectorIndex(Math.max(0, models.indexOf(model)));
+      setSelector({ kind: 'model', title: `Switch model (${provider}):`, items: models });
+    } catch (e) {
+      dispatch({ type: 'system', content: `✖ failed to list models: ${e instanceof Error ? e.message : String(e)}` });
+    }
+  }, [provider, model]);
+
   const runCommand = useCallback(
     (name: string, args: string) => {
       switch (name) {
@@ -171,14 +187,22 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
           setSelector({ kind: 'provider', title: 'Switch provider:', items });
           break;
         }
-        case '/model':
-          dispatch({ type: 'system', content: `${name} switching is not wired yet — set it via config/flags.` });
+        case '/model': {
+          // `/model <name>` switches directly; bare `/model` opens an async selector. (INT-1961)
+          const target = args.trim();
+          if (target) {
+            setModel(target);
+            dispatch({ type: 'system', content: `Model → ${target}` });
+            break;
+          }
+          void openModelSelector();
           break;
+        }
         default:
           dispatch({ type: 'system', content: `Unknown command: ${name}` });
       }
     },
-    [runPlan, runGoal, provider],
+    [runPlan, runGoal, provider, openModelSelector],
   );
 
   // Apply the highlighted choice in the /provider | /model selector. (INT-1960/1961)


### PR DESCRIPTION
## 목표 (부모 INT-1948)
ChatPanel에서 model 런타임 전환. INT-1960 selector 메커니즘 재사용.

## 변경
- `chatBackend.ts`: `curatedModels`(순수, 기본+별칭 model id dedupe) + `listChatModels`(async: 어댑터 listModels 있으면 live, 실패/부재 시 curated).
- `ChatPanel.tsx`: `openModelSelector`(async) → selector{kind:model}. `/model`(bare)→selector, `/model <name>`→직접 전환.

## 검증
curatedModels 2건(default-first/dedupe·전 provider) + /model 직접 전환. tsc/build clean, 전체 **1127 green**.