### PR TITLE
fix(daemon): stop running tasks after every project is disabled (INT-2207)

### DIFF
--- a/src/automation/autonomousRunner.enable.test.ts
+++ b/src/automation/autonomousRunner.enable.test.ts
@@ -30,3 +30,32 @@ describe('AutonomousRunner.enableProject (INT-1973)', () => {
     expect(r.getEnabledProjects()).toContain('/x/a');
   });
 });
+
+describe('AutonomousRunner project-selection gating (INT-2207)', () => {
+  // shouldFilterByEnabled is private; the gating behavior is what matters.
+  type Internal = { shouldFilterByEnabled(): boolean };
+  const filtersOn = (r: AutonomousRunner) => (r as unknown as Internal).shouldFilterByEnabled();
+
+  it('untouched + empty → filter OFF (legacy run-all fallback)', () => {
+    const r = new AutonomousRunner(cfg());
+    expect(r.getEnabledProjects()).toHaveLength(0);
+    expect(filtersOn(r)).toBe(false); // no explicit selection yet → run all allowed
+  });
+
+  it('disabling every project → filter ON even though empty → nothing runs', () => {
+    const r = new AutonomousRunner(cfg({ allowedProjects: ['/x/a'] }));
+    r.enableProject('/x/a');
+    expect(filtersOn(r)).toBe(true);
+    r.disableProject('/x/a');
+    expect(r.getEnabledProjects()).toHaveLength(0);
+    // The bug: empty used to mean "run all". Now touched → filter stays ON, so an
+    // empty enabled-set means nothing runs.
+    expect(filtersOn(r)).toBe(true);
+  });
+
+  it('disabling alone (no prior enable) still touches the selection', () => {
+    const r = new AutonomousRunner(cfg());
+    r.disableProject('/x/a');
+    expect(filtersOn(r)).toBe(true);
+  });
+});

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -75,8 +75,15 @@ export class AutonomousRunner {
   // Heartbeat concurrency guard
   private _heartbeatRunning = false;
 
-  // Explicitly enabled project paths (allow-list; empty = nothing runs)
+  // Explicitly enabled project paths (allow-list; empty = nothing runs ONLY once
+  // the selection has been touched — see projectSelectionTouched).
   private enabledProjects = new Set<string>();
+
+  // Whether the user has explicitly enabled/disabled any project (dashboard/CLI).
+  // Before this, an empty enabledProjects means "no selection yet → all allowed
+  // projects run" (legacy fallback). After, an empty set means "nothing runs" —
+  // so disabling every project actually stops the daemon. (INT-2207)
+  private projectSelectionTouched = false;
 
   /**
    * macOS (APFS default) and Windows have case-insensitive filesystems by
@@ -103,6 +110,15 @@ export class AutonomousRunner {
       if (needle.startsWith(hay + '/')) return true;
     }
     return false;
+  }
+
+  /**
+   * Whether to apply the enabledProjects allow-list. True once the user has made
+   * an explicit selection (touched), OR while any project is enabled. Empty +
+   * untouched stays the legacy "run all allowed projects" fallback. (INT-2207)
+   */
+  private shouldFilterByEnabled(): boolean {
+    return this.projectSelectionTouched || this.enabledProjects.size > 0;
   }
 
   // Last fetched Linear tasks (for dashboard display)
@@ -852,7 +868,7 @@ export class AutonomousRunner {
     const executableTasks = tasks.filter(t => t.linearState !== 'Backlog');
 
     let tasksForEngine = executableTasks;
-    if (this.enabledProjects.size > 0) {
+    if (this.shouldFilterByEnabled()) {
       // Explicit repo↔Linear mapping — match fetched issues to repos by the Linear
       // projectId the user picked in `openswarm add` (written to <repo>/openswarm.json),
       // NOT by guessing from the repo directory name. Built fresh each cycle so a
@@ -939,7 +955,7 @@ export class AutonomousRunner {
         continue;
       }
 
-      if (this.enabledProjects.size > 0 && !this.isProjectEnabled(projectPath)) {
+      if (this.shouldFilterByEnabled() && !this.isProjectEnabled(projectPath)) {
         this.syslog(`  Project not enabled: ${projectPath}`);
         continue;
       }
@@ -1043,7 +1059,7 @@ export class AutonomousRunner {
     }
 
     // Skip if project is not in enabled list (allow-list; empty = nothing runs)
-    if (this.enabledProjects.size > 0 && !this.isProjectEnabled(projectPath)) {
+    if (this.shouldFilterByEnabled() && !this.isProjectEnabled(projectPath)) {
       console.log(`[AutonomousRunner] Project not enabled, skipping: ${projectPath}`);
       return;
     }
@@ -1405,6 +1421,7 @@ export class AutonomousRunner {
   }
 
   disableProject(projectPath: string): void {
+    this.projectSelectionTouched = true; // empty set now means "nothing runs" (INT-2207)
     this.enabledProjects.delete(projectPath);
     console.log(`[AutonomousRunner] Project disabled: ${projectPath}`);
     // Disabling gates new selection AND cancels any in-flight pipeline for this
@@ -1416,6 +1433,7 @@ export class AutonomousRunner {
   }
 
   enableProject(projectPath: string): void {
+    this.projectSelectionTouched = true; // explicit selection from here on (INT-2207)
     this.enabledProjects.add(projectPath);
     // Enabling a repo (via `openswarm add` / the dashboard) must also ALLOW it:
     // resolveProjectPath only reads a repo's openswarm.json for paths in


### PR DESCRIPTION
## Problem
Disabling every project in the dashboard left the daemon still picking up tasks.

## Root cause
The project allow-list guards (`autonomousRunner.ts` task filter `:871`, two skip-checks `:958`/`:1062`) were all wrapped in `enabledProjects.size > 0`. An empty set skipped the filter entirely and ran **everything** — but an empty set is exactly what "disable all" produces. The comment at `:1045` even claimed "empty = nothing runs" while the code did the opposite. `enabledProjects` starts empty and is only filled by `enableProject`, so "empty at startup (fallback: run all)" and "empty because the user disabled all (expected: nothing)" were indistinguishable.

## Fix
`projectSelectionTouched` flag, set on enable/disable. Filtering applies when **touched OR non-empty** (`shouldFilterByEnabled`):
- untouched + empty → legacy run-all fallback (fresh start unchanged)
- touched + empty (disabled everything) → nothing runs

`disableProject` already cancels in-flight tasks; the flag also gates new pickup.

## Verified
3 new unit tests (untouched→fallback, disable-all→filter-on→nothing, disable touches selection) + autonomousRunner regression (13 tests). typecheck/build/oxlint clean.

## Follow-up
`enabledProjects` is in-memory only — a daemon **restart** reverts to the run-all fallback, so the disabled selection isn't persisted across restarts. Disk persistence is a separate issue.

Closes INT-2207.