### PR TITLE
Sync task state on cancellation

### DIFF
--- a/src/automation/autonomousRunner.cancel.test.ts
+++ b/src/automation/autonomousRunner.cancel.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PipelineResult } from '../agents/pairPipeline.js';
+import type { TaskScheduler } from '../orchestration/taskScheduler.js';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import type { AutonomousConfig } from './runnerTypes.js';
+import type { ITaskSource } from './taskSource.js';
+
+type AutonomousRunnerCtor = typeof import('./autonomousRunner.js').AutonomousRunner;
+type RunnerExecutionModule = typeof import('./runnerExecution.js');
+type TaskStateStoreModule = typeof import('../taskState/store.js');
+
+let tempDir = '';
+let AutonomousRunner: AutonomousRunnerCtor;
+let runnerExecution: RunnerExecutionModule;
+let taskStateStore: TaskStateStoreModule;
+
+const cfg = (over: Partial<AutonomousConfig> = {}): AutonomousConfig => ({
+  linearTeamId: 'team',
+  allowedProjects: ['/repo'],
+  heartbeatSchedule: '0 * * * *',
+  autoExecute: false,
+  maxConsecutiveTasks: 1,
+  cooldownSeconds: 0,
+  dryRun: true,
+  ...over,
+});
+
+const task = (): TaskItem => ({
+  id: 'task-1',
+  source: 'linear',
+  issueId: 'ISSUE-1',
+  issueIdentifier: 'INT-1',
+  title: 'Cancel me',
+  priority: 3,
+  createdAt: Date.now(),
+});
+
+const cancelledResult = (): PipelineResult => ({
+  success: false,
+  sessionId: 'pipeline-1',
+  iterations: 0,
+  totalDuration: 25,
+  finalStatus: 'cancelled',
+  stages: [],
+});
+
+function mockTaskSource() {
+  return {
+    kind: 'local',
+    updateState: vi.fn(async () => {}),
+    addComment: vi.fn(async () => {}),
+  } as unknown as ITaskSource & {
+    updateState: ReturnType<typeof vi.fn>;
+    addComment: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('AutonomousRunner cancellation state sync', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    tempDir = mkdtempSync(join(tmpdir(), 'openswarm-cancel-sync-'));
+    vi.stubEnv('OPENSWARM_TASK_STATE_FILE', join(tempDir, 'task-state.json'));
+    ({ AutonomousRunner } = await import('./autonomousRunner.js'));
+    runnerExecution = await import('./runnerExecution.js');
+    taskStateStore = await import('../taskState/store.js');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('parks durable task state when the scheduler emits cancelled', async () => {
+    const source = mockTaskSource();
+    runnerExecution.setTaskSource(source);
+    taskStateStore.markTaskInProgress('ISSUE-1', {
+      issueIdentifier: 'INT-1',
+      title: 'Cancel me',
+      sessionId: 'pipeline-1',
+      branchName: 'fix/int-1',
+      worktreePath: '/tmp/openswarm/int-1',
+    });
+
+    const runner = new AutonomousRunner(cfg());
+    const scheduler = (runner as unknown as { scheduler: TaskScheduler }).scheduler;
+
+    scheduler.startTask(task(), '/repo', async () => cancelledResult());
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const state = taskStateStore.getTaskState('ISSUE-1');
+    expect(state?.execution.status).toBe('backlog');
+    expect(state?.linearState).toBe('Backlog');
+    expect(state?.worktree.worktreePath).toBeUndefined();
+    expect(source.updateState).toHaveBeenCalledWith('ISSUE-1', 'Backlog');
+    expect(source.addComment).toHaveBeenCalledWith(
+      'ISSUE-1',
+      expect.stringContaining('Task cancelled')
+    );
+  });
+});

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -265,6 +265,14 @@ export class AutonomousRunner {
       this.scheduleNextHeartbeat();
     });
 
