### PR TITLE
feat(review): PM agent — synthesize audit follow-ups into <=10 cohesive issues (INT-2225)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -244,6 +244,7 @@ program
   .description('Review the working-tree changes; --max audits the whole codebase with reviewer subagents')
   .option('--path <path>', 'Project path (default: cwd)')
   .option('--issues [parent]', 'File follow-ups as Linear sub-issues (parent inferred from the git branch, or pass an id)')
+  .option('--issues-per-area [parent]', 'For --max: legacy per-area follow-up fan-out (skips the PM synthesis)')
   .option('--file [parent]', 'Alias for --issues (back-compat)')
   .option('--adapter <name>', 'Adapter override for the reviewer')
   .option('--debug', 'Verbose logging')
@@ -258,7 +259,7 @@ program
   .option('--fallback <adapter>', 'For --max: retry usage-limited areas on this adapter (default: claude for codex)')
   .option('--no-fallback', 'For --max: disable the automatic usage-limit fallback')
   .action(async (opts: {
-    path?: string; issues?: string | boolean; file?: string | boolean; adapter?: string; debug?: boolean;
+    path?: string; issues?: string | boolean; issuesPerArea?: string | boolean; file?: string | boolean; adapter?: string; debug?: boolean;
     max?: boolean; concurrency?: number; maxFilesPerArea?: number; yes?: boolean; dryRun?: boolean;
     out?: string; linear?: boolean; fallback?: string | boolean;
   }) => {
@@ -271,6 +272,7 @@ program
           maxFilesPerArea: opts.maxFilesPerArea,
           adapter: opts.adapter,
           fileIssue: opts.issues ?? opts.file,
+          issuesPerArea: opts.issuesPerArea,
           yes: opts.yes,
           dryRun: opts.dryRun,
           out: opts.out,

--- a/src/cli/auditPM.test.ts
+++ b/src/cli/auditPM.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildSynthesisPrompt,
+  parseSynthesisOutput,
+  synthesizeAuditIssues,
+} from './auditPM.js';
+import type { RecommendedAction } from '../agents/agentPair.js';
+
+const actions: RecommendedAction[] = [
+  { type: 'refactor', title: 'extract shared parser', location: 'src/a.ts:10' },
+  { type: 'test', title: 'cover error path', location: 'src/b.ts:42' },
+  { type: 'fix', title: 'handle null input' }, // no location
+];
+
+describe('buildSynthesisPrompt (INT-2225)', () => {
+  it('lists each follow-up as "- [type] title (location)"', () => {
+    const prompt = buildSynthesisPrompt(actions, 'OpenSwarm');
+    expect(prompt).toContain('- [refactor] extract shared parser (src/a.ts:10)');
+    expect(prompt).toContain('- [test] cover error path (src/b.ts:42)');
+    // No location → no parenthetical.
+    expect(prompt).toContain('- [fix] handle null input');
+    expect(prompt).not.toContain('handle null input (');
+  });
+
+  it('includes the repo name and the AT MOST 10 / maximum 10 guidance', () => {
+    const prompt = buildSynthesisPrompt(actions, 'MyRepo');
+    expect(prompt).toContain('MyRepo');
+    expect(prompt).toContain('PM triaging a codebase audit');
+    expect(prompt).toContain('AT MOST 10');
+    expect(prompt).toContain('maximum 10');
+    expect(prompt).toContain('type(scope): what — why');
+  });
+});
+
+describe('parseSynthesisOutput (INT-2225)', () => {
+  it('parses a well-formed ```json block', () => {
+    const stdout = [
+      'Here is the plan:',
+      '```json',
+      JSON.stringify({
+        issues: [
+          {
+            title: 'refactor(parser): consolidate parsing — reduce dup',
+            priority: 2,
+            items: ['extract shared parser', 'cover error path'],
+            description: '## Background\nstuff',
+          },
+        ],
+      }),
+      '```',
+    ].join('\n');
+    const out = parseSynthesisOutput(stdout);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({
+      title: 'refactor(parser): consolidate parsing — reduce dup',
+      priority: 2,
+      items: ['extract shared parser', 'cover error path'],
+      description: '## Background\nstuff',
+    });
+  });
+
+  it('clamps 11 issues down to 10', () => {
+    const many = Array.from({ length: 11 }, (_, i) => ({
+      title: `fix(x): issue ${i}`,
+      priority: 3,
+      items: [`item ${i}`],
+      description: `body ${i}`,
+    }));
+    const stdout = '```json\n' + JSON.stringify({ issues: many }) + '\n```';
+    const out = parseSynthesisOutput(stdout);
+    expect(out).toHaveLength(10);
+    expect(out[9].title).toBe('fix(x): issue 9');
+  });
+
+  it('returns [] for invalid JSON', () => {
+    const stdout = '```json\n{ not valid json,, }\n```';
+    expect(parseSynthesisOutput(stdout)).toEqual([]);
+  });
+
+  it('returns [] when there is no json block', () => {
+    expect(parseSynthesisOutput('just some prose, no block')).toEqual([]);
+  });
+
+  it('returns [] when the issues array is missing', () => {
+    expect(parseSynthesisOutput('```json\n{"foo":1}\n```')).toEqual([]);
+  });
+
+  it('applies defaults for missing/out-of-range fields and drops titleless issues', () => {
+    const stdout =
+      '```json\n' +
+      JSON.stringify({
+        issues: [
+          { title: 'fix(a): real one' }, // missing priority/items/description
+          { title: 'fix(b): bad priority', priority: 99, items: 'nope', description: 5 },
+          { priority: 2, items: ['x'] }, // no title → dropped
+        ],
+      }) +
+      '\n```';
+    const out = parseSynthesisOutput(stdout);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toEqual({ title: 'fix(a): real one', priority: 3, items: [], description: '' });
+    // Out-of-range priority → default 3; non-array items → []; non-string description → ''.
+    expect(out[1]).toEqual({ title: 'fix(b): bad priority', priority: 3, items: [], description: '' });
+  });
+
+  it('logs a warning via onLog when parsing fails', () => {
+    const logs: string[] = [];
+    parseSynthesisOutput('no block here', (l) => logs.push(l));
+    expect(logs.some((l) => l.includes('No ```json block'))).toBe(true);
+  });
+});
+
+describe('synthesizeAuditIssues guard (INT-2225)', () => {
+  it('returns [] without invoking the LLM when there are too few follow-ups', async () => {
+    // 3 actions ≤ MIN_ACTIONS_TO_SYNTHESIZE (3) → short-circuit, no adapter call.
+    const out = await synthesizeAuditIssues(actions, { cwd: '/tmp', repoName: 'X' });
+    expect(out).toEqual([]);
+  });
+
+  it('returns [] for an empty action list', async () => {
+    const out = await synthesizeAuditIssues([], { cwd: '/tmp', repoName: 'X' });
+    expect(out).toEqual([]);
+  });
+});

--- a/src/cli/auditPM.ts
+++ b/src/cli/auditPM.ts
@@ -1,0 +1,173 @@
+// ============================================
+// OpenSwarm - PM agent layer for `review --max --issues` (INT-2225)
+// ============================================
+//
+// `review --max --issues` used to file one Linear sub-issue per audit area,
+// which fanned a single audit into dozens or 100+ near-duplicate follow-ups.
+// This module routes the deduped follow-ups through an LLM "PM" pass that groups
+// related items by theme/module/root-cause into AT MOST 10 cohesive issues.
+//
+// The LLM call reuses the planner pattern (getAdapter → spawnCli → extract the
+// ```json block → JSON.parse), so it inherits the same adapter wiring, timeout,
+// and read-only agentic loop.
+
+import type { RecommendedAction } from '../agents/agentPair.js';
+import { getAdapter, spawnCli } from '../adapters/index.js';
+import { getPrompts } from '../locale/index.js';
+
+/** A cohesive issue synthesized from several related audit follow-ups. */
+export interface SynthesizedIssue {
+  /** `type(scope): what — why` */
+  title: string;
+  /** Linear priority: 1 (urgent) … 4 (low). */
+  priority: number;
+  /** Titles of the follow-ups grouped under this issue (for traceability). */
+  items: string[];
+  /** Markdown body (Background / Included follow-ups / Completion criteria). */
+  description: string;
+}
+
+/** Below this many follow-ups, synthesis adds no value — the caller files them directly. */
+const MIN_ACTIONS_TO_SYNTHESIZE = 3;
+/** Hard cap on synthesized issues — the whole point is to stop the fan-out. */
+const MAX_ISSUES = 10;
+
+/**
+ * Build the PM synthesis prompt. Lists the deduped follow-ups as
+ * `- [type] title (location)` and asks for AT MOST 10 cohesive issues.
+ */
+export function buildSynthesisPrompt(actions: RecommendedAction[], repoName: string): string {
+  const list = actions
+    .map((a) => `- [${a.type}] ${a.title}${a.location ? ` (${a.location})` : ''}`)
+    .join('\n');
+
+  return [
+    'You are a PM triaging a codebase audit.',
+    '',
+    `Repository: ${repoName}`,
+    `Below are ${actions.length} deduped audit follow-ups discovered by reviewer agents:`,
+    '',
+    list,
+    '',
+    'Group RELATED follow-ups by theme, module, or root cause into a small set of',
+    'cohesive, actionable issues. Rules:',
+    '- Produce AT MOST 10 issues (maximum 10). Fewer is better when items overlap.',
+    '- Do NOT map follow-ups 1:1 to issues, and do NOT over-split. Each issue should',
+    '  cover MULTIPLE related follow-ups whenever they share a theme or root cause.',
+    '- Each issue title MUST follow `type(scope): what — why`',
+    '  (type ∈ feat|fix|refactor|chore|docs|test|perf).',
+    '- priority is a number 1..4 (1=urgent, 2=high, 3=medium, 4=low).',
+    '',
+    'Output ONLY a JSON object in a ```json code block, shaped exactly like this',
+    '(maximum 10 issues in the array):',
+    '',
+    '```json',
+    '{',
+    '  "issues": [',
+    '    {',
+    '      "title": "refactor(scope): consolidate X — why",',
+    '      "priority": 2,',
+    '      "items": ["grouped follow-up title", "another grouped follow-up title"],',
+    '      "description": "## Background\\n…\\n## Included follow-ups\\n- title (file:line)\\n…\\n## Completion criteria\\n- …"',
+    '    }',
+    '  ]',
+    '}',
+    '```',
+  ].join('\n');
+}
+
+/**
+ * Parse the PM output: extract the ```json block, validate `.issues`, normalize
+ * each field with type guards, and clamp to the first 10. Returns [] (with an
+ * optional warning) when nothing usable is found.
+ */
+export function parseSynthesisOutput(stdout: string, onLog?: (l: string) => void): SynthesizedIssue[] {
+  const block = stdout.match(/```json\s*([\s\S]*?)\s*```/);
+  if (!block) {
+    onLog?.('[auditPM] No ```json block in synthesis output — skipping synthesis.');
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(block[1]);
+  } catch (e) {
+    onLog?.(`[auditPM] Failed to parse synthesis JSON: ${e instanceof Error ? e.message : String(e)}`);
+    return [];
+  }
+
+  const issuesRaw = (parsed as { issues?: unknown })?.issues;
+  if (!Array.isArray(issuesRaw)) {
+    onLog?.('[auditPM] Synthesis JSON missing an "issues" array — skipping synthesis.');
+    return [];
+  }
+
+  const normalized: SynthesizedIssue[] = [];
+  for (const raw of issuesRaw) {
+    if (typeof raw !== 'object' || raw === null) continue;
+    const r = raw as Record<string, unknown>;
+
+    const title = typeof r.title === 'string' ? r.title.trim() : '';
+    if (!title) continue; // a titleless issue is unfileable
+
+    const priorityNum = typeof r.priority === 'number' ? Math.trunc(r.priority) : 3;
+    const priority = priorityNum >= 1 && priorityNum <= 4 ? priorityNum : 3;
+
+    const items = Array.isArray(r.items) ? r.items.filter((i): i is string => typeof i === 'string') : [];
+    const description = typeof r.description === 'string' ? r.description : '';
+
+    normalized.push({ title, priority, items, description });
+  }
+
+  return normalized.slice(0, MAX_ISSUES);
+}
+
+export interface SynthesizeOptions {
+  /** Adapter override (default: configured default). */
+  adapter?: string;
+  /** Repo path the synthesis runs in (read-only). */
+  cwd: string;
+  /** Repo name, shown in the prompt. */
+  repoName: string;
+  /** Optional log sink for progress/warnings. */
+  onLog?: (l: string) => void;
+}
+
+/**
+ * Run the PM synthesis pass over deduped audit follow-ups. Returns AT MOST 10
+ * cohesive issues, or [] when there's too little to synthesize / the LLM output
+ * can't be parsed (the caller then falls back gracefully).
+ */
+export async function synthesizeAuditIssues(
+  actions: RecommendedAction[],
+  opts: SynthesizeOptions,
+): Promise<SynthesizedIssue[]> {
+  // Too few follow-ups → synthesis adds no value; let the caller file directly.
+  if (actions.length <= MIN_ACTIONS_TO_SYNTHESIZE) return [];
+
+  const prompt = buildSynthesisPrompt(actions, opts.repoName);
+
+  try {
+    const adapter = getAdapter(opts.adapter);
+    const raw = await spawnCli(adapter, {
+      prompt,
+      cwd: opts.cwd,
+      timeoutMs: 600_000,
+      maxTurns: 10,
+      systemPrompt: getPrompts().systemPrompt,
+      onLog: opts.onLog,
+    });
+
+    if (raw.exitCode !== 0 && !raw.stdout.trim()) {
+      opts.onLog?.(
+        `[auditPM] Synthesis adapter exited ${raw.exitCode}: ${raw.stderr.slice(0, 200) || 'no output'}`,
+      );
+      return [];
+    }
+
+    return parseSynthesisOutput(raw.stdout, opts.onLog);
+  } catch (e) {
+    opts.onLog?.(`[auditPM] Synthesis failed: ${e instanceof Error ? e.message : String(e)}`);
+    return [];
+  }
+}

--- a/src/cli/reviewMaxCommand.tsx
+++ b/src/cli/reviewMaxCommand.tsx
@@ -26,6 +26,7 @@ import {
 } from './reviewAudit.js';
 import { AuditBoard } from '../tui/components/AuditBoard.js';
 import { resolveIssueFromBranch, ensureTaskSource, resolveProjectId } from './reviewCommand.js';
+import { synthesizeAuditIssues } from './auditPM.js';
 import type { AdapterName } from '../adapters/types.js';
 
 export interface ReviewMaxOptions {
@@ -37,8 +38,10 @@ export interface ReviewMaxOptions {
   maxFilesPerArea?: number;
   /** Adapter override for the reviewers. */
   adapter?: string;
-  /** File per-area follow-ups as Linear issues (parent id or branch-inferred). */
+  /** PM-synthesize follow-ups into ≤10 cohesive Linear sub-issues (parent id or branch-inferred). */
   fileIssue?: string | boolean;
+  /** Legacy: file one follow-up batch per audit area (the old --issues behavior). (INT-2225) */
+  issuesPerArea?: string | boolean;
   /** Skip the interactive cost gate (CI / scripted). */
   yes?: boolean;
   /** Partition only, print the plan, and exit (no subagents spawned). */
@@ -221,10 +224,14 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
     console.warn(`Could not save report: ${e instanceof Error ? e.message : String(e)}`);
   }
 
-  // (4) Linear: --issues files per-area follow-ups (opt-in); otherwise a single
-  //     master audit issue by default; --no-linear skips Linear entirely. (INT-2022)
-  if (opts.fileIssue) {
-    await filePerAreaFollowups(cwd, opts.fileIssue, run);
+  // (4) Linear: --issues runs the PM synthesis (a master parent + ≤10 cohesive
+  //     sub-issues); --issues-per-area keeps the legacy per-area fan-out;
+  //     otherwise a single master audit issue by default; --no-linear skips
+  //     Linear entirely. (INT-2022 / INT-2225)
+  if (opts.issuesPerArea) {
+    await filePerAreaFollowups(cwd, opts.issuesPerArea, run);
+  } else if (opts.fileIssue) {
+    await filePmSynthesizedIssues(cwd, opts, run.summary, report, ts);
   } else if (!opts.noLinear && run.summary.recommendedActions.length) {
     await createMasterAuditIssue(cwd, run.summary, report, ts);
   } else if (run.summary.recommendedActions.length) {
@@ -234,12 +241,21 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
   return { decision: run.summary.decision };
 }
 
-/** Create one master audit issue holding the full report (default Linear behavior). (INT-2022) */
-async function createMasterAuditIssue(cwd: string, summary: AuditSummary, report: string, ts: string): Promise<void> {
+/**
+ * Create one master audit issue holding the full report (default Linear
+ * behavior). Returns the created issue's internal id (usable as a sub-issue
+ * parent) or null on failure. (INT-2022 / INT-2225)
+ */
+async function createMasterAuditIssue(
+  cwd: string,
+  summary: AuditSummary,
+  report: string,
+  ts: string,
+): Promise<string | null> {
   const source = await ensureTaskSource();
   if (!source) {
     console.log('Linear not connected — report saved to file only. `openswarm auth login --provider linear` to enable.');
-    return;
+    return null;
   }
   const projectId = await resolveProjectId(cwd);
   const title = `chore(audit): codebase audit ${ts.slice(0, 10)} — review --max (${summary.recommendedActions.length} follow-ups)`;
@@ -247,10 +263,94 @@ async function createMasterAuditIssue(cwd: string, summary: AuditSummary, report
     const res = await source.createTask(title, report, projectId);
     if ('identifier' in res) {
       console.log(`Linear master audit issue: ${res.identifier}`);
-    } else {
-      console.warn(`Could not create Linear issue (report saved to file): ${res.error}`);
+      return res.id;
     }
+    console.warn(`Could not create Linear issue (report saved to file): ${res.error}`);
+    return null;
   } catch (e) {
     console.warn(`Could not create Linear issue (report saved to file): ${e instanceof Error ? e.message : String(e)}`);
+    return null;
   }
+}
+
+/**
+ * PM layer for `--issues`: synthesize the deduped follow-ups into ≤10 cohesive
+ * issues and file them as sub-issues. The parent is the explicit `--issues <id>`
+ * when given, otherwise a freshly created master audit issue (which also holds
+ * the full report). Falls back gracefully — if synthesis yields nothing (too few
+ * follow-ups, or the LLM output couldn't be parsed), the master issue alone still
+ * captures everything. (INT-2225)
+ */
+async function filePmSynthesizedIssues(
+  cwd: string,
+  opts: ReviewMaxOptions,
+  summary: AuditSummary,
+  report: string,
+  ts: string,
+): Promise<void> {
+  const actions = summary.recommendedActions;
+  if (!actions.length) {
+    console.log('No follow-ups to file.');
+    return;
+  }
+  const source = await ensureTaskSource();
+  if (!source) {
+    console.log(
+      'Could not file follow-ups: Linear not connected. Run `openswarm auth login --provider linear` (or set linearApiKey).',
+    );
+    return;
+  }
+  const projectId = await resolveProjectId(cwd);
+
+  // Resolve the parent: explicit --issues <id>, else create the master report issue.
+  let parentId: string | undefined =
+    typeof opts.fileIssue === 'string' && opts.fileIssue ? opts.fileIssue : undefined;
+  if (!parentId && !opts.noLinear) {
+    parentId = (await createMasterAuditIssue(cwd, summary, report, ts)) ?? undefined;
+  }
+
+  console.log(`Synthesizing ${actions.length} follow-up(s) into cohesive issues (PM pass)...`);
+  const issues = await synthesizeAuditIssues(actions, {
+    adapter: opts.adapter,
+    cwd,
+    repoName: basename(cwd) || cwd,
+    onLog: (l) => console.error(`  · ${l}`),
+  });
+
+  if (!issues.length) {
+    console.log(
+      parentId
+        ? 'PM synthesis produced no grouped issues — the master audit issue captures all follow-ups.'
+        : 'PM synthesis produced no grouped issues — follow-ups are captured in the saved report.',
+    );
+    return;
+  }
+
+  let filed = 0;
+  for (const issue of issues) {
+    try {
+      const res = parentId
+        ? await source.createSubIssue(parentId, issue.title, issue.description, {
+            priority: issue.priority,
+            projectId,
+          })
+        : await source.createTask(issue.title, issue.description, projectId);
+      if ('identifier' in res) {
+        filed++;
+        console.log(`  ✓ ${res.identifier}  ${issue.title}  (${issue.items.length} follow-up(s))`);
+      } else {
+        console.warn(`  ✗ Could not create issue "${issue.title}": ${res.error}`);
+      }
+    } catch (e) {
+      console.warn(`  ✗ Could not create issue "${issue.title}": ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  console.log(
+    filed > 0
+      ? parentId
+        ? `Filed ${filed} synthesized sub-issue(s) under the master audit issue.`
+        : `Filed ${filed} synthesized issue(s).`
+      : 'Could not file synthesized issues (0 created).',
+  );
 }


### PR DESCRIPTION
## Problem
`review --max --issues` filed audit follow-ups per-area, spraying dozens-to-100+ Linear issues (STONKS audit had ~279 follow-ups). A human PM would group related items into a handful of real work items, not file 279 cards.

## PM agent layer
- **auditPM.ts** — `synthesizeAuditIssues(actions, opts)` uses the planner pattern (`getAdapter` → `spawnCli` → ```json parse). `buildSynthesisPrompt` asks the LLM to group follow-ups by theme/module/root-cause into **at most 10 cohesive issues** (no 1:1 mapping, no over-split). `parseSynthesisOutput` clamps to 10, guards every field, and returns `[]` gracefully on bad JSON. Synthesis is skipped for ≤3 items.
- **reviewMaxCommand** — `--issues` now creates the master audit issue (parent) + **≤10 synthesized sub-issues** (`createSubIssue` with priority). Empty synthesis → master only (graceful). The old per-area spray is preserved behind `--issues-per-area`.
- **cli** — `--issues-per-area` flag.

## Verified
11 unit tests (prompt build, parse clamp at 10, bad-JSON → empty, field defaults), typecheck / build / oxlint clean. The LLM synthesis itself runs via the codex/claude adapter at runtime.

Closes INT-2225. Refs INT-2022 (master issue), INT-2210 (multi-team createIssue this builds on).