### PR TITLE
fix(review): parse escaped PM synthesis JSON + warn on unmapped project (INT-2239) [v0.10.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.10.1 — 2026-07-01
+
+### Fixed
+
+- **PM synthesis JSON parsing** — `review --max`'s PM agent failed to parse codex-responses' **escaped JSON** output (literal `\n` / `\"`), so synthesis produced no grouped issues and only the master issue remained. `parseSynthesisOutput` now decodes an escaped JSON block before parsing. (INT-2239)
+- **Orphan audit issue** — when a repo has no `openswarm.json` `linear.projectId` mapping, `review --max` now warns instead of silently filing the master issue without a project (and, on a multi-team config, on the wrong team). Run `openswarm add` in the repo to map it. (INT-2239)
+
 ## 0.10.0 — 2026-06-30
 
 Full-codebase review pipeline (multi-agent audit → report → PM triage → Linear), chat session persistence, and a batch of daemon / TUI / adapter fixes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",

--- a/src/cli/auditPM.test.ts
+++ b/src/cli/auditPM.test.ts
@@ -85,6 +85,16 @@ describe('parseSynthesisOutput (INT-2225)', () => {
     expect(parseSynthesisOutput('```json\n{"foo":1}\n```')).toEqual([]);
   });
 
+  it('parses an ESCAPED JSON block (codex-responses emits literal \\n / \\") (INT-2239)', () => {
+    // The block content is an escaped JSON string, not raw JSON — raw JSON.parse
+    // fails on the leading backslash; parseJsonLoose decodes once then parses.
+    const inner = '\\n{\\n  \\"issues\\": [{ \\"title\\": \\"fix(x): y\\", \\"priority\\": 2, \\"items\\": [], \\"description\\": \\"d\\" }]\\n}';
+    const out = parseSynthesisOutput('```json\n' + inner + '\n```');
+    expect(out).toHaveLength(1);
+    expect(out[0].title).toBe('fix(x): y');
+    expect(out[0].priority).toBe(2);
+  });
+
   it('applies defaults for missing/out-of-range fields and drops titleless issues', () => {
     const stdout =
       '```json\n' +

--- a/src/cli/auditPM.ts
+++ b/src/cli/auditPM.ts
@@ -77,6 +77,27 @@ export function buildSynthesisPrompt(actions: RecommendedAction[], repoName: str
 }
 
 /**
+ * Parse a JSON block. codex-responses sometimes emits the block as an *escaped*
+ * JSON string (literal \n, \"), so a raw JSON.parse fails on the leading `\`. Try
+ * raw first, then decode-once-then-parse. Returns undefined on total failure. (INT-2239)
+ */
+function parseJsonLoose(s: string): unknown {
+  const t = s.trim();
+  try {
+    return JSON.parse(t);
+  } catch {
+    /* maybe an escaped JSON string — fall through */
+  }
+  try {
+    const decoded = JSON.parse(`"${t}"`);
+    if (typeof decoded === 'string') return JSON.parse(decoded);
+  } catch {
+    /* fall through */
+  }
+  return undefined;
+}
+
+/**
  * Parse the PM output: extract the ```json block, validate `.issues`, normalize
  * each field with type guards, and clamp to the first 10. Returns [] (with an
  * optional warning) when nothing usable is found.
@@ -88,11 +109,9 @@ export function parseSynthesisOutput(stdout: string, onLog?: (l: string) => void
     return [];
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(block[1]);
-  } catch (e) {
-    onLog?.(`[auditPM] Failed to parse synthesis JSON: ${e instanceof Error ? e.message : String(e)}`);
+  const parsed = parseJsonLoose(block[1]);
+  if (parsed === undefined) {
+    onLog?.('[auditPM] Failed to parse synthesis JSON (raw + escaped) — skipping synthesis.');
     return [];
   }
 

--- a/src/cli/reviewMaxCommand.tsx
+++ b/src/cli/reviewMaxCommand.tsx
@@ -299,6 +299,14 @@ async function filePmSynthesizedIssues(
     return;
   }
   const projectId = await resolveProjectId(cwd);
+  if (!projectId) {
+    // No <repo>/openswarm.json mapping → issues get filed without a project (and
+    // on a multi-team config, only the first team). Tell the user how to map it. (INT-2239)
+    console.warn(
+      '⚠ No Linear project mapped for this repo (openswarm.json `linear.projectId` missing) — ' +
+        'issues will not be linked to a project. Run `openswarm add` here to map it.',
+    );
+  }
 
   // Resolve the parent: explicit --issues <id>, else create the master report issue.
   let parentId: string | undefined =


### PR DESCRIPTION
Two bugs from a real `review --max` run on intrect-platform.

## PM synthesis JSON parse failure
`[auditPM] Failed to parse synthesis JSON: Unexpected token '\\'` — codex-responses emits the ```json block as an **escaped JSON string** (literal `\n` / `\"`), which raw `JSON.parse` rejects on the leading backslash. `parseJsonLoose` now tries raw, then decode-once-then-parse → synthesis works again.

## Orphan audit issue
The master issue was filed without a project (and on a multi-team config, the wrong team) because `resolveProjectId` returned undefined for a repo with no `openswarm.json`. Now **warns** with a pointer to `openswarm add` instead of silently orphaning it.

Bumps 0.10.0 → 0.10.1. Verified: escaped-JSON unit test + 12 auditPM tests, typecheck/build/oxlint.

Closes INT-2239. Refs INT-2225, INT-2210.