### PR TITLE
1. [Fix] Restore provider override persistence module

### DIFF
--- a/src/core/providerOverride.test.ts
+++ b/src/core/providerOverride.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const homedirMock = vi.fn(() => '/tmp/openswarm-home');
+
+vi.mock('node:os', () => ({ homedir: homedirMock }));
+
+describe('providerOverride', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('reads and writes a valid override', async () => {
+    const fs = await import('node:fs');
+    fs.rmSync('/tmp/openswarm-home', { recursive: true, force: true });
+
+    const { writeProviderOverride, readProviderOverride } = await import('./providerOverride.js');
+    writeProviderOverride('codex');
+
+    expect(readProviderOverride()).toBe('codex');
+    expect(fs.readFileSync('/tmp/openswarm-home/.config/openswarm/provider-override.json', 'utf8')).toContain('"provider": "codex"');
+  });
+
+  it('returns undefined for missing or invalid files', async () => {
+    const fs = await import('node:fs');
+    fs.rmSync('/tmp/openswarm-home', { recursive: true, force: true });
+
+    const { readProviderOverride } = await import('./providerOverride.js');
+    expect(readProviderOverride()).toBeUndefined();
+
+    fs.mkdirSync('/tmp/openswarm-home/.config/openswarm', { recursive: true });
+    fs.writeFileSync('/tmp/openswarm-home/.config/openswarm/provider-override.json', '{not json', 'utf8');
+    expect(readProviderOverride()).toBeUndefined();
+
+    fs.writeFileSync('/tmp/openswarm-home/.config/openswarm/provider-override.json', JSON.stringify({ provider: 'unknown' }), 'utf8');
+    expect(readProviderOverride()).toBeUndefined();
+  });
+
+  it('does not persist claude overrides', async () => {
+    const fs = await import('node:fs');
+    fs.rmSync('/tmp/openswarm-home', { recursive: true, force: true });
+
+    const { writeProviderOverride, readProviderOverride } = await import('./providerOverride.js');
+    writeProviderOverride('claude');
+
+    expect(fs.existsSync('/tmp/openswarm-home/.config/openswarm/provider-override.json')).toBe(false);
+    expect(readProviderOverride()).toBeUndefined();
+  });
+
+  it('ignores claude persisted values if the file is present', async () => {
+    const fs = await import('node:fs');
+    fs.rmSync('/tmp/openswarm-home', { recursive: true, force: true });
+    fs.mkdirSync('/tmp/openswarm-home/.config/openswarm', { recursive: true });
+    fs.writeFileSync('/tmp/openswarm-home/.config/openswarm/provider-override.json', JSON.stringify({ provider: 'claude' }), 'utf8');
+
+    const { readProviderOverride } = await import('./providerOverride.js');
+    expect(readProviderOverride()).toBeUndefined();
+  });
+});

--- a/src/core/providerOverride.ts
+++ b/src/core/providerOverride.ts
@@ -13,14 +13,15 @@ const OVERRIDE_DIR = join(homedir(), '.config', 'openswarm');
 const OVERRIDE_PATH = join(OVERRIDE_DIR, 'provider-override.json');
 // `claude` is intentionally excluded: it is an opt-in fallback provider, not a primary the operator
 // should be able to pin via a persisted toggle (a stale claude pin with no credits hangs the loop).
-const VALID: readonly AdapterName[] = ['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter'];
+const VALID: readonly Exclude<AdapterName, 'claude'>[] = ['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter'];
+const VALID_SET = new Set<Exclude<AdapterName, 'claude'>>(VALID);
 
 /** The provider the user last selected via the dashboard, or undefined if never toggled. */
 export function readProviderOverride(): AdapterName | undefined {
   try {
     if (!existsSync(OVERRIDE_PATH)) return undefined;
     const { provider } = JSON.parse(readFileSync(OVERRIDE_PATH, 'utf8')) as { provider?: string };
-    return VALID.includes(provider as AdapterName) ? (provider as AdapterName) : undefined;
+    return VALID_SET.has(provider as Exclude<AdapterName, 'claude'>) ? (provider as Exclude<AdapterName, 'claude'>) : undefined;
   } catch {
     return undefined;
   }
@@ -29,6 +30,7 @@ export function readProviderOverride(): AdapterName | undefined {
 /** Record the user's provider choice so it survives a restart. Best-effort — never blocks the toggle. */
 export function writeProviderOverride(provider: AdapterName): void {
   try {
+    if (provider === 'claude') return;
     mkdirSync(OVERRIDE_DIR, { recursive: true });
     writeFileSync(OVERRIDE_PATH, `${JSON.stringify({ provider }, null, 2)}\n`, 'utf8');
   } catch {


### PR DESCRIPTION
## Summary
Restore or implement src/core/providerOverride.ts with readProviderOverride/writeProviderOverride behavior for persisted adapter selection. Preserve the stated rule that claude is not persisted. Add/adjust unit coverage for valid override read/write, invalid/missing files, and claude exclusion. Completion criteria: provider override module compiles and tests pass.

* File scope: src/core/providerOverride.ts, src/core/providerOverride.test.ts
* Estimate: 35 min

*Split out from "fix(provider): codex 고정이 새는 두 회귀 — provider-override 부트 미적용 + jobProfile model 미전달 → Codex-Spark 자체 한도 소진" during planning.*

## Linear
Closes INT-1980

---
🤖 Generated with [OpenSwarm](https://github.com/Intrect-io/OpenSwarm)