### PR TITLE
Constrain project cancellation path matching

### DIFF
--- a/src/orchestration/taskScheduler.cancel.test.ts
+++ b/src/orchestration/taskScheduler.cancel.test.ts
@@ -47,6 +47,17 @@ describe('TaskScheduler cancellation', () => {
     expect(c.wasAborted()).toBe(false);
   });
 
+  it('cancelProjectTasks does not abort sibling paths with the same prefix', () => {
+    const a = deferredExecutor();
+    const b = deferredExecutor();
+    sched.startTask(task('a'), '/dev/WAVE', a.exec);
+    sched.startTask(task('b'), '/dev/WAVE-next', b.exec);
+    const n = sched.cancelProjectTasks('/dev/WAVE');
+    expect(n).toBe(1);
+    expect(a.wasAborted()).toBe(true);
+    expect(b.wasAborted()).toBe(false);
+  });
+
   it("a cancelled result is not counted as failed", async () => {
     const d = deferredExecutor();
     const events: string[] = [];

--- a/src/orchestration/taskScheduler.ts
+++ b/src/orchestration/taskScheduler.ts
@@ -7,6 +7,17 @@ import { EventEmitter } from 'node:events';
 import type { TaskItem } from './decisionEngine.js';
 import type { PipelineResult } from '../agents/pairPipeline.js';
 
+function normalizeProjectPath(path: string): string {
+  const normalized = path.replace(/\\/g, '/').replace(/\/+$/g, '');
+  return normalized || '/';
+}
+
+function isSameProjectOrDescendant(candidatePath: string, projectPath: string): boolean {
+  const candidate = normalizeProjectPath(candidatePath);
+  const project = normalizeProjectPath(projectPath);
+  return candidate === project || candidate.startsWith(`${project}/`);
+}
+
 // Types
 
 export interface QueuedTask {
@@ -353,7 +364,7 @@ export class TaskScheduler extends EventEmitter {
     let n = 0;
     for (const running of this.runningTasks.values()) {
       const p = running.projectPath;
-      if (p === projectPath || p.startsWith(projectPath) || projectPath.startsWith(p)) {
+      if (isSameProjectOrDescendant(p, projectPath)) {
         running.abortController.abort();
         n++;
       }


### PR DESCRIPTION
## Summary

This tightens `TaskScheduler.cancelProjectTasks()` so disabling a project only aborts tasks whose running path is the exact project path or a real descendant path.

Previously the matcher used raw string prefixes. That preserved worktree cancellation, but it also meant disabling `/dev/WAVE` could abort an unrelated running task under a sibling path like `/dev/WAVE-next`.

Changes:

- normalize scheduler cancellation paths before comparison
- match exact project paths or child path boundaries only
- add a regression test covering the sibling-prefix case

## Related issue

No linked issue; this is a small scheduler lifecycle bug fix.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Docs

## Validation

- [x] `npm test -- src/orchestration/taskScheduler.cancel.test.ts`
- [x] `npm test -- src/orchestration/taskScheduler.cancel.test.ts src/orchestration/taskScheduler.concurrency.test.ts`
- [x] `npm run lint` (passes with existing warnings outside this change)
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] `npm test` passes (added/updated tests where relevant)

Full `npm test` currently has unrelated failures that reproduce standalone on this checkout:

- `src/automation/autonomousRunner.cancel.test.ts`: hook timeout while importing runner modules
- `src/automation/autonomousRunner.infraError.test.ts`: hook timeout while importing runner modules
- `src/core/service.test.ts`: provider override expectations fail (`setDefaultAdapter`/`readProviderOverride`)
- `src/tui/components/AuditBoard.test.tsx`: errored area tally expectation does not update to `1 failed`

The scheduler cancellation tests covering this patch pass.