### PR TITLE
feat(chat): persist chat sessions + openswarm resume + /goal clear (INT-2014)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -156,12 +156,24 @@ program
   .argument('[session]', 'Session name to load/create (optional)')
   .option('--tui', 'Deprecated — chat always uses the TUI now (kept for compatibility)')
   .action(async (session?: string) => {
-    // Pass the session argument via process.argv for the TUI to pick up.
-    if (session) {
-      process.argv = [process.argv[0], process.argv[1], session];
-    }
     // Always launch the TUI — the legacy readline path is retired.
-    await launchChatTui();
+    await launchChatTui(session);
+  });
+
+// openswarm resume — reopen the most recent chat session
+
+program
+  .command('resume')
+  .description('Resume the most recently used chat session (its conversation + goal)')
+  .action(async () => {
+    const { latestSession } = await import('./support/chatSession.js');
+    const id = await latestSession();
+    if (!id) {
+      console.log('No saved chat sessions to resume. Run `openswarm chat` to start one.');
+      return;
+    }
+    console.log(`Resuming session ${id}…`);
+    await launchChatTui(id);
   });
 
 // openswarm mcp add|list|remove
@@ -548,7 +560,7 @@ program
 
 // 서브커맨드 없이 `openswarm`만 입력 시 → TUI chat 실행 (`openswarm chat`과 동일)
 
