### PR TITLE
feat(tui): Logs 탭 라이브 로그 (INT-1962)

### DIFF
--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -21,7 +21,7 @@ describe('Ink shell (EPIC INT-1813 S3/S4/S5)', () => {
     const { lastFrame, stdin } = render(<App version="1.0.0" initialTab={1} />); // start on Pipeline
     stdin.write('7'); // 7 → Logs (distinct placeholder text)
     await tick();
-    expect(lastFrame()).toContain('live log lands');
+    expect(lastFrame()).toContain('stream logs');
   });
 
   it('renders the Pipeline panel (idle, no port) at initialTab 1', () => {
@@ -37,7 +37,7 @@ describe('Ink shell (EPIC INT-1813 S3/S4/S5)', () => {
 
   it('cycles forward with Tab, wrapping from the last tab back to Chat', async () => {
     const { lastFrame, stdin } = render(<App initialTab={6} />); // start at Logs
-    expect(lastFrame()).toContain('live log lands');
+    expect(lastFrame()).toContain('stream logs');
     stdin.write('\t'); // Tab → wrap forward to Chat
     await tick();
     expect(lastFrame()).toContain('type a message'); // chat input back
@@ -45,6 +45,6 @@ describe('Ink shell (EPIC INT-1813 S3/S4/S5)', () => {
 
   it('honors an initialTab', () => {
     const { lastFrame } = render(<App initialTab={6} />); // Logs
-    expect(lastFrame()).toContain('live log lands');
+    expect(lastFrame()).toContain('stream logs');
   });
 });

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -15,6 +15,7 @@ import { HelpBar } from './components/HelpBar.js';
 import { PipelinePanel } from './panels/PipelinePanel.js';
 import { ChatPanel } from './panels/ChatPanel.js';
 import { MonitorPanel } from './panels/MonitorPanel.js';
+import { LogsPanel } from './panels/LogsPanel.js';
 import { fetchProjects, fetchTasks, fetchStuck, fetchIssues } from './monitorApi.js';
 import { useTerminalSize } from './hooks/useTerminalSize.js';
 
@@ -68,10 +69,12 @@ export function App({ version, provider, model, port, cwd, branch, initialTab = 
           <ChatPanel active={chatActive} provider={provider} model={model} />
         ) : activeTab.id === 'pipeline' ? (
           <PipelinePanel port={port} />
+        ) : activeTab.id === 'logs' ? (
+          <LogsPanel port={port} />
         ) : activeTab.id in MONITOR_FETCHERS ? (
           <MonitorPanel port={port} fetcher={MONITOR_FETCHERS[activeTab.id as keyof typeof MONITOR_FETCHERS]} />
         ) : (
-          <Text>{`${activeTab.label} — live log lands with the bin cutover (S9).`}</Text>
+          <Text>{`${activeTab.label} — not yet implemented.`}</Text>
         )}
       </Box>
       <HelpBar />

--- a/src/tui/panels/LogsPanel.test.tsx
+++ b/src/tui/panels/LogsPanel.test.tsx
@@ -1,0 +1,17 @@
+// Purpose: Logs tab renders the live-log view with connection status (INT-1962).
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import { LogsPanel } from './LogsPanel.js';
+
+describe('LogsPanel (INT-1962)', () => {
+  it('shows an idle status and the live-log frame when no daemon port', () => {
+    const f = render(<LogsPanel />).lastFrame()!;
+    expect(f).toContain('daemon port unknown');
+    expect(f).toContain('Live log');
+  });
+
+  it('shows a connecting status when a port is set', () => {
+    const f = render(<LogsPanel port={3847} />).lastFrame()!;
+    expect(f).toMatch(/:3847/);
+  });
+});

--- a/src/tui/panels/LogsPanel.tsx
+++ b/src/tui/panels/LogsPanel.tsx
@@ -1,0 +1,30 @@
+// LogsPanel — the Logs tab: live daemon log stream (INT-1962). Reuses the SSE
+// subscription (usePipelineEvents) and the LiveLog presenter; a fuller, timeline-
+// free view of the same log lines the Pipeline tab shows.
+import { Box, Text } from 'ink';
+import { LiveLog } from '../components/LiveLog.js';
+import { usePipelineEvents } from '../hooks/usePipelineEvents.js';
+
+export interface LogsPanelProps {
+  /** Daemon HTTP port; when unset the panel renders idle (no connection). */
+  port?: number;
+  /** Max log lines to show (default 30). */
+  max?: number;
+}
+
+export function LogsPanel({ port, max = 30 }: LogsPanelProps) {
+  const { logs, connected } = usePipelineEvents(port);
+  const status = !port
+    ? '○ daemon port unknown — start the daemon to stream logs'
+    : connected
+      ? `● live (:${port})`
+      : `○ connecting :${port}…`;
+  return (
+    <Box flexDirection="column">
+      <Text dimColor>{status}</Text>
+      <Box marginTop={1}>
+        <LiveLog logs={logs} max={max} />
+      </Box>
+    </Box>
+  );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -93,6 +93,7 @@ const integrationBoundaryCoverageExcludes = [
   'src/tui/monitorApi.ts',
   'src/tui/hooks/useMonitor.ts',
   'src/tui/panels/MonitorPanel.tsx',
+  'src/tui/panels/LogsPanel.tsx',
 ];
 
 export default defineConfig({


### PR DESCRIPTION
## 목표 (부모 INT-1948, 독립)
탭 7(Logs)의 placeholder('live log lands with the bin cutover (S9)')를 실제 라이브 로그 뷰로 교체.

## 변경
- `panels/LogsPanel.tsx`: usePipelineEvents(SSE) 구독 → LiveLog로 daemon `/api/events` 로그 스트림(연결 상태, max 30). 타임라인 없는 풀 로그 뷰.
- `App.tsx`: logs 탭 분기, placeholder 제거(미구현 탭 없음).
- `vitest.config`: LogsPanel 경계 제외 추가.

## 검증
LogsPanel 렌더(idle/connecting) + App 탭 단언 갱신. tsc/build clean, 전체 **1129 green**.