### PR TITLE
feat(telemetry): opt-out 익명 사용 텔레메트리 — Cloudflare D1 (INT-1992)

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,10 +423,48 @@ src/
 | `~/.openswarm/registry.db` | Code entity registry (SQLite) |
 | `~/.openswarm/issues.db` | Local issue tracker (SQLite) |
 | `~/.claude/openswarm-*.json` | Pipeline history and task state |
+| `~/.config/openswarm/telemetry.json` | Anonymous install id + opt-out notice flag |
 | `config.yaml` | Main configuration |
 | `dist/` | Compiled output |
 
 ---
+
+
+## Privacy & Telemetry
+
+OpenSwarm collects **anonymous, opt-out** usage telemetry to understand how it's
+actually used (npm downloads and GitHub stars don't tell us). A single event is
+sent per command invocation.
+
+**What is sent** (and nothing else):
+
+| Field | Example | Why |
+|-------|---------|-----|
+| Random install id | `V1StGXR8_Z5j...` (nanoid) | De-duplicate installs — anonymous, local-only |
+| Command | `start`, `run`, `chat` | Which features are used |
+| Version | `0.9.3` | Version adoption |
+| OS / arch | `darwin` / `arm64` | Platform support priorities |
+| Node version | `22.3.0` | Runtime support |
+| Adapter family | `codex` | Which providers are popular |
+| Error flag | `0` / `1` | Failure rate (boolean only) |
+
+**Never sent:** source code, prompts, file paths, repo or issue names, Linear/Discord
+content, environment variables, API keys, or any personal data.
+
+**How to opt out** (any one):
+
+```bash
+export OPENSWARM_TELEMETRY=0      # or DO_NOT_TRACK=1
+```
+```yaml
+# config.yaml
+telemetry:
+  enabled: false
+```
+
+CI environments (`CI` / `GITHUB_ACTIONS`) are excluded automatically. The collector
+is a Cloudflare Worker writing to a private D1 table; telemetry never blocks or slows
+the CLI (fire-and-forget with a short timeout, and failures are silently ignored).
 
 
 ## Tech Stack

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -145,3 +145,9 @@ prProcessor:
   schedule: "*/15 * * * *"    # Check every 15 minutes
   cooldownHours: 6            # Wait 6 hours after processing
   maxIterations: 3            # Max 3 Worker-Reviewer iterations
+
+# Anonymous usage telemetry (opt-out). Sends command name, version, and OS only —
+# never code, prompts, paths, or personal data. Disable here, or via
+# OPENSWARM_TELEMETRY=0 / DO_NOT_TRACK=1. CI environments are excluded automatically.
+telemetry:
+  enabled: true

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
 import { runCli } from './runners/cliRunner.js';
 import { loadConfig, validateConfig, generateSampleConfig } from './core/config.js';
 import { loadEnvFile } from './core/envFile.js';
+import { initTelemetry, track } from './telemetry/telemetry.js';
 
 // Load .env so CLI commands (e.g. `auth login --provider linear` reading
 // LINEAR_OAUTH_CLIENT_ID) see the same env the daemon does. Idempotent; never
@@ -23,6 +24,21 @@ const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8
 const VERSION = pkg.version;
 
 const program = new Command();
+
+// Anonymous, opt-out usage telemetry (INT-1992). Honors OPENSWARM_TELEMETRY=0 /
+// DO_NOT_TRACK / CI. One event per command invocation (command name only — never
+// arguments). Fire-and-forget: not awaited, and track() never throws.
+initTelemetry({ version: VERSION });
+program.hook('preAction', (_thisCommand, actionCommand) => {
+  // Honor config telemetry.enabled when a config exists (best-effort — `run`/`init`
+  // may have none, in which case the env opt-out still applies).
+  try {
+    initTelemetry({ version: VERSION, enabled: loadConfig().telemetry?.enabled });
+  } catch {
+    /* no/invalid config — leave the opt-out default */
+  }
+  void track({ command: actionCommand.name() });
+});
 
 program
   .name('openswarm')

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -340,6 +340,14 @@ const McpConfigSchema = z
   })
   .optional();
 
