### PR TITLE
feat(daemon): persist project selection across restarts (INT-2208)

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -18,6 +18,8 @@ import {
   recordProjectCompletion,
   canProjectAcceptTask,
   getProjectWindowCount,
+  loadProjectSelection,
+  saveProjectSelection,
   type TaskState,
   type ProjectInfo,
 } from './runnerState.js';
@@ -121,6 +123,13 @@ export class AutonomousRunner {
     return this.projectSelectionTouched || this.enabledProjects.size > 0;
   }
 
+  /** Persist the project selection so it survives a restart. No-op under dryRun
+   * (tests) to avoid touching the real ~/.openswarm. (INT-2208) */
+  private persistSelection(): void {
+    if (this.config.dryRun) return;
+    saveProjectSelection({ enabled: [...this.enabledProjects], touched: this.projectSelectionTouched });
+  }
+
   // Last fetched Linear tasks (for dashboard display)
   private lastFetchedTasks: TaskItem[] = [];
 
@@ -174,6 +183,13 @@ export class AutonomousRunner {
   constructor(config: AutonomousConfig) {
     this.config = config;
     this.loadTaskState();  // Restore completed/failed task IDs from disk
+    // Restore the persisted project selection so "disable all" survives a daemon
+    // restart. Skipped under dryRun (tests) so the real ~/.openswarm isn't touched. (INT-2208)
+    if (!config.dryRun) {
+      const sel = loadProjectSelection();
+      this.enabledProjects = new Set(sel.enabled);
+      this.projectSelectionTouched = sel.touched;
+    }
     this.engine = getDecisionEngine({
       allowedProjects: config.allowedProjects,
       linearTeamId: config.linearTeamId,
@@ -1430,6 +1446,7 @@ export class AutonomousRunner {
     if (cancelled > 0) {
       this.syslog(`⏹ Cancelled ${cancelled} in-flight task(s) for disabled project ${projectPath.split('/').pop()}`);
     }
+    this.persistSelection();
   }
 
   enableProject(projectPath: string): void {
@@ -1444,6 +1461,7 @@ export class AutonomousRunner {
       this.updateAllowedProjects([...allowed, projectPath]);
     }
     console.log(`[AutonomousRunner] Project enabled: ${projectPath}`);
+    this.persistSelection();
   }
 
   /** Get all currently enabled project paths */

--- a/src/automation/projectSelection.test.ts
+++ b/src/automation/projectSelection.test.ts
@@ -1,0 +1,38 @@
+// project-selection persistence: "disable all" must survive a daemon restart. (INT-2208)
+import { describe, it, expect, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { writeFileSync, rmSync } from 'node:fs';
+import { loadProjectSelection, saveProjectSelection } from './runnerState.js';
+
+describe('project selection persistence (INT-2208)', () => {
+  const tmp = join(tmpdir(), `os-proj-sel-${process.pid}.json`);
+  afterEach(() => {
+    try {
+      rmSync(tmp);
+    } catch {
+      /* already gone */
+    }
+  });
+
+  it('round-trips enabled + touched through disk', () => {
+    saveProjectSelection({ enabled: ['/x/a', '/x/b'], touched: true }, tmp);
+    expect(loadProjectSelection(tmp)).toEqual({ enabled: ['/x/a', '/x/b'], touched: true });
+  });
+
+  it('persists an empty-but-touched selection (disabled everything → nothing runs)', () => {
+    saveProjectSelection({ enabled: [], touched: true }, tmp);
+    const restored = loadProjectSelection(tmp);
+    expect(restored.enabled).toEqual([]);
+    expect(restored.touched).toBe(true); // the key: empty stays "touched" so the fallback doesn't return
+  });
+
+  it('returns a safe default when the file is absent', () => {
+    expect(loadProjectSelection(join(tmpdir(), 'os-nonexistent-xyz.json'))).toEqual({ enabled: [], touched: false });
+  });
+
+  it('tolerates corrupt JSON → default', () => {
+    writeFileSync(tmp, '{ not json', 'utf8');
+    expect(loadProjectSelection(tmp)).toEqual({ enabled: [], touched: false });
+  });
+});

--- a/src/automation/runnerState.ts
+++ b/src/automation/runnerState.ts
@@ -5,7 +5,7 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
 
 /** Check if a resolved path matches or is under any enabled project path */
@@ -22,6 +22,7 @@ export const PIPELINE_HISTORY_FILE = join(homedir(), '.claude', 'openswarm-pipel
 export const REJECTION_STATE_FILE = join(homedir(), '.claude', 'openswarm-rejection-state.json');
 export const DECOMPOSITION_STATE_FILE = join(homedir(), '.claude', 'openswarm-decomposition-state.json');
 export const DAILY_PACE_FILE = join(homedir(), '.openswarm', 'daily-pace.json');
+export const PROJECT_SELECTION_FILE = join(homedir(), '.openswarm', 'project-selection.json');
 const MAX_PIPELINE_HISTORY = 100;
 const MAX_REJECTION_ATTEMPTS = 3;
 
@@ -78,6 +79,35 @@ function savePace(): void {
     writeFileSync(DAILY_PACE_FILE, JSON.stringify(paceState, null, 2), 'utf8');
   } catch (err) {
     console.warn('[Pace] Failed to save:', err);
+  }
+}
+
+// Persisted dashboard/CLI project selection so "disable all" survives a daemon
+// restart (otherwise enabledProjects resets and the run-all fallback kicks back
+// in). (INT-2208) `touched` mirrors AutonomousRunner.projectSelectionTouched.
+export interface ProjectSelection {
+  enabled: string[];
+  touched: boolean;
+}
+
+export function loadProjectSelection(file: string = PROJECT_SELECTION_FILE): ProjectSelection {
+  try {
+    if (existsSync(file)) {
+      const data = JSON.parse(readFileSync(file, 'utf8'));
+      return { enabled: Array.isArray(data.enabled) ? data.enabled : [], touched: !!data.touched };
+    }
+  } catch {
+    /* corrupt/unreadable → safe default below */
+  }
+  return { enabled: [], touched: false };
+}
+
+export function saveProjectSelection(sel: ProjectSelection, file: string = PROJECT_SELECTION_FILE): void {
+  try {
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify(sel, null, 2), 'utf8');
+  } catch (err) {
+    console.warn('[ProjectSelection] Failed to save:', err);
   }
 }
 


### PR DESCRIPTION
Follow-up to INT-2207 (PR #172). That fix stopped the daemon at runtime when all projects are disabled, but `enabledProjects`/`projectSelectionTouched` were in-memory only — a **daemon restart** reset them and the run-all fallback returned, so a disabled project would resume.

## Change
- `runnerState`: `PROJECT_SELECTION_FILE` (`~/.openswarm/project-selection.json`) + `loadProjectSelection`/`saveProjectSelection` (best-effort, reuses the DAILY_PACE pattern; file param injectable for tests).
- `AutonomousRunner`: restore the selection in the constructor; persist on every enable/disable. Both gated on `!dryRun` so tests/dry runs never touch the real `~/.openswarm`.

Now "disable all" survives a restart: the empty-but-**touched** selection is persisted, so the fallback stays off and nothing runs until you re-enable.

## Verified
4 persistence unit tests (round-trip, empty-but-touched, missing-file default, corrupt-JSON default) + autonomousRunner regression (8). Isolation confirmed: dryRun runners leave `~/.openswarm` untouched. typecheck/build/oxlint clean.

Closes INT-2208. Refs INT-2207.