### PR TITLE
fix(tui): collapse multi-grapheme and N-repeat Hangul input doubling (INT-2012)

### DIFF
--- a/src/tui/chatModel.test.ts
+++ b/src/tui/chatModel.test.ts
@@ -95,6 +95,24 @@ describe('dedupeDoubledGrapheme (INT-1964)', () => {
     expect(dedupeDoubledGrapheme(' ')).toBe(' ');
   });
 
+  // INT-2012: shapes INT-1964 missed — N-repeat and multi-grapheme doubling.
+  it('collapses a single grapheme repeated N times (shape A)', () => {
+    expect(dedupeDoubledGrapheme('이이이')).toBe('이');
+    expect(dedupeDoubledGrapheme('렇렇렇렇')).toBe('렇');
+  });
+
+  it('collapses a multi-grapheme event where each grapheme is doubled (shape B)', () => {
+    expect(dedupeDoubledGrapheme('이이렇렇게게')).toBe('이렇게'); // '이렇게' doubled in place
+    expect(dedupeDoubledGrapheme('가가나나')).toBe('가나');
+  });
+
+  it('leaves a normal multi-grapheme word untouched (no doubling)', () => {
+    expect(dedupeDoubledGrapheme('이렇게')).toBe('이렇게'); // odd length, not paired
+    expect(dedupeDoubledGrapheme('안녕하세요')).toBe('안녕하세요');
+    expect(dedupeDoubledGrapheme('가나')).toBe('가나'); // even length but pairs differ
+    expect(dedupeDoubledGrapheme('hello')).toBe('hello');
+  });
+
   it('leaves longer input (real pastes) untouched', () => {
     expect(dedupeDoubledGrapheme('이이렇')).toBe('이이렇');
     expect(dedupeDoubledGrapheme('가나다')).toBe('가나다');

--- a/src/tui/chatModel.ts
+++ b/src/tui/chatModel.ts
@@ -96,20 +96,41 @@ export function normalizeConfirm(input: string): 'yes' | 'no' | 'edit' {
 }
 
 /**
- * Mobile-SSH multibyte input mitigation (INT-1964). Some terminals deliver a
- * single multibyte keystroke as the character doubled in one input event
- * ('이' → '이이'), so each Hangul syllable appears twice while ASCII is fine.
- * Collapse an input event that is exactly one NON-ASCII grapheme repeated twice
- * back to a single grapheme. ASCII, single graphemes, differing graphemes, and
- * longer inputs (real pastes) pass through untouched — so normal typing is
- * unaffected. The only false positive is pasting exactly two identical multibyte
- * characters, which is vanishingly rare.
+ * Mobile-SSH multibyte input mitigation (INT-1964, extended INT-2012). Some
+ * terminals deliver a multibyte keystroke as the character(s) doubled in one
+ * input event, so Hangul appears doubled while ASCII is fine. Two observed shapes:
+ *
+ *   (A) one grapheme repeated N times      — '이' → '이이' or '이이이'
+ *   (B) each grapheme doubled in place      — '이렇게' → '이이렇렇게게'
+ *
+ * Collapse both back to the intended text. Only NON-ASCII graphemes are touched;
+ * ASCII, single graphemes, odd-length mixed events, and differing graphemes pass
+ * through untouched, so normal typing is unaffected. The only false positive is
+ * pasting an exact run/pairing of identical multibyte characters (e.g. '각각'),
+ * which is vanishingly rare. (INT-1964 only handled shape A at exactly length 2.)
  */
 export function dedupeDoubledGrapheme(input: string): string {
-  const graphemes = Array.from(input);
-  if (graphemes.length === 2 && graphemes[0] === graphemes[1] && (graphemes[0].codePointAt(0) ?? 0) > 0x7f) {
-    return graphemes[0];
+  const g = Array.from(input);
+  if (g.length < 2) return input;
+
+  // (A) a single non-ASCII grapheme repeated N times → one.
+  if ((g[0].codePointAt(0) ?? 0) > 0x7f && g.every((c) => c === g[0])) {
+    return g[0];
   }
+
+  // (B) even-length event where every adjacent pair is the same non-ASCII
+  //     grapheme → keep one of each pair.
+  if (g.length % 2 === 0) {
+    let paired = true;
+    for (let i = 0; i < g.length; i += 2) {
+      if (g[i] !== g[i + 1] || (g[i].codePointAt(0) ?? 0) <= 0x7f) {
+        paired = false;
+        break;
+      }
+    }
+    if (paired) return g.filter((_, i) => i % 2 === 0).join('');
+  }
+
   return input;
 }
 


### PR DESCRIPTION
## Problem

Korean input in the ink chat box comes out doubled ('이렇게' → garbled). INT-1964's `dedupeDoubledGrapheme` only collapsed a **single non-ASCII grapheme doubled exactly twice** ('이' → '이이', `graphemes.length === 2`). It missed the common real shapes:

- **Each grapheme doubled in place**: '이렇게' → '이이렇렇게게' (the exact example in `inputDebug.ts`'s docstring) — 6 graphemes, passed through.
- **One grapheme tripled**: '이이이' — length 3, passed through.

## Fix

Extend `dedupeDoubledGrapheme` to two shapes:
- **(A)** one non-ASCII grapheme repeated N times → one
- **(B)** even length, every adjacent pair the same non-ASCII grapheme → one per pair

ASCII, odd-length mixed events, and differing graphemes are untouched, so normal typing is unaffected. It runs per keystroke chunk in `ChatInput`, so doubling split across keystrokes is covered too.

## Verified

- chatModel unit tests: 이이이 / 이이렇렇게게 collapse; 이렇게 / 안녕하세요 / 가나 / hello untouched.
- typecheck / build / oxlint; **tui 97 tests pass**.

## Out of scope

Fully irregular doubling or broken jamo composition ('렇' → '러러헣') is environment-dependent — it's either ink-level (ink hands us the char repeated) or terminal echo (client redraws). Diagnose with `OPENSWARM_DEBUG_INPUT=1` → `~/.openswarm/input-debug.log` (per-keypress code points). This PR covers ink-level uniform doubling.

Closes INT-2012