### PR TITLE
fix(tui): 모바일 SSH 멀티바이트 입력 doubling 정규화 (INT-1964)

### DIFF
--- a/src/tui/chat.test.tsx
+++ b/src/tui/chat.test.tsx
@@ -65,6 +65,15 @@ describe('ChatInput', () => {
     expect(onSubmit).toHaveBeenCalledWith('hi');
   });
 
+  it('collapses a doubled multibyte keystroke event to one (INT-1964)', async () => {
+    const onSubmit = vi.fn();
+    const { lastFrame, stdin } = render(<Harness onSubmit={onSubmit} />);
+    stdin.write('이이'); // mobile-SSH delivers the doubled syllable as one event
+    await tick();
+    expect(lastFrame()).toContain('이');
+    expect(lastFrame()).not.toContain('이이');
+  });
+
   it('routes nav/select keys to the palette when open, not submit (INT-1959)', async () => {
     const onSubmit = vi.fn();
     const onPaletteMove = vi.fn();

--- a/src/tui/chatModel.test.ts
+++ b/src/tui/chatModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { chatReducer, initialChatState, parseInput, matchSlash, movePaletteSelection, normalizeConfirm, isActivityNoise } from './chatModel.js';
+import { chatReducer, initialChatState, parseInput, matchSlash, movePaletteSelection, dedupeDoubledGrapheme, normalizeConfirm, isActivityNoise } from './chatModel.js';
 
 describe('chatReducer (EPIC INT-1813 S4)', () => {
   it('appends user and system lines', () => {
@@ -78,6 +78,26 @@ describe('matchSlash', () => {
   it('does not match plain chat or once an argument is being typed', () => {
     expect(matchSlash('hello')).toEqual([]);
     expect(matchSlash('/model gpt')).toEqual([]);
+  });
+});
+
+describe('dedupeDoubledGrapheme (INT-1964)', () => {
+  it('collapses a doubled multibyte keystroke event', () => {
+    expect(dedupeDoubledGrapheme('이이')).toBe('이');
+    expect(dedupeDoubledGrapheme('렇렇')).toBe('렇');
+    expect(dedupeDoubledGrapheme('😀😀')).toBe('😀'); // astral grapheme, one code point each
+  });
+
+  it('leaves single graphemes, ASCII, and differing pairs untouched', () => {
+    expect(dedupeDoubledGrapheme('이')).toBe('이');
+    expect(dedupeDoubledGrapheme('aa')).toBe('aa'); // ASCII — not our bug
+    expect(dedupeDoubledGrapheme('이렇')).toBe('이렇'); // different graphemes
+    expect(dedupeDoubledGrapheme(' ')).toBe(' ');
+  });
+
+  it('leaves longer input (real pastes) untouched', () => {
+    expect(dedupeDoubledGrapheme('이이렇')).toBe('이이렇');
+    expect(dedupeDoubledGrapheme('가나다')).toBe('가나다');
   });
 });
 

--- a/src/tui/chatModel.ts
+++ b/src/tui/chatModel.ts
@@ -95,6 +95,24 @@ export function normalizeConfirm(input: string): 'yes' | 'no' | 'edit' {
   return 'no';
 }
 
+/**
+ * Mobile-SSH multibyte input mitigation (INT-1964). Some terminals deliver a
+ * single multibyte keystroke as the character doubled in one input event
+ * ('이' → '이이'), so each Hangul syllable appears twice while ASCII is fine.
+ * Collapse an input event that is exactly one NON-ASCII grapheme repeated twice
+ * back to a single grapheme. ASCII, single graphemes, differing graphemes, and
+ * longer inputs (real pastes) pass through untouched — so normal typing is
+ * unaffected. The only false positive is pasting exactly two identical multibyte
+ * characters, which is vanishingly rare.
+ */
+export function dedupeDoubledGrapheme(input: string): string {
+  const graphemes = Array.from(input);
+  if (graphemes.length === 2 && graphemes[0] === graphemes[1] && (graphemes[0].codePointAt(0) ?? 0) > 0x7f) {
+    return graphemes[0];
+  }
+  return input;
+}
+
 /** Wrap-around move of the palette selection index. Returns 0 for an empty list. (INT-1959) */
 export function movePaletteSelection(current: number, delta: number, count: number): number {
   if (count <= 0) return 0;

--- a/src/tui/components/ChatInput.tsx
+++ b/src/tui/components/ChatInput.tsx
@@ -7,6 +7,7 @@ import { Box, Text, useInput } from 'ink';
 import Spinner from 'ink-spinner';
 import { theme, ICON } from '../theme.js';
 import { inputDebugEnabled, appendInputDebug } from '../inputDebug.js';
+import { dedupeDoubledGrapheme } from '../chatModel.js';
 
 // Read once at module load — toggling mid-session isn't a use case. (INT-1964)
 const INPUT_DEBUG = inputDebugEnabled();
@@ -55,7 +56,8 @@ export function ChatInput({
         return;
       }
       if (key.tab || key.leftArrow || key.rightArrow || key.upArrow || key.downArrow || key.escape) return;
-      if (input && !key.ctrl && !key.meta) onChange(value + input);
+      // dedupeDoubledGrapheme: mobile-SSH multibyte doubling mitigation (INT-1964).
+      if (input && !key.ctrl && !key.meta) onChange(value + dedupeDoubledGrapheme(input));
     },
     { isActive: active && !busy },
   );


### PR DESCRIPTION
## 목표
ink-레벨 doubling 가정 선제 수정(사용자 지시). 증상 `이이렇렇게`(한글만 중복, ASCII 정상)는 한 키 입력이 한 이벤트에 `이이`로 doubling되는 형태와 일치.

## 변경
- `chatModel.ts`: `dedupeDoubledGrapheme` — 입력 이벤트가 **정확히 비-ASCII 그래핀 2회 반복**일 때만 1개로 접음. ASCII·단일·상이 그래핀·긴 입력(붙여넣기) 불변 → 일반 타이핑 무영향(유일 오탐: 동일 멀티바이트 2자 붙여넣기, 극히 드묾).
- `ChatInput.tsx`: 타이핑 append 경로에 적용. 진단 계측(PR #143) 유지.

## 검증
dedupeDoubledGrapheme(접힘/불변) + ChatInput `이이`→`이` 회귀. tsc/build clean, 전체 **1144 green**.

Termius Local Echo가 원인이면 README 문서로, ink-레벨이면 이 수정으로 해결(이중 대비).