### PR TITLE
fix(tui): unify Ink TUI colors on the theme scheme (INT-2209)

### DIFF
--- a/src/tui/components/AuditBoard.tsx
+++ b/src/tui/components/AuditBoard.tsx
@@ -79,7 +79,18 @@ export function AuditBoard({ areas, concurrency, events }: AuditBoardProps) {
         </Text>
       ))}
       <Text color={theme.dim}>
-        {`  ✓ ${approved} done · ✎ ${revised} revise · ✗ ${rejected} reject${failed ? ` · ⚠ ${failed} failed` : ''}`}
+        {'  '}
+        <Text color={theme.ok}>{`✓ ${approved} done`}</Text>
+        {' · '}
+        <Text color={theme.accentAlt}>{`✎ ${revised} revise`}</Text>
+        {' · '}
+        <Text color={theme.err}>{`✗ ${rejected} reject`}</Text>
+        {failed ? (
+          <Text>
+            {' · '}
+            <Text color={theme.warn}>{`⚠ ${failed} failed`}</Text>
+          </Text>
+        ) : null}
       </Text>
     </Box>
   );

--- a/src/tui/components/ChatInput.tsx
+++ b/src/tui/components/ChatInput.tsx
@@ -66,7 +66,9 @@ export function ChatInput({
     <Box borderStyle="round" borderColor={active ? theme.borderActive : theme.border} paddingX={1}>
       {busy ? (
         <Text color={theme.dim}>
-          <Spinner type="dots" />
+          <Text color={theme.accent}>
+            <Spinner type="dots" />
+          </Text>
           <Text>{' working… (Esc to leave)'}</Text>
         </Text>
       ) : (

--- a/src/tui/components/CommandPalette.tsx
+++ b/src/tui/components/CommandPalette.tsx
@@ -1,6 +1,7 @@
 // CommandPalette — slash-command suggestions for the current input (S4).
 // Interactive: the selected row (↑/↓) is highlighted; Enter/Tab completes it. (INT-1959)
 import { Box, Text } from 'ink';
+import { theme } from '../theme.js';
 import type { SlashCommand } from '../chatModel.js';
 
 export function CommandPalette({ matches, selectedIndex = 0 }: { matches: SlashCommand[]; selectedIndex?: number }) {
@@ -11,7 +12,7 @@ export function CommandPalette({ matches, selectedIndex = 0 }: { matches: SlashC
         const selected = i === selectedIndex;
         return (
           <Text key={c.name} inverse={selected}>
-            <Text color="cyan">{`${selected ? '❯ ' : '  '}${c.name}`}</Text>
+            <Text color={theme.accent}>{`${selected ? '❯ ' : '  '}${c.name}`}</Text>
             {c.args ? <Text dimColor>{` ${c.args}`}</Text> : null}
             <Text dimColor>{`  ${c.desc}`}</Text>
           </Text>

--- a/src/tui/components/SelectList.tsx
+++ b/src/tui/components/SelectList.tsx
@@ -2,6 +2,7 @@
 // /provider and /model switchers (INT-1960/INT-1961). Key handling lives in the
 // caller (ChatInput's palette routing); this is pure presentation.
 import { Box, Text } from 'ink';
+import { theme } from '../theme.js';
 
 export function SelectList({
   title,
@@ -15,7 +16,7 @@ export function SelectList({
   if (items.length === 0) return null;
   return (
     <Box flexDirection="column" marginTop={1}>
-      <Text color="yellow">{title}</Text>
+      <Text color={theme.system}>{title}</Text>
       {items.map((item, i) => {
         const selected = i === selectedIndex;
         return (

--- a/src/tui/components/StageTimeline.tsx
+++ b/src/tui/components/StageTimeline.tsx
@@ -2,10 +2,11 @@
 // Presentational: takes already-reduced stage entries (parity with the
 // dashboard's renderStages).
 import { Box, Text } from 'ink';
+import { theme } from '../theme.js';
 import type { StageEntry } from '../pipelineEvents.js';
 
 const ICON: Record<StageEntry['status'], string> = { start: '▶', complete: '✓', fail: '✗' };
-const COLOR: Record<StageEntry['status'], string> = { start: 'yellow', complete: 'green', fail: 'red' };
+const COLOR: Record<StageEntry['status'], string> = { start: theme.running, complete: theme.ok, fail: theme.err };
 
 export interface StageTimelineProps {
   stages: StageEntry[];

--- a/src/tui/components/SubagentTree.tsx
+++ b/src/tui/components/SubagentTree.tsx
@@ -1,10 +1,11 @@
 // SubagentTree — concurrent tasks as a per-worktree agent tree (S7).
 // Presentational: takes nodes built by buildSubagentTree.
 import { Box, Text } from 'ink';
+import { theme } from '../theme.js';
 import type { TaskNode, TaskStatus } from '../subagentTree.js';
 
 const ICON: Record<TaskStatus, string> = { start: '◐', complete: '●', fail: '✗' };
-const COLOR: Record<TaskStatus, string> = { start: 'yellow', complete: 'green', fail: 'red' };
+const COLOR: Record<TaskStatus, string> = { start: theme.running, complete: theme.ok, fail: theme.err };
 
 export interface SubagentTreeProps {
   tasks: TaskNode[];

--- a/src/tui/components/TabBar.tsx
+++ b/src/tui/components/TabBar.tsx
@@ -1,6 +1,7 @@
 // TabBar — the 6-tab strip; highlights the active tab (EPIC INT-1813 S3).
 import { Box, Text } from 'ink';
 import { TABS } from '../tabs.js';
+import { theme } from '../theme.js';
 
 export interface TabBarProps {
   active: number;
@@ -11,7 +12,7 @@ export function TabBar({ active }: TabBarProps) {
     <Box>
       {TABS.map((tab, i) => (
         <Box key={tab.id} marginRight={1}>
-          <Text inverse={i === active} color={i === active ? 'cyan' : undefined}>
+          <Text inverse={i === active} color={i === active ? theme.accent : undefined}>
             {` ${i + 1}:${tab.label} `}
           </Text>
         </Box>

--- a/src/tui/logFormat.ts
+++ b/src/tui/logFormat.ts
@@ -8,6 +8,8 @@
 // readable output instead of a monochrome wall. Pure — the Ink <Text> spans are
 // produced by components/LogLine.tsx from these segments.
 
+import { theme } from './theme.js';
+
 export interface LogSegment {
   text: string;
   /** Ink color name (cyan/green/yellow/red/magenta/blue…). Omit for default. */
@@ -18,13 +20,13 @@ export interface LogSegment {
 
 /** Per-pipeline-stage tag color. */
 const STAGE_COLORS: Record<string, string> = {
-  worker: 'cyan',
-  reviewer: 'magenta',
-  tester: 'yellow',
-  planner: 'blue',
-  documenter: 'green',
-  auditor: 'red',
-  'skill-documenter': 'green',
+  worker: theme.accent,
+  reviewer: theme.accentAlt,
+  tester: theme.system,
+  planner: theme.info,
+  documenter: theme.ok,
+  auditor: theme.err,
+  'skill-documenter': theme.ok,
 };
 
 const ISSUE_RE = /^[A-Z]{2,}-\d+$/;
@@ -32,8 +34,8 @@ const ISSUE_RE = /^[A-Z]{2,}-\d+$/;
 /** Level color for the message body. */
 function bodyColor(body: string): string | undefined {
   const l = body.toLowerCase();
-  if (/(\berror\b|\bfail|✖|✗|"success":\s*false|halt)/.test(l)) return 'red';
-  if (/(✓|completed|succeed|success|done|approved|passed)/.test(l)) return 'green';
+  if (/(\berror\b|\bfail|✖|✗|"success":\s*false|halt)/.test(l)) return theme.err;
+  if (/(✓|completed|succeed|success|done|approved|passed)/.test(l)) return theme.ok;
   return undefined;
 }
 
@@ -47,7 +49,7 @@ function formatBody(body: string): LogSegment[] {
   let m: RegExpExecArray | null;
   while ((m = re.exec(body))) {
     if (m.index > last) out.push({ text: body.slice(last, m.index), color });
-    out.push({ text: `\`${m[1]}\``, color: 'cyan' });
+    out.push({ text: `\`${m[1]}\``, color: theme.accent });
     last = m.index + m[0].length;
   }
   if (last < body.length) out.push({ text: body.slice(last), color });
@@ -63,7 +65,7 @@ export function parseLogLine(line: string): LogSegment[] {
   const stageM = rest.match(/^\[([a-z][\w-]*)\]\s*/i);
   if (stageM) {
     const stage = stageM[1].toLowerCase();
-    segs.push({ text: `[${stageM[1]}]`, color: STAGE_COLORS[stage] ?? 'white', bold: true });
+    segs.push({ text: `[${stageM[1]}]`, color: STAGE_COLORS[stage] ?? theme.assistant, bold: true });
     segs.push({ text: ' ' });
     rest = rest.slice(stageM[0].length);
   }
@@ -75,9 +77,9 @@ export function parseLogLine(line: string): LogSegment[] {
     const parts = ctxM[1].split('|').map((p) => p.trim());
     parts.forEach((p, i) => {
       if (i > 0) segs.push({ text: ' | ', dim: true });
-      if (ISSUE_RE.test(p)) segs.push({ text: p, color: 'yellow', bold: true });
+      if (ISSUE_RE.test(p)) segs.push({ text: p, color: theme.system, bold: true });
       else if (p.startsWith('worktree/')) segs.push({ text: p, dim: true });
-      else segs.push({ text: p, color: 'green' });
+      else segs.push({ text: p, color: theme.ok });
     });
     segs.push({ text: ']', dim: true });
     segs.push({ text: ' ' });

--- a/src/tui/panels/LogsPanel.tsx
+++ b/src/tui/panels/LogsPanel.tsx
@@ -4,6 +4,7 @@
 import { Box, Text } from 'ink';
 import { LiveLog } from '../components/LiveLog.js';
 import { usePipelineEvents } from '../hooks/usePipelineEvents.js';
+import { theme } from '../theme.js';
 
 export interface LogsPanelProps {
   /** Daemon HTTP port; when unset the panel renders idle (no connection). */
@@ -14,14 +15,18 @@ export interface LogsPanelProps {
 
 export function LogsPanel({ port, max = 30 }: LogsPanelProps) {
   const { logs, connected } = usePipelineEvents(port);
-  const status = !port
-    ? '○ daemon port unknown — start the daemon to stream logs'
+  const live = !!port && connected;
+  const label = !port
+    ? ' daemon port unknown — start the daemon to stream logs'
     : connected
-      ? `● live (:${port})`
-      : `○ connecting :${port}…`;
+      ? ` live (:${port})`
+      : ` connecting :${port}…`;
   return (
     <Box flexDirection="column">
-      <Text dimColor>{status}</Text>
+      <Text>
+        <Text color={live ? theme.ok : theme.dim}>{live ? '●' : '○'}</Text>
+        <Text dimColor>{label}</Text>
+      </Text>
       <Box marginTop={1}>
         <LiveLog logs={logs} max={max} />
       </Box>

--- a/src/tui/panels/MonitorPanel.tsx
+++ b/src/tui/panels/MonitorPanel.tsx
@@ -4,6 +4,7 @@
 import { Text } from 'ink';
 import { DataTable } from '../components/DataTable.js';
 import { useMonitor } from '../hooks/useMonitor.js';
+import { theme } from '../theme.js';
 import type { Table } from '../monitorRows.js';
 
 export interface MonitorPanelProps {
@@ -15,7 +16,7 @@ export interface MonitorPanelProps {
 export function MonitorPanel({ port, fetcher, empty }: MonitorPanelProps) {
   const { table, error, loading } = useMonitor(port, fetcher);
   if (!port) return <Text dimColor>○ daemon port unknown</Text>;
-  if (error) return <Text color="red">{`load failed: ${error}`}</Text>;
+  if (error) return <Text color={theme.err}>{`load failed: ${error}`}</Text>;
   if (!table) return <Text dimColor>{loading ? 'loading…' : '(no data)'}</Text>;
   return <DataTable columns={table.columns} rows={table.rows} empty={empty} />;
 }

--- a/src/tui/panels/PipelinePanel.tsx
+++ b/src/tui/panels/PipelinePanel.tsx
@@ -7,6 +7,7 @@ import { SubagentTree } from '../components/SubagentTree.js';
 import { LiveLog } from '../components/LiveLog.js';
 import { usePipelineEvents } from '../hooks/usePipelineEvents.js';
 import { buildSubagentTree } from '../subagentTree.js';
+import { theme } from '../theme.js';
 
 export interface PipelinePanelProps {
   /** Daemon HTTP port; when unset the panel renders idle (no connection). */
@@ -15,14 +16,18 @@ export interface PipelinePanelProps {
 
 export function PipelinePanel({ port }: PipelinePanelProps) {
   const { stages, logs, connected } = usePipelineEvents(port);
-  const status = !port
-    ? '○ daemon port unknown'
+  const live = !!port && connected;
+  const label = !port
+    ? ' daemon port unknown'
     : connected
-    ? `● live (:${port})`
-    : `○ connecting :${port}…`;
+    ? ` live (:${port})`
+    : ` connecting :${port}…`;
   return (
     <Box flexDirection="column">
-      <Text dimColor>{status}</Text>
+      <Text>
+        <Text color={live ? theme.ok : theme.dim}>{live ? '●' : '○'}</Text>
+        <Text dimColor>{label}</Text>
+      </Text>
       <SubagentTree tasks={buildSubagentTree(stages)} />
       <Box marginTop={1}>
         <StageTimeline stages={stages} />

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -14,6 +14,8 @@ export const theme = {
   ok: 'green',
   warn: 'yellow',
   err: 'red',
+  running: 'yellow',
+  info: 'blue',
   border: 'gray',
   borderActive: 'cyan',
 } as const;


### PR DESCRIPTION
## Problem
Ink TUI components mixed `theme.ts` tokens with hardcoded color literals (`"red"`/`"cyan"`/`"yellow"`) and left some status text uncolored. A full audit of components(14) + panels(4) found 11 direct violations + ~13 literals in logFormat.ts.

## Change
- **theme**: add `running` (in-progress, distinct from `warn`) and `info` (planner) tokens.
- **components/panels**: hardcoded literals → theme tokens (SubagentTree, StageTimeline, MonitorPanel, TabBar, CommandPalette, SelectList) + color the previously all-gray status text (AuditBoard verdict tallies: ✓→ok/✎→accentAlt/✗→err/⚠→warn; panel `●` live dots → ok when connected; ChatInput busy spinner → accent).
- **logFormat.ts**: tokenize STAGE_COLORS + body/inline/stage colors (worker→accent, reviewer→accentAlt, planner→info, …) — the source feeding LogLine/LiveLog/Logs/Pipeline tabs.

## Visual impact
Unchanged except the intended status-color fixes — most tokens equal their prior literal (accent=cyan, system=yellow, ok=green, err=red, info=blue). No behavior/layout change.

## Verified
typecheck / build / oxlint clean; **tui 99 tests pass** (no literal-assertion regressions).

Closes INT-2209.