### PR TITLE
fix(adapters): codex/codex-responses → claude fallback 제거 (INT-1990)

### DIFF
--- a/src/agents/draftAnalyzer.test.ts
+++ b/src/agents/draftAnalyzer.test.ts
@@ -58,29 +58,16 @@ describe('runDraftAnalysis fallback', () => {
     vi.restoreAllMocks();
   });
 
-  it('falls back to claude when codex quota error happens', async () => {
+  it('does NOT fall back to claude on a codex quota error (single adapter, best-effort)', async () => {
+    // INT-1979 follow-up: claude is no longer a draft fallback. A codex quota error
+    // must NOT switch providers (claude is opt-in / usually out-of-credits, which
+    // turned a transient blip into a hard `claude CLI failed code 1` + noisy alert).
+    // Draft is non-blocking, so the quota error just yields a best-effort draft.
     vi.spyOn(adapterModule, 'getDefaultAdapterName').mockReturnValue('codex');
-    vi.spyOn(adapterModule, 'getAdapter').mockImplementation((name) => {
-      if (name === 'codex') {
-        return makeAdapter('codex');
-      }
-      return makeAdapter('claude');
-    });
+    vi.spyOn(adapterModule, 'getAdapter').mockImplementation((name) => makeAdapter(name));
 
     vi.spyOn(adapterModule, 'spawnCli')
-      .mockRejectedValueOnce(new Error('quota exceeded'))
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: JSON.stringify({
-          taskType: 'bugfix',
-          intentSummary: 'Handle billing edge case',
-          relevantFiles: ['src/payments.ts'],
-          suggestedApproach: 'Use retry queue and fallback',
-          completionCriteria: ['payments.ts retry path covered by a passing test'],
-        }),
-        stderr: '',
-        durationMs: 1,
-      } as CliRunResult);
+      .mockRejectedValueOnce(new Error('quota exceeded'));
 
     const result = await runDraftAnalysis({
       taskTitle: 'Fix edge',
@@ -88,13 +75,13 @@ describe('runDraftAnalysis fallback', () => {
       projectPath: '/tmp/project',
     });
 
-    expect(result.taskType).toBe('bugfix');
+    // codex is tried; claude is never invoked.
     expect(adapterModule.getAdapter).toHaveBeenCalledWith('codex');
-    expect(adapterModule.getAdapter).toHaveBeenCalledWith('claude');
-    // codex(quota) → claude(sufficient on first attempt): 2 calls, no gate retry.
-    expect(adapterModule.spawnCli).toHaveBeenCalledTimes(2);
-    expect(result.sufficient).toBe(true);
-    expect(result.completionCriteria.length).toBeGreaterThan(0);
+    expect(adapterModule.getAdapter).not.toHaveBeenCalledWith('claude');
+    // Single adapter attempt only — quota error breaks out to best-effort, no fallback.
+    expect(adapterModule.spawnCli).toHaveBeenCalledTimes(1);
+    // Pipeline continues with a best-effort (insufficient) draft.
+    expect(result.sufficient).toBe(false);
   });
 
   it('drafter hard gate: retries on the same adapter when the brief is insufficient', async () => {

--- a/src/agents/draftAnalyzer.ts
+++ b/src/agents/draftAnalyzer.ts
@@ -345,14 +345,13 @@ function findJsonObject(text: string): string | null {
 }
 
 function getDraftFallbackAdapters(primary: AdapterName): AdapterName[] {
-  const fallbackMap: Partial<Record<AdapterName, AdapterName>> = {
-    codex: 'claude',
-    'codex-responses': 'claude',
-    claude: 'codex',
-  };
-
-  const fallback = fallbackMap[primary];
-  return fallback && fallback !== primary ? [primary, fallback] : [primary];
+  // No cross-provider fallback to claude. Draft is non-blocking (best-effort), and
+  // claude is an opt-in provider that's usually rate-limited / out-of-credits — so
+  // a transient codex quota blip would cascade into a hard `claude CLI failed code 1`
+  // + a noisy Discord alert for zero benefit. Single adapter only; a codex quota
+  // error just leaves the draft as best-effort (type=unknown) and the pipeline
+  // continues. (INT-1979 follow-up)
+  return [primary];
 }
 
 function isProviderQuotaError(message?: string): boolean {

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -69,14 +69,12 @@ function buildWorkerPrompt(options: WorkerOptions): string {
 }
 
 function getWorkerFallbackAdapters(primary: AdapterName): AdapterName[] {
-  const fallbackMap: Partial<Record<AdapterName, AdapterName>> = {
-    codex: 'claude',
-    'codex-responses': 'claude',
-    claude: 'codex',
-  };
-
-  const fallback = fallbackMap[primary];
-  return fallback && fallback !== primary ? [primary, fallback] : [primary];
+  // No cross-provider fallback to claude: it's opt-in and usually rate-limited /
+  // out-of-credits, so switching to it on a codex quota error just turns a pause
+  // into a hard `claude CLI failed code 1`. A codex/codex-responses quota error
+  // now surfaces as RateLimitError → scheduler pause (INT-1906) instead of a
+  // silent provider switch. Single adapter only. (INT-1979 follow-up)
+  return [primary];
 }
 
 export function isProviderQuotaError(message?: string): boolean {


### PR DESCRIPTION
## 문제
Draft Analyzer와 Worker가 codex/codex-responses 쿼터 에러 시 **claude로 fallback**했다. claude는 opt-in이고 보통 out-of-credits 상태라, 일시적 쿼터 blip이 `claude CLI failed with code 1`이라는 hard failure + Discord 알림 폭주로 번졌다 (예: STO-1203 알림, reviewer 2초마다 실패).

## 원인
- `src/agents/draftAnalyzer.ts` `getDraftFallbackAdapters`: `codex-responses → claude` 매핑.
- `src/agents/worker.ts` `getWorkerFallbackAdapters`: 동일하게 claude를 fallback 후보로 포함.

## 해결
- 두 함수 모두 `return [primary]`로 변경 — claude fallback 경로 제거. codex 계열은 단일 어댑터 best-effort.
- Draft는 non-blocking이라 쿼터 에러 시 best-effort(insufficient) draft로 파이프라인 진행.

## 검증
- `draftAnalyzer.test.ts` 갱신: "codex 쿼터 에러 시 claude로 fallback하지 않음" — `getAdapter('claude')` 미호출, `spawnCli` 1회, `result.sufficient === false` 단언. 9/9 통과.
- 런타임: 새 dist 재시작 후 STO-1373·STO-1371이 worker→reviewer 정상 통과, `claude cli failed` 0회 재발 (재시작 마커 이후 로그 전수 확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)