### PR TITLE
fix(review): make review --max language-agnostic (INT-2240) [v0.10.2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.10.2 — 2026-07-01
+
+### Fixed
+
+- **`review --max` is now language-agnostic** — Rust/Go/JVM/C/… repos hit `No production source files to audit` because `SOURCE_EXTENSIONS` only knew JS/TS/Python. Now covers Rust, Go, JVM (Java/Kotlin/Scala/Groovy), C/C++/C#, Ruby, PHP, Swift, Obj-C, Elixir, Clojure, OCaml, Haskell, Dart, Lua, Julia, Zig, Nim — with language-specific test-file exclusions (`_test.go`, `*Test.java`, `*_spec.rb`, …) and build dirs (`target/`, `__pycache__`, `bin`, `obj`). The reviewer is an LLM, so the audit is genuinely language-neutral now. (INT-2240)
+
 ## 0.10.1 — 2026-07-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",

--- a/src/cli/reviewAudit.test.ts
+++ b/src/cli/reviewAudit.test.ts
@@ -31,6 +31,16 @@ describe('filterSourceFiles (INT-2006)', () => {
     const out = filterSourceFiles(['src/a.ts', 'dist/a.js', 'trash/old.ts', '.openswarm/x.ts']);
     expect(out).toEqual(['src/a.ts']);
   });
+
+  it('keeps non-JS/Python languages (Rust/Go/JVM/C/Ruby) (INT-2240)', () => {
+    const files = ['src/lib.rs', 'cmd/main.go', 'App.java', 'core/util.cpp', 'a.kt', 'b.rb', 'c.swift'];
+    expect(filterSourceFiles(files)).toEqual(files);
+  });
+
+  it('excludes language test files and build dirs (INT-2240)', () => {
+    expect(filterSourceFiles(['pkg/foo_test.go', 'FooTest.java', 'spec/bar_spec.rb'])).toEqual([]);
+    expect(filterSourceFiles(['target/debug/x.rs', 'src/lib.rs'])).toEqual(['src/lib.rs']);
+  });
 });
 
 describe('preferSrcRoot (INT-2006)', () => {

--- a/src/cli/reviewAudit.ts
+++ b/src/cli/reviewAudit.ts
@@ -18,11 +18,31 @@ import { RateLimitError } from '../adapters/rateLimitError.js';
 // Source extensions and test patterns mirror src/knowledge/scanner.ts. Kept
 // local (not imported) because those are unexported module consts; the audit
 // only needs the stable subset and drift here is low-risk.
-const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.py', '.pyw']);
-const TEST_PATTERNS = [/\.test\.[tj]sx?$/, /\.spec\.[tj]sx?$/, /_test\.py$/, /test_.*\.py$/, /\.test\.py$/];
+// Language-agnostic: the reviewer is an LLM, so collect source across languages.
+// Data/config/docs (.json/.toml/.yaml/.md/…) are intentionally NOT source.
+const SOURCE_EXTENSIONS = new Set([
+  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', // JS/TS
+  '.py', '.pyw', // Python
+  '.rs', '.go', // Rust / Go
+  '.java', '.kt', '.kts', '.scala', '.groovy', // JVM
+  '.c', '.cc', '.cpp', '.cxx', '.h', '.hpp', '.hxx', '.cs', // C / C++ / C#
+  '.rb', '.php', '.swift', '.m', '.mm', // Ruby / PHP / Swift / Obj-C
+  '.ex', '.exs', '.clj', '.cljs', '.ml', '.mli', '.hs', '.dart', '.lua', '.jl', '.zig', '.nim', // others
+]);
+const TEST_PATTERNS = [
+  /\.test\.[tj]sx?$/, /\.spec\.[tj]sx?$/, // JS/TS
+  /_test\.py$/, /test_.*\.py$/, /\.test\.py$/, // Python
+  /_test\.go$/, // Go
+  /Tests?\.java$/, /Tests?\.kt$/, // JVM
+  /_spec\.rb$/, /_test\.rb$/, // Ruby
+  // Rust uses inline #[cfg(test)] — no file-level test split; reviewer sees it inline.
+];
 // Belt-and-suspenders: git ls-files already honors .gitignore, but tracked
 // junk dirs (snapshots, coverage) shouldn't be audited as if they were source.
-const SKIP_DIR_SEGMENTS = new Set(['node_modules', 'dist', 'build', 'trash', '.openswarm', 'htmlcov', 'coverage', 'vendor']);
+const SKIP_DIR_SEGMENTS = new Set([
+  'node_modules', 'dist', 'build', 'trash', '.openswarm', 'htmlcov', 'coverage', 'vendor',
+  'target', '__pycache__', 'bin', 'obj', // Rust/JVM build, Python cache, .NET output
+]);
 
 /** One reviewer-subagent unit of work: a directory (or a chunk of a big one). */
 export interface AuditArea {


### PR DESCRIPTION
## Problem
`openswarm review --max` returned `No production source files to audit` on a Rust repo (enzyme, 86 .rs files).

## Root cause
`reviewAudit.ts` `SOURCE_EXTENSIONS` only allowed JS/TS/Python, so `git ls-files` → `filterSourceFiles` dropped every `.rs`. The reviewer is an LLM, so the audit should be language-neutral.

## Fix
- **SOURCE_EXTENSIONS**: + Rust/Go/JVM(Java/Kotlin/Scala/Groovy)/C/C++/C#/Ruby/PHP/Swift/Obj-C + Elixir/Clojure/OCaml/Haskell/Dart/Lua/Julia/Zig/Nim. (Data/config/docs stay excluded.)
- **TEST_PATTERNS**: + `_test.go`, `*Test.java/kt`, `*_spec.rb` (Rust uses inline `#[cfg(test)]`).
- **SKIP_DIR_SEGMENTS**: + `target`/`__pycache__`/`bin`/`obj`.

## Verified
filterSourceFiles language tests (22 total), typecheck/build/oxlint, and a real **enzyme (Rust) dry-run** now plans `10 files / 2 areas` (was 0).

Closes INT-2240.