### PR TITLE
fix(linear): use a single team UUID in createIssue for multi-team configs (INT-2210)

### DIFF
--- a/src/automation/taskSource.ts
+++ b/src/automation/taskSource.ts
@@ -71,8 +71,10 @@ export class LinearTaskSource implements ITaskSource {
   constructor(private readonly fetch: () => Promise<TaskItem[]>) {}
 
   fetchTasks(): Promise<TaskItem[]> { return this.fetch(); }
-  async createTask(title: string, description: string, _projectId?: string): Promise<SubIssueResult> {
-    const r = await linear.createIssue(title, description, []);
+  async createTask(title: string, description: string, projectId?: string): Promise<SubIssueResult> {
+    // Pass projectId so createIssue links the issue AND resolves the project's team
+    // (multi-team configs would otherwise hit "teamId must be a UUID"). (INT-2210)
+    const r = await linear.createIssue(title, description, [], { projectId });
     return 'error' in r ? r : { id: r.id, identifier: r.identifier, title: r.title };
   }
   updateState(issueId: string, state: TaskState): Promise<void> { return linear.updateIssueState(issueId, state); }

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -1097,7 +1097,7 @@ export async function createIssue(
   title: string,
   description: string,
   labels: string[] = [],
-  options?: { bypassLimit?: boolean }
+  options?: { bypassLimit?: boolean; projectId?: string }
 ): Promise<LinearIssueInfo | { error: string }> {
   if (!isLinearInitialized()) return { error: 'Linear not configured' };
   resetDailyCounterIfNeeded();
@@ -1111,18 +1111,33 @@ export async function createIssue(
 
   const linear = getClient();
 
+  // Resolve a single team UUID. Multi-team configs hold a comma-joined list in the
+  // module `teamId` (e.g. "uuid1,uuid2"), which is NOT a valid UUID for the API.
+  // Prefer the given project's team, else the first configured team. (INT-2210)
+  let resolvedTeamId = teamIds[0] ?? teamId;
+  if (options?.projectId) {
+    try {
+      const proj = await linear.project(options.projectId);
+      const projTeam = (await proj.teams()).nodes[0]; // a project can span teams; take the first
+      if (projTeam?.id) resolvedTeamId = projTeam.id;
+    } catch {
+      /* project/team lookup failed → keep teamIds[0] fallback */
+    }
+  }
+
   // Look up label IDs
-  const team = await linear.team(teamIds[0] ?? teamId);
+  const team = await linear.team(resolvedTeamId);
   const teamLabels = await team.labels();
   const labelIds = labels
     .map((name) => teamLabels.nodes.find((l) => l.name === name)?.id)
     .filter((id): id is string => !!id);
 
   const issuePayload = await linear.createIssue({
-    teamId,
+    teamId: resolvedTeamId,
     title,
     description,
     labelIds,
+    ...(options?.projectId ? { projectId: options.projectId } : {}),
   });
 
   const issue = await issuePayload.issue;


### PR DESCRIPTION
## Problem
`openswarm review --max`'s Linear master issue failed with `Argument Validation Error - teamId must be a UUID` on multi-team configs (`teamId: uuid1,uuid2,…`).

## Root cause
`linear.ts:createIssue` looked up labels with `teamIds[0]` (single) but passed the module `teamId` — the **comma-joined full string** — to `linear.createIssue({ teamId })`. Single-team configs have one UUID so it worked by accident; the daemon uses `createSubIssue` (inherits the parent's team) so it never hit this. review's top-level `createIssue` did. Plus `LinearTaskSource.createTask` dropped projectId (`_projectId`), so the master issue wasn't linked to a project either.

## Fix
- `createIssue`: resolve a single team UUID — the given project's team (`project.teams[0]`) when a projectId is passed, else `teamIds[0]`. Never pass the comma string. Also forward `projectId` to link the issue.
- `LinearTaskSource.createTask`: forward projectId.

## Verified
typecheck / build / oxlint clean; linear + taskSource regression (24 tests).

Closes INT-2210. Refs INT-2022.