### PR TITLE
feat(cli): openswarm review 진행 표시 (INT-1963)

### DIFF
--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -29,6 +29,10 @@ export interface ReviewerOptions {
   completionCriteria?: string[];
   /** MCP tools to expose (e.g. linear__*). When unset the adapter self-sources (INT-1951). (INT-1950) */
   mcpTools?: ToolDefinition[];
+  /** Tool-activity log lines (🔧 read_file …) for live progress display. (INT-1963) */
+  onLog?: (line: string) => void;
+  /** Streamed reasoning/text deltas for live progress display. (INT-1963) */
+  onToken?: (delta: string) => void;
   /** Abort the run + in-flight adapter call (pipeline cancel / project disable). */
   signal?: AbortSignal;
 }
@@ -133,6 +137,7 @@ export async function runPreCheck(options: ReviewerOptions): Promise<PreCheckRes
       model: options.model,
       maxTurns: options.maxTurns,
       processContext: options.processContext,
+      onLog: options.onLog,
       signal: options.signal,
     });
 
@@ -211,6 +216,8 @@ export async function runReviewer(options: ReviewerOptions): Promise<ReviewResul
       systemPrompt: getPrompts().systemPrompt,
       reasoningEffort: options.reasoningEffort,
       mcpTools: options.mcpTools,
+      onLog: options.onLog,
+      onToken: options.onToken,
       signal: options.signal,
     });
 

--- a/src/cli/reviewCommand.test.ts
+++ b/src/cli/reviewCommand.test.ts
@@ -63,6 +63,49 @@ describe('runReviewCommand (INT-1955)', () => {
     expect(fileFollowups).toHaveBeenCalledWith('INT-1', expect.objectContaining({ decision: 'approve' }));
   });
 