+// Anonymous usage telemetry (opt-out). Defaults to enabled; the daemon/CLI also
+// honor OPENSWARM_TELEMETRY=0 / DO_NOT_TRACK / CI env. (INT-1992)
+const TelemetryConfigSchema = z
+  .object({
+    enabled: z.boolean().default(true),
+  })
+  .optional();
+
 const RawConfigSchema = z.object({
   adapter: AdapterNameSchema.default('codex'),
   language: z.enum(['en', 'ko']).default('en'),
@@ -354,6 +362,7 @@ const RawConfigSchema = z.object({
   ciWorker: CIWorkerConfigSchema,
   monitors: z.array(LongRunningMonitorConfigSchema).optional(),
   mcp: McpConfigSchema,
+  telemetry: TelemetryConfigSchema,
   agents: z.array(AgentSessionSchema).min(1, 'At least one agent is required'),
   defaultHeartbeatInterval: z.number().positive().default(DEFAULT_HEARTBEAT_INTERVAL),
 });
@@ -560,6 +569,7 @@ function transformConfig(raw: RawConfig): SwarmConfig {
     } : undefined,
     monitors: raw.monitors as LongRunningMonitorConfig[] | undefined,
     mcp: raw.mcp ? { servers: raw.mcp.servers as McpConfig['servers'] } : undefined,
+    telemetry: raw.telemetry ? { enabled: raw.telemetry.enabled } : undefined,
   };
 }
 
@@ -731,6 +741,12 @@ agents:
     projectPath: ~/dev/backend-api
     linearLabel: backend
     enabled: true
