### PR TITLE
fix(linear): stop doubling project overview summary + readme note (INT-1907, INT-1858)

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Background: decay, consolidation, contradiction detection, distillation.
 (success → `system_pattern` with files changed + approach, review rejection →
 `constraint` pitfall), and the next task on the same repo recalls the most
 relevant entries into the worker prompt as a "Repository Knowledge" section.
-Workers get better at a codebase the more they work on it.
+Workers get better at a codebase the more they work on it. Workers can also actively query accumulated repo knowledge mid-task via the `search_memory` tool.
 
 ### Benchmarks (L0–L6)
 

--- a/src/linear/projectUpdater.ts
+++ b/src/linear/projectUpdater.ts
@@ -412,9 +412,11 @@ async function refreshProjectOverview(projectId: string, projectPath?: string): 
     // The full overview section is posted via Status Updates instead.
     const currentDesc = project.description ?? '';
     const markerIdx = currentDesc.indexOf(AUTOMATION_SECTION_MARKER);
-    const baseDesc = markerIdx >= 0
+    const stripped = markerIdx >= 0
       ? currentDesc.slice(0, markerIdx).trimEnd()
       : currentDesc;
+    // Strip any previously-appended compact summary so it isn't doubled on each call.
+    const baseDesc = stripped.replace(/\s*\[Done:\d+ InProgress:\d+ Todo:\d+\]$/, '').trimEnd();
 
     // Build a compact summary line for description (fits within 255 chars)
     const doneCount = stateCounts.get('Done') ?? 0;


### PR DESCRIPTION
Salvages two valuable swarm worktree branches that were never merged (verified against main, not stale).

## INT-1907 — Linear project overview summary doubling (real bug)
`refreshProjectOverview` appends a compact `[Done:X InProgress:Y Todo:Z]` summary to the project description each call but never strips the previous one — so it doubles on every refresh. main has no dedup. Fix: strip any prior `[Done:… Todo:…]` suffix before re-appending (`projectUpdater.ts:412`).

## INT-1858 — README note (docs)
One-line note that workers can query repo knowledge via `search_memory` (tool verified to exist: `tools.ts:110`, `mcp/memoryServer.ts`). Absent from main README.

The other 3 candidate swarm branches were dropped: INT-1675 (byte-identical to main already), INT-1871 (README already documents escalateModel), INT-1965 (superseded by INT-2014 + conflicts).

Verified: typecheck / build / oxlint clean; cherry-picks applied without conflict.