### PR TITLE
[Fix] Implement provider override reapply in service bootstrap

### DIFF
--- a/src/core/service.test.ts
+++ b/src/core/service.test.ts
@@ -60,11 +60,17 @@ vi.mock('../support/web.js', () => ({
 vi.mock('../automation/autonomousRunner.js', () => ({
   setTaskSource: vi.fn(),
   setNotifier: vi.fn(),
-  startAutonomous: vi.fn(async () => ({})),
+  startAutonomous: vi.fn(async () => ({
+    switchProvider: vi.fn(),
+  })),
 }));
 
 vi.mock('../adapters/index.js', () => ({
   setDefaultAdapter: vi.fn(),
+}));
+
+vi.mock('./providerOverride.js', () => ({
+  readProviderOverride: vi.fn(),
 }));
 
 vi.mock('../automation/prProcessor.js', () => {
@@ -170,6 +176,41 @@ describe('service', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('reapplies a persisted provider override on boot when it differs from config', async () => {
+    const { readProviderOverride } = await import('./providerOverride.js');
+    const { setDefaultAdapter } = await import('../adapters/index.js');
+    const { startAutonomous } = await import('../automation/autonomousRunner.js');
+
+    vi.mocked(readProviderOverride).mockReturnValue('gpt');
+
+    const config = {
+      ...mockConfig,
+      adapter: 'claude',
+      autonomous: {
+        ...mockConfig.autonomous,
+      },
+    } as SwarmConfig;
+
+    await startService(config);
+
+    expect(setDefaultAdapter).toHaveBeenCalledWith('gpt');
+    expect(vi.mocked(startAutonomous)).toHaveBeenCalled();
+    const runner = await vi.mocked(startAutonomous).mock.results[0].value;
+    expect(runner.switchProvider).toHaveBeenCalledWith('gpt');
+  });
+
+  it('does not reapply provider override when it matches the configured adapter', async () => {
+    const { readProviderOverride } = await import('./providerOverride.js');
+    const { setDefaultAdapter } = await import('../adapters/index.js');
+
+    vi.mocked(readProviderOverride).mockReturnValue('claude');
+
+    await startService(mockConfig);
+
+    expect(setDefaultAdapter).toHaveBeenCalledWith('claude');
+    expect(setDefaultAdapter).toHaveBeenCalledTimes(1);
   });
 
   // ============================================


### PR DESCRIPTION
## Summary
service.ts의 bootstrap 로직에서 web.setWebRunner 호출 이후 readProviderOverride() 호출. Override가 존재하고 config.adapter default와 다르면 setDefaultAdapter + runnerInstance.switchProvider로 재적용. Override가 current adapter와 일치하면 no-op. Completion criteria: 코드 실행 시 override가 실제로 복원되며, 일치 시 불필요한 재적용이 발생하지 않음.

**Estimated time:** 25 min

---

*Auto-decomposed from "2. \[Fix\] Reapply persisted provider override during service boot" by Planner*

## Linear
Closes INT-1988

---
🤖 Generated with [OpenSwarm](https://github.com/Intrect-io/OpenSwarm)