### PR TITLE
feat(tools): edit_file fuzzy fallback + edit prompt guidelines (INT-2011)

### DIFF
--- a/src/adapters/tools.test.ts
+++ b/src/adapters/tools.test.ts
@@ -182,6 +182,42 @@ describe('executeTool', () => {
       expect(result.content).toContain('2 times');
       expect(result.content).toContain('unique');
     });
+
+    // ── fuzzy fallback (INT-2011) ──
+    it('fuzzy: matches despite a trailing-whitespace difference', async () => {
+      const filePath = path.join(TMP_DIR, 'edit-fuzzy-ws.txt');
+      await fs.writeFile(filePath, 'line one   \nline two\nline three', 'utf-8'); // line one has trailing spaces
+      const result = await executeTool(
+        makeCall('edit_file', { path: filePath, old_string: 'line one\nline two', new_string: 'X\nY' }),
+        TMP_DIR,
+      );
+      expect(result.is_error).toBe(false);
+      expect(result.content).toContain('normalization');
+      expect(await fs.readFile(filePath, 'utf-8')).toBe('X\nY\nline three');
+    });
+
+    it('fuzzy: matches despite smart-quote difference', async () => {
+      const filePath = path.join(TMP_DIR, 'edit-fuzzy-quote.txt');
+      await fs.writeFile(filePath, "const s = 'hello';", 'utf-8'); // straight quotes in file
+      const result = await executeTool(
+        makeCall('edit_file', { path: filePath, old_string: "const s = ‘hello’;", new_string: "const s = 'bye';" }),
+        TMP_DIR,
+      );
+      expect(result.is_error).toBe(false);
+      expect(await fs.readFile(filePath, 'utf-8')).toBe("const s = 'bye';");
+    });
+
+    it('fuzzy: refuses when the normalized match is ambiguous', async () => {
+      const filePath = path.join(TMP_DIR, 'edit-fuzzy-ambig.txt');
+      await fs.writeFile(filePath, "a = 'x'\nb\na = 'x'", 'utf-8'); // two straight-quote lines
+      const result = await executeTool(
+        makeCall('edit_file', { path: filePath, old_string: "a = ‘x’", new_string: 'CHANGED' }), // smart quotes → exact miss, fuzzy hits 2
+        TMP_DIR,
+      );
+      expect(result.is_error).toBe(true);
+      expect(result.content).toContain('not found');
+      expect(await fs.readFile(filePath, 'utf-8')).toBe("a = 'x'\nb\na = 'x'"); // unchanged
+    });
   });
 
   // ── search_files ──

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -279,6 +279,56 @@ export function validatePath(filePath: string, cwd: string): string {
   return resolved;
 }
 
+// Normalize a single line for fuzzy edit matching: strip trailing whitespace and
+// fold common typographic variants (smart quotes, en/em dashes) plus NFKC. Lets a
+// near-miss old_string (a model re-typed a quote or trailing space) still locate
+// its line, instead of failing edit_file outright. (INT-2011)
+function normalizeEditLine(line: string): string {
+  return line
+    .replace(/[ \t]+$/, '')
+    .replace(/[‘’]/g, "'")
+    .replace(/[“”]/g, '"')
+    .replace(/[–—]/g, '-')
+    .normalize('NFKC');
+}
+
+/**
+ * Fuzzy fallback for edit_file: when `oldString` is not an exact substring, match
+ * it line-by-line under {@link normalizeEditLine}. Returns the EXACT original span
+ * only when the match is unique — 0 or >1 matches return null so the caller refuses
+ * rather than editing the wrong place. The span is line-bounded, so the offsets are
+ * exact (no ratio approximation). (INT-2011)
+ */
+function findFuzzyEditSpan(original: string, oldString: string): { start: number; end: number } | null {
+  const fileLines = original.split('\n');
+  const oldLines = oldString.split('\n');
+  if (oldLines.length === 0 || oldLines.length > fileLines.length) return null;
+  const normFile = fileLines.map(normalizeEditLine);
+  const normOld = oldLines.map(normalizeEditLine);
+
+  let matchIndex = -1;
+  let count = 0;
+  for (let i = 0; i <= normFile.length - normOld.length; i++) {
+    let ok = true;
+    for (let j = 0; j < normOld.length; j++) {
+      if (normFile[i + j] !== normOld[j]) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) {
+      count++;
+      matchIndex = i;
+      if (count > 1) return null; // ambiguous → refuse
+    }
+  }
+  if (count !== 1) return null; // not found → refuse
+
+  const start = fileLines.slice(0, matchIndex).join('\n').length + (matchIndex > 0 ? 1 : 0);
+  const matched = fileLines.slice(matchIndex, matchIndex + oldLines.length).join('\n');
+  return { start, end: start + matched.length };
+}
+
 /**
  * 단일 도구 호출 실행
  */
