### PR TITLE
feat(cli): review 후속이슈 부모를 git 브랜치에서 자동 추론 (INT-1967)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -215,13 +215,14 @@ program
   .command('review')
   .description('Review the working-tree changes; optionally file follow-ups as Linear sub-issues')
   .option('--path <path>', 'Project path (default: cwd)')
-  .option('--file <issue>', 'Parent Linear issue id — file recommendedActions as sub-issues under it')
+  .option('--issues [parent]', 'File follow-ups as Linear sub-issues (parent inferred from the git branch, or pass an id)')
+  .option('--file [parent]', 'Alias for --issues (back-compat)')
   .option('--adapter <name>', 'Adapter override for the reviewer')
   .option('--debug', 'Verbose logging')
-  .action(async (opts: { path?: string; file?: string; adapter?: string; debug?: boolean }) => {
+  .action(async (opts: { path?: string; issues?: string | boolean; file?: string | boolean; adapter?: string; debug?: boolean }) => {
     const { runReviewCommand } = await import('./cli/reviewCommand.js');
     try {
-      const result = await runReviewCommand({ path: opts.path, fileIssue: opts.file, adapter: opts.adapter, debug: opts.debug });
+      const result = await runReviewCommand({ path: opts.path, fileIssue: opts.issues ?? opts.file, adapter: opts.adapter, debug: opts.debug });
       if (result && result.decision === 'reject') process.exitCode = 1;
     } catch (e) {
       console.error(e instanceof Error ? e.message : String(e));

--- a/src/cli/reviewCommand.test.ts
+++ b/src/cli/reviewCommand.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { buildReviewWorkerResult, formatReviewOutput, runReviewCommand } from './reviewCommand.js';
+import { buildReviewWorkerResult, formatReviewOutput, runReviewCommand, resolveIssueFromBranch } from './reviewCommand.js';
 import type { ReviewResult } from '../agents/agentPair.js';
 
 describe('buildReviewWorkerResult (INT-1955)', () => {
@@ -33,6 +33,70 @@ describe('formatReviewOutput (INT-1955)', () => {
     expect(colored).toContain('\x1b['); // has ANSI codes
     expect(colored).toContain('Decision: REJECT'); // substring still intact
     expect(formatReviewOutput(review, false)).not.toContain('\x1b['); // plain by default
+  });
+});
+
+describe('resolveIssueFromBranch (INT-1967)', () => {
+  it('extracts an uppercased issue id from common branch shapes', () => {
+    expect(resolveIssueFromBranch('unoheeofficial/int-1705-fix-foo')).toBe('INT-1705');
+    expect(resolveIssueFromBranch('swarm/INT-1821-s8-plan')).toBe('INT-1821');
+    expect(resolveIssueFromBranch('feat/int-1967-branch-infer')).toBe('INT-1967');
+  });
+  it('returns undefined when no issue id is present', () => {
+    expect(resolveIssueFromBranch('main')).toBeUndefined();
+    expect(resolveIssueFromBranch('develop')).toBeUndefined();
+  });
+});
+
+describe('runReviewCommand --issues branch inference (INT-1967)', () => {
+  const approveWithFollowups = async () =>
+    ({ decision: 'approve', feedback: 'ok', recommendedActions: [{ type: 'test', title: 't' }] }) as ReviewResult;
+
+  it('infers the parent from the branch when --issues has no value', async () => {
+    const fileFollowups = vi.fn(async () => 1);
+    const logs: string[] = [];
+    await runReviewCommand(
+      { fileIssue: true },
+      {
+        getChangedFiles: async () => ['x.ts'],
+        review: approveWithFollowups,
+        getBranch: async () => 'feat/int-1705-thing',
+        fileFollowups,
+        startProgress: () => null,
+        log: (l) => logs.push(l),
+      },
+    );
+    expect(fileFollowups).toHaveBeenCalledWith('INT-1705', expect.anything());
+    expect(logs.join('\n')).toContain('inferred from branch');
+  });
+
+  it('uses an explicit id over branch inference', async () => {
+    const fileFollowups = vi.fn(async () => 1);
+    const getBranch = vi.fn(async () => 'feat/int-9999-x');
+    await runReviewCommand(
+      { fileIssue: 'INT-1' },
+      { getChangedFiles: async () => ['x.ts'], review: approveWithFollowups, getBranch, fileFollowups, startProgress: () => null, log: () => {} },
+    );
+    expect(fileFollowups).toHaveBeenCalledWith('INT-1', expect.anything());
+    expect(getBranch).not.toHaveBeenCalled();
+  });
+
+  it('guides when --issues is set but the branch has no issue id', async () => {
+    const fileFollowups = vi.fn(async () => 1);
+    const logs: string[] = [];
+    await runReviewCommand(
+      { fileIssue: true },
+      {
+        getChangedFiles: async () => ['x.ts'],
+        review: approveWithFollowups,
+        getBranch: async () => 'main',
+        fileFollowups,
+        startProgress: () => null,
+        log: (l) => logs.push(l),
+      },
+    );
+    expect(fileFollowups).not.toHaveBeenCalled();
+    expect(logs.join('\n')).toMatch(/no issue could be inferred/);
   });
 });
 
@@ -128,7 +192,7 @@ describe('runReviewCommand (INT-1955)', () => {
     );
     const out = logs.join('\n');
     expect(out).toMatch(/1 follow-up\(s\) suggested/);
-    expect(out).toContain('--file');
+    expect(out).toContain('--issues');
   });
 
   it('does not file when there are no recommendedActions', async () => {

--- a/src/cli/reviewCommand.ts
+++ b/src/cli/reviewCommand.ts
@@ -67,11 +67,23 @@ export function formatReviewOutput(review: ReviewResult, color = false): string 
   return lines.join('\n');
 }
 
+/**
+ * Extract a Linear-style issue id (e.g. INT-1705) from a git branch name so the
+ * user can run `--issues` without typing the id. Returns undefined if none. (INT-1967)
+ */
+export function resolveIssueFromBranch(branch: string): string | undefined {
+  const m = branch.match(/([a-z]{2,}-\d+)/i);
+  return m ? m[1].toUpperCase() : undefined;
+}
+
 export interface ReviewCommandOptions {
   /** Project path (default cwd). */
   path?: string;
-  /** Parent Linear issue id — file recommendedActions as sub-issues under it. */
-  fileIssue?: string;
+  /**
+   * File recommendedActions as Linear sub-issues. A string is the explicit parent
+   * id; `true` (bare `--issues`) infers the parent from the git branch. (INT-1967)
+   */
+  fileIssue?: string | boolean;
   /** Adapter override. */
   adapter?: string;
   /** Verbose logging. */
@@ -90,6 +102,8 @@ export async function runReviewCommand(
     log?: (line: string) => void;
     /** Override the progress indicator (default: TTY-gated spinner). Tests pass a stub. */
     startProgress?: () => { note: (line: string) => void; stop: () => void } | null;
+    /** Current git branch (default: `git rev-parse --abbrev-ref HEAD`). For --issues inference. */
+    getBranch?: (cwd: string) => Promise<string>;
   } = {},
 ): Promise<ReviewResult | null> {
   const cwd = opts.path ?? process.cwd();
@@ -136,17 +150,42 @@ export async function runReviewCommand(
 
   const followups = result.recommendedActions?.length ?? 0;
   if (opts.fileIssue && followups) {
+    // Resolve the parent issue: explicit id, else inferred from the git branch. (INT-1967)
+    let parent = typeof opts.fileIssue === 'string' ? opts.fileIssue : undefined;
+    if (!parent) {
+      const getBranch =
+        deps.getBranch ??
+        (async (c: string) => {
+          const { execFileSync } = await import('node:child_process');
+          return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+            cwd: c,
+            stdio: ['ignore', 'pipe', 'ignore'],
+          })
+            .toString()
+            .trim();
+        });
+      const branch = await getBranch(cwd).catch(() => '');
+      parent = resolveIssueFromBranch(branch);
+      if (parent) log(`Filing follow-ups under ${parent} (inferred from branch "${branch}").`);
+    }
+    if (!parent) {
+      log(
+        `\n${followups} follow-up(s) suggested, but no issue could be inferred from the branch. ` +
+          'Re-run with `--issues <issue-id>` to choose the parent.',
+      );
+      return result;
+    }
     const fileFollowups =
       deps.fileFollowups ??
-      (async (parent: string, r: ReviewResult) => {
+      (async (p: string, r: ReviewResult) => {
         const { fileReviewerFollowups, getTaskSource } = await import('../automation/runnerExecution.js');
-        return fileReviewerFollowups(getTaskSource(), parent, r, { autoFile: true });
+        return fileReviewerFollowups(getTaskSource(), p, r, { autoFile: true });
       });
-    const filed = await fileFollowups(opts.fileIssue, result);
-    log(`Filed ${filed} follow-up sub-issue(s) under ${opts.fileIssue}.`);
+    const filed = await fileFollowups(parent, result);
+    log(`Filed ${filed} follow-up sub-issue(s) under ${parent}.`);
   } else if (followups) {
-    // Suggestions were made but nothing was filed — make the --file flag discoverable. (INT-1966)
-    log(`\n${followups} follow-up(s) suggested. Re-run with \`--file <issue-id>\` to create them as Linear sub-issues.`);
+    // Suggestions were made but nothing was filed — make the flag discoverable. (INT-1966/1967)
+    log(`\n${followups} follow-up(s) suggested. Re-run with \`--issues\` to create them as Linear sub-issues (parent inferred from the branch, or pass \`--issues <id>\`).`);
   }
 
   return result;


### PR DESCRIPTION
## 목표 (사용자 피드백, INT-1966 후속)
`--file <이슈ID>`를 매번 손입력하는 게 번거로움 → `--issues`만 치면 git 브랜치에서 부모 이슈를 자동 추론.

## 변경
- `resolveIssueFromBranch(branch)`: `[A-Z]{2,}-\d+` 추출·대문자화(`feat/int-1705-x` → INT-1705).
- runReviewCommand: `fileIssue: string|boolean` — 값 있으면 명시 부모, `true`(bare `--issues`)면 브랜치(getBranch dep)에서 추론, 실패 시에만 안내.
- cli.ts: `--issues [parent]` 신설 + `--file [parent]` 별칭(back-compat).

## 사용
`openswarm review --issues` (브랜치 feat/int-1705-*) → INT-1705 하위 생성 · 명시는 `--issues INT-123`.

## 검증
resolveIssueFromBranch(추출/미존재) + 추론 파일링·명시 우선·추론실패 안내. tsc/build clean, 전체 **1155 green**.