+    this.scheduler.on('cancelled', async ({ task, result }) => {
+      const taskCtx = this.formatTaskContext(task);
+      console.log(`[Scheduler] Task cancelled: ${taskCtx} ${task.title}`);
+      broadcastEvent({ type: 'task:completed', data: { taskId: task.id, success: false, duration: result.totalDuration } });
+      this.recordPipelineHistory(task, result);
+      await execution.syncCancellationState(task);
+    });
+
     this.scheduler.on('failed', async ({ task, result }) => {
       const taskCtx = this.formatTaskContext(task);
 

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -271,6 +271,10 @@ export class AutonomousRunner {
       broadcastEvent({ type: 'task:completed', data: { taskId: task.id, success: false, duration: result.totalDuration } });
       this.recordPipelineHistory(task, result);
       await execution.syncCancellationState(task);
+      // Keep parity with the completed/failed handlers: kick the next heartbeat
+      // so discovery resumes immediately instead of waiting for the next cron
+      // tick (matters in serial mode, where slotFreed/runAvailableTasks is a no-op).
+      this.scheduleNextHeartbeat();
     });
 
     this.scheduler.on('failed', async ({ task, result }) => {

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -44,6 +44,7 @@ import {
   buildTaskStateSyncComment,
   completeParentIfChildrenDone,
   markTaskBlocked,
+  markTaskBacklog,
   markTaskDecomposed,
   markTaskDone,
   markTaskInProgress,
@@ -1062,6 +1063,27 @@ export async function syncFailureState(task: TaskItem, reason: string): Promise<
     await taskSource?.addComment(task.issueId, buildTaskStateSyncComment(state, 'Task blocked'));
   } catch (err) {
     console.warn(`[AutonomousRunner] Failed to sync blocked state for ${task.issueId}:`, err);
+  }
+}
+
+export async function syncCancellationState(task: TaskItem): Promise<void> {
+  if (!task.issueId) return;
+  const state = markTaskBacklog(task.issueId, {
+    issueIdentifier: task.issueIdentifier,
+    title: task.title,
+    linearState: 'Backlog',
+  });
+
+  try {
+    await taskSource?.updateState(task.issueId, 'Backlog');
+  } catch (err) {
+    console.warn(`[AutonomousRunner] Failed to move cancelled task ${task.issueId} to Backlog:`, err);
+  }
+
+  try {
+    await taskSource?.addComment(task.issueId, buildTaskStateSyncComment(state, 'Task cancelled'));
+  } catch (err) {
+    console.warn(`[AutonomousRunner] Failed to sync cancelled state for ${task.issueId}:`, err);
   }
 }
 

--- a/src/taskState/store.test.ts
+++ b/src/taskState/store.test.ts
@@ -10,6 +10,7 @@ import {
   completeParentIfChildrenDone,
   buildTaskStateSyncComment,
   hydrateTaskStateFromComments,
+  markTaskBacklog,
 } from './store.js';
 
 describe('task state store', () => {
@@ -159,6 +160,28 @@ describe('task state store', () => {
     markTaskInProgress('KT-402', { linearState: 'In Progress' });
     const running = updateTaskLinearState('KT-402', 'In Progress');
     expect(running.execution.status).toBe('in_progress');
+  });
+
+  it('parks a claimed task back in backlog and clears stale worktree data', () => {
+    markTaskInProgress('KT-450', {
+      issueIdentifier: 'KT-450',
+      title: 'Cancel running task',
+      linearState: 'In Progress',
+      sessionId: 'pipeline-1',
+      branchName: 'fix/kt-450',
+      worktreePath: '/tmp/openswarm/kt-450',
+    });
+
+    const parked = markTaskBacklog('KT-450', {
+      issueIdentifier: 'KT-450',
+      title: 'Cancel running task',
+    });
+
+    expect(parked.execution.status).toBe('backlog');
+    expect(parked.execution.lastSessionId).toBe('pipeline-1');
+    expect(parked.linearState).toBe('Backlog');
+    expect(parked.worktree.branchName).toBeUndefined();
+    expect(parked.worktree.worktreePath).toBeUndefined();
   });
 
   it('completes decomposed parent only after all child issues are done', () => {

--- a/src/taskState/store.ts
+++ b/src/taskState/store.ts
@@ -224,6 +224,30 @@ export function markTaskInProgress(
   });
 }
 
+export function markTaskBacklog(
+  issueId: string,
+  patch: {
+    issueIdentifier?: string;
+    title?: string;
+    linearState?: string;
+  } = {},
+): OpenSwarmTaskState {
+  return upsertTaskState(issueId, {
+    issueIdentifier: patch.issueIdentifier,
+    title: patch.title,
+    linearState: patch.linearState ?? 'Backlog',
+    execution: {
+      status: 'backlog',
+      blockedReason: undefined,
+      retryCount: 0,
+    },
+    worktree: {
+      branchName: undefined,
+      worktreePath: undefined,
+    },
+  });
+}
+
 export function markTaskDone(
   issueId: string,
   patch: {


### PR DESCRIPTION
## Summary

This fixes cancellation handling for running pair-mode tasks. The scheduler already emits a `cancelled` event when a pipeline returns `finalStatus: "cancelled"`, but `AutonomousRunner` did not subscribe to that event, so the scheduler slot could be freed while the canonical task-state store still reported the issue as `in_progress`.

Changes:

- handle scheduler `cancelled` events in `AutonomousRunner`
- add `syncCancellationState` to move cancelled tasks back to `Backlog` and write the standard task-state sync comment
- add `markTaskBacklog` to the canonical task-state store, clearing stale worktree metadata
- add regression coverage for the runner event wiring and store transition

## Why

Without this, a manually cancelled or project-disabled task can disappear from the running scheduler set but remain durably marked as `in_progress`. That stale state can confuse dashboard/task-state views and dependency/readiness logic after cancellation.

## Maintainer note

I followed the current repository semantics: the task-state schema does not currently include a `cancelled` execution status, and the local task source maps `cancelled` back to `Backlog`. Long term, it may be worth deciding whether user cancellation should remain a "park back in backlog" operation or become its own durable terminal `cancelled` state.

## Validation

- `npm test -- src/taskState/store.test.ts src/automation/autonomousRunner.cancel.test.ts src/orchestration/taskScheduler.cancel.test.ts`
- `npm run lint` (passes with existing warnings)
- `npm run typecheck`
- `npm run build`

Note: full `npm test` currently fails in `src/core/service.test.ts` provider-override expectations; this reproduces when that test file is run standalone and appears unrelated to this cancellation change.