-async function launchChatTui(): Promise<void> {
+async function launchChatTui(sessionId?: string): Promise<void> {
   // Auto-start the background daemon so the monitor tabs (Projects/Tasks/Stuck/
   // Issues) — which are read-only clients of the daemon's :3847 API — have data
   // to show. If it's already running or fails to start, just continue: the chat
@@ -572,9 +584,29 @@ async function launchChatTui(): Promise<void> {
   // no blessed terminfo noise to mute and no manual redraw/flicker. The old
   // console-mute hack is gone with blessed.
   const { startInkTui } = await import('./tui/index.js');
-  const { loadDefaultProvider } = await import('./support/chatSession.js');
+  const { loadDefaultProvider, loadSession, generateSessionId } = await import('./support/chatSession.js');
   const { getDefaultChatModel } = await import('./support/chatBackend.js');
-  const provider = loadDefaultProvider();
+
+  // Resume an existing session when an id is given, else start a fresh one. A
+  // missing id falls back to a new session rather than erroring. (INT-2014)
+  let provider = loadDefaultProvider();
+  let model = getDefaultChatModel(provider);
+  let initialHistory: import('./tui/chatModel.js').ChatLine[] | undefined;
+  let goal: string | undefined;
+  let resolvedSessionId = sessionId ?? generateSessionId();
+  if (sessionId) {
+    const sess = await loadSession(sessionId);
+    if (sess) {
+      provider = sess.provider;
+      model = sess.model;
+      goal = sess.goal;
+      const { messagesToHistory } = await import('./tui/chatModel.js');
+      initialHistory = messagesToHistory(sess.messages);
+      resolvedSessionId = sess.id;
+    } else {
+      process.stdout.write(`Session "${sessionId}" not found — starting a new session.\n`);
+    }
+  }
   const cwd = process.cwd();
   let branch: string | undefined;
   try {
@@ -585,7 +617,7 @@ async function launchChatTui(): Promise<void> {
   } catch {
     // not a git repo — omit the branch
   }
-  await startInkTui({ version: VERSION, provider, model: getDefaultChatModel(provider), port: 3847, cwd, branch });
+  await startInkTui({ version: VERSION, provider, model, port: 3847, cwd, branch, sessionId: resolvedSessionId, initialHistory, goal });
 }
 
 program.action(launchChatTui);

--- a/src/support/chatSession.test.ts
+++ b/src/support/chatSession.test.ts
@@ -18,6 +18,8 @@ import {
   inferProvider,
   saveSession,
   loadSession,
+  listSessions,
+  latestSession,
   callChatModel,
   type Session,
 } from './chatSession.js';
@@ -25,6 +27,32 @@ import {
 describe('generateSessionId', () => {
   it('produces a YYYYMMDD-HHMM id', () => {
     expect(generateSessionId()).toMatch(/^\d{8}-\d{4}$/);
+  });
+});
+
+describe('listSessions / latestSession (INT-2014)', () => {
+  const mk = (id: string): Session => ({
+    id, provider: 'codex', model: 'm', messages: [], totalCost: 0, totalTokens: 0, createdAt: '', updatedAt: '',
+  });
+
+  it('lists newest-first and returns the latest id', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'os-sess-'));
+    try {
+      await saveSession(mk('s1'), dir);
+      await new Promise((r) => setTimeout(r, 15));
+      await saveSession(mk('s2'), dir);
+      const list = await listSessions(dir);
+      expect(list.map((m) => m.id)).toEqual(['s2', 's1']);
+      expect(await latestSession(dir)).toBe('s2');
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns [] / null for a missing dir', async () => {
+    const nope = path.join(os.tmpdir(), 'os-nope-' + process.pid);
+    expect(await listSessions(nope)).toEqual([]);
+    expect(await latestSession(nope)).toBeNull();
   });
 });
 

--- a/src/support/chatSession.ts
+++ b/src/support/chatSession.ts
@@ -9,14 +9,23 @@
 
 import { homedir } from 'node:os';
 import { resolve } from 'node:path';
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, readdir, stat } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { loadConfig } from '../core/config.js';
 import { getDefaultAdapterName, isKnownAdapter, type AdapterName } from '../adapters/index.js';
 import { getDefaultChatModel, runChatCompletion } from './chatBackend.js';
 
-/** Default on-disk location for persisted chat sessions. */
-export const CHAT_DIR = resolve(homedir(), '.openswarm', 'chat');
+/**
+ * On-disk location for persisted chat sessions. Read via OPENSWARM_CHAT_DIR when
+ * set (lets tests redirect writes away from the real home dir). Evaluated per
+ * call so the env override applies even after module load. (INT-2014)
+ */
+export function getChatDir(): string {
+  return process.env.OPENSWARM_CHAT_DIR ?? resolve(homedir(), '.openswarm', 'chat');
+}
+
+/** Default chat-session dir at module-load time (back-compat for direct imports). */
+export const CHAT_DIR = getChatDir();
 
 export type Message = { role: 'user' | 'assistant'; content: string; cost?: number };
 
@@ -35,17 +44,17 @@ export type Session = {
 
 // Session persistence
 
-export async function ensureChatDir(dir: string = CHAT_DIR): Promise<void> {
+export async function ensureChatDir(dir: string = getChatDir()): Promise<void> {
   await mkdir(dir, { recursive: true });
 }
 
-export async function saveSession(session: Session, dir: string = CHAT_DIR): Promise<void> {
+export async function saveSession(session: Session, dir: string = getChatDir()): Promise<void> {
   await ensureChatDir(dir);
   session.updatedAt = new Date().toISOString();
   await writeFile(resolve(dir, `${session.id}.json`), JSON.stringify(session, null, 2));
 }
 
-export async function loadSession(id: string, dir: string = CHAT_DIR): Promise<Session | null> {
+export async function loadSession(id: string, dir: string = getChatDir()): Promise<Session | null> {
   const path = resolve(dir, `${id}.json`);
   if (!existsSync(path)) return null;
   const data = JSON.parse(await readFile(path, 'utf-8'));
@@ -58,6 +67,9 @@ export async function loadSession(id: string, dir: string = CHAT_DIR): Promise<S
     ...data,
     provider,
     model,
+    // Older session files may predate the messages field — default to [] so
+    // messagesToHistory never sees undefined. (INT-2014)
+    messages: Array.isArray(data.messages) ? data.messages : [],
     totalCost: data.totalCost ?? 0,
     totalTokens: data.totalTokens ?? 0,
   };
@@ -67,6 +79,42 @@ export function generateSessionId(): string {
   const now = new Date();
   const pad = (n: number) => String(n).padStart(2, '0');
   return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}`;
+}
+
+export interface SessionMeta {
+  id: string;
+  mtimeMs: number;
+}
+
+/**
+ * List persisted sessions, most-recently-modified first. Sorted by file mtime
+ * rather than the id (generateSessionId is minute-granular, so ids collide and
+ * sort poorly). Returns [] if the dir doesn't exist yet. (INT-2014)
+ */
+export async function listSessions(dir: string = getChatDir()): Promise<SessionMeta[]> {
+  let files: string[];
+  try {
+    files = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const metas: SessionMeta[] = [];
+  for (const f of files) {
+    if (!f.endsWith('.json')) continue;
+    try {
+      const s = await stat(resolve(dir, f));
+      metas.push({ id: f.slice(0, -'.json'.length), mtimeMs: s.mtimeMs });
+    } catch {
+      // unreadable / removed mid-scan — skip
+    }
+  }
+  return metas.sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
+
+/** Id of the most recently modified session, or null if there are none. (INT-2014) */
+export async function latestSession(dir: string = getChatDir()): Promise<string | null> {
+  const list = await listSessions(dir);
+  return list.length > 0 ? list[0].id : null;
 }
 
 // Provider / model resolution

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -14,6 +14,7 @@ import { TabBar } from './components/TabBar.js';
 import { HelpBar } from './components/HelpBar.js';
 import { PipelinePanel } from './panels/PipelinePanel.js';
 import { ChatPanel } from './panels/ChatPanel.js';
+import type { ChatLine } from './chatModel.js';
 import { MonitorPanel } from './panels/MonitorPanel.js';
 import { LogsPanel } from './panels/LogsPanel.js';
 import { fetchProjects, fetchTasks, fetchStuck, fetchIssues } from './monitorApi.js';
@@ -38,9 +39,13 @@ export interface AppProps {
   branch?: string;
   /** Initial active tab index (deep-link / tests). Defaults to Chat. */
   initialTab?: number;
+  /** Chat session id + restored conversation/goal for resume. (INT-2014) */
+  sessionId?: string;
+  initialHistory?: ChatLine[];
+  goal?: string;
 }
 
-export function App({ version, provider, model, port, cwd, branch, initialTab = 0 }: AppProps) {
+export function App({ version, provider, model, port, cwd, branch, initialTab = 0, sessionId, initialHistory, goal }: AppProps) {
   const [active, setActive] = useState(initialTab);
   const { columns, rows } = useTerminalSize();
   const { exit } = useApp();
@@ -66,7 +71,7 @@ export function App({ version, provider, model, port, cwd, branch, initialTab = 
       <TabBar active={active} />
       <Box flexDirection="column" paddingY={1} minHeight={Math.max(1, rows - 4)}>
         {activeTab.id === 'chat' ? (
-          <ChatPanel active={chatActive} provider={provider} model={model} projectPath={cwd} />
+          <ChatPanel active={chatActive} provider={provider} model={model} projectPath={cwd} sessionId={sessionId} initialHistory={initialHistory} goal={goal} />
         ) : activeTab.id === 'pipeline' ? (
           <PipelinePanel port={port} />
         ) : activeTab.id === 'logs' ? (

--- a/src/tui/chatModel.test.ts
+++ b/src/tui/chatModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { chatReducer, initialChatState, parseInput, matchSlash, movePaletteSelection, dedupeDoubledGrapheme, normalizeConfirm, isActivityNoise } from './chatModel.js';
+import { chatReducer, initialChatState, parseInput, matchSlash, movePaletteSelection, dedupeDoubledGrapheme, normalizeConfirm, isActivityNoise, historyToMessages, messagesToHistory, type ChatLine } from './chatModel.js';
 
 describe('chatReducer (EPIC INT-1813 S4)', () => {
   it('appends user and system lines', () => {
@@ -67,6 +67,30 @@ describe('isActivityNoise', () => {
     expect(isActivityNoise('🔧 read_file: src/auth.ts')).toBe(false);
     expect(isActivityNoise('📝 SEARCH/REPLACE: applied 1/1 block(s)')).toBe(false);
     expect(isActivityNoise('edit_file auth.ts')).toBe(false);
+  });
+});
+
+describe('historyToMessages / messagesToHistory (INT-2014)', () => {
+  it('keeps user/assistant turns and drops system lines', () => {
+    const h: ChatLine[] = [
+      { role: 'user', content: 'hi' },
+      { role: 'system', content: '/clear done' },
+      { role: 'assistant', content: 'hello' },
+    ];
+    expect(historyToMessages(h)).toEqual([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'hello' },
+    ]);
+  });
+
+  it('restores messages to history lines', () => {
+    expect(messagesToHistory([
+      { role: 'user', content: 'a' },
+      { role: 'assistant', content: 'b' },
+    ])).toEqual([
+      { role: 'user', content: 'a' },
+      { role: 'assistant', content: 'b' },
+    ]);
   });
 });
 

--- a/src/tui/chatModel.ts
+++ b/src/tui/chatModel.ts
@@ -5,9 +5,27 @@
 // to chatSession.callChatModel.
 // ============================================
 
+import type { Message } from '../support/chatSession.js';
+
 export interface ChatLine {
   role: 'user' | 'assistant' | 'system';
   content: string;
+}
+
+/**
+ * Convert chat history to persistable messages: only user/assistant turns are
+ * saved. System lines (slash-command output, UI notices) are transient and
+ * dropped — they aren't part of the conversation to resume. (INT-2014)
+ */
+export function historyToMessages(history: ChatLine[]): Message[] {
+  return history
+    .filter((l): l is ChatLine & { role: 'user' | 'assistant' } => l.role === 'user' || l.role === 'assistant')
+    .map((l) => ({ role: l.role, content: l.content }));
+}
+
+/** Restore persisted messages back to chat history lines. (INT-2014) */
+export function messagesToHistory(messages: Message[]): ChatLine[] {
+  return messages.map((m) => ({ role: m.role, content: m.content }));
 }
 
 export interface ChatState {

--- a/src/tui/components/ChatLog.tsx
+++ b/src/tui/components/ChatLog.tsx
@@ -29,6 +29,16 @@ const ROLE_ICON: Record<ChatLine['role'], string> = {
   system: ICON.system,
 };
 
+// Cap the in-flight streaming preview so a long reply (or reasoning spill) can't
+// fill the full-screen frame and push the input box off-screen. The finalized
+// message renders in full once committed to history. (INT-2014 / INT-2013)
+const STREAM_TAIL_LINES = 14;
+
+function tailLines(text: string, n: number): string {
+  const lines = text.split('\n');
+  return lines.length <= n ? text : `…\n${lines.slice(-n).join('\n')}`;
+}
+
 function Message({ line }: { line: ChatLine }) {
   const body = line.role === 'assistant' ? renderMarkdown(line.content) : line.content;
   return (
@@ -66,7 +76,7 @@ export function ChatLog({ history, streaming, activity = [], busy, maxMessages =
             {activity.slice(-5).map((line, i) => (
               <Text key={i} color={theme.dim}>{`${ICON.tool} ${line}`}</Text>
             ))}
-            {streaming ? <Text>{streaming}</Text> : null}
+            {streaming ? <Text>{tailLines(streaming, STREAM_TAIL_LINES)}</Text> : null}
             {busy ? <WorkingIndicator /> : null}
           </Box>
         </Box>

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -6,6 +6,7 @@
 
 import { withFullScreen } from 'fullscreen-ink';
 import { App } from './App.js';
+import type { ChatLine } from './chatModel.js';
 
 export interface StartInkTuiOptions {
   version?: string;
@@ -15,6 +16,12 @@ export interface StartInkTuiOptions {
   port?: number;
   cwd?: string;
   branch?: string;
+  /** Chat session id to save under (resume reuses an existing id). (INT-2014) */
+  sessionId?: string;
+  /** Conversation restored from a resumed session. (INT-2014) */
+  initialHistory?: ChatLine[];
+  /** Session goal restored from a resumed session. (INT-2014) */
+  goal?: string;
 }
 
 /**
@@ -30,6 +37,9 @@ export async function startInkTui(opts: StartInkTuiOptions = {}): Promise<void> 
       port={opts.port}
       cwd={opts.cwd}
       branch={opts.branch}
+      sessionId={opts.sessionId}
+      initialHistory={opts.initialHistory}
+      goal={opts.goal}
     />,
     { exitOnCtrlC: true },
   );

--- a/src/tui/panels/ChatPanel.tsx
+++ b/src/tui/panels/ChatPanel.tsx
@@ -7,7 +7,7 @@
 // ============================================
 
 import { Box } from 'ink';
-import { useReducer, useState, useCallback } from 'react';
+import { useReducer, useState, useCallback, useEffect, useRef } from 'react';
 import {
   chatReducer,
   initialChatState,
@@ -16,14 +16,16 @@ import {
   movePaletteSelection,
   normalizeConfirm,
   isActivityNoise,
+  historyToMessages,
   SLASH_COMMANDS,
+  type ChatLine,
 } from '../chatModel.js';
 import { ChatLog } from '../components/ChatLog.js';
 import { ChatInput } from '../components/ChatInput.js';
 import { CommandPalette } from '../components/CommandPalette.js';
 import { SelectList } from '../components/SelectList.js';
 import { listAdapterNames } from '../../adapters/index.js';
-import { callChatModel, loadDefaultProvider } from '../../support/chatSession.js';
+import { callChatModel, loadDefaultProvider, saveSession, generateSessionId } from '../../support/chatSession.js';
 import { getDefaultChatModel, listChatModels } from '../../support/chatBackend.js';
 import { runPlanCommand, type PlanIO } from '../../support/planCommand.js';
 import { runGoalCommand, buildGoalPursuitPrompt, GOAL_PURSUIT_MAX_TURNS } from '../../support/goalCommand.js';
@@ -35,14 +37,32 @@ export interface ChatPanelProps {
   model?: string;
   /** Project root for /plan + /goal dispatch (defaults to cwd). */
   projectPath?: string;
+  /** Session id to persist under; resume passes the existing id. (INT-2014) */
+  sessionId?: string;
+  /** Conversation restored from a resumed session. (INT-2014) */
+  initialHistory?: ChatLine[];
+  /** Session goal restored from a resumed session — keeps it "in pursuit". (INT-2014) */
+  goal?: string;
 }
 
-export function ChatPanel({ active, provider: providerProp, model: modelProp, projectPath }: ChatPanelProps) {
-  const [state, dispatch] = useReducer(chatReducer, initialChatState);
+export function ChatPanel({ active, provider: providerProp, model: modelProp, projectPath, sessionId: sessionIdProp, initialHistory, goal: goalProp }: ChatPanelProps) {
+  const [state, dispatch] = useReducer(
+    chatReducer,
+    undefined,
+    () => (initialHistory && initialHistory.length > 0 ? { history: initialHistory, streaming: null } : initialChatState),
+  );
   const [input, setInput] = useState('');
   const [paletteIndex, setPaletteIndex] = useState(0);
   const [busy, setBusy] = useState(false);
   const [activity, setActivity] = useState<string[]>([]);
+  // A /goal pursuit is active — only /goal clear stops it (no Esc/other input). (INT-2014)
+  const [goalActive, setGoalActive] = useState<boolean>(!!goalProp);
+  // Stable across renders: session id, createdAt, the active goal, and the abort
+  // controller that /goal clear fires. (INT-2014)
+  const sessionIdRef = useRef<string>(sessionIdProp ?? generateSessionId());
+  const createdAtRef = useRef<string>(new Date().toISOString());
+  const goalRef = useRef<string | undefined>(goalProp);
+  const abortRef = useRef<AbortController | null>(null);
   // When set, the next submitted line is routed here (a /plan confirm or edit)
   // instead of being treated as chat — the Ink analogue of blessed pendingInput.
   const [pending, setPending] = useState<{ resolve: (value: string) => void } | null>(null);
@@ -54,6 +74,24 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
   const [selector, setSelector] = useState<{ kind: 'provider' | 'model'; title: string; items: string[] } | null>(null);
   const [selectorIndex, setSelectorIndex] = useState(0);
   const cwd = projectPath ?? process.cwd();
+
+  // Persist the conversation on every change so it survives exit and can be
+  // reopened with `openswarm resume`. System/UI lines are dropped by
+  // historyToMessages; the goal rides along so resume keeps pursuing it. (INT-2014)
+  useEffect(() => {
+    if (state.history.length === 0) return;
+    void saveSession({
+      id: sessionIdRef.current,
+      provider,
+      model,
+      messages: historyToMessages(state.history),
+      totalCost: 0,
+      totalTokens: 0,
+      createdAt: createdAtRef.current,
+      updatedAt: '', // saveSession stamps this
+      goal: goalRef.current,
+    });
+  }, [state.history, provider, model]);
 
   const ask = useCallback(
     (prompt: string) =>
@@ -92,26 +130,36 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
       dispatch({ type: 'stream', chunk: '' });
       setActivity([]);
       setBusy(true);
+      const ac = new AbortController();
+      abortRef.current = ac;
       try {
         await callChatModel(
           prompt,
           provider,
           model,
-          (t) => dispatch({ type: 'stream', chunk: t }),
+          // Reasoning/thinking deltas (isThinking=true) must NOT land in the answer
+          // buffer — that's the /goal token-spam (INT-2013). Drop them here; codex
+          // surfaces reasoning separately via onLog ('💭 …'). (INT-2014)
+          (t, isThinking) => {
+            if (!isThinking) dispatch({ type: 'stream', chunk: t });
+          },
           (line) => {
             if (isActivityNoise(line)) return;
             setActivity((a) => [...a, line].slice(-10));
           },
           maxTurns,
-          undefined, // no abort signal wired here yet
+          ac.signal, // wired so /goal clear can abort a pursuit (INT-2014)
           cwd, // run in the repo `openswarm chat` was launched from (INT-2005)
         );
       } catch (e) {
-        dispatch({ type: 'stream', chunk: `\n[error] ${e instanceof Error ? e.message : String(e)}` });
+        const msg = e instanceof Error ? e.message : String(e);
+        // An abort (from /goal clear) is intentional, not an error.
+        if (!ac.signal.aborted) dispatch({ type: 'stream', chunk: `\n[error] ${msg}` });
       } finally {
         dispatch({ type: 'commit' });
         setActivity([]);
         setBusy(false);
+        abortRef.current = null;
       }
     },
     [provider, model, cwd],
@@ -121,6 +169,8 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
   // decompose & dispatch via the /plan flow. (INT-1821 / S8)
   const runGoal = useCallback(
     async (goal: string) => {
+      goalRef.current = goal; // rides along into saveSession so resume keeps it
+      setGoalActive(true);
       setBusy(true);
       try {
         await runGoalCommand(
@@ -133,6 +183,9 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
         dispatch({ type: 'system', content: `✖ goal failed: ${e instanceof Error ? e.message : String(e)}` });
       } finally {
         setBusy(false);
+        // Pursuit turn finished — unblock input. The goal itself stays set
+        // (goalRef) until /goal clear, so resume keeps pursuing it.
+        setGoalActive(false);
       }
     },
     [cwd, model, provider, streamChat], // eslint-disable-line react-hooks/exhaustive-deps
@@ -166,11 +219,21 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
         case '/plan':
           void runPlan(args);
           break;
-        case '/goal':
+        case '/goal': {
+          // /goal clear stops the active pursuit — the only way to interrupt it.
+          // It aborts the in-flight turn and releases the session goal. (INT-2014)
+          if (args.trim() === 'clear') {
+            abortRef.current?.abort();
+            goalRef.current = undefined;
+            setGoalActive(false);
+            dispatch({ type: 'system', content: '✖ Goal cleared.' });
+            break;
+          }
           // /goal routes by complexity (INT-1821): simple → pursue in-session,
           // complex → decompose & dispatch. Shared, UI-agnostic goalCommand.
           void runGoal(args);
           break;
+        }
         case '/provider': {
           // `/provider <name>` switches directly; bare `/provider` opens a selector. (INT-1960)
           const items = listAdapterNames();
@@ -237,6 +300,16 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
       }
       const parsed = parseInput(raw);
       if (!parsed) return;
+      // While a goal is actively being pursued, only "/goal clear" is honored —
+      // the pursuit runs to completion and nothing else can interrupt it. (INT-2014)
+      if (goalActive && busy) {
+        if (parsed.kind === 'command' && parsed.name === '/goal' && parsed.args.trim() === 'clear') {
+          runCommand(parsed.name, parsed.args);
+        } else {
+          dispatch({ type: 'system', content: 'Goal in progress — type "/goal clear" to stop it.' });
+        }
+        return;
+      }
       if (parsed.kind === 'command') {
         runCommand(parsed.name, parsed.args);
         return;
@@ -244,11 +317,12 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
       dispatch({ type: 'user', content: parsed.text });
       await streamChat(parsed.text);
     },
-    [pending, runCommand, streamChat],
+    [pending, runCommand, streamChat, goalActive, busy],
   );
 
-  // While a /plan confirm is pending, keep the field active even though busy.
-  const inputActive = active && (!busy || pending !== null);
+  // Keep the field active while a /plan confirm is pending, or while a goal is
+  // being pursued (so the user can type "/goal clear"). (INT-2014)
+  const inputActive = active && (!busy || pending !== null || goalActive);
 
   // Interactive command palette (INT-1959): ↑/↓ select, Enter/Tab complete.
   // A /provider|/model selector (INT-1960/1961) takes precedence when open.
@@ -279,7 +353,7 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
       <ChatInput
         value={input}
         active={inputActive}
-        busy={busy && pending === null}
+        busy={busy && pending === null && !goalActive}
         onChange={handleChange}
         onSubmit={submit}
         paletteOpen={menuOpen}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -100,6 +100,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'tests/**/*.test.ts'],
     exclude: ['node_modules', 'dist'],
     testTimeout: 30000,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,7 @@
+// Global test setup (vitest). Keep tests from touching the real home dir.
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Redirect chat-session persistence to a temp dir so ChatPanel renders (which
+// fire a saveSession effect) never write to the real ~/.openswarm/chat. (INT-2014)
+process.env.OPENSWARM_CHAT_DIR = join(tmpdir(), 'openswarm-test-chat');


### PR DESCRIPTION
## Problem

Chat-session persistence was **dead code** — `saveSession`/`loadSession` were never called from the ink TUI, so the conversation was lost on exit and `chat <session>` restored nothing. A `/goal` also couldn't be stopped except by waiting out its 5-minute timeout.

## What

- **chatSession**: `getChatDir()` (`OPENSWARM_CHAT_DIR` override), `listSessions`/`latestSession` (mtime-sorted), `loadSession` messages-default for older files.
- **chatModel**: `historyToMessages`/`messagesToHistory` (drops transient system/UI lines).
- **ChatPanel**: seed history from a resumed session; `saveSession` every turn (goal rides along); **/goal clear** aborts the pursuit and releases the goal; while a goal is being pursued **only `/goal clear` is honored** — nothing else interrupts it (per maintainer: goal is autonomous until cleared).
- **streamChat**: wire the abort signal (so /goal clear works) + **drop `isThinking` reasoning deltas** from the answer buffer (the /goal token-spam — INT-2013).
- **ChatLog**: cap the live streaming preview to the last N lines so a long reply can't fill the full-screen frame (INT-2013).
- **cli**: `chat <session>` now flows through `launchChatTui(sessionId)` → `loadSession`; new **`openswarm resume`** reopens the most recent session.
- **tests**: vitest setup redirects `OPENSWARM_CHAT_DIR` to a temp dir so ChatPanel renders don't write to the real `~/.openswarm/chat`.

## Verified

- chatSession/chatModel unit (round-trip, mtime sort, conversion), **tui 106 tests**, typecheck/build/oxlint.
- Test isolation confirmed: file count in real `~/.openswarm/chat` unchanged across a full run.

## Out of scope / follow-up

**goal fan-out**: the complex-goal path POSTs to the daemon (`127.0.0.1:3847`) and **stalls when the daemon is down** — that's the real INT-2013 /goal "hang". Next: dispatch to the daemon when it's up, else run an in-session `runPool` fan-out. Agreed direction with maintainer; separate PR.

Closes INT-2014. Refs INT-2013.