+
+# Anonymous usage telemetry (opt-out). Helps guide development with real usage
+# data: command name, version, OS — never code, prompts, paths, or personal data.
+# Disable here, or via OPENSWARM_TELEMETRY=0 / DO_NOT_TRACK=1. CI is auto-excluded.
+telemetry:
+  enabled: true
 
 # Default heartbeat interval (ms)
 defaultHeartbeatInterval: 1800000

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -133,6 +133,8 @@ export type SwarmConfig = {
   linearTeamId: string;
   /** Agent session list */
   agents: AgentSession[];
+  /** Anonymous usage telemetry (opt-out). undefined = default on. (INT-1992) */
+  telemetry?: { enabled: boolean };
   /** Default heartbeat interval (ms) */
   defaultHeartbeatInterval: number;
   /** GitHub repo list (for CI monitoring) */

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,11 @@ async function main(): Promise<void> {
   // Load configuration
   const config = loadConfig();
 
+  // Apply the telemetry opt-out from config for this daemon process (the detached
+  // daemon runs index.js directly, bypassing the CLI hook). (INT-1992)
+  const { initTelemetry } = await import('./telemetry/telemetry.js');
+  initTelemetry({ version: VERSION, enabled: config.telemetry?.enabled });
+
   // Validate configuration
   const validation = validateConfig(config);
 

--- a/src/telemetry/telemetry.test.ts
+++ b/src/telemetry/telemetry.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Stub disk IO: a stable install id + noticeShown so getInstallId/maybeShowNotice
+// never touch the real ~/.config/openswarm/telemetry.json during tests.
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(() => JSON.stringify({ installId: 'test-install', noticeShown: true })),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+import { initTelemetry, isTelemetryEnabled, track, buildPayload } from './telemetry.js';
+
+const ENV_KEYS = [
+  'OPENSWARM_TELEMETRY',
+  'DO_NOT_TRACK',
+  'CI',
+  'GITHUB_ACTIONS',
+  'OPENSWARM_TELEMETRY_URL',
+];
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  initTelemetry({ version: '9.9.9', enabled: true });
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 204 })));
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  vi.unstubAllGlobals();
+});
+
+describe('telemetry opt-out gating', () => {
+  it('is enabled by default (opt-out model)', () => {
+    expect(isTelemetryEnabled()).toBe(true);
+  });
+
+  it('OPENSWARM_TELEMETRY=0 disables', () => {
+    process.env.OPENSWARM_TELEMETRY = '0';
+    expect(isTelemetryEnabled()).toBe(false);
+  });
+
+  it('DO_NOT_TRACK=1 disables', () => {
+    process.env.DO_NOT_TRACK = '1';
+    expect(isTelemetryEnabled()).toBe(false);
+  });
+
+  it('CI env is auto-excluded (bots are not real users)', () => {
+    process.env.CI = 'true';
+    expect(isTelemetryEnabled()).toBe(false);
+  });
+
+  it('config telemetry.enabled=false hard-disables', () => {
+    initTelemetry({ version: '9.9.9', enabled: false });
+    expect(isTelemetryEnabled()).toBe(false);
+  });
+});
+
+describe('track() transport', () => {
+  it('sends nothing when disabled', async () => {
+    process.env.OPENSWARM_TELEMETRY = '0';
+    await track({ command: 'run' });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('POSTs one event to the endpoint when enabled', async () => {
+    process.env.OPENSWARM_TELEMETRY_URL = 'https://t.example/x';
+    await track({ command: 'start' });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = (fetch as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0];
+    expect(url).toBe('https://t.example/x');
+    expect(opts.method).toBe('POST');
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body.command).toBe('start');
+    expect(body.installId).toBe('test-install');
+  });
+
+  it('never throws on a network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('network down');
+    }));
+    await expect(track({ command: 'run' })).resolves.toBeUndefined();
+  });
+});
+
+describe('privacy contract (payload shape)', () => {
+  it('contains only the anonymous whitelist — no PII keys', () => {
+    initTelemetry({ version: '1.2.3', enabled: true });
+    const p = buildPayload({ command: 'run', adapter: 'codex' }, 'iid');
+    expect(Object.keys(p).sort()).toEqual(
+      ['adapter', 'arch', 'command', 'event', 'installId', 'isError', 'nodeVersion', 'platform', 'version'].sort(),
+    );
+    // No filesystem paths, tokens, keys, or prompt text can appear.
+    expect(JSON.stringify(p)).not.toMatch(/\/Users\/|\/home\/|token|apiKey|prompt/i);
+    expect(p.installId).toBe('iid');
+    expect(p.version).toBe('1.2.3');
+    expect(p.command).toBe('run');
+  });
+
+  it('isError is a 0/1 flag, never free text', () => {
+    expect(buildPayload({ isError: true }, 'i').isError).toBe(1);
+    expect(buildPayload({ isError: false }, 'i').isError).toBe(0);
+    expect(buildPayload({}, 'i').isError).toBe(0);
+  });
+
+  it('defaults event to "invoke"', () => {
+    expect(buildPayload({ command: 'chat' }, 'i').event).toBe('invoke');
+  });
+});

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -1,0 +1,170 @@
+// ============================================
+// OpenSwarm - Anonymous usage telemetry (opt-out)
+// ============================================
+//
+// Why: npm download counts are bot/mirror noise and GitHub stars are a cumulative
+// vanity metric — neither tells us how OpenSwarm is actually used. This sends a
+// tiny anonymous event (command name, version, OS) so development can be guided by
+// real usage. (INT-1992)
+//
+// Privacy contract (enforced by the payload shape below + telemetry.test.ts):
+//   - NO code, prompts, file paths, repo names, issue content, env values, or PII.
+//   - A random install id (nanoid) is the only identifier; it is local and anonymous.
+//   - Opt out any time: OPENSWARM_TELEMETRY=0 / DO_NOT_TRACK=1 / config telemetry.enabled=false.
+//   - CI environments are excluded automatically (they are not real users).
+//   - Fire-and-forget: a telemetry failure must NEVER affect the CLI/daemon.
+
+import os from 'node:os';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { nanoid } from 'nanoid';
+
+const STATE_DIR = join(homedir(), '.config', 'openswarm');
+const TELEMETRY_FILE = join(STATE_DIR, 'telemetry.json');
+
+// Collection endpoint (Cloudflare Worker → D1 intrect-telemetry.openswarm_events).
+// Overridable via env so the worker route can move without a client release.
+const DEFAULT_ENDPOINT = 'https://telemetry.intrect.io/v1/openswarm';
+const SEND_TIMEOUT_MS = 2500;
+
+interface TelemetryState {
+  installId: string;
+  noticeShown?: boolean;
+}
+
+// Set once from the CLI/daemon entry point so the module need not resolve
+// package.json itself (its dist location is ambiguous).
+let version = 'unknown';
+// config telemetry.enabled=false hard-disables regardless of env.
+let configDisabled = false;
+
+/** Initialize from the entry point: inject version and the config opt-out flag. */
+export function initTelemetry(opts: { version: string; enabled?: boolean }): void {
+  version = opts.version;
+  // Only an explicit `false` disables; undefined leaves the opt-out default (on).
+  configDisabled = opts.enabled === false;
+}
+
+function readState(): TelemetryState | null {
+  try {
+    return JSON.parse(readFileSync(TELEMETRY_FILE, 'utf8')) as TelemetryState;
+  } catch {
+    return null;
+  }
+}
+
+function writeState(state: TelemetryState): void {
+  try {
+    mkdirSync(STATE_DIR, { recursive: true });
+    writeFileSync(TELEMETRY_FILE, JSON.stringify(state, null, 2));
+  } catch {
+    // A read-only home or race is non-fatal: telemetry just stays best-effort.
+  }
+}
+
+/** Truthy env opt-out signals (OpenSwarm-specific + the cross-tool DO_NOT_TRACK). */
+function envDisabled(): boolean {
+  const v = (process.env.OPENSWARM_TELEMETRY ?? '').trim().toLowerCase();
+  if (v === '0' || v === 'false' || v === 'off' || v === 'no') return true;
+  const dnt = (process.env.DO_NOT_TRACK ?? '').trim().toLowerCase();
+  if (dnt === '1' || dnt === 'true') return true;
+  // CI/automation are not real users — exclude so the signal stays clean.
+  if (process.env.CI || process.env.GITHUB_ACTIONS) return true;
+  return false;
+}
+
+export function isTelemetryEnabled(): boolean {
+  return !configDisabled && !envDisabled();
+}
+
+function getInstallId(): string {
+  const state = readState();
+  if (state?.installId) return state.installId;
+  const installId = nanoid();
+  writeState({ installId, noticeShown: state?.noticeShown });
+  return installId;
+}
+
+/**
+ * Print the one-time opt-out notice (to stderr, so it never pollutes piped stdout).
+ * Subsequent runs are silent. No-op when telemetry is disabled.
+ */
+export function maybeShowNotice(): void {
+  if (!isTelemetryEnabled()) return;
+  const state = readState();
+  if (state?.noticeShown) return;
+  process.stderr.write(
+    '\nOpenSwarm collects anonymous usage data (command, version, OS) to guide development.\n' +
+      'No code, prompts, paths, or personal data are sent. Opt out: OPENSWARM_TELEMETRY=0\n' +
+      'Details: https://github.com/unohee/OpenSwarm#privacy--telemetry\n\n',
+  );
+  writeState({ installId: state?.installId ?? nanoid(), noticeShown: true });
+}
+
+export interface TrackOptions {
+  /** Subcommand name (run/start/chat/...) — NOT its arguments. */
+  command?: string;
+  /** Adapter family (codex/claude/...) — NOT a model or key. */
+  adapter?: string;
+  /** Whether the run ended in an error (boolean only). */
+  isError?: boolean;
+  /** Event kind; defaults to 'invoke'. */
+  event?: string;
+}
+
+/** The exact wire payload — kept flat and asserted by tests so PII can't creep in. */
+export interface TelemetryPayload {
+  installId: string;
+  event: string;
+  version: string;
+  platform: string;
+  arch: string;
+  nodeVersion: string;
+  command?: string;
+  adapter?: string;
+  isError: 0 | 1;
+}
+
+/** Build the payload (pure — used directly by tests to assert the privacy contract). */
+export function buildPayload(opts: TrackOptions, installId: string): TelemetryPayload {
+  return {
+    installId,
+    event: opts.event ?? 'invoke',
+    version,
+    platform: os.platform(),
+    arch: os.arch(),
+    nodeVersion: process.versions.node,
+    command: opts.command,
+    adapter: opts.adapter,
+    isError: opts.isError ? 1 : 0,
+  };
+}
+
+/**
+ * Send one telemetry event. Fire-and-forget: resolves quietly on any failure and
+ * NEVER throws. Awaitable so short-lived CLI commands can flush before exit, but a
+ * timeout guarantees it won't hang the process.
+ */
+export async function track(opts: TrackOptions): Promise<void> {
+  if (!isTelemetryEnabled()) return;
+  try {
+    maybeShowNotice();
+    const payload = buildPayload(opts, getInstallId());
+    const endpoint = process.env.OPENSWARM_TELEMETRY_URL || DEFAULT_ENDPOINT;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), SEND_TIMEOUT_MS);
+    try {
+      await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'User-Agent': `OpenSwarm/${version}` },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    // Telemetry is best-effort by contract — swallow everything.
+  }
+}