@@ -358,27 +408,41 @@ export async function executeTool(
         }
         const original = await fs.readFile(filePath, 'utf-8');
         const occurrences = original.split(args.old_string).length - 1;
-        if (occurrences === 0) {
-          return { tool_call_id: callId, content: `old_string not found in ${filePath}`, is_error: true };
-        }
         if (occurrences > 1) {
           return { tool_call_id: callId, content: `old_string found ${occurrences} times — must be unique. Provide more context.`, is_error: true };
         }
-        const updated = original.replace(args.old_string, args.new_string);
+        // Resolve the exact span to replace. Exact match first; on a miss, fall back
+        // to line-normalized fuzzy matching (trailing whitespace / smart quotes /
+        // dashes) — but only when it's unique, so we never edit the wrong place. (INT-2011)
+        let editStart: number;
+        let editEnd: number;
+        let fuzzy = false;
+        if (occurrences === 1) {
+          editStart = original.indexOf(args.old_string);
+          editEnd = editStart + args.old_string.length;
+        } else {
+          const span = findFuzzyEditSpan(original, args.old_string);
+          if (!span) {
+            return { tool_call_id: callId, content: `old_string not found in ${filePath}`, is_error: true };
+          }
+          editStart = span.start;
+          editEnd = span.end;
+          fuzzy = true;
+        }
+        const updated = original.slice(0, editStart) + args.new_string + original.slice(editEnd);
         await fs.writeFile(filePath, updated, 'utf-8');
         invalidateCache(cache, filePath);
         // Return the changed region so the model can verify without a re-read.
-        // Locate the edit via old_string's position in the ORIGINAL (guaranteed
-        // unique above) — indexOf(new_string) on the updated text could match an
-        // earlier pre-existing occurrence and show the wrong region.
+        // editStart is the exact offset in the ORIGINAL (exact or fuzzy), so the
+        // line math is correct either way.
         const newLines = updated.split('\n');
-        const editLine = original.slice(0, original.indexOf(args.old_string)).split('\n').length - 1;
+        const editLine = original.slice(0, editStart).split('\n').length - 1;
         const from = Math.max(0, editLine - 3);
         const to = Math.min(newLines.length, editLine + args.new_string.split('\n').length + 3);
         const snippet = newLines.slice(from, to).map((l, i) => `${from + i + 1}\t${l}`).join('\n');
         return {
           tool_call_id: callId,
-          content: `Edited: ${filePath}\nResulting region:\n${snippet}`,
+          content: `Edited: ${filePath}${fuzzy ? ' (matched with whitespace/quote normalization)' : ''}\nResulting region:\n${snippet}`,
           is_error: false,
         };
       }