+  it('forwards an onLog progress callback to the reviewer (INT-1963)', async () => {
+    let received: ((line: string) => void) | undefined;
+    const logs: string[] = [];
+    await runReviewCommand(
+      {},
+      {
+        getChangedFiles: async () => ['x.ts'],
+        review: async (_wr, _cwd, onLog) => {
+          received = onLog;
+          onLog?.('🔧 read_file: x.ts');
+          return { decision: 'approve', feedback: 'ok' } as ReviewResult;
+        },
+        // no TTY spinner in this test → onLog falls back to log()
+        startProgress: () => null,
+        log: (l) => logs.push(l),
+      },
+    );
+    expect(typeof received).toBe('function');
+    expect(logs.join('\n')).toContain('🔧 read_file: x.ts');
+  });
+
+  it('routes onLog to the progress note when a spinner is active (INT-1963)', async () => {
+    const notes: string[] = [];
+    const stop = vi.fn();
+    const logs: string[] = [];
+    await runReviewCommand(
+      {},
+      {
+        getChangedFiles: async () => ['x.ts'],
+        review: async (_wr, _cwd, onLog) => {
+          onLog?.('🔧 edit_file: x.ts');
+          return { decision: 'approve', feedback: 'ok' } as ReviewResult;
+        },
+        startProgress: () => ({ note: (l) => notes.push(l), stop }),
+        log: (l) => logs.push(l),
+      },
+    );
+    expect(notes).toContain('🔧 edit_file: x.ts');
+    expect(stop).toHaveBeenCalled();
+    // activity went to the spinner, not the plain log
+    expect(logs.join('\n')).not.toContain('· 🔧 edit_file');
+  });
+
   it('does not file when there are no recommendedActions', async () => {
     const fileFollowups = vi.fn(async () => 0);
     await runReviewCommand(

--- a/src/cli/reviewCommand.ts
+++ b/src/cli/reviewCommand.ts
@@ -9,6 +9,7 @@
 // command shell wires git + reviewer + Linear.
 
 import type { ReviewResult, WorkerResult } from '../agents/agentPair.js';
+import { startReviewProgress } from './reviewProgress.js';
 
 /** Synthesize a WorkerResult describing the working-tree changes for the reviewer. */
 export function buildReviewWorkerResult(changedFiles: string[], summary?: string): WorkerResult {
@@ -62,9 +63,11 @@ export async function runReviewCommand(
   opts: ReviewCommandOptions = {},
   deps: {
     getChangedFiles?: (cwd: string) => Promise<string[]>;
-    review?: (wr: WorkerResult, cwd: string) => Promise<ReviewResult>;
+    review?: (wr: WorkerResult, cwd: string, onLog?: (line: string) => void) => Promise<ReviewResult>;
     fileFollowups?: (parentIssueId: string, review: ReviewResult) => Promise<number>;
     log?: (line: string) => void;
+    /** Override the progress indicator (default: TTY-gated spinner). Tests pass a stub. */
+    startProgress?: () => { note: (line: string) => void; stop: () => void } | null;
   } = {},
 ): Promise<ReviewResult | null> {
   const cwd = opts.path ?? process.cwd();
@@ -80,7 +83,7 @@ export async function runReviewCommand(
 
   const review =
     deps.review ??
-    (async (wr: WorkerResult, c: string) => {
+    (async (wr: WorkerResult, c: string, onLog?: (line: string) => void) => {
       const { runReviewer } = await import('../agents/reviewer.js');
       return runReviewer({
         taskTitle: 'CLI working-tree review',
@@ -88,10 +91,25 @@ export async function runReviewCommand(
         workerResult: wr,
         projectPath: c,
         adapterName: opts.adapter as never,
+        onLog,
       });
     });
 
-  const result = await review(buildReviewWorkerResult(changed), cwd);
+  // Live "still working" feedback so a multi-second review doesn't look frozen.
+  // On a TTY, a spinner heartbeat; otherwise each tool line is printed. (INT-1963)
+  const startProgress = deps.startProgress ?? (() => (process.stderr.isTTY ? startReviewProgress() : null));
+  const progress = startProgress();
+  const onLog = (line: string) => {
+    if (progress) progress.note(line);
+    else log(`  · ${line}`);
+  };
+
+  let result: ReviewResult;
+  try {
+    result = await review(buildReviewWorkerResult(changed), cwd, onLog);
+  } finally {
+    progress?.stop();
+  }
   log(formatReviewOutput(result));
 
   if (opts.fileIssue && result.recommendedActions?.length) {

--- a/src/cli/reviewProgress.test.ts
+++ b/src/cli/reviewProgress.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { spinnerFrame, formatProgress, startReviewProgress } from './reviewProgress.js';
+
+describe('spinnerFrame / formatProgress (INT-1963)', () => {
+  it('cycles spinner frames and is safe for any tick', () => {
+    expect(spinnerFrame(0)).toBe('⠋');
+    expect(spinnerFrame(10)).toBe(spinnerFrame(0)); // wraps
+    expect(typeof spinnerFrame(-1)).toBe('string');
+  });
+
+  it('formats elapsed seconds and an optional activity note', () => {
+    expect(formatProgress(0, 3)).toBe('⠋ reviewing… 3s');
+    expect(formatProgress(0, 5, '🔧 read_file')).toBe('⠋ reviewing… 5s · 🔧 read_file');
+  });
+});
+
+describe('startReviewProgress (INT-1963)', () => {
+  it('renders an immediate frame, ticks on the interval, and clears on stop', () => {
+    const writes: string[] = [];
+    let t = 0;
+    let intervalFn: (() => void) | null = null;
+    const cleared = vi.fn();
+    const p = startReviewProgress({
+      write: (s) => writes.push(s),
+      now: () => t,
+      setIntervalFn: (fn) => {
+        intervalFn = fn as () => void;
+        return 1 as never;
+      },
+      clearIntervalFn: cleared,
+    });
+
+    expect(writes.length).toBe(1); // immediate first frame
+    expect(writes[0]).toContain('reviewing… 0s');
+
+    p.note('🔧 read_file: a.ts');
+    t = 4000;
+    intervalFn!(); // next tick
+    expect(writes.at(-1)).toContain('reviewing… 4s');
+    expect(writes.at(-1)).toContain('🔧 read_file: a.ts');
+
+    p.stop();
+    expect(cleared).toHaveBeenCalled();
+    expect(writes.at(-1)).toContain('\x1b[2K'); // clears the line
+  });
+});

--- a/src/cli/reviewProgress.ts
+++ b/src/cli/reviewProgress.ts
@@ -1,0 +1,72 @@
+// ============================================
+// OpenSwarm - review progress indicator (INT-1963)
+// ============================================
+//
+// A live "still working" heartbeat for `openswarm review`, so a multi-second
+// reviewer run doesn't look frozen. The formatter is pure (unit-tested); the
+// runtime owns a timer + stderr writes (injectable for tests).
+
+const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+/** Braille spinner frame for a tick. Pure. */
+export function spinnerFrame(tick: number): string {
+  return FRAMES[((tick % FRAMES.length) + FRAMES.length) % FRAMES.length];
+}
+
+/** One progress line: `⠙ reviewing… 3s · 🔧 read_file`. Pure. */
+export function formatProgress(tick: number, elapsedSec: number, last?: string): string {
+  const base = `${spinnerFrame(tick)} reviewing… ${elapsedSec}s`;
+  return last ? `${base} · ${last}` : base;
+}
+
+export interface ReviewProgressDeps {
+  write?: (s: string) => void;
+  now?: () => number;
+  setIntervalFn?: (fn: () => void, ms: number) => ReturnType<typeof setInterval>;
+  clearIntervalFn?: (h: ReturnType<typeof setInterval>) => void;
+  intervalMs?: number;
+}
+
+export interface ReviewProgress {
+  /** Update the trailing activity note (e.g. the latest tool line). */
+  note: (line: string) => void;
+  /** Stop the spinner and clear the line. */
+  stop: () => void;
+}
+
+const CLEAR_LINE = '\r\x1b[2K';
+
+/**
+ * Start a spinner heartbeat that re-renders every intervalMs until stop().
+ * Returns handles to update the activity note and to stop. (INT-1963)
+ */
+export function startReviewProgress(deps: ReviewProgressDeps = {}): ReviewProgress {
+  const write = deps.write ?? ((s: string) => process.stderr.write(s));
+  const now = deps.now ?? (() => Date.now());
+  const setIntervalFn = deps.setIntervalFn ?? setInterval;
+  const clearIntervalFn = deps.clearIntervalFn ?? clearInterval;
+  const intervalMs = deps.intervalMs ?? 200;
+
+  const start = now();
+  let tick = 0;
+  let last: string | undefined;
+
+  const render = () => {
+    const elapsedSec = Math.max(0, Math.floor((now() - start) / 1000));
+    write(`${CLEAR_LINE}${formatProgress(tick, elapsedSec, last)}`);
+    tick += 1;
+  };
+
+  render(); // immediate first frame
+  const handle = setIntervalFn(render, intervalMs);
+
+  return {
+    note: (line: string) => {
+      last = line.trim() || last;
+    },
+    stop: () => {
+      clearIntervalFn(handle);
+      write(CLEAR_LINE);
+    },
+  };
+}


### PR DESCRIPTION
## 문제
`openswarm review`(INT-1955)가 리뷰어 실행 ~수십 초 동안 출력이 없어 멈춘(렉) 것처럼 보임. `CliRunOptions`엔 onLog/onToken이 있으나 `ReviewerOptions`→spawnCli가 전달하지 않음.

## 변경
- `agents/reviewer.ts`: ReviewerOptions에 onLog/onToken + runReviewer·runPreCheck spawnCli 전달.
- `cli/reviewProgress.ts`: spinnerFrame/formatProgress(순수) + startReviewProgress(timer+stderr, deps 주입) — `⠙ reviewing… 3s · 🔧 read_file` 하트비트.
- `cli/reviewCommand.ts`: onLog 전달. TTY→스피너 하트비트(최신 도구 활동·경과시간), 비TTY→`· line` 출력.

## 검증
spinner/format 순수 + startReviewProgress(즉시프레임·tick·clear) + onLog 전달(스피너/비TTY). tsc/build clean, 전체 **1134 green**.