### PR TITLE
feat(reviewer): multi-lens review fan-out (PoC, opt-in) (INT-2230)

### DIFF
--- a/src/agents/multiLensReview.test.ts
+++ b/src/agents/multiLensReview.test.ts
@@ -1,0 +1,171 @@
+// Created: 2026-06-30
+// Purpose: Unit tests for multi-lens reviewer fan-out (INT-2230)
+// Test Status: Complete
+
+import { describe, it, expect, vi } from 'vitest';
+import type { ReviewResult } from './agentPair.js';
+import type { ReviewerOptions } from './reviewer.js';
+import {
+  REVIEW_LENSES,
+  buildLensTaskDescription,
+  mergeReviewResults,
+  shouldFanoutReview,
+  runMultiLensReview,
+} from './multiLensReview.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
+
+const baseOptions = (): ReviewerOptions => ({
+  taskTitle: 'Fix the thing',
+  taskDescription: 'Base description',
+  projectPath: '/tmp/x',
+  workerResult: {
+    success: true,
+    summary: 's',
+    filesChanged: ['a.ts'],
+    commands: [],
+    output: 'o',
+  },
+});
+
+describe('mergeReviewResults', () => {
+  it('takes the worst decision (reject > revise > approve)', () => {
+    const merged = mergeReviewResults([
+      { decision: 'approve', feedback: 'a' },
+      { decision: 'revise', feedback: 'b' },
+      { decision: 'reject', feedback: 'c' },
+    ]);
+    expect(merged.decision).toBe('reject');
+  });
+
+  it('returns approve for empty input', () => {
+    const merged = mergeReviewResults([]);
+    expect(merged.decision).toBe('approve');
+    expect(merged.issues).toEqual([]);
+    expect(merged.suggestions).toEqual([]);
+    expect(merged.recommendedActions).toEqual([]);
+    expect(merged.feedback).toBe('');
+  });
+
+  it('unions and dedups issues (case/whitespace-insensitive)', () => {
+    const merged = mergeReviewResults([
+      { decision: 'revise', feedback: 'f1', issues: ['Null deref', 'Off by one'] },
+      { decision: 'approve', feedback: 'f2', issues: ['  null deref  ', 'Race condition'] },
+    ]);
+    expect(merged.issues).toEqual(['Null deref', 'Off by one', 'Race condition']);
+  });
+
+  it('unions and dedups recommendedActions by type|location|title', () => {
+    const merged = mergeReviewResults([
+      {
+        decision: 'approve',
+        feedback: 'f1',
+        recommendedActions: [{ type: 'test', title: 'Add tests', location: 'a.ts:10' }],
+      },
+      {
+        decision: 'approve',
+        feedback: 'f2',
+        recommendedActions: [
+          { type: 'test', title: 'Add tests', location: 'a.ts:10' }, // duplicate
+          { type: 'refactor', title: 'Split fn' },
+        ],
+      },
+    ]);
+    expect(merged.recommendedActions).toHaveLength(2);
+    expect(merged.recommendedActions?.map((a) => a.title)).toEqual(['Add tests', 'Split fn']);
+  });
+
+  it('joins one feedback line per result', () => {
+    const merged = mergeReviewResults([
+      { decision: 'approve', feedback: '[correctness] looks fine\nextra detail' },
+      { decision: 'reject', feedback: '[security] secret leaked' },
+    ]);
+    expect(merged.feedback).toBe('[correctness] looks fine\n[security] secret leaked');
+  });
+});
+
+describe('shouldFanoutReview', () => {
+  it('triggers when filesChanged meets the default threshold (3)', () => {
+    expect(shouldFanoutReview({ filesChanged: ['a', 'b', 'c'] })).toBe(true);
+  });
+
+  it('triggers on high priority even with few files', () => {
+    expect(shouldFanoutReview({ filesChanged: ['a', 'b'], priority: 1 })).toBe(true);
+  });
+
+  it('does not trigger for a small, normal-priority, unlabeled task', () => {
+    expect(shouldFanoutReview({ filesChanged: ['a'], priority: 3 })).toBe(false);
+  });
+
+  it('triggers on the deep-review label', () => {
+    expect(shouldFanoutReview({ filesChanged: ['a'], priority: 3, labels: ['deep-review'] })).toBe(true);
+  });
+
+  it('respects a custom fileThreshold', () => {
+    expect(shouldFanoutReview({ filesChanged: ['a', 'b'], priority: 4 }, { fileThreshold: 2 })).toBe(true);
+  });
+});
+
+describe('runMultiLensReview', () => {
+  it('runs every lens and merges results', async () => {
+    const seen: string[] = [];
+    const review = vi.fn(async (o: ReviewerOptions): Promise<ReviewResult> => {
+      seen.push(o.taskDescription);
+      return { decision: 'approve', feedback: 'ok', issues: [] };
+    });
+
+    const merged = await runMultiLensReview(baseOptions(), { review });
+
+    expect(review).toHaveBeenCalledTimes(REVIEW_LENSES.length);
+    // Each lens injected its directive into the description.
+    for (const lens of REVIEW_LENSES) {
+      expect(seen.some((d) => d.includes(`## Review lens: ${lens.key}`))).toBe(true);
+    }
+    expect(merged.decision).toBe('approve');
+  });
+
+  it('produces a reject when any lens rejects', async () => {
+    const review = vi.fn(async (o: ReviewerOptions): Promise<ReviewResult> => {
+      const isSecurity = o.taskDescription.includes('## Review lens: security');
+      return isSecurity
+        ? { decision: 'reject', feedback: 'secret leaked', issues: ['leaked key'] }
+        : { decision: 'approve', feedback: 'fine' };
+    });
+
+    const merged = await runMultiLensReview(baseOptions(), { review });
+    expect(merged.decision).toBe('reject');
+    expect(merged.issues).toContain('leaked key');
+  });
+
+  it('skips a lens that throws a non-rate-limit error', async () => {
+    const review = vi.fn(async (o: ReviewerOptions): Promise<ReviewResult> => {
+      if (o.taskDescription.includes('## Review lens: security')) {
+        throw new Error('cli crashed');
+      }
+      return { decision: 'revise', feedback: 'meh' };
+    });
+
+    const merged = await runMultiLensReview(baseOptions(), { review });
+    // Two surviving lenses both revise → revise overall (no throw).
+    expect(merged.decision).toBe('revise');
+  });
+
+  it('propagates a RateLimitError thrown by any lens', async () => {
+    const review = vi.fn(async (o: ReviewerOptions): Promise<ReviewResult> => {
+      if (o.taskDescription.includes('## Review lens: security')) {
+        throw new RateLimitError(undefined, 'usage limit reached');
+      }
+      return { decision: 'approve', feedback: 'fine' };
+    });
+
+    await expect(runMultiLensReview(baseOptions(), { review })).rejects.toBeInstanceOf(RateLimitError);
+  });
+});
+
+describe('buildLensTaskDescription', () => {
+  it('appends the lens directive to the base description', () => {
+    const out = buildLensTaskDescription('BASE', REVIEW_LENSES[0]);
+    expect(out.startsWith('BASE')).toBe(true);
+    expect(out).toContain('## Review lens: correctness');
+    expect(out).toContain(REVIEW_LENSES[0].focus);
+  });
+});