--- a/workers/telemetry/worker.ts
+++ b/workers/telemetry/worker.ts
@@ -1,0 +1,66 @@
+// ============================================
+// OpenSwarm telemetry collector — Cloudflare Worker → D1
+// ============================================
+//
+// Receives anonymous usage events from the OpenSwarm CLI/daemon and appends them
+// to D1 `intrect-telemetry.openswarm_events`. (INT-1992)
+//
+// Defense in depth: even though the client only sends a flat anonymous payload,
+// this worker re-whitelists fields and clamps lengths so nothing unexpected (PII,
+// oversized blobs) can be smuggled into the table.
+
+export interface Env {
+  DB: D1Database;
+}
+
+/** Coerce to a trimmed string of bounded length, or null. */
+function str(v: unknown, max: number): string | null {
+  if (typeof v !== 'string') return null;
+  const s = v.trim();
+  return s ? s.slice(0, max) : null;
+}
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    if (req.method === 'OPTIONS') return new Response(null, { status: 204 });
+    if (req.method !== 'POST') return new Response('method not allowed', { status: 405 });
+
+    let body: Record<string, unknown>;
+    try {
+      body = (await req.json()) as Record<string, unknown>;
+    } catch {
+      return new Response('bad json', { status: 400 });
+    }
+
+    const installId = str(body.installId, 64);
+    if (!installId) return new Response('missing installId', { status: 400 });
+
+    // Cloudflare-provided coarse geo (country only — no IP is stored).
+    const country = req.headers.get('cf-ipcountry');
+
+    try {
+      await env.DB.prepare(
+        `INSERT INTO openswarm_events
+           (install_id, event, version, platform, arch, node_version, command, adapter, is_error, country)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+        .bind(
+          installId,
+          str(body.event, 32) ?? 'invoke',
+          str(body.version, 32),
+          str(body.platform, 16),
+          str(body.arch, 16),
+          str(body.nodeVersion, 16),
+          str(body.command, 32),
+          str(body.adapter, 32),
+          body.isError ? 1 : 0,
+          country && country !== 'XX' ? country.slice(0, 2) : null,
+        )
+        .run();
+    } catch {
+      return new Response('db error', { status: 500 });
+    }
+
+    return new Response(null, { status: 204 });
+  },
+};

--- a/workers/telemetry/wrangler.toml
+++ b/workers/telemetry/wrangler.toml
@@ -1,0 +1,20 @@
+# OpenSwarm telemetry collector (INT-1992)
+# Deploy:  cd workers/telemetry && wrangler deploy
+# Schema:  table openswarm_events already created in D1 intrect-telemetry.
+
+name = "intrect-openswarm-telemetry"
+main = "worker.ts"
+compatibility_date = "2026-06-01"
+workers_dev = true
+
+[[d1_databases]]
+binding = "DB"
+database_name = "intrect-telemetry"
+database_id = "f36e5371-9204-4a02-a0ea-2bf014dec031"
+
+# Public collection host (DNS + cert auto-provisioned by wrangler). The worker
+# ignores the path, so the client posts to telemetry.intrect.io/v1/openswarm —
+# matching DEFAULT_ENDPOINT in src/telemetry/telemetry.ts.
+[[routes]]
+pattern = "telemetry.intrect.io"
+custom_domain = true


### PR DESCRIPTION
## 배경
npm 다운로드(지난주 1717)는 버전 균등 분포·중간 0일로 봇/미러 확정, GitHub stars(814)는 4월 피크 후 6월 신규 17로 누적·정체 — 실사용을 알 수 없다. 명령 단위 익명 텔레메트리로 실채택을 측정한다.

## 변경
- **`src/telemetry/telemetry.ts`** — installId(nanoid, `~/.config/openswarm/telemetry.json`), opt-out 게이트, 첫 실행 1회 고지, fire-and-forget `track()`(throw 금지, 2.5s timeout).
- **opt-out** — `OPENSWARM_TELEMETRY=0` / `DO_NOT_TRACK=1` / config `telemetry.enabled=false`. CI(`CI`/`GITHUB_ACTIONS`) 자동 제외.
- **수집 항목** — 명령·버전·OS/arch·node·adapter·에러여부(boolean)만. **코드·프롬프트·경로·repo/이슈명·키·PII 전부 제외** (페이로드 화이트리스트, 테스트로 단언).
- **통합** — `cli.ts` preAction hook(명령마다 1회 + config opt-out 존중), 데몬은 `index.ts`에서 config 반영. config Zod 스키마 + `SwarmConfig` 타입 + sample/example.
- **수집 백엔드** — `workers/telemetry/` Cloudflare Worker → D1 `intrect-telemetry.openswarm_events`. 서버측에서도 필드 화이트리스트·길이 clamp로 PII 차단. custom domain `telemetry.intrect.io`.
- **문서** — README Privacy & Telemetry 섹션.

## 검증
- 단위 **11/11**: opt-out 게이트(env/config/CI), 페이로드 키 화이트리스트(PII 부재 단언), 네트워크 실패 시 throw 금지.
- 전체 스위트 1189 pass (1 fail은 `service.test.ts` provider-override 환경 의존 — 텔레메트리 무관, stash로 입증).
- **E2E**: 실제 `node dist/cli.js doctor`가 nanoid 생성·전송 → D1 적재 확인. curl 정상 204 / installId 누락 400 / custom domain 204. 테스트 row는 정리 완료.

## 배포 메모
- D1 테이블 `openswarm_events` 생성 완료, worker 배포 완료(`telemetry.intrect.io`).
- `DEFAULT_ENDPOINT`는 `telemetry.intrect.io/v1/openswarm`, `OPENSWARM_TELEMETRY_URL`로 override 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)