### PR TITLE
fix(tui): 모바일 SSH 한글 입력 doubling 진단·문서화 (INT-1964)

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,34 @@ src/
 
 ---
 
+## Troubleshooting
+
+### Korean / multibyte input doubles over mobile SSH (e.g. Termius)
+
+If the chat TUI shows each Hangul (or other multibyte) character twice —
+`이이렇렇게 쓰쓰이는것` — while ASCII characters look fine, the cause is almost
+always **client-side local / predictive echo** in the mobile SSH app drawing an
+extra copy of wide characters. The keystroke reaches OpenSwarm once; the terminal
+paints it twice.
+
+Fix it in the SSH client:
+
+- **Termius** → Host/Terminal settings → turn **Local Echo** (a.k.a. predictive
+  echo) **off**, and ensure the encoding is **UTF-8**.
+- Confirm the server side is fine by running with diagnostics:
+
+  ```bash
+  OPENSWARM_DEBUG_INPUT=1 openswarm chat
+  ```
+
+  Type a few Korean characters, then inspect `~/.openswarm/input-debug.log`. If a
+  single keypress logs **one** code point (`cp=[51060]`) but you saw two glyphs,
+  the doubling is terminal echo (client-side). If it logs the code point **twice**
+  in one event, it's an app-level issue — please attach the log to
+  [a bug report](https://github.com/unohee/OpenSwarm/issues/new?template=bug_report.md).
+
+---
+
 ## Contributing
 
 Contributions are welcome — OpenSwarm is MIT-licensed and accepts pull requests from anyone. See **[CONTRIBUTING.md](CONTRIBUTING.md)** for development setup, the local check gates, branch/commit conventions, and the PR process. By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/src/tui/components/ChatInput.tsx
+++ b/src/tui/components/ChatInput.tsx
@@ -6,6 +6,10 @@
 import { Box, Text, useInput } from 'ink';
 import Spinner from 'ink-spinner';
 import { theme, ICON } from '../theme.js';
+import { inputDebugEnabled, appendInputDebug } from '../inputDebug.js';
+
+// Read once at module load — toggling mid-session isn't a use case. (INT-1964)
+const INPUT_DEBUG = inputDebugEnabled();
 
 export interface ChatInputProps {
   value: string;
@@ -33,6 +37,8 @@ export function ChatInput({
 }: ChatInputProps) {
   useInput(
     (input, key) => {
+      // Diagnostics for mobile-SSH multibyte doubling (OPENSWARM_DEBUG_INPUT). (INT-1964)
+      if (INPUT_DEBUG) appendInputDebug(input, key);
       // When the palette is open it claims navigation + selection keys (INT-1959).
       if (paletteOpen) {
         if (key.upArrow) return onPaletteMove?.(-1);

--- a/src/tui/inputDebug.test.ts
+++ b/src/tui/inputDebug.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { formatInputDebug, inputDebugEnabled, appendInputDebug } from './inputDebug.js';
+
+describe('formatInputDebug (INT-1964)', () => {
+  it('shows code points so multibyte doubling is visible', () => {
+    expect(formatInputDebug('이')).toBe('input="이" len=1 cp=[51060]');
+    // ink-level doubling would surface as two code points in ONE event:
+    expect(formatInputDebug('이이')).toBe('input="이이" len=2 cp=[51060,51060]');
+  });
+
+  it('records active key flags', () => {
+    expect(formatInputDebug('', { return: true })).toContain('keys=return');
+    expect(formatInputDebug('a', { ctrl: true, meta: true })).toContain('keys=ctrl+meta');
+  });
+
+  it('ascii is single code point (the non-doubled case)', () => {
+    expect(formatInputDebug(' ')).toBe('input=" " len=1 cp=[32]');
+  });
+});
+
+describe('inputDebugEnabled (INT-1964)', () => {
+  it('honors OPENSWARM_DEBUG_INPUT truthy values', () => {
+    expect(inputDebugEnabled({ OPENSWARM_DEBUG_INPUT: '1' } as NodeJS.ProcessEnv)).toBe(true);
+    expect(inputDebugEnabled({ OPENSWARM_DEBUG_INPUT: 'true' } as NodeJS.ProcessEnv)).toBe(true);
+    expect(inputDebugEnabled({ OPENSWARM_DEBUG_INPUT: '0' } as NodeJS.ProcessEnv)).toBe(false);
+    expect(inputDebugEnabled({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+});
+
+describe('appendInputDebug (INT-1964)', () => {
+  it('appends diagnostic lines and never throws', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'indbg-'));
+    try {
+      const path = join(dir, 'nested', 'input-debug.log');
+      appendInputDebug('이', {}, path);
+      appendInputDebug('a', { return: true }, path);
+      const lines = readFileSync(path, 'utf8').trim().split('\n');
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toContain('cp=[51060]');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('swallows write errors (invalid path)', () => {
+    expect(() => appendInputDebug('x', {}, '/this/should/not/exist/\0/bad')).not.toThrow();
+  });
+});

--- a/src/tui/inputDebug.ts
+++ b/src/tui/inputDebug.ts
@@ -1,0 +1,57 @@
+// ============================================
+// OpenSwarm - TUI input diagnostics (INT-1964)
+// ============================================
+//
+// Mobile SSH clients (e.g. Termius) can show doubled multibyte input
+// ('이이렇렇게'). To tell apart an ink-level doubling (ink hands us the char
+// twice) from a terminal-side echo artifact (the value is correct, the terminal
+// draws an extra copy), set OPENSWARM_DEBUG_INPUT=1 and type: each key event is
+// logged with its code points to ~/.openswarm/input-debug.log. If a single
+// keypress logs one code point but the screen shows two glyphs, it's terminal
+// echo (fix in the client); if it logs the code point twice, it's ink-level.
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+
+export const INPUT_DEBUG_LOG = join(homedir(), '.openswarm', 'input-debug.log');
+
+/** Key flags we care about for diagnostics (subset of ink's Key). */
+export interface DebugKeyFlags {
+  return?: boolean;
+  backspace?: boolean;
+  delete?: boolean;
+  ctrl?: boolean;
+  meta?: boolean;
+  tab?: boolean;
+}
+
+/**
+ * One diagnostic line for an input event: the raw string, its Unicode code
+ * points (so doubling is visible), and any active key flags. Pure. (INT-1964)
+ */
+export function formatInputDebug(input: string, key: DebugKeyFlags = {}): string {
+  const codepoints = Array.from(input).map((ch) => (ch.codePointAt(0) ?? 0));
+  const flags = Object.entries(key)
+    .filter(([, v]) => v)
+    .map(([k]) => k);
+  return `input=${JSON.stringify(input)} len=${codepoints.length} cp=[${codepoints.join(',')}]${
+    flags.length ? ` keys=${flags.join('+')}` : ''
+  }`;
+}
+
+/** Whether input diagnostics are enabled (OPENSWARM_DEBUG_INPUT truthy). */
+export function inputDebugEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = env.OPENSWARM_DEBUG_INPUT;
+  return v === '1' || v === 'true';
+}
+
+/** Append a diagnostic line to the debug log (best-effort, never throws). (INT-1964) */
+export function appendInputDebug(input: string, key: DebugKeyFlags = {}, path = INPUT_DEBUG_LOG): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    appendFileSync(path, `${formatInputDebug(input, key)}\n`);
+  } catch {
+    // diagnostics must never break input handling
+  }
+}


### PR DESCRIPTION
## 증상
Termius 등 모바일 SSH에서 한글 입력이 `이이렇렇게 쓰쓰이는것`처럼 음절마다 중복(ASCII는 정상).

## 분석 (triage)
멀티바이트만 중복 + ASCII 정상 + 'flush 안 됨' 설명 → 서버 raw mode와 무관한 **클라이언트 측 local/predictive echo**가 와이드 문자를 한 번 더 그리는 것이 유력(키 입력 자체는 1회 도달). ink-레벨 doubling 가능성도 잔존.

## 변경 (추측 수정 대신 결정적 진단 + 문서)
- `tui/inputDebug.ts`: `formatInputDebug`(코드포인트 노출 — ink-레벨이면 한 이벤트에 cp 2개) · `inputDebugEnabled` · `appendInputDebug`(best-effort). ChatInput이 `OPENSWARM_DEBUG_INPUT=1`일 때 키 이벤트를 `~/.openswarm/input-debug.log`에 기록.
- `README`: 트러블슈팅 — Termius Local Echo 끄기 + 진단으로 echo vs ink-레벨 판별.

## 검증
formatInputDebug(단일/중복 cp·key flags·ascii) + inputDebugEnabled + appendInputDebug. tsc/build clean, 전체 **1140 green**.

판별 결과 ink-레벨이면 후속 수정 이슈로 진행.