--- a/src/agents/multiLensReview.ts
+++ b/src/agents/multiLensReview.ts
@@ -1,0 +1,179 @@
+// ============================================
+// OpenSwarm - Multi-Lens Reviewer Fan-out (INT-2230)
+// ============================================
+//
+// PoC: verify one worker result through several independent review "lenses" in
+// parallel, then merge into a single ReviewResult. Each lens is just a focused
+// prompt injected into `taskDescription` — no extra adapter/infra needed — so the
+// existing reviewer agent runs N times, each told to concentrate on one concern
+// (correctness / security / regression-risk). The merge takes the WORST decision
+// and unions the issues/suggestions/recommendedActions so nothing a lens caught
+// is dropped. Gated + opt-in (config.review.multiLens.enabled, default false) to
+// avoid multiplying usage on every task.
+
+import type { ReviewResult, ReviewDecision } from './agentPair.js';
+import type { ReviewerOptions } from './reviewer.js';
+import { runReviewer } from './reviewer.js';
+import { runPool } from '../support/concurrencyPool.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
+
+// Lenses
+
+/** A single review perspective. `focus` is injected verbatim into the prompt. */
+export interface ReviewLens {
+  key: string;
+  focus: string;
+}
+
+/** The three default lenses a fan-out review runs in parallel. */
+export const REVIEW_LENSES: ReviewLens[] = [
+  {
+    key: 'correctness',
+    focus: 'logic errors, unhandled edge cases, off-by-one, wrong assumptions, error handling',
+  },
+  {
+    key: 'security',
+    focus: 'injection, unsafe input, leaked secrets/keys, auth gaps, unsafe deserialization',
+  },
+  {
+    key: 'regression-risk',
+    focus: 'breaks existing behavior, changes a shared contract, missing/!updated tests, side effects on callers',
+  },
+];
+
+/**
+ * Append a lens directive to the base task description so the reviewer
+ * concentrates on one concern. Other concerns are explicitly delegated to the
+ * sibling lenses so a single reviewer doesn't try to cover everything.
+ */
+export function buildLensTaskDescription(base: string, lens: ReviewLens): string {
+  return `${base}\n\n## Review lens: ${lens.key}\nFocus your review specifically on: ${lens.focus}. Other concerns are secondary — another reviewer covers them.`;
+}
+
+// Merge
+
+/** Severity ordering: reject is worst, approve is best. */
+const DECISION_RANK: Record<ReviewDecision, number> = {
+  approve: 0,
+  revise: 1,
+  reject: 2,
+};
+
+/** First non-empty line of a feedback blob, trimmed (one-line lens summary). */
+function firstLine(text: string | undefined): string {
+  if (!text) return '';
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed) return trimmed;
+  }
+  return '';
+}
+
+/** Stable dedup of strings by trimmed/lowercased value, keeping first original. */
+function dedupStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    const key = v.trim().toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(v);
+  }
+  return out;
+}
+
+/**
+ * Combine several lens reviews into one verdict:
+ * - decision = the WORST across lenses (reject > revise > approve)
+ * - issues / suggestions / recommendedActions = deduped union
+ * - feedback = one line per lens result, joined
+ * Empty input yields a clean approve (nothing flagged).
+ */
+export function mergeReviewResults(results: ReviewResult[]): ReviewResult {
+  if (results.length === 0) {
+    return { decision: 'approve', feedback: '', issues: [], suggestions: [], recommendedActions: [] };
+  }
+
+  let decision: ReviewDecision = 'approve';
+  for (const r of results) {
+    if (DECISION_RANK[r.decision] > DECISION_RANK[decision]) decision = r.decision;
+  }
+
+  const issues = dedupStrings(results.flatMap((r) => r.issues ?? []));
+  const suggestions = dedupStrings(results.flatMap((r) => r.suggestions ?? []));
+
+  const actionSeen = new Set<string>();
+  const recommendedActions: NonNullable<ReviewResult['recommendedActions']> = [];
+  for (const action of results.flatMap((r) => r.recommendedActions ?? [])) {
+    const key = `${action.type}|${action.location ?? ''}|${action.title}`;
+    if (actionSeen.has(key)) continue;
+    actionSeen.add(key);
+    recommendedActions.push(action);
+  }
+
+  const feedback = results
+    .map((r) => firstLine(r.feedback))
+    .filter(Boolean)
+    .join('\n');
+
+  return { decision, feedback, issues, suggestions, recommendedActions };
+}
+
+// Gating
+
+/**
+ * Decide whether a task is worth the extra cost of multi-lens fan-out. Triggers
+ * on a wide change surface, high priority (1=Urgent, 2=High), or an explicit
+ * `deep-review` label. Threshold defaults to 3 changed files.
+ */
+export function shouldFanoutReview(
+  task: { filesChanged?: string[]; priority?: number; labels?: string[] },
+  opts?: { fileThreshold?: number },
+): boolean {
+  const fileThreshold = opts?.fileThreshold ?? 3;
+  const fileCount = task.filesChanged?.length ?? 0;
+  if (fileCount >= fileThreshold) return true;
+  if (task.priority != null && task.priority <= 2) return true;
+  return !!task.labels?.includes('deep-review');
+}
+
+// Fan-out
+
+/**
+ * Run every lens in parallel and merge. Each lens calls the reviewer with a
+ * lens-scoped task description. A lens that fails for a non-rate-limit reason is
+ * skipped (its slot carries an error from the pool). A RateLimitError from ANY
+ * lens propagates so the pipeline's existing usage-limit handling / claude
+ * fallback can take over (INT-2192) instead of silently dropping a lens.
+ * `deps` is injectable for tests.
+ */
+export async function runMultiLensReview(
+  options: ReviewerOptions,
+  deps?: {
+    review?: (o: ReviewerOptions) => Promise<ReviewResult>;
+    concurrency?: number;
+    lenses?: ReviewLens[];
+  },
+): Promise<ReviewResult> {
+  const review = deps?.review ?? runReviewer;
+  const lenses = deps?.lenses ?? REVIEW_LENSES;
+  const concurrency = deps?.concurrency ?? lenses.length;
+
+  const settled = await runPool(lenses, concurrency, async (lens) => {
+    const result = await review({
+      ...options,
+      taskDescription: buildLensTaskDescription(options.taskDescription, lens),
+    });
+    // Tag the feedback with the lens so the merged summary reads "[correctness] …".
+    return { ...result, feedback: `[${lens.key}] ${firstLine(result.feedback)}` };
+  });
+
+  // A rate limit on any lens means the quota is exhausted — propagate so the
+  // pipeline pauses / falls back rather than merging a partial review.
+  for (const s of settled) {
+    if (s.error instanceof RateLimitError) throw s.error;
+  }
+
+  const ok = settled.filter((s): s is { index: number; value: ReviewResult } => s.value !== undefined).map((s) => s.value);
+  return mergeReviewResults(ok);
+}

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -32,6 +32,7 @@ import { recallRepoKnowledge } from '../memory/repoKnowledge.js';
 import type { WorkerContext } from '../locale/types.js';
 import * as workerAgent from './worker.js';
 import * as reviewerAgent from './reviewer.js';
