### PR TITLE
fix(daemon): 어댑터 CLI 인프라 오류를 STUCK 카운트에서 분리 (INT-2010)

### DIFF
--- a/src/adapters/errorClassification.test.ts
+++ b/src/adapters/errorClassification.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { isInfraError } from './errorClassification.js';
+
+describe('isInfraError (INT-2010)', () => {
+  it('flags CLI non-zero exit as infra (the production STUCK driver)', () => {
+    expect(isInfraError(new Error('codex CLI failed with code 1: Reading prompt from stdin...'))).toBe(true);
+    expect(isInfraError(new Error('Reviewer execution failed: claude CLI failed with code 1'))).toBe(true);
+    expect(isInfraError(new Error('process exited with code 127'))).toBe(true);
+  });
+
+  it('flags spawn / auth / timeout / network failures', () => {
+    expect(isInfraError(new Error('spawn codex ENOENT'))).toBe(true);
+    expect(isInfraError(new Error('Request failed: 401 Unauthorized'))).toBe(true);
+    expect(isInfraError(new Error('connect ETIMEDOUT'))).toBe(true);
+    expect(isInfraError(new Error('read ECONNRESET'))).toBe(true);
+    expect(isInfraError('getaddrinfo ENOTFOUND api.openai.com')).toBe(true);
+  });
+
+  it('does NOT flag genuine task/code failures', () => {
+    expect(isInfraError(new Error('TypeError: cannot read property foo of undefined'))).toBe(false);
+    expect(isInfraError(new Error('Test failed: expected 3 to equal 4'))).toBe(false);
+    expect(isInfraError(new Error('old_string not found in file'))).toBe(false);
+    expect(isInfraError(new Error('Reviewer rejected: missing null check'))).toBe(false);
+  });
+
+  it('handles non-Error inputs safely', () => {
+    expect(isInfraError(undefined)).toBe(false);
+    expect(isInfraError(null)).toBe(false);
+    expect(isInfraError('')).toBe(false);
+  });
+});

--- a/src/adapters/errorClassification.ts
+++ b/src/adapters/errorClassification.ts
@@ -1,0 +1,54 @@
+// ============================================
+// OpenSwarm - Error classification (INT-2010)
+// ============================================
+//
+// Distinguish "the agent's CLI/runtime failed to execute" (infrastructure) from
+// "the agent ran and the work is wrong" (a real task failure). Infra failures —
+// CLI non-zero exit, auth expiry, spawn ENOENT, timeouts, network drops — must
+// NOT count toward the rejection/failure budgets that mark an issue durably
+// STUCK: the task itself never got a fair attempt. This mirrors how RateLimitError
+// is already special-cased (INT-1906), extended to the broader infra class.
+//
+// Observed in production (2026-06-28~29): `codex CLI failed with code 1` and
+// `Reviewer execution failed: claude CLI failed with code 1` repeatedly drove
+// otherwise-completable tasks to STUCK after worker had already edited files.
+
+// Substrings (matched case-insensitively) that mark a failure as infrastructural
+// rather than a verdict on the work. Kept conservative — code-logic errors
+// (TypeError, assertion failures) are deliberately NOT here, so a genuinely
+// broken edit still counts.
+const INFRA_ERROR_PATTERNS = [
+  'cli failed with code', // codex/claude CLI exited non-zero
+  'exited with code',
+  'exited with non-zero',
+  'non-zero code',
+  'enoent', // spawn: binary not found
+  'spawn ', // spawn EACCES / spawn failures
+  'etimedout',
+  'timed out',
+  'esockettimedout',
+  'econnreset',
+  'econnrefused',
+  'enotfound',
+  'socket hang up',
+  'network error',
+  'unauthorized',
+  'not authenticated',
+  'authentication failed',
+  'invalid api key',
+  'permission denied',
+  '401',
+  '403',
+];
+
+/**
+ * True when `error` looks like an infrastructure/runtime failure of the agent
+ * CLI rather than a substantive failure of the task. Used to keep such failures
+ * out of the STUCK-inducing rejection/failure counts (they get a backoff retry
+ * instead). (INT-2010)
+ */
+export function isInfraError(error: unknown): boolean {
+  const msg = (error instanceof Error ? error.message : String(error ?? '')).toLowerCase();
+  if (!msg) return false;
+  return INFRA_ERROR_PATTERNS.some((p) => msg.includes(p));
+}

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -38,6 +38,7 @@ import * as auditorAgent from './auditor.js';
 import * as skillDocumenterAgent from './skillDocumenter.js';
 import { StuckDetector, createStuckDetector } from '../support/stuckDetector.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
+import { isInfraError } from '../adapters/errorClassification.js';
 
 // Types
 
