### PR TITLE
feat(review): review --max --fix + saturate the reviewer pool (INT-2249)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -258,10 +258,11 @@ program
   .option('--no-linear', 'For --max: skip creating the default Linear master audit issue')
   .option('--fallback <adapter>', 'For --max: retry usage-limited areas on this adapter (default: claude for codex)')
   .option('--no-fallback', 'For --max: disable the automatic usage-limit fallback')
+  .option('--fix', 'For --max: apply the reviewer fixes to each flagged area (working tree only, no commit)')
   .action(async (opts: {
     path?: string; issues?: string | boolean; issuesPerArea?: string | boolean; file?: string | boolean; adapter?: string; debug?: boolean;
     max?: boolean; concurrency?: number; maxFilesPerArea?: number; yes?: boolean; dryRun?: boolean;
-    out?: string; linear?: boolean; fallback?: string | boolean;
+    out?: string; linear?: boolean; fallback?: string | boolean; fix?: boolean;
   }) => {
     try {
       if (opts.max) {
@@ -281,6 +282,7 @@ program
           // --fallback <adapter> → string; --no-fallback → false; default → undefined (auto)
           fallbackAdapter: typeof opts.fallback === 'string' ? opts.fallback : undefined,
           noFallback: opts.fallback === false,
+          fix: opts.fix,
         });
         if (result && result.decision === 'reject') process.exitCode = 1;
         return;

--- a/src/cli/reviewAudit.test.ts
+++ b/src/cli/reviewAudit.test.ts
@@ -3,9 +3,13 @@ import {
   filterSourceFiles,
   preferSrcRoot,
   partitionIntoAreas,
+  balanceAreasToConcurrency,
   aggregateAuditResults,
   formatAuditReport,
   runMaxReview,
+  runAreaFixes,
+  fixTargets,
+  buildFixTaskDescription,
   mergeFallback,
   type AuditArea,
   type AuditAreaResult,
@@ -294,5 +298,86 @@ describe('mergeFallback (INT-2192)', () => {
     expect(merged.summary.completed).toBe(2);
     expect(merged.summary.failed).toBe(0);
     expect(merged.rateLimit).toBeUndefined(); // fallback succeeded → resolved
+  });
+});
+
+describe('balanceAreasToConcurrency (INT-2249)', () => {
+  // Two dirs, 5 files each — the plain partition gives 2 areas.
+  const files = [
+    ...Array.from({ length: 5 }, (_, i) => `src/a/f${i}.ts`),
+    ...Array.from({ length: 5 }, (_, i) => `src/b/f${i}.ts`),
+  ];
+
+  it('splits below-pool partitions so the fan-out saturates concurrency', () => {
+    expect(partitionIntoAreas(files, 12)).toHaveLength(2); // baseline: 2 dirs
+    const balanced = balanceAreasToConcurrency(files, 8, 12);
+    expect(balanced.length).toBeGreaterThanOrEqual(8);
+    // Every original file is still covered exactly once.
+    expect(balanced.flatMap((a) => a.files).sort()).toEqual([...files].sort());
+  });
+
+  it('is a no-op when the directory partition already fills the pool', () => {
+    const balanced = balanceAreasToConcurrency(files, 2, 12);
+    expect(balanced).toHaveLength(2);
+  });
+
+  it('does not over-split past what the files allow (cap floors at 1/file)', () => {
+    // 10 files, concurrency 50 → at most 10 areas (one file each).
+    const balanced = balanceAreasToConcurrency(files, 50, 12);
+    expect(balanced).toHaveLength(files.length);
+  });
+
+  it('concurrency <= 1 returns the plain partition', () => {
+    expect(balanceAreasToConcurrency(files, 1, 12)).toHaveLength(2);
+  });
+});
+
+describe('fixTargets + runAreaFixes (INT-2249)', () => {
+  const area = (label: string): AuditArea => ({ label, dir: label, files: [`${label}/f.ts`] });
+  const run = (): AuditRun => ({
+    results: [
+      { area: area('src/a'), review: { decision: 'approve', feedback: '' } },
+      { area: area('src/b'), review: { decision: 'revise', feedback: '', issues: ['bug in f'] } },
+      { area: area('src/c'), review: { decision: 'reject', feedback: '' } },
+      { area: area('src/d'), error: 'reviewer crashed' },
+    ],
+    summary: aggregateAuditResults([]),
+  });
+
+  it('targets only non-approve areas with a review', () => {
+    const targets = fixTargets(run());
+    expect(targets.map((t) => t.area.label)).toEqual(['src/b', 'src/c']);
+  });
+
+  it('buildFixTaskDescription scopes to the area files and lists issues', () => {
+    const desc = buildFixTaskDescription(area('src/b'), { decision: 'revise', feedback: '', issues: ['bug in f'] });
+    expect(desc).toContain('src/b/f.ts');
+    expect(desc).toContain('bug in f');
+    expect(desc).toContain('do not touch files outside src/b');
+  });
+
+  it('fans a fix worker out over each target and reports edited files', async () => {
+    const seen: string[] = [];
+    const fixes = await runAreaFixes(run(), '/repo', { concurrency: 2 }, {
+      fix: async (a) => {
+        seen.push(a.label);
+        return { success: true, filesChanged: a.files };
+      },
+    });
+    expect(seen.sort()).toEqual(['src/b', 'src/c']); // approve + error areas skipped
+    expect(fixes.every((f) => f.applied)).toBe(true);
+    expect(fixes.flatMap((f) => f.filesChanged).sort()).toEqual(['src/b/f.ts', 'src/c/f.ts']);
+  });
+
+  it('a failed fix lands as an error, not a throw', async () => {
+    const fixes = await runAreaFixes(run(), '/repo', { concurrency: 1 }, {
+      fix: async (a) => {
+        if (a.label === 'src/c') throw new Error('worker died');
+        return { success: true, filesChanged: a.files };
+      },
+    });
+    const c = fixes.find((f) => f.label === 'src/c');
+    expect(c?.applied).toBe(false);
+    expect(c?.error).toContain('worker died');
   });
 });

--- a/src/cli/reviewAudit.ts
+++ b/src/cli/reviewAudit.ts
@@ -146,6 +146,29 @@ export function partitionIntoAreas(files: string[], maxFilesPerArea = 12): Audit
 }
 
 /**
+ * Partition, then shrink the per-area cap until the fan-out can saturate the
+ * reviewer pool. The plain directory partition can yield far fewer areas than
+ * `concurrency` (e.g. two dirs, concurrency 8 → 2 subagents, 6 idle), so when
+ * we're under the pool size we re-partition with a smaller cap — more, smaller
+ * areas finish sooner in parallel. Monotonic (smaller cap ⇒ ≥ areas), so it
+ * converges; it stops as soon as areas ≥ concurrency or the cap bottoms out at
+ * one file per area. No-op when the directory partition already fills the pool.
+ * (INT-2249)
+ */
+export function balanceAreasToConcurrency(
+  files: string[],
+  concurrency: number,
+  maxFilesPerArea = 12,
+): AuditArea[] {
+  let areas = partitionIntoAreas(files, maxFilesPerArea);
+  if (concurrency <= 1) return areas;
+  for (let cap = maxFilesPerArea - 1; areas.length < concurrency && cap >= 1; cap--) {
+    areas = partitionIntoAreas(files, cap);
+  }
+  return areas;
+}
+
+/**
  * Roll N per-area results into one verdict + merged issues/actions. The worst
  * decision wins (reject > revise > approve); errored areas are counted but don't
  * affect the decision (a crashed subagent shouldn't silently "approve"). Pure.
@@ -419,4 +442,125 @@ export function mergeFallback(primary: AuditRun, fallback: AuditRun): AuditRun {
   const fb = new Map(fallback.results.map((r) => [r.area.label, r]));
   const results = primary.results.map((r) => (r.error && fb.has(r.area.label) ? fb.get(r.area.label)! : r));
   return { summary: aggregateAuditResults(results), results, rateLimit: fallback.rateLimit };
+}
+
+// ── Fix pass (--fix) ─────────────────────────────────────────────────────────
+
+/** Outcome of applying a reviewer's findings to one area. */
+export interface FixAreaResult {
+  label: string;
+  /** true when the worker ran and reported success. */
+  applied: boolean;
+  filesChanged: string[];
+  error?: string;
+}
+
+/** Live fix-pass progress — mirrors AuditProgress for the same board/logging. */
+export type FixProgress =
+  | { type: 'start'; label: string; done: number; total: number }
+  | { type: 'log'; label: string; line: string }
+  | { type: 'done'; label: string; filesChanged: number; done: number; total: number }
+  | { type: 'error'; label: string; error: string; done: number; total: number };
+
+export interface RunAreaFixesOptions {
+  concurrency: number;
+  adapter?: AdapterName;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+export interface RunAreaFixesDeps {
+  /** Apply one area's fixes → worker result. Default spawns a real worker. Injectable for tests. */
+  fix?: (area: AuditArea, review: ReviewResult, onLog: (line: string) => void) => Promise<{ success: boolean; filesChanged: string[] }>;
+  onProgress?: (e: FixProgress) => void;
+}
+
+/** Only areas the reviewer did not approve are worth a fix pass. */
+export function fixTargets(run: AuditRun): AuditAreaResult[] {
+  return run.results.filter(
+    (r): r is AuditAreaResult & { review: ReviewResult } =>
+      !!r.review && r.review.decision !== 'approve',
+  );
+}
+
+/** Turn one area's reviewer verdict into a worker task that applies the fixes. */
+export function buildFixTaskDescription(area: AuditArea, review: ReviewResult): string {
+  const issues = (review.issues ?? []).map((i) => `- ${i}`);
+  const actions = (review.recommendedActions ?? []).map(
+    (a) => `- [${a.type}] ${a.title}${a.location ? ` (${a.location})` : ''}`,
+  );
+  return [
+    `A code review of ${area.label} found issues. Apply the MINIMAL edits needed to resolve them.`,
+    '',
+    `Files in scope (edit only these — do not touch files outside ${area.dir}):`,
+    ...area.files.map((f) => `- ${f}`),
+    '',
+    issues.length ? `Issues to fix:\n${issues.join('\n')}` : '',
+    actions.length ? `\nRecommended actions:\n${actions.join('\n')}` : '',
+    '',
+    'Do not refactor beyond the fixes. Do not add features. Keep changes tight and verifiable.',
+  ]
+    .filter((l) => l !== '')
+    .join('\n');
+}
+
+/** Default fix applier: spawn a worker subagent that edits the area in place. */
+async function defaultFixArea(
+  area: AuditArea,
+  review: ReviewResult,
+  cwd: string,
+  opts: RunAreaFixesOptions,
+  onLog: (line: string) => void,
+): Promise<{ success: boolean; filesChanged: string[] }> {
+  const { runWorker } = await import('../agents/worker.js');
+  const result = await runWorker({
+    taskTitle: `Apply review fixes: ${area.label}`,
+    taskDescription: buildFixTaskDescription(area, review),
+    projectPath: cwd,
+    adapterName: opts.adapter,
+    timeoutMs: opts.timeoutMs,
+    nudgeMaxOnNoEdit: 1,
+    signal: opts.signal,
+    onLog,
+  });
+  return { success: result.success, filesChanged: result.filesChanged };
+}
+
+/**
+ * Apply reviewer-recommended fixes for every non-approve area, fanned out with
+ * the same concurrency cap as the review. Edits land in the working tree — no
+ * commit, no re-review — so the user reviews the diff before committing. Never
+ * throws on a single area: a failed fix lands as an error in its result. (INT-2249)
+ */
+export async function runAreaFixes(
+  run: AuditRun,
+  cwd: string,
+  opts: RunAreaFixesOptions,
+  deps: RunAreaFixesDeps = {},
+): Promise<FixAreaResult[]> {
+  const fix = deps.fix ?? ((area, review, onLog) => defaultFixArea(area, review, cwd, opts, onLog));
+  const targets = fixTargets(run);
+  const total = targets.length;
+  let done = 0;
+
+  const settled = await runPool(
+    targets,
+    opts.concurrency,
+    async (t) => {
+      deps.onProgress?.({ type: 'start', label: t.area.label, done, total });
+      return fix(t.area, t.review!, (line) => deps.onProgress?.({ type: 'log', label: t.area.label, line }));
+    },
+    (s) => {
+      done++;
+      const label = targets[s.index].area.label;
+      if (s.error) deps.onProgress?.({ type: 'error', label, error: String(s.error), done, total });
+      else if (s.value) deps.onProgress?.({ type: 'done', label, filesChanged: s.value.filesChanged.length, done, total });
+    },
+  );
+
+  return settled.map((s, i) => {
+    const label = targets[i].area.label;
+    if (s.error || !s.value) return { label, applied: false, filesChanged: [], error: s.error ? String(s.error) : 'no result' };
+    return { label, applied: s.value.success, filesChanged: s.value.filesChanged };
+  });
 }

--- a/src/cli/reviewMaxCommand.tsx
+++ b/src/cli/reviewMaxCommand.tsx
@@ -15,8 +15,10 @@ import { writeFile, mkdir } from 'node:fs/promises';
 import { join, dirname, basename } from 'node:path';
 import {
   listSourceFiles,
-  partitionIntoAreas,
+  balanceAreasToConcurrency,
   runMaxReview,
+  runAreaFixes,
+  fixTargets,
   formatAuditSummary,
   formatAuditReport,
   mergeFallback,
@@ -54,6 +56,8 @@ export interface ReviewMaxOptions {
   fallbackAdapter?: string;
   /** Disable the automatic usage-limit fallback. (INT-2192) */
   noFallback?: boolean;
+  /** Apply the reviewer's fixes to each non-approve area (working tree only). (INT-2249) */
+  fix?: boolean;
 }
 
 /**
@@ -147,7 +151,9 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
     console.log('No production source files to audit.');
     return null;
   }
-  const areas: AuditArea[] = partitionIntoAreas(files, opts.maxFilesPerArea ?? 12);
+  // Split down to fill the reviewer pool: fewer areas than `concurrency` would
+  // leave subagents idle, so the fastest audit maximizes parallel spread. (INT-2249)
+  const areas: AuditArea[] = balanceAreasToConcurrency(files, concurrency, opts.maxFilesPerArea ?? 12);
 
   if (opts.dryRun) {
     console.log(`Audit plan — ${files.length} file(s) across ${areas.length} area(s):`);
@@ -222,6 +228,37 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
     console.log(`\nReport saved: ${outPath}`);
   } catch (e) {
     console.warn(`Could not save report: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  // (3.5) --fix: apply the reviewer's findings for every non-approve area,
+  //       fanned out with the same concurrency. Edits land in the working tree —
+  //       no commit, no re-review — so the user reviews the diff first. (INT-2249)
+  if (opts.fix) {
+    const targets = fixTargets(run);
+    if (!targets.length) {
+      console.log('\n--fix: nothing to apply (every area approved).');
+    } else {
+      console.log(`\nApplying fixes across ${targets.length} area(s) with ${concurrency} concurrent worker(s)...`);
+      const fixes = await runAreaFixes(
+        run,
+        cwd,
+        { concurrency, adapter: opts.adapter as AdapterName | undefined },
+        {
+          onProgress: (e) => {
+            if (e.type === 'done') console.log(`  ✓ ${e.label} — ${e.filesChanged} file(s) changed`);
+            else if (e.type === 'error') console.log(`  ✗ ${e.label} — ${e.error}`);
+          },
+        },
+      );
+      const edited = fixes.filter((f) => f.applied && f.filesChanged.length);
+      const failed = fixes.filter((f) => !f.applied);
+      const touched = [...new Set(edited.flatMap((f) => f.filesChanged))];
+      console.log(
+        `\n--fix: ${edited.length}/${targets.length} area(s) edited, ${touched.length} file(s) touched` +
+          `${failed.length ? `, ${failed.length} failed` : ''}.`,
+      );
+      console.log('Changes are in the working tree — review the diff before committing.');
+    }
   }
 
   // (4) Linear: PM synthesis is the DEFAULT — a master parent + ≤10 cohesive


### PR DESCRIPTION
## Summary
Two throughput/usability improvements to `openswarm review --max`, both requested by the user:

### 1. Saturate the reviewer pool (`balanceAreasToConcurrency`)
`partitionIntoAreas` splits by directory only, so a repo with 2 directories runs just 2 reviewer subagents even at `--concurrency 8` (6 idle). Now, when the directory partition yields fewer areas than the pool, we re-partition with a progressively smaller per-area cap until `areas >= concurrency` (floored at one file per area).

- Monotonic, reuses `partitionIntoAreas` so labels stay clean (`src/a (1/5)`).
- **No-op when the partition already fills the pool** — module cohesion is preserved for the common case.
- Verified via `--dry-run`: 2 dirs / 10 files → **2 areas at concurrency 2**, **10 areas at concurrency 8**.

### 2. `--fix` — apply the reviewer's findings
After the audit, fan a fix worker out over every non-approve area (same concurrency), each told to apply that area's reviewer findings to its files.

- Edits land in the **working tree only** — no commit, no re-review — so you review the diff before committing.
- `runAreaFixes` + `buildFixTaskDescription` + `fixTargets`, mirroring the review fan-out.

Design (user-confirmed): fix result → leave in working tree + summary; fix unit → per-area parallel, revise/reject areas only.

## Changes
- `src/cli/reviewAudit.ts`: `balanceAreasToConcurrency`, `runAreaFixes`, `buildFixTaskDescription`, `fixTargets`, `FixAreaResult`/`FixProgress` types.
- `src/cli/reviewMaxCommand.tsx`: use `balanceAreasToConcurrency`; run the `--fix` pass after the report.
- `src/cli.ts`: `--fix` flag.
- `src/cli/reviewAudit.test.ts`: +8 tests.

## Verification
- typecheck / build / lint (0 errors) all green.
- `reviewAudit.test.ts`: 31 passed (8 new). Full suite: only the 2 pre-existing `service.test.ts` failures (unrelated, fail on `main` too).

## Note
Independent of #181 (multi-lens removal) — different files, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)