### PR TITLE
feat(chat): 실행 cwd 저장소 컨텍스트를 chat·/plan·/goal에 배선·주입 (INT-2005)

### DIFF
--- a/src/support/chatBackend.test.ts
+++ b/src/support/chatBackend.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { curatedModels, getDefaultChatModel } from './chatBackend.js';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { curatedModels, getDefaultChatModel, buildRepoContext } from './chatBackend.js';
 
 describe('curatedModels (INT-1961)', () => {
   it('includes the provider default first and dedupes', () => {
@@ -14,5 +18,72 @@ describe('curatedModels (INT-1961)', () => {
       const m = curatedModels(p);
       expect(m).toContain(getDefaultChatModel(p));
     }
+  });
+});
+
+describe('buildRepoContext (INT-2005)', () => {
+  let dir = '';
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'openswarm-repoctx-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns the repo name and absolute cwd path', () => {
+    const ctx = buildRepoContext(dir);
+    expect(ctx).toContain('## Repository context');
+    expect(ctx).toContain(`(${dir})`);
+    // basename of the temp dir is the repo label
+    expect(ctx).toContain(`repo: ${dir.split('/').pop()}`);
+  });
+
+  it('injects AGENTS.md project rules when present', () => {
+    writeFileSync(join(dir, 'AGENTS.md'), '# House rules\nAlways write English comments.');
+    const ctx = buildRepoContext(dir);
+    expect(ctx).toContain('## Project rules (AGENTS.md)');
+    expect(ctx).toContain('Always write English comments.');
+  });
+
+  it('prefers AGENTS.md over CLAUDE.md (first match wins)', () => {
+    writeFileSync(join(dir, 'AGENTS.md'), 'agents-rules-marker');
+    writeFileSync(join(dir, 'CLAUDE.md'), 'claude-rules-marker');
+    const ctx = buildRepoContext(dir);
+    expect(ctx).toContain('agents-rules-marker');
+    expect(ctx).not.toContain('claude-rules-marker');
+  });
+
+  it('falls back to CLAUDE.md when AGENTS.md is absent', () => {
+    writeFileSync(join(dir, 'CLAUDE.md'), 'claude-only-marker');
+    const ctx = buildRepoContext(dir);
+    expect(ctx).toContain('## Project rules (CLAUDE.md)');
+    expect(ctx).toContain('claude-only-marker');
+  });
+
+  it('truncates an over-long rules file', () => {
+    writeFileSync(join(dir, 'AGENTS.md'), 'x'.repeat(5000));
+    const ctx = buildRepoContext(dir);
+    expect(ctx).toContain('… (truncated');
+    expect(ctx.length).toBeLessThan(5000);
+  });
+
+  it('includes the git branch inside a real repo', () => {
+    const git = (...args: string[]) =>
+      execFileSync('git', ['-c', 'user.email=t@t', '-c', 'user.name=t', ...args], { cwd: dir });
+    git('init', '-q', '-b', 'feature-xyz');
+    git('commit', '--allow-empty', '-q', '-m', 'init'); // rev-parse HEAD needs a commit
+    const ctx = buildRepoContext(dir);
+    expect(ctx).toContain('branch: feature-xyz');
+  });
+
+  it('omits the branch line for a non-git directory', () => {
+    const ctx = buildRepoContext(dir);
+    expect(ctx).not.toContain('branch:');
+  });
+
+  it('returns empty string for a non-existent cwd', () => {
+    expect(buildRepoContext(join(dir, 'does-not-exist'))).toBe('');
   });
 });

--- a/src/support/chatBackend.ts
+++ b/src/support/chatBackend.ts
@@ -1,5 +1,7 @@
-import { spawn } from 'node:child_process';
+import { spawn, execFileSync } from 'node:child_process';
 import { writeFile, unlink } from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
 import type { AdapterName } from '../adapters/index.js';
 import { getAdapter, getDefaultAdapterName } from '../adapters/index.js';
 
