### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.10.0 — 2026-06-30
+
+Full-codebase review pipeline (multi-agent audit → report → PM triage → Linear), chat session persistence, and a batch of daemon / TUI / adapter fixes.
+
+### Added
+
+- **`openswarm review --max`** — full-codebase audit that fans reviewer subagents out over directory-shaped areas, with **area isolation + dedup** so a shared file isn't flagged by every area. Persists a markdown report to `.openswarm/audit/audit-<ts>.md` and files a Linear master issue by default (`--out`, `--no-linear`). (INT-2006, INT-2022)
+- **PM agent issue synthesis (default)** — `review --max` files Linear issues by default as **at most 10 cohesive issues** (a master parent + synthesized sub-issues), grouped by an LLM PM by theme/root-cause instead of one-per-follow-up. `--no-linear` skips Linear (report only); `--issues-per-area` keeps the legacy per-area filing; `--issues <id>` sets an existing parent. (INT-2225)
+- **Codex usage-limit handling + claude fallback** — typed `RateLimitError` from the rich `x-codex-*` 429 headers (used %, reset time), early-abort instead of hammering a dead quota, and **automatic fallback to the `claude` adapter** (Claude subscription) for the remaining areas (`--fallback`, `--no-fallback`). (INT-2192)
+- **Chat session persistence + `openswarm resume`** — conversations persist to `~/.openswarm/chat`; `resume` reopens the latest with its goal. `/goal clear` is the only way to stop an in-flight goal. (INT-2014)
+- **Execution cwd context** — chat / `/plan` / `/goal` operate in the repo `openswarm` was launched from. (INT-2005)
+- **Project selection persistence** — the daemon's enabled-project selection survives restarts. (INT-2208)
+- **Planner rich-markdown sub-tasks** — each sub-task description is a full markdown doc (Background / Investigation / Approach / Completion) so the worker starts with context. (INT-1581)
+- **`edit_file` fuzzy fallback** — line-normalized matching (whitespace / quotes / unicode) when exact match fails, plus edit prompt guidelines. (INT-2011)
+
+### Fixed
+
+- **Daemon kept running after every project was disabled** — an empty enabled-set was treated as "run all"; now an explicit "disable all" actually stops the daemon (and persists across restarts). (INT-2207, INT-2208)
+- **Multi-team config `createIssue`** — passed the comma-joined teamId string to Linear ("teamId must be a UUID"); now resolves a single team (the project's, else the first). (INT-2210)
+- **Ink TUI color consistency** — hardcoded color literals + uncolored status text routed through the theme scheme; new `running` / `info` tokens. (INT-2209)
+- **Hangul input doubling** — multi-grapheme / N-repeat cases collapsed. (INT-2012)
+- **Adapter CLI infra errors no longer counted as STUCK** — codex CLI / usage-limit errors are infra, not task failures. (INT-2010)
+- **Linear project overview summary doubling** — strip the prior compact summary before re-appending. (INT-1907)
+- **Cancel syncs task-state to Backlog.** (#162)
+
+> Note: 0.8.x–0.9.x were tagged without changelog entries; see git history for those.
+
 ## 0.7.0 — 2026-06-19
 
 Runs with **no external SaaS** from a clean install, plus a native ChatGPT-OAuth Codex path.

--- a/README.md
+++ b/README.md
@@ -64,12 +64,21 @@ Status bar shows: provider · model · message count · cumulative cost
 ```bash
 openswarm                        # TUI chat (default)
 openswarm chat [session]         # Simple readline chat
+openswarm resume                 # Reopen the most recent chat session (conversation + goal)
 openswarm start                  # Start full daemon (requires config.yaml)
 openswarm run "Fix the bug" -p ~/my-project   # Run a single task
 openswarm exec "Run tests" --local --pipeline # Execute via daemon
 openswarm init                   # Interactive setup wizard (provider auth, Linear OAuth, config)
 openswarm doctor                 # Diagnose environment (runtime, native deps, providers, ports)
 openswarm validate               # Validate config.yaml
+
+# Code review
+openswarm review                 # Review the working-tree changes
+openswarm review --max           # Full-codebase audit: fan reviewer subagents over areas
+                                 #   → report at .openswarm/audit/ + PM-synthesized Linear
+                                 #   issues by default (≤10 cohesive, master + sub-issues)
+                                 #   --no-linear (report only), --issues-per-area (legacy spray),
+                                 #   --issues <id> (set parent), --fallback <adapter>, --out <file>
 
 # Code Registry & BS Detector
 openswarm check --scan           # Scan repo → register all entities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.9.3",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",

--- a/src/cli/reviewMaxCommand.tsx
+++ b/src/cli/reviewMaxCommand.tsx
@@ -224,18 +224,16 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
     console.warn(`Could not save report: ${e instanceof Error ? e.message : String(e)}`);
   }
 
-  // (4) Linear: --issues runs the PM synthesis (a master parent + ≤10 cohesive
-  //     sub-issues); --issues-per-area keeps the legacy per-area fan-out;
-  //     otherwise a single master audit issue by default; --no-linear skips
-  //     Linear entirely. (INT-2022 / INT-2225)
+  // (4) Linear: PM synthesis is the DEFAULT — a master parent + ≤10 cohesive
+  //     sub-issues. `--issues <id>` overrides the parent with an existing issue;
+  //     `--issues-per-area` keeps the legacy per-area fan-out; `--no-linear`
+  //     skips Linear entirely (report only). (INT-2022 / INT-2225)
   if (opts.issuesPerArea) {
     await filePerAreaFollowups(cwd, opts.issuesPerArea, run);
-  } else if (opts.fileIssue) {
-    await filePmSynthesizedIssues(cwd, opts, run.summary, report, ts);
   } else if (!opts.noLinear && run.summary.recommendedActions.length) {
-    await createMasterAuditIssue(cwd, run.summary, report, ts);
+    await filePmSynthesizedIssues(cwd, opts, run.summary, report, ts);
   } else if (run.summary.recommendedActions.length) {
-    console.log(`\n${run.summary.recommendedActions.length} follow-up(s) — captured in the report above.`);
+    console.log(`\n${run.summary.recommendedActions.length} follow-up(s) — captured in the report (--no-linear).`);
   }
 
   return { decision: run.summary.decision };


### PR DESCRIPTION
## v0.10.0 — full-codebase review pipeline + session persistence + daemon/TUI/adapter fixes

Bumps 0.9.3 → 0.10.0. See CHANGELOG for the full list. Highlights:

**Added**
- `review --max` — multi-agent full-codebase audit (area isolation + dedup), markdown report at `.openswarm/audit/`, **PM-synthesized Linear issues by default** (master + ≤10 cohesive sub-issues, not one-per-follow-up). `--no-linear`, `--issues-per-area`, `--fallback`, `--out`.
- Codex usage-limit handling + **automatic claude fallback** (Claude subscription).
- Chat session persistence + `openswarm resume`; `/goal clear`.
- Execution cwd context; daemon project-selection persistence; planner rich-markdown sub-tasks; `edit_file` fuzzy fallback.

**Fixed**
- Daemon kept running after disabling all projects (INT-2207/2208).
- Multi-team config `createIssue` ("teamId must be a UUID") (INT-2210).
- Ink TUI color consistency (INT-2209); Hangul input doubling (INT-2012); STUCK infra-error counting (INT-2010); Linear overview doubling (INT-1907).

This PR also flips PM synthesis to the **default** for `review --max` (was --issues-gated). (INT-2225)