+import { runMultiLensReview, shouldFanoutReview } from './multiLensReview.js';
 import * as testerAgent from './tester.js';
 import * as documenterAgent from './documenter.js';
 import * as auditorAgent from './auditor.js';
@@ -88,6 +89,19 @@ export interface PipelineConfig {
     sufficient?: boolean;
     impactAnalysis?: import('../knowledge/types.js').ImpactAnalysis;
     registrySnapshot?: Array<{ filePath: string; summary: string; highlights: string[] }>;
+  };
+  /**
+   * Review behavior. `multiLens` opts a task into the multi-lens reviewer fan-out
+   * (INT-2230): one worker result verified by several focused review lenses in
+   * parallel. Default OFF — opt-in so the daemon doesn't multiply usage on every
+   * task. Only when enabled is `shouldFanoutReview(task)` consulted as a gate.
+   */
+  review?: {
+    multiLens?: {
+      enabled?: boolean;
+      /** Min changed files to trigger fan-out (default 3). */
+      fileThreshold?: number;
+    };
   };
 }
 
@@ -656,8 +670,7 @@ export class PairPipeline extends EventEmitter {
           // scaffolded task was getting LESS review — exactly the wrong incentive. The
           // completion-criteria hard gate is the real check now.
           const reviewerMaxTurns = this.config.roles?.reviewer?.maxTurns;
-          console.log(`[${prefix}] Running full review...`);
-          result = await reviewerAgent.runReviewer({
+          const reviewerOptions = {
             taskTitle: context.task.title,
             taskDescription: context.task.description || '',
             workerResult: context.workerResult,
@@ -671,7 +684,30 @@ export class PairPipeline extends EventEmitter {
             completionCriteria: this.config.draftAnalysis?.completionCriteria,
             processContext: { taskId: context.task.id, stage: 'reviewer' },
             signal: this.abortSignal,
-          });
+          };
+
+          // Multi-lens fan-out (INT-2230): opt-in, and only for tasks the gate
+          // deems worth the extra cost (wide change surface / high priority /
+          // deep-review label). Otherwise a single reviewer pass as before.
+          const multiLens = this.config.review?.multiLens;
+          const fanout =
+            multiLens?.enabled === true &&
+            shouldFanoutReview(
+              {
+                filesChanged: context.workerResult.filesChanged,
+                priority: context.task.priority,
+                labels: context.task.labels,
+              },
+              { fileThreshold: multiLens.fileThreshold },
+            );
+
+          if (fanout) {
+            console.log(`[${prefix}] Running multi-lens review (${context.workerResult.filesChanged.length} files)...`);
+            result = await runMultiLensReview(reviewerOptions);
+          } else {
+            console.log(`[${prefix}] Running full review...`);
+            result = await reviewerAgent.runReviewer(reviewerOptions);
+          }
 
           agentPair.saveReviewerResult(context.session.id, result as ReviewResult);
           context.reviewResult = result as ReviewResult;


### PR DESCRIPTION
PoC porting review --max's fan-out + adversarial-verify into the task pipeline: review a worker result through multiple lenses (correctness / security / regression-risk) in parallel, merged to a single verdict.

- **multiLensReview.ts** — REVIEW_LENSES, buildLensTaskDescription, runMultiLensReview (runPool; RateLimitError propagates so the claude fallback kicks in), mergeReviewResults (worst decision + dedup findings), shouldFanoutReview (gating).
- **pairPipeline** — gated branch: multi-lens only when `config.review.multiLens.enabled` (default **false**, opt-in) AND `shouldFanoutReview` passes (diff size / priority / deep-review label). Else single reviewer — so the codex quota isn't burned on every task.

15 unit tests, typecheck/build/oxlint. **Dormant by default** (opt-in). The open question — does multi-lens actually catch more than a single reviewer? — needs an A/B run once the codex quota frees up.

Refs INT-2230, INT-2006/2022 (fan-out pattern), INT-2192 (fallback).