### PR TITLE
2. [Fix] Reapply persisted provider override during service boot

### DIFF
--- a/src/core/service.test.ts
+++ b/src/core/service.test.ts
@@ -10,6 +10,10 @@ import {
 } from './service.js';
 import { setDefaultAdapter } from '../adapters/index.js';
 
+const mockRunnerInstance = {
+  switchProvider: vi.fn(),
+};
+
 // Mock external dependencies
 // Mock auth so service.test never reads the real ~/.openswarm/auth-profiles.json
 // (a present linear:default OAuth profile would route Linear init down the OAuth
@@ -60,11 +64,15 @@ vi.mock('../support/web.js', () => ({
 vi.mock('../automation/autonomousRunner.js', () => ({
   setTaskSource: vi.fn(),
   setNotifier: vi.fn(),
-  startAutonomous: vi.fn(async () => ({})),
+  startAutonomous: vi.fn(async () => mockRunnerInstance),
 }));
 
 vi.mock('../adapters/index.js', () => ({
   setDefaultAdapter: vi.fn(),
+}));
+
+vi.mock('./providerOverride.js', () => ({
+  readProviderOverride: vi.fn(),
 }));
 
 vi.mock('../automation/prProcessor.js', () => {
@@ -198,6 +206,26 @@ describe('service', () => {
         mockConfig.discordToken,
         mockConfig.discordChannelId
       );
+    });
+
+    it('should reapply persisted provider override when it differs from config adapter', async () => {
+      vi.mocked(readProviderOverride).mockReturnValue('codex');
+
+      await startService(mockConfig);
+
+      expect(setDefaultAdapter).toHaveBeenNthCalledWith(1, 'claude');
+      expect(setDefaultAdapter).toHaveBeenNthCalledWith(2, 'codex');
+      expect(mockRunnerInstance.switchProvider).toHaveBeenCalledWith('codex');
+    });
+
+    it('should not reapply persisted provider override when it matches config adapter', async () => {
+      vi.mocked(readProviderOverride).mockReturnValue('claude');
+
+      await startService(mockConfig);
+
+      expect(setDefaultAdapter).toHaveBeenCalledTimes(1);
+      expect(setDefaultAdapter).toHaveBeenCalledWith('claude');
+      expect(mockRunnerInstance.switchProvider).not.toHaveBeenCalled();
     });
 
     it('should stop service without errors', async () => {

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -242,7 +242,8 @@ export async function startService(config: SwarmConfig): Promise<void> {
     // restart silently reverts to config.yaml's adapter. Reusing switchProvider keeps the role +
     // jobProfile remapping identical to a live dashboard toggle.
     const providerOverride = readProviderOverride();
-    if (providerOverride && providerOverride !== (config.adapter ?? 'codex')) {
+    const currentAdapter = config.adapter ?? 'codex';
+    if (providerOverride && providerOverride !== currentAdapter) {
       setDefaultAdapter(providerOverride);
       runnerInstance.switchProvider(providerOverride);
       console.log(`[Service] Restored persisted provider: ${providerOverride}`);


### PR DESCRIPTION
## Summary
Update service bootstrap after web.setWebRunner to readProviderOverride() and reapply it via setDefaultAdapter/runnerInstance.switchProvider when it differs from config.adapter default. Keep boot no-op when override matches current adapter. Add/adjust service test coverage if existing harness supports it. Completion criteria: daemon startup restores codex override even if config.yaml was reset.

* Depends on: 1. [Fix] Restore provider override persistence module
* File scope: src/core/service.ts, src/core/service.test.ts
* Estimate: 35 min

*Split out from "fix(provider): codex 고정이 새는 두 회귀 — provider-override 부트 미적용 + jobProfile model 미전달 → Codex-Spark 자체 한도 소진" during planning.*

## Linear
Closes INT-1981

---
🤖 Generated with [OpenSwarm](https://github.com/Intrect-io/OpenSwarm)