### PR TITLE
feat(scheduler): 같은 repo 비의존성 이슈 워크트리 병렬 실행 (INT-1975)

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -168,9 +168,11 @@ export class AutonomousRunner {
     });
 
     // Initialize TaskScheduler
+    // Same-repo parallelism is opt-in via config (default true) but the scheduler
+    // force-disables it unless worktreeMode is on — see TaskScheduler guard. (INT-1975)
     this.scheduler = initScheduler({
       maxConcurrent: config.maxConcurrentTasks ?? 1,
-      allowSameProjectConcurrent: false,
+      allowSameProjectConcurrent: config.allowSameProjectConcurrent ?? true,
       worktreeMode: config.worktreeMode ?? false,
     });
 

--- a/src/automation/runnerTypes.ts
+++ b/src/automation/runnerTypes.ts
@@ -34,6 +34,8 @@ export interface AutonomousConfig {
   plannerTimeoutMs?: number;
   decomposition?: import('../core/types.js').DecompositionConfig;
   worktreeMode?: boolean;
+  /** Allow concurrent tasks on the same repo (requires worktreeMode). Default true. (INT-1975) */
+  allowSameProjectConcurrent?: boolean;
   guards?: Partial<import('../core/types.js').PipelineGuardsConfig>;
   /** Max objective self-repair attempts (lint/bs/test) before giving up (default: 3) */
   maxReflections?: number;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -248,6 +248,8 @@ const AutonomousConfigSchema = z.object({
   decomposition: DecompositionConfigSchema,
   /** Git worktree mode: each task runs in isolated worktree */
   worktreeMode: z.boolean().default(false),
+  /** Allow concurrent tasks on the same repo (requires worktreeMode). (INT-1975) */
+  allowSameProjectConcurrent: z.boolean().default(true),
   /** Dynamic job profiles for model selection */
   jobProfiles: z.array(JobProfileSchema).optional(),
   /** Pipeline quality guards (bad-edit lint gate, BS detector, etc.) */
@@ -533,6 +535,7 @@ function transformConfig(raw: RawConfig): SwarmConfig {
         plannerTimeoutMs: raw.autonomous.decomposition.plannerTimeoutMs,
       } : undefined,
       worktreeMode: raw.autonomous.worktreeMode,
+      allowSameProjectConcurrent: raw.autonomous.allowSameProjectConcurrent,
       guards: raw.autonomous.guards,
       maxReflections: raw.autonomous.maxReflections,
       dailyTaskCap: raw.autonomous.dailyTaskCap,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -460,6 +460,13 @@ export type AutonomousStartupConfig = {
   decomposition?: DecompositionConfig;
   /** Git worktree mode: work in independent worktree per issue and auto-create PR */
   worktreeMode?: boolean;
+  /**
+   * Allow concurrent tasks on the SAME repo. Requires worktreeMode (per-task
+   * filesystem isolation); ignored otherwise to avoid corrupting a shared tree.
+   * Non-conflicting issues are still gated by KG file-conflict detection and the
+   * blockedBy dependency graph. Default: true. (INT-1975)
+   */
+  allowSameProjectConcurrent?: boolean;
   /** Pipeline guards configuration */
   guards?: Partial<PipelineGuardsConfig>;
   /**

--- a/src/orchestration/taskScheduler.concurrency.test.ts
+++ b/src/orchestration/taskScheduler.concurrency.test.ts
@@ -1,0 +1,49 @@
+// Purpose: same-repo concurrency flag + worktree-isolation guard (INT-1975).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TaskScheduler } from './taskScheduler.js';
+import type { TaskItem } from './decisionEngine.js';
+import type { PipelineResult } from '../agents/pairPipeline.js';
+
+const task = (id: string): TaskItem => ({ id, title: id, priority: 3 } as TaskItem);
+
+// Executor that never resolves — keeps the task "running" so isProjectBusy is testable.
+function pendingExecutor() {
+  return () => new Promise<PipelineResult>(() => {});
+}
+
+describe('TaskScheduler same-project concurrency (INT-1975)', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => { warn = vi.spyOn(console, 'warn').mockImplementation(() => {}); });
+  afterEach(() => { warn.mockRestore(); });
+
+  it('serializes same-repo tasks by default (no flag)', () => {
+    const s = new TaskScheduler({ maxConcurrent: 4, worktreeMode: true });
+    s.startTask(task('a'), '/repo', pendingExecutor());
+    expect(s.isProjectBusy('/repo')).toBe(true);
+  });
+
+  it('allows same-repo parallelism when flag + worktreeMode are both on', () => {
+    const s = new TaskScheduler({ maxConcurrent: 4, worktreeMode: true, allowSameProjectConcurrent: true });
+    s.startTask(task('a'), '/repo', pendingExecutor());
+    expect(s.isProjectBusy('/repo')).toBe(false);
+    expect(s.getBusyProjects()).toEqual([]);
+  });
+
+  it('force-disables the flag when worktreeMode is off, and warns', () => {
+    const s = new TaskScheduler({ maxConcurrent: 4, worktreeMode: false, allowSameProjectConcurrent: true });
+    s.startTask(task('a'), '/repo', pendingExecutor());
+    // Guard ignored the flag → project is still busy (serialized, safe).
+    expect(s.isProjectBusy('/repo')).toBe(true);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('requires worktreeMode'));
+  });
+
+  it('getNextExecutable hands out two same-repo tasks when concurrency is allowed', () => {
+    const s = new TaskScheduler({ maxConcurrent: 4, worktreeMode: true, allowSameProjectConcurrent: true });
+    s.enqueue(task('a'), '/repo');
+    s.enqueue(task('b'), '/repo');
+    const first = s.getNextExecutable();
+    s.startTask(first!.task, first!.projectPath, pendingExecutor());
+    // Without the flag this would return null (project busy); with it, 'b' is dispatchable.
+    expect(s.getNextExecutable()?.task.id).toBe('b');
+  });
+});

--- a/src/orchestration/taskScheduler.ts
+++ b/src/orchestration/taskScheduler.ts
@@ -56,10 +56,23 @@ export class TaskScheduler extends EventEmitter {
 
   constructor(config: SchedulerConfig) {
     super();
-    this.config = {
+    const merged: SchedulerConfig = {
       allowSameProjectConcurrent: false,
       ...config,
     };
+    // Same-project parallelism REQUIRES per-task worktree isolation. Without it,
+    // two concurrent tasks would mutate one shared working tree and corrupt each
+    // other. Guard at the one place that holds both flags: force-disable + warn.
+    // (INT-1975)
+    if (merged.allowSameProjectConcurrent && !merged.worktreeMode) {
+      console.warn(
+        '[Scheduler] allowSameProjectConcurrent ignored: requires worktreeMode ' +
+          '(a shared working tree would be corrupted by concurrent tasks). ' +
+          'Set worktreeMode:true to enable same-project parallelism.'
+      );
+      merged.allowSameProjectConcurrent = false;
+    }
+    this.config = merged;
   }
 
   // ============================================


### PR DESCRIPTION
## 문제
워크트리 격리(FS)·KG 파일충돌 감지·blockedBy 의존성 게이트가 이미 구현돼 있지만, `TaskScheduler`의 `allowSameProjectConcurrent`가 `autonomousRunner.ts`에 하드코딩 `false`라서 같은 repo의 비의존성 이슈가 직렬화됨. 라이브 config가 `worktreeMode:true`, `maxConcurrentTasks:6`인데도 한 repo는 heartbeat당 1개씩만 처리.

## 해결
- `allowSameProjectConcurrent`를 config 스키마로 노출 (기본 ON, default `true`).
- 안전 가드: `worktreeMode`가 꺼져 있으면 강제 무시 + warn. 공유 워킹트리 동시 변경 손상 차단. 가드는 두 플래그를 모두 가진 `TaskScheduler` 생성자(단일 지점)에 배치.
- `autonomousRunner`는 config 값을 그대로 전달, 안전성은 스케줄러 가드가 보장.

기존 안전망(KG 파일충돌 감지 → 같은 모듈 수정 이슈 defer, blockedBy 의존성 게이트)은 그대로 유지되어 "비의존성 + 비충돌" 이슈만 병렬 진입한다.

## 검증
- 신규 단위 테스트 4건: 기본 직렬화 / 플래그+worktree 병렬 허용 / worktree 없을 때 force-disable+warn / `getNextExecutable` 같은 repo 2개 디스패치.
- `npm test` 전체 1175 통과, `tsc` 0 error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)