@@ -105,7 +106,7 @@ export interface PipelineResult {
   success: boolean;
   sessionId: string;
   stages: StageResult[];
-  finalStatus: 'approved' | 'rejected' | 'failed' | 'cancelled' | 'decomposed' | 'rate_limited';
+  finalStatus: 'approved' | 'rejected' | 'failed' | 'cancelled' | 'decomposed' | 'rate_limited' | 'infra_error';
   /** Unix timestamp (ms) when the rate-limit quota resets — set when finalStatus is 'rate_limited'. */
   rateLimitResetsAt?: number;
   totalDuration: number;
@@ -361,10 +362,16 @@ export class PairPipeline extends EventEmitter {
       // Surface it as its own finalStatus so the runner pauses until quota resets
       // instead of counting a failure and spamming Linear comments. (INT-1906)
       const rateLimited = !cancelled && error instanceof RateLimitError;
+      // An infra/CLI failure (worker/reviewer never ran: non-zero exit, auth,
+      // spawn, timeout) is not a task failure — surface it distinctly so the
+      // runner does a backoff retry instead of counting it toward STUCK. (INT-2010)
+      const infra = !cancelled && !rateLimited && isInfraError(error);
       if (cancelled) {
         console.log(`[${context.taskPrefix}] Pipeline cancelled`);
       } else if (rateLimited) {
         console.warn(`[${context.taskPrefix}] Pipeline rate-limited: ${(error as RateLimitError).message}`);
+      } else if (infra) {
+        console.warn(`[${context.taskPrefix}] Pipeline infra error (not counted toward STUCK): ${error instanceof Error ? error.message : String(error)}`);
       } else {
         console.error('[%s] Error:', context.taskPrefix, error);
       }
@@ -373,7 +380,7 @@ export class PairPipeline extends EventEmitter {
         success: false,
         sessionId: session.id,
         stages,
-        finalStatus: cancelled ? 'cancelled' : rateLimited ? 'rate_limited' : 'failed',
+        finalStatus: cancelled ? 'cancelled' : rateLimited ? 'rate_limited' : infra ? 'infra_error' : 'failed',
         rateLimitResetsAt: rateLimited && (error as RateLimitError).resetsAt
           ? (error as RateLimitError).resetsAt! * 1000
           : undefined,

--- a/src/agents/pipelineFormat.ts
+++ b/src/agents/pipelineFormat.ts
@@ -24,6 +24,7 @@ export function formatPipelineResult(result: PipelineResult): string {
     cancelled: '🚫',
     decomposed: '🔀',
     rate_limited: '⏸',
+    infra_error: '🔌',
   }[result.finalStatus];
 
   const lines: string[] = [];
@@ -80,6 +81,7 @@ export function formatPipelineResultEmbed(result: PipelineResult): EmbedBuilder 
     cancelled: { emoji: '🚫', color: 0xFFAA00, label: 'CANCELLED' },
     decomposed: { emoji: '🔀', color: 0x00AAFF, label: 'DECOMPOSED' },
     rate_limited: { emoji: '⏸', color: 0xFFAA00, label: 'RATE LIMITED' },
+    infra_error: { emoji: '🔌', color: 0xFFAA00, label: 'INFRA ERROR' },
   }[result.finalStatus] || { emoji: '❓', color: 0x808080, label: 'UNKNOWN' };
 
   const embed = new EmbedBuilder()

--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -10,6 +10,7 @@ import type { ToolDefinition } from '../adapters/tools.js';
 import { getAdapter, spawnCli } from '../adapters/index.js';
 import { expandPath } from '../core/config.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
+import { isInfraError } from '../adapters/errorClassification.js';
 
 // Types
 
@@ -226,6 +227,11 @@ export async function runReviewer(options: ReviewerOptions): Promise<ReviewResul
   } catch (error) {
     // Rate limit errors must propagate so the scheduler can pause.
     if (error instanceof RateLimitError) throw error;
+    // An infra failure (CLI exit, auth, spawn, timeout) means the REVIEWER never
+    // ran — it is NOT a quality verdict. Propagate so the pipeline classifies it
+    // as 'infra_error' instead of letting it masquerade as a 'reject' that
+    // increments the rejection-limit STUCK counter. (INT-2010)
+    if (isInfraError(error)) throw error;
     return {
       decision: 'reject',
       feedback: `Reviewer execution failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -12,6 +12,7 @@ import type { ToolDefinition } from '../adapters/tools.js';
 import { getAdapter, getDefaultAdapterName, spawnCli } from '../adapters/index.js';
 import { expandPath } from '../core/config.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
+import { isInfraError } from '../adapters/errorClassification.js';
 import { resolveEditFormat, SEARCH_REPLACE_PROMPT, WHOLE_FILE_PROMPT, type EditFormat } from '../support/editParser.js';
 
 // Types
@@ -250,6 +251,12 @@ export async function runWorker(options: WorkerOptions): Promise<WorkerResult> {
       if (!isFallbackAttempt && isProviderQuotaError(errMsg) && adaptersToTry.length > 1) {
         continue;
       }
+
+      // CLI/infra failure (non-zero exit, auth, spawn, timeout): the worker never
+      // got to actually run, so this is NOT a task failure. Propagate so the
+      // pipeline marks it 'infra_error' → backoff retry instead of a STUCK-counting
+      // failure. (INT-2010)
+      if (isInfraError(error)) throw error;
 
       return {
         success: false,

--- a/src/automation/autonomousRunner.infraError.test.ts
+++ b/src/automation/autonomousRunner.infraError.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PipelineResult } from '../agents/pairPipeline.js';
+import type { TaskScheduler } from '../orchestration/taskScheduler.js';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import type { AutonomousConfig } from './runnerTypes.js';
+import type { ITaskSource } from './taskSource.js';
+
+// Regression for INT-2010: adapter CLI/infra failures (the worker/reviewer never
+// ran) must NOT drive a completable issue to durable STUCK. They get a backoff
+// retry, like rate limits — not a logStuck.
+
+type AutonomousRunnerCtor = typeof import('./autonomousRunner.js').AutonomousRunner;
+type RunnerExecutionModule = typeof import('./runnerExecution.js');
+
+let tempDir = '';
+let AutonomousRunner: AutonomousRunnerCtor;
+let runnerExecution: RunnerExecutionModule;
+
+const cfg = (over: Partial<AutonomousConfig> = {}): AutonomousConfig => ({
+  linearTeamId: 'team',
+  allowedProjects: ['/repo'],
+  heartbeatSchedule: '0 * * * *',
+  autoExecute: false,
+  maxConsecutiveTasks: 1,
+  cooldownSeconds: 0,
+  dryRun: true,
+  ...over,
+});
+
+const task = (): TaskItem => ({
+  id: 'task-1',
+  source: 'linear',
+  issueId: 'ISSUE-1',
+  issueIdentifier: 'INT-1',
+  title: 'Edit some files',
+  priority: 3,
+  createdAt: Date.now(),
+});
+
+const result = (finalStatus: PipelineResult['finalStatus']): PipelineResult => ({
+  success: false,
+  sessionId: 'pipeline-1',
+  iterations: 0,
+  totalDuration: 5,
+  finalStatus,
+  stages: [],
+  workerResult: { success: false, summary: '', filesChanged: [], commands: [], output: '', error: 'codex CLI failed with code 1' },
+});
+
+function mockTaskSource() {
+  return {
+    kind: 'local',
+    updateState: vi.fn(async () => {}),
+    addComment: vi.fn(async () => {}),
+    logStuck: vi.fn(async () => {}),
+    logBlocked: vi.fn(async () => {}),
+  } as unknown as ITaskSource & {
+    updateState: ReturnType<typeof vi.fn>;
+    logStuck: ReturnType<typeof vi.fn>;
+  };
+}
+
+async function runN(scheduler: TaskScheduler, finalStatus: PipelineResult['finalStatus'], n: number) {
+  for (let i = 0; i < n; i++) {
+    scheduler.startTask(task(), '/repo', async () => result(finalStatus));
+    await new Promise((resolve) => setTimeout(resolve, 15));
+  }
+}
+
+describe('AutonomousRunner infra_error handling (INT-2010)', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    tempDir = mkdtempSync(join(tmpdir(), 'openswarm-infra-'));
+    vi.stubEnv('OPENSWARM_TASK_STATE_FILE', join(tempDir, 'task-state.json'));
+    ({ AutonomousRunner } = await import('./autonomousRunner.js'));
+    runnerExecution = await import('./runnerExecution.js');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('never marks STUCK even after many infra_error runs', async () => {
+    const source = mockTaskSource();
+    runnerExecution.setTaskSource(source);
+    const runner = new AutonomousRunner(cfg());
+    const scheduler = (runner as unknown as { scheduler: TaskScheduler }).scheduler;
+
+    await runN(scheduler, 'infra_error', 6); // well past MAX_RETRY_COUNT (4)
+
+    expect(source.logStuck).not.toHaveBeenCalled();
+    expect(source.updateState).not.toHaveBeenCalled(); // no failure-state sync
+  });
+
+  it('still marks STUCK after MAX_RETRY_COUNT genuine failures (control)', async () => {
+    const source = mockTaskSource();
+    runnerExecution.setTaskSource(source);
+    const runner = new AutonomousRunner(cfg());
+    const scheduler = (runner as unknown as { scheduler: TaskScheduler }).scheduler;
+
+    await runN(scheduler, 'failed', 4);
+
+    expect(source.logStuck).toHaveBeenCalled();
+  });
+});

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -296,6 +296,27 @@ export class AutonomousRunner {
         return;
       }
 
+      // Infra/CLI failure: the worker/reviewer never actually ran (non-zero exit,
+      // auth expiry, spawn, timeout). This is NOT a task failure — do NOT increment
+      // the rejection/failure counters that mark an issue durably STUCK. Backoff-
+      // retry instead; the operator fixes the root cause (e.g. re-auth) and the task
+      // resumes on its own. This is what kept completable tasks (worker had already
+      // edited files) STUCK in production. (INT-2010)
+      if (result.finalStatus === 'infra_error') {
+        const detail = result.workerResult?.error || result.reviewResult?.feedback || 'infra/CLI execution error';
+        if (task.issueId) {
+          // Fixed mid-range backoff — we intentionally don't bump failure counts,
+          // so there's no attempt number to scale by.
+          const nextRetryTime = setRetryTime(task.issueId, 3, this.failedTaskRetryTimes);
+          this.saveTaskState();
+          console.warn(`[Scheduler] Infra error for ${taskCtx} (NOT counted toward STUCK) — backoff retry ${formatRetryTime(nextRetryTime)}: ${detail}`);
+        } else {
+          console.warn(`[Scheduler] Infra error for ${taskCtx} (NOT counted toward STUCK): ${detail}`);
+        }
+        this.scheduleNextHeartbeat();
+        return;
+      }
+
       console.log(`[Scheduler] Task failed: ${taskCtx} ${task.title}`);
       broadcastEvent({ type: 'task:completed', data: { taskId: task.id, success: false, duration: result.totalDuration } });
       this.recordPipelineHistory(task, result);


### PR DESCRIPTION
## 문제

자율 데몬이 멀쩡한(worker가 편집까지 성공한) 이슈를 **어댑터 CLI 인프라 오류** 때문에 기계적으로 STUCK으로 빠뜨렸다. 실측(2026-06-28~29 데몬 로그 + Linear 코멘트)으로 100% 확정 — STO-1362·1360·1361·1357·1324·1368이 `codex CLI failed with code 1` / `Reviewer execution failed: claude CLI failed with code 1`로 무더기 STUCK. worker는 9~10파일 편집 + ruff·pytest까지 성공한 상태였다.

## 원인 (두 오염 경로)

1. **worker 인프라 실패 → failure count**: CLI exit·auth·spawn·timeout이 일반 'failed'로 강등 → 4회면 logStuck.
2. **reviewer 인프라 실패 → 'rejected' 둔갑** (핵심): reviewer CLI가 죽은 것이 `decision:'reject'`로 반환(reviewer.ts) → rejection-limit(3) STUCK. 품질 reject가 전혀 아닌데.

rate_limited만 유일하게 분리돼 있었다(INT-1906).

## 수정

| 파일 | 변경 |
|---|---|
| `adapters/errorClassification.ts` (신규) | `isInfraError()` — CLI exit·auth·spawn·timeout·network 식별(코드 로직 에러는 제외) |
| `agents/reviewer.ts` | 인프라 오류 시 reject 둔갑 대신 throw |
| `agents/worker.ts` | 인프라 오류 시 throw(fallback 소진 후) |
| `agents/pairPipeline.ts` | finalStatus `'infra_error'` 추가 + catch 분류 |
| `automation/autonomousRunner.ts` | infra_error를 rejection·failure 카운트 양쪽 제외 + 백오프 재시도 |
| `agents/pipelineFormat.ts` | infra_error 표시 |

핵심 철학: 인프라 오류는 **작업 실패가 아니라 운영 문제** — STUCK(작업 문제) 대신 백오프 재시도. 운영자가 근본원인(re-auth 등) 해결 시 자동 재개. rate_limited와 동일.

## 검증

- 통합 테스트: **infra_error 6회 → STUCK 안 됨**, **failed 4회 → STUCK 유지**(control)
- errorClassification 단위 테스트, typecheck/build/oxlint, **agents 312 회귀 통과**

## 후속 (INT-2010 잔여, 이 PR 범위 밖)

stuckDetector 에러 정규화·sameErrorRepeat 상향, STUCK 마킹 Linear 반영 선행/롤백(로컬↔Linear 불일치), rtx 멀티호스트 중복 데몬 정리.

Refs INT-2010