@@ -147,6 +149,66 @@ export function shortenChatModel(model: string): string {
  * not a shell — their buildCommand is a stub, so spawning it returns nothing
  * ("No response"). Route chat through run() as a plain, tool-free single turn.
  */
+
+// Project-rules files read into the repo context block, in preference order
+// (first found wins — AGENTS.md is the OpenSwarm convention, CLAUDE.md the fallback).
+const REPO_RULES_FILES = ['AGENTS.md', 'CLAUDE.md'] as const;
+// Cap injected rules so a long file doesn't dominate the prompt budget.
+const REPO_RULES_MAX_CHARS = 2000;
+
+export const BASE_CHAT_SYSTEM_PROMPT =
+  'You are a capable coding assistant operating in the user\'s current working directory, with tools to ' +
+  'read/search/edit/create files, run shell commands, and call configured MCP server tools (named `server__tool`). ' +
+  'Work like a thoughtful pair programmer who thinks out loud. Before each tool call, write one short sentence ' +
+  'saying what you are about to do and why (e.g. "To find where X is defined, I\'ll search the source."). After a ' +
+  'tool returns, briefly note what you found and your next step, then continue. Actually use the tools to perform ' +
+  'the task — never just describe it. Keep narration to a sentence or two between actions, not essays. ' +
+  'For a trivial question with no task, just answer directly without tools.';
+
+/**
+ * Build a repo-context block injected into the chat agent's system prompt so it
+ * knows which repository it is in, the active branch, and the project's own
+ * rules (AGENTS.md / CLAUDE.md). This is what lets `openswarm chat`/`/plan`/
+ * `/goal` operate in the cwd the CLI was launched from rather than guessing.
+ * Returns '' when `cwd` doesn't exist (caller then uses the base prompt alone).
+ * Best-effort: a missing git/rules file is silently skipped. (INT-2005)
+ */
+export function buildRepoContext(cwd: string): string {
+  if (!cwd || !existsSync(cwd)) return '';
+  const repo = basename(cwd.replace(/[/\\]+$/, '')) || cwd;
+  const lines = ['## Repository context', `repo: ${repo}  (${cwd})`];
+
+  try {
+    const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+    if (branch) lines.push(`branch: ${branch}`);
+  } catch {
+    // not a git repo — omit the branch
+  }
+
+  for (const name of REPO_RULES_FILES) {
+    const path = join(cwd, name);
+    if (!existsSync(path)) continue;
+    try {
+      let body = readFileSync(path, 'utf8').trim();
+      if (!body) continue;
+      if (body.length > REPO_RULES_MAX_CHARS) {
+        body = `${body.slice(0, REPO_RULES_MAX_CHARS)}\n… (truncated — read ${name} for the rest)`;
+      }
+      lines.push('', `## Project rules (${name})`, body);
+      break; // first match wins
+    } catch {
+      // unreadable — skip
+    }
+  }
+
+  return lines.join('\n');
+}
+
 async function runChatViaAdapter(
   adapter: ReturnType<typeof getAdapter>,
   provider: AdapterName,
@@ -165,19 +227,18 @@ async function runChatViaAdapter(
   const { getMcpTools } = await import('../mcp/mcpClient.js');
   const mcpTools = await getMcpTools().catch(() => []);
 
+  // Tell the agent which repo/branch it's in and surface the project's own rules
+  // so chat/plan/goal work in the launch cwd, not a guessed one. (INT-2005)
+  const repoContext = buildRepoContext(cwd);
+
   let streamed = false;
   const raw = await adapter.run!({
     prompt: options.prompt,
     cwd,
     model,
-    systemPrompt:
-      'You are a capable coding assistant operating in the user\'s current working directory, with tools to ' +
-      'read/search/edit/create files, run shell commands, and call configured MCP server tools (named `server__tool`). ' +
-      'Work like a thoughtful pair programmer who thinks out loud. Before each tool call, write one short sentence ' +
-      'saying what you are about to do and why (e.g. "To find where X is defined, I\'ll search the source."). After a ' +
-      'tool returns, briefly note what you found and your next step, then continue. Actually use the tools to perform ' +
-      'the task — never just describe it. Keep narration to a sentence or two between actions, not essays. ' +
-      'For a trivial question with no task, just answer directly without tools.',
+    systemPrompt: repoContext
+      ? `${BASE_CHAT_SYSTEM_PROMPT}\n\n${repoContext}`
+      : BASE_CHAT_SYSTEM_PROMPT,
     enableTools: true,
     webTools: true,
     mcpTools,

--- a/src/support/chatSession.ts
+++ b/src/support/chatSession.ts
@@ -95,11 +95,17 @@ export async function callChatModel(
   onToolLog?: (line: string) => void,
   maxTurns?: number,
   signal?: AbortSignal,
+  // Working directory the agent's tools (file/bash/MCP) operate in, and the root
+  // used to build the repo context block. Defaults to process.cwd() downstream
+  // when omitted — but the chat TUI threads the launch cwd through so the agent
+  // works in the repo `openswarm chat` was started from. (INT-2005)
+  cwd?: string,
 ): Promise<{ response: string; sessionId: string; cost: number; tokens: number }> {
   const result = await runChatCompletion({
     prompt,
     provider,
     model,
+    cwd,
     timeoutMs: 300000,
     onText: onStream,
     onLog: onToolLog,

--- a/src/support/goalCommand.ts
+++ b/src/support/goalCommand.ts
@@ -116,6 +116,7 @@ async function defaultPursue(goal: string, io: PlanIO, opts: GoalCommandOptions)
     (line) => io.print(line),
     opts.maxTurns ?? GOAL_PURSUIT_MAX_TURNS,
     opts.signal,
+    opts.projectPath, // pursue the goal in the target repo, not process.cwd() (INT-2005)
   );
   if (out.trim()) io.print(out.trim());
 }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -66,7 +66,7 @@ export function App({ version, provider, model, port, cwd, branch, initialTab = 
       <TabBar active={active} />
       <Box flexDirection="column" paddingY={1} minHeight={Math.max(1, rows - 4)}>
         {activeTab.id === 'chat' ? (
-          <ChatPanel active={chatActive} provider={provider} model={model} />
+          <ChatPanel active={chatActive} provider={provider} model={model} projectPath={cwd} />
         ) : activeTab.id === 'pipeline' ? (
           <PipelinePanel port={port} />
         ) : activeTab.id === 'logs' ? (

--- a/src/tui/panels/ChatPanel.tsx
+++ b/src/tui/panels/ChatPanel.tsx
@@ -103,6 +103,8 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
             setActivity((a) => [...a, line].slice(-10));
           },
           maxTurns,
+          undefined, // no abort signal wired here yet
+          cwd, // run in the repo `openswarm chat` was launched from (INT-2005)
         );
       } catch (e) {
         dispatch({ type: 'stream', chunk: `\n[error] ${e instanceof Error ? e.message : String(e)}` });
@@ -112,7 +114,7 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
         setBusy(false);
       }
     },
-    [provider, model],
+    [provider, model, cwd],
   );
 
   // /goal routes by complexity: simple → pursue in-session (streamed), complex →


### PR DESCRIPTION
## 요약

`openswarm chat`을 실행한 저장소(cwd)가 채팅 에이전트와 `/plan`·`/goal`까지 온전히 흐르게 하고, 에이전트가 "여기가 어떤 저장소·브랜치이며 규칙이 무엇인지" 인지하도록 시스템 프롬프트에 저장소 컨텍스트를 주입한다.

기존엔 cli.ts가 cwd/branch를 계산해도 App→ContextBar(화면 표시)까지만 흐르고, 실제 채팅/실행 경로로는 단절돼 있었다. 끊김 3곳을 메운다.

## 변경

| 파일 | 변경 |
|---|---|
| `support/chatSession.ts` | `callChatModel`에 `cwd` 파라미터 추가 → `runChatCompletion`에 전달 (GAP #2) |
| `tui/App.tsx` | `<ChatPanel projectPath={cwd}>` 배선 — `process.cwd()` 폴백 의존 제거 (GAP #1) |
| `tui/panels/ChatPanel.tsx` | `streamChat`이 컴포넌트 `cwd`를 `callChatModel`로 전달 |
| `support/goalCommand.ts` | simple-goal 추격도 `opts.projectPath`에서 실행 |
| `support/chatBackend.ts` | `buildRepoContext` 헬퍼(repo·branch·AGENTS.md/CLAUDE.md) + `BASE_CHAT_SYSTEM_PROMPT` 추출, 시스템 프롬프트 주입 (GAP #3) |
| `chatBackend.test.ts` | `buildRepoContext` 단위 테스트 8건 |

## 한계

codex **CLI**(`buildCommand`) 경로는 systemPrompt를 안 받아 컨텍스트 블록이 안 들어간다. 단 cwd 자체는 spawn cwd로 전달되고 codex가 자체적으로 cwd의 AGENTS.md를 읽으므로 실질 영향은 작다. `adapter.run` 경로(gpt/openrouter/local/codex-responses)는 모두 주입됨.

## 검증

- `npm run typecheck` / `npm run build` / `oxlint` 클린
- `buildRepoContext` 단위 테스트 10/10, 영향 테스트(chat/App/goalCommand/chatSession) green
- 실측: 이 저장소에서 `buildRepoContext(cwd)` → `repo: OpenSwarm / branch: …` 출력, 없는 경로는 `""`

Closes INT-2005