### PR TITLE
fix(cli): review 진행표시 스팸 수정 + 결과 색상 + --file 힌트 (INT-1966)

### DIFF
--- a/src/cli/reviewCommand.test.ts
+++ b/src/cli/reviewCommand.test.ts
@@ -26,6 +26,14 @@ describe('formatReviewOutput (INT-1955)', () => {
     expect(out).toContain('- add a test');
     expect(out).toContain('[test] cover edge case (a.ts:3)');
   });
+
+  it('color mode wraps with ANSI but keeps plain substrings (INT-1966)', () => {
+    const review: ReviewResult = { decision: 'reject', feedback: 'nope' };
+    const colored = formatReviewOutput(review, true);
+    expect(colored).toContain('\x1b['); // has ANSI codes
+    expect(colored).toContain('Decision: REJECT'); // substring still intact
+    expect(formatReviewOutput(review, false)).not.toContain('\x1b['); // plain by default
+  });
 });
 
 describe('runReviewCommand (INT-1955)', () => {
@@ -104,6 +112,23 @@ describe('runReviewCommand (INT-1955)', () => {
     expect(stop).toHaveBeenCalled();
     // activity went to the spinner, not the plain log
     expect(logs.join('\n')).not.toContain('· 🔧 edit_file');
+  });
+
+  it('hints about --file when follow-ups exist but no parent issue is given (INT-1966)', async () => {
+    const logs: string[] = [];
+    await runReviewCommand(
+      {},
+      {
+        getChangedFiles: async () => ['x.ts'],
+        review: async () =>
+          ({ decision: 'approve', feedback: 'ok', recommendedActions: [{ type: 'test', title: 't' }] }) as ReviewResult,
+        startProgress: () => null,
+        log: (l) => logs.push(l),
+      },
+    );
+    const out = logs.join('\n');
+    expect(out).toMatch(/1 follow-up\(s\) suggested/);
+    expect(out).toContain('--file');
   });
 
   it('does not file when there are no recommendedActions', async () => {

--- a/src/cli/reviewCommand.ts
+++ b/src/cli/reviewCommand.ts
@@ -22,24 +22,46 @@ export function buildReviewWorkerResult(changedFiles: string[], summary?: string
   };
 }
 
-/** Render a review verdict for the terminal. */
-export function formatReviewOutput(review: ReviewResult): string {
+// Minimal ANSI helpers — no extra dep. Wrappers only, so plain substrings
+// (e.g. 'Decision: APPROVE') survive for tests/grep. (INT-1966)
+const ANSI = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+};
+
+/**
+ * Render a review verdict for the terminal. `color` adds ANSI styling (decision
+ * green/yellow/red, bold section headers, dim locations); off → plain text. (INT-1966)
+ */
+export function formatReviewOutput(review: ReviewResult, color = false): string {
+  const c = (code: string, s: string) => (color ? `${code}${s}${ANSI.reset}` : s);
+  const header = (s: string) => c(ANSI.bold, s);
+  const decisionColor =
+    review.decision === 'approve' ? ANSI.green : review.decision === 'reject' ? ANSI.red : ANSI.yellow;
+
   const lines: string[] = [];
   const mark = review.decision === 'approve' ? '✓' : review.decision === 'reject' ? '✗' : '✎';
-  lines.push(`${mark} Decision: ${review.decision.toUpperCase()}`);
+  lines.push(c(decisionColor, `${c(ANSI.bold, mark)} Decision: ${review.decision.toUpperCase()}`));
   if (review.feedback) lines.push(`  ${review.feedback}`);
   if (review.issues?.length) {
-    lines.push('  Issues:');
-    review.issues.forEach((i) => lines.push(`    - ${i}`));
+    lines.push(`  ${header('Issues:')}`);
+    review.issues.forEach((i) => lines.push(`    ${c(ANSI.red, '-')} ${i}`));
   }
   if (review.suggestions?.length) {
-    lines.push('  Suggestions:');
-    review.suggestions.forEach((s) => lines.push(`    - ${s}`));
+    lines.push(`  ${header('Suggestions:')}`);
+    review.suggestions.forEach((s) => lines.push(`    ${c(ANSI.cyan, '-')} ${s}`));
   }
   if (review.recommendedActions?.length) {
-    lines.push('  Recommended follow-ups:');
+    lines.push(`  ${header('Recommended follow-ups:')}`);
     review.recommendedActions.forEach((a) =>
-      lines.push(`    - [${a.type}] ${a.title}${a.location ? ` (${a.location})` : ''}`),
+      lines.push(
+        `    - ${c(ANSI.cyan, `[${a.type}]`)} ${a.title}${a.location ? ` ${c(ANSI.dim, `(${a.location})`)}` : ''}`,
+      ),
     );
   }
   return lines.join('\n');
@@ -110,9 +132,10 @@ export async function runReviewCommand(
   } finally {
     progress?.stop();
   }
-  log(formatReviewOutput(result));
+  log(formatReviewOutput(result, !!process.stdout.isTTY));
 
-  if (opts.fileIssue && result.recommendedActions?.length) {
+  const followups = result.recommendedActions?.length ?? 0;
+  if (opts.fileIssue && followups) {
     const fileFollowups =
       deps.fileFollowups ??
       (async (parent: string, r: ReviewResult) => {
@@ -121,6 +144,9 @@ export async function runReviewCommand(
       });
     const filed = await fileFollowups(opts.fileIssue, result);
     log(`Filed ${filed} follow-up sub-issue(s) under ${opts.fileIssue}.`);
+  } else if (followups) {
+    // Suggestions were made but nothing was filed — make the --file flag discoverable. (INT-1966)
+    log(`\n${followups} follow-up(s) suggested. Re-run with \`--file <issue-id>\` to create them as Linear sub-issues.`);
   }
 
   return result;

--- a/src/cli/reviewProgress.test.ts
+++ b/src/cli/reviewProgress.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { spinnerFrame, formatProgress, startReviewProgress } from './reviewProgress.js';
+import { spinnerFrame, formatProgress, startReviewProgress, oneLine, truncateLine } from './reviewProgress.js';
 
 describe('spinnerFrame / formatProgress (INT-1963)', () => {
   it('cycles spinner frames and is safe for any tick', () => {
@@ -11,6 +11,45 @@ describe('spinnerFrame / formatProgress (INT-1963)', () => {
   it('formats elapsed seconds and an optional activity note', () => {
     expect(formatProgress(0, 3)).toBe('⠋ reviewing… 3s');
     expect(formatProgress(0, 5, '🔧 read_file')).toBe('⠋ reviewing… 5s · 🔧 read_file');
+  });
+});
+
+describe('oneLine / truncateLine (INT-1966)', () => {
+  it('collapses newlines and whitespace runs to one line', () => {
+    expect(oneLine('first line\nsecond   line\t\nthird')).toBe('first line second line third');
+    expect(oneLine('  trim  ')).toBe('trim');
+  });
+  it('truncates with an ellipsis and is a no-op under width', () => {
+    expect(truncateLine('hello world', 8)).toBe('hello w…');
+    expect(truncateLine('short', 80)).toBe('short');
+  });
+  it('formatProgress truncates to width and never wraps', () => {
+    const out = formatProgress(0, 3, 'a'.repeat(100), 20);
+    expect(out.length).toBe(20);
+  });
+});
+
+describe('startReviewProgress multi-line note (INT-1966)', () => {
+  it('renders a multi-line note as a single truncated line (no stacking)', () => {
+    const writes: string[] = [];
+    let intervalFn: (() => void) | null = null;
+    const p = startReviewProgress({
+      write: (s) => writes.push(s),
+      now: () => 0,
+      setIntervalFn: (fn) => {
+        intervalFn = fn as () => void;
+        return 1 as never;
+      },
+      clearIntervalFn: () => {},
+      columns: 40,
+    });
+    p.note('line one\nline two\nline three with lots of detail here');
+    intervalFn!();
+    const frame = writes.at(-1)!;
+    // exactly one line of content after the clear sequence — no embedded newlines
+    expect(frame.replace('\r\x1b[2K', '')).not.toContain('\n');
+    expect(frame.replace('\r\x1b[2K', '').length).toBeLessThanOrEqual(40);
+    p.stop();
   });
 });
 

--- a/src/cli/reviewProgress.ts
+++ b/src/cli/reviewProgress.ts
@@ -13,10 +13,23 @@ export function spinnerFrame(tick: number): string {
   return FRAMES[((tick % FRAMES.length) + FRAMES.length) % FRAMES.length];
 }
 
+/** Collapse newlines/whitespace runs to single spaces so a note stays one line. Pure. */
+export function oneLine(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+/** Truncate to width (with an ellipsis) so the spinner never wraps. Pure. */
+export function truncateLine(s: string, width: number): string {
+  if (width <= 0 || s.length <= width) return s;
+  if (width <= 1) return s.slice(0, width);
+  return `${s.slice(0, width - 1)}…`;
+}
+
 /** One progress line: `⠙ reviewing… 3s · 🔧 read_file`. Pure. */
-export function formatProgress(tick: number, elapsedSec: number, last?: string): string {
+export function formatProgress(tick: number, elapsedSec: number, last?: string, width?: number): string {
   const base = `${spinnerFrame(tick)} reviewing… ${elapsedSec}s`;
-  return last ? `${base} · ${last}` : base;
+  const line = last ? `${base} · ${last}` : base;
+  return width ? truncateLine(line, width) : line;
 }
 
 export interface ReviewProgressDeps {
@@ -25,6 +38,8 @@ export interface ReviewProgressDeps {
   setIntervalFn?: (fn: () => void, ms: number) => ReturnType<typeof setInterval>;
   clearIntervalFn?: (h: ReturnType<typeof setInterval>) => void;
   intervalMs?: number;
+  /** Terminal width to truncate the line to (default stdout.columns ?? 80). */
+  columns?: number;
 }
 
 export interface ReviewProgress {
@@ -46,6 +61,7 @@ export function startReviewProgress(deps: ReviewProgressDeps = {}): ReviewProgre
   const setIntervalFn = deps.setIntervalFn ?? setInterval;
   const clearIntervalFn = deps.clearIntervalFn ?? clearInterval;
   const intervalMs = deps.intervalMs ?? 200;
+  const columns = deps.columns ?? process.stdout.columns ?? 80;
 
   const start = now();
   let tick = 0;
@@ -53,7 +69,8 @@ export function startReviewProgress(deps: ReviewProgressDeps = {}): ReviewProgre
 
   const render = () => {
     const elapsedSec = Math.max(0, Math.floor((now() - start) / 1000));
-    write(`${CLEAR_LINE}${formatProgress(tick, elapsedSec, last)}`);
+    // Single line, truncated to width — a multi-line note must never stack. (INT-1966)
+    write(`${CLEAR_LINE}${formatProgress(tick, elapsedSec, last, columns)}`);
     tick += 1;
   };
 
@@ -62,7 +79,7 @@ export function startReviewProgress(deps: ReviewProgressDeps = {}): ReviewProgre
 
   return {
     note: (line: string) => {
-      last = line.trim() || last;
+      last = oneLine(line) || last;
     },
     stop: () => {
       clearIntervalFn(handle);


### PR DESCRIPTION
## 문제 (INT-1963 후속, 사용자 피드백+스크린샷)
1. 진행표시 활동 노트에 리뷰어 추론 텍스트가 **개행 포함 여러 줄**로 들어와 `\r\x1b[2K`(한 줄 클리어)로 못 지워 화면 도배.
2. 최종 출력이 무채색 평문.
3. `--file` 없으면 제안만 하고 Linear 이슈 미생성(의도된 동작이나 혼동).

## 변경
1. `reviewProgress`: `oneLine`(개행/공백 정규화) + `truncateLine`(폭 절단) → 항상 한 줄 갱신. formatProgress(width)/startReviewProgress(columns).
2. `formatReviewOutput(review, color)`: TTY면 ANSI 색(approve=green/revise=yellow/reject=red, 헤더 bold, location dim). 색코드 감싸기만 → 평문 substring 유지.
3. recommendedActions 있는데 `--file` 미지정 시 'N follow-up(s) suggested — --file <issue>로 생성' 힌트.

## 검증
oneLine/truncate/formatProgress(width) + 멀티라인 노트→단일 라인 + 색 래핑 + --file 힌트. tsc/build clean, 전체 **1150 green**.