--- a/src/locale/prompts/en.ts
+++ b/src/locale/prompts/en.ts
@@ -136,7 +136,7 @@ Optional: \`cxt\` (code registry, only if this repo already has one — do NOT r
 
 ## Making the change (this is the point — do not stop at reading)
 Reading/searching is only to LOCATE the change. As soon as you know what to change, EDIT — do not keep reading.
-- **edit_file** — surgical change to an existing file. \`old_string\` must match the file EXACTLY (whitespace included) and be UNIQUE; keep it as small as possible while still unique. For several changes, call edit_file several times.
+- **edit_file** — surgical change to an existing file. \`old_string\` must locate a UNIQUE span; copy it from the file and keep it as small as possible while still unique. Minor differences (trailing whitespace, smart vs straight quotes, en/em dashes) are auto-corrected, but indentation and the rest of the code must still match. For several changes, call edit_file several times.
 - **write_file** — a NEW file, or a full rewrite of a small file.
 - If an edit_file fails with "not found", you copied old_string imperfectly — re-read just that span and copy the exact text; do NOT restart the whole investigation.
 - Most tasks need 1–3 edits, not 20+ reads. If you've read the relevant code, make the edit now.

--- a/src/locale/prompts/ko.ts
+++ b/src/locale/prompts/ko.ts
@@ -137,7 +137,7 @@ ${feedbackSection}${contextSection}${completionSection}
 
 ## 변경하기 (이게 목적이다 — 읽기에서 멈추지 말 것)
 읽기/검색은 변경 지점을 찾기 위한 것뿐. 무엇을 바꿀지 알았으면 즉시 편집하라 — 계속 읽지 말 것.
-- **edit_file** — 기존 파일의 surgical 변경. \`old_string\`은 파일과 EXACT하게(공백 포함) 일치하고 UNIQUE해야 함; 유일성을 유지하는 선에서 최대한 작게. 여러 변경은 edit_file을 여러 번 호출.
+- **edit_file** — 기존 파일의 surgical 변경. \`old_string\`은 UNIQUE한 구간을 지정해야 하며 파일에서 복사해 유일성을 유지하는 선에서 최대한 작게. 사소한 차이(trailing whitespace, smart/straight 따옴표, en/em 대시)는 자동 보정되지만 들여쓰기와 나머지 코드는 일치해야 함. 여러 변경은 edit_file을 여러 번 호출.
 - **write_file** — 새 파일, 또는 작은 파일의 전체 재작성.
 - edit_file이 "not found"로 실패하면 old_string을 부정확하게 복사한 것 — 그 구간만 다시 읽어 정확히 복사하라; 조사를 처음부터 다시 하지 말 것.
 - 대부분 작업은 read 20+회가 아니라 edit 1~3회면 된다. 관련 코드를 읽었으면 지금 편집하라.


### PR DESCRIPTION
## Why

Make a **single worker's edits land more often** instead of spinning up N workers (best-of-N is wasteful + luck-based for a production daemon). JSON `edit_file` matched `old_string` exactly, so a trailing space / smart quote / unicode dash made it fail `old_string not found` and the worker stalled re-reading instead of editing.

## What

- **`tools.ts`** — line-normalized fuzzy fallback for `edit_file`. On an exact miss, match `old_string` line-by-line under normalization (trailing whitespace, smart→straight quotes, en/em dashes, NFKC). Applied **only on a unique match** — 0 or >1 refuses, so it never edits the wrong place. The span is line-bounded, so offsets stay exact (unlike `editParser.fuzzyMatch`, which approximates start by ratio and is unsafe for replace).
- **`en.ts`/`ko.ts`** — worker edit prompt guidelines now note that minor whitespace/quote differences are auto-corrected; keep `old_string` small and unique.

## Safety

- Exact path unchanged (`occurrences===1` → indexOf span; `>1` → unique error). Fuzzy runs only when exact finds nothing.
- Ambiguous fuzzy (normalized match hits 2+ lines) → refuses, file left unchanged.

## Verified

- Fuzzy unit/integration: trailing-ws and smart-quote succeed, ambiguous refuses (file unchanged); existing edit_file tests regress clean.
- typecheck / build / oxlint; **adapters+agents 496 tests pass**.

## Context

Implements the `fuzzy` half of the pi-reference guidance (memory: edit robustness = fuzzy + promptGuidelines + edits[]). `edits[]` batching is a follow-up. Chosen over best-of-N per maintainer direction: improve one worker's reliability, don't multiply workers.

Closes INT-2011