### PR TITLE
fix(scheduler): 외부 'In Progress' 이슈 가로채 중복 decompose/PR 방지 (INT-1985)

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -44,6 +44,7 @@ import { reportToDiscord, fetchLinearTasks, getTaskSource } from './runnerExecut
 import { t } from '../locale/index.js';
 import { broadcastEvent, type SwarmStats } from '../core/eventHub.js';
 import { writeProviderOverride } from '../core/providerOverride.js';
+import { getTaskState } from '../taskState/store.js';
 import { pruneWorktrees } from '../support/worktreeManager.js';
 import { loadRepoMetadata } from '../support/repoMetadata.js';
 import { STUCK_LABEL } from '../linear/index.js';
@@ -461,6 +462,17 @@ export class AutonomousRunner {
 
       if (this.completedTaskIds.has(id)) return false;
       if ((this.failedTaskCounts.get(id) ?? 0) >= AutonomousRunner.MAX_RETRY_COUNT) return false;
+
+      // External-claim guard (INT-1979 dup): an issue set to 'In Progress' that THIS
+      // daemon never claimed is owned by a human or another agent — picking it up
+      // would re-decompose work someone is already doing (that spawned duplicate
+      // INT-1980 sub-issues + a redundant PR). markTaskInProgress writes
+      // execution.status='in_progress' when WE claim, so our own in-flight work
+      // (incl. resumption after a restart) still passes; a bare Linear 'In Progress'
+      // with no local claim record is skipped.
+      if (task.linearState === 'In Progress' && getTaskState(id)?.execution?.status !== 'in_progress') {
+        return false;
+      }
 
       // Check if task is in exponential backoff period
       if (!canRetryNow(id, this.failedTaskRetryTimes)) {


### PR DESCRIPTION
## 문제

사용자/Claude가 Linear 이슈를 직접 `In Progress`로 점유해 수동 작업 중인데, 데몬이 같은 이슈를 집어 decompose해 **중복 서브이슈 + PR**을 만든다.

실제 사례: INT-1979를 수동 작업(PR #153)하는 동안 데몬이 INT-1979를 decompose → INT-1980 서브이슈 + PR #154 중복 생성.

## 원인

`autonomousRunner.filterAlreadyProcessed`(이슈 선택 관문)가 `completedTaskIds`/`failed`/`stuck`/`backoff`는 거르지만 **`linearState === 'In Progress'`(외부 점유)를 거르지 않는다**. 단순히 "In Progress = skip"은 불가 — 데몬도 작업 시작 시 자신을 In Progress로 claim하므로 재시작 후 자기 미완 작업을 못 재개하게 된다.

## 해결

task-state store로 **데몬 claim과 외부 점유를 구분**. `markTaskInProgress`가 `execution.status='in_progress'`를 영속 기록하므로:
- Linear `In Progress` + 로컬 claim 기록 **없음** = 외부/사용자 점유 → **skip**
- Linear `In Progress` + 로컬 `in_progress` = 데몬 자기 claim → 통과(재시작 재개 보존)

`filterAlreadyProcessed`에 가드 1줄 + `getTaskState` import. 이슈 선택 관문이라 여기서 막으면 decompose/실행에 도달하지 않는다.

## overthinking 측면

별도 코드 불필요로 판단 — 기존 가드 충분: maxTurns 20 + no-progress 3턴 조기종료, maxReflections 3, maxIterations 3, stuck detection(sameError 2/revisionLoop 4), worker disableReasoning, nudgeMaxOnNoEdit 3. config도 보수적(decomposition: threshold 60, maxDepth 1, maxChildren 3, dailyLimit 5).

## 검증

`tsc` 0 · `build` OK · `vitest` automation 29/29 · 로직 엣지(사용자 수동 In Progress=skip / 데몬 claim=통과 / Backlog=정상) 검토.