### PR TITLE
[Test] Add service test coverage for override boot behavior

### DIFF
--- a/src/core/service.test.ts
+++ b/src/core/service.test.ts
@@ -9,6 +9,8 @@ import {
   getPRProcessor,
 } from './service.js';
 import { setDefaultAdapter } from '../adapters/index.js';
+import { readProviderOverride } from './providerOverride.js';
+import * as autonomousRunner from '../automation/autonomousRunner.js';
 
 // Mock external dependencies
 // Mock auth so service.test never reads the real ~/.openswarm/auth-profiles.json
@@ -65,6 +67,10 @@ vi.mock('../automation/autonomousRunner.js', () => ({
 
 vi.mock('../adapters/index.js', () => ({
   setDefaultAdapter: vi.fn(),
+}));
+
+vi.mock('./providerOverride.js', () => ({
+  readProviderOverride: vi.fn(),
 }));
 
 vi.mock('../automation/prProcessor.js', () => {
@@ -168,6 +174,21 @@ describe('service', () => {
     defaultHeartbeatInterval: 1800000,
   };
 
+  const mockAutonomousConfig: SwarmConfig = {
+    ...mockConfig,
+    autonomous: {
+      enabled: true,
+      pairMode: true,
+      schedule: '*/30 * * * *',
+      maxAttempts: 3,
+      allowedProjects: ['/tmp'],
+      models: {
+        worker: 'gpt-4.1',
+        reviewer: 'claude',
+      },
+    },
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -189,6 +210,7 @@ describe('service', () => {
       await startService(mockConfig);
 
       expect(setDefaultAdapter).toHaveBeenCalledWith('claude');
+      expect(readProviderOverride).toHaveBeenCalled();
       expect(initLocale).toHaveBeenCalled();
       expect(initLinear).toHaveBeenCalledWith(
         mockConfig.linearApiKey,
@@ -198,6 +220,60 @@ describe('service', () => {
         mockConfig.discordToken,
         mockConfig.discordChannelId
       );
+    });
+
+    it('should reapply a persisted provider override when it differs from config default', async () => {
+      const runner = {
+        provider: 'claude',
+        switchProvider: vi.fn((nextProvider: string) => {
+          runner.provider = nextProvider;
+        }),
+      };
+      vi.mocked(autonomousRunner.startAutonomous).mockResolvedValue(runner as any);
+      vi.mocked(readProviderOverride).mockReturnValue('codex');
+
+      await startService(mockAutonomousConfig);
+
+      expect(setDefaultAdapter).toHaveBeenCalledWith('codex');
+      expect(vi.mocked(readProviderOverride)).toHaveBeenCalled();
+      expect(autonomousRunner.startAutonomous).toHaveBeenCalled();
+      expect(runner.switchProvider).toHaveBeenCalledWith('codex');
+      expect(runner.provider).toBe('codex');
+    });
+
+    it('should no-op when persisted override matches current provider', async () => {
+      const runner = {
+        provider: 'claude',
+        switchProvider: vi.fn((nextProvider: string) => {
+          runner.provider = nextProvider;
+        }),
+      };
+      vi.mocked(autonomousRunner.startAutonomous).mockResolvedValue(runner as any);
+      vi.mocked(readProviderOverride).mockReturnValue('claude');
+
+      await startService(mockAutonomousConfig);
+
+      expect(setDefaultAdapter).toHaveBeenCalledWith('claude');
+      expect(runner.switchProvider).not.toHaveBeenCalled();
+      expect(runner.provider).toBe('claude');
+    });
+
+    it('should preserve default adapter behavior when no override exists', async () => {
+      const runner = {
+        provider: 'claude',
+        switchProvider: vi.fn((nextProvider: string) => {
+          runner.provider = nextProvider;
+        }),
+      };
+      vi.mocked(autonomousRunner.startAutonomous).mockResolvedValue(runner as any);
+      vi.mocked(readProviderOverride).mockReturnValue(undefined);
+
+      await startService(mockAutonomousConfig);
+
+      expect(setDefaultAdapter).toHaveBeenCalledWith('claude');
+      expect(autonomousRunner.startAutonomous).toHaveBeenCalled();
+      expect(runner.switchProvider).not.toHaveBeenCalled();
+      expect(runner.provider).toBe('claude');
     });
 
     it('should stop service without errors', async () => {


### PR DESCRIPTION
## Summary
service.test.ts에 provider override restore 시나리오 추가. (1) override 있고 config default와 다름 → switchProvider 호출 검증, (2) override 있지만 current와 일치 → no-op 검증, (3) override 없음 → 기본 동작 유지 검증. 기존 harness 패턴 따라 daemon startup 후 provider state 확인. Completion criteria: 3가지 케이스 모두 pass, coverage 충분.

**Estimated time:** 15 min

**Prerequisites:** [Fix] Implement provider override reapply in service bootstrap

---

*Auto-decomposed from "2. \[Fix\] Reapply persisted provider override during service boot" by Planner*

## Linear
Closes INT-1989

---
🤖 Generated with [OpenSwarm](https://github.com/Intrect-io/OpenSwarm)