### PR TITLE
release: v0.11.0 — review --max --fix, saturating audit, unified status UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.11.0 — 2026-07-01
+
+Wider, faster codebase audits — plus the audit can now fix what it finds.
+
+### Added
+
+- **`review --max --fix`** — after the audit, a worker subagent is fanned out per flagged (revise/reject) area and applies that area's reviewer findings to its files. Edits land in the **working tree only** — no commit, no re-review — so you review the diff before committing. Uses the same `--concurrency` as the review. (INT-2249)
+- **Concurrency-saturating area distribution** — `review --max` previously ran one reviewer per directory, so a 2-directory repo used only 2 subagents even at `--concurrency 8`. Areas now auto-split until the fan-out fills the pool (floored at one file per area), and it stays a no-op when the directory partition already saturates it. Faster wall-clock on wide audits. (INT-2249)
+
+### Changed
+
+- **Multi-lens reviewer removed** — the opt-in multi-lens reviewer fan-out (PoC, shipped dormant in 0.10.0) is gone. A synthetic planted-defect A/B showed **zero detection uplift** over the single reviewer and **complete lens overlap** (every lens named every defect), so the 3× cost bought nothing. The reproducible A/B harness lives in `benchmarks/reviewLensAB.ts`. (INT-2230)
+
+### Fixed
+
+- **Project cancellation no longer aborts sibling paths** — disabling a project (e.g. `/dev/WAVE`) used a raw string prefix, so it could abort an unrelated running task under a sibling path like `/dev/WAVE-next`. Cancellation now matches the exact project path or a real descendant (worktree) path only, with path normalization. Thanks to [@ag-linden](https://github.com/ag-linden) for the fix. (#182)
+
 ## 0.10.2 — 2026-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Wider, faster codebase audits — plus the audit can now fix what it finds.
 
 ### Changed
 
+- **Unified CLI/TUI status design** — glyphs (`◐ ✓ ✗ ⚠ ✎`) and the braille spinner are now single-sourced (`src/support/glyphs.ts`), consumed by both the Ink TUI (`<StatusIcon>` / `<Spinner>` + `theme.STATUS`) and plain console output (`status` in `src/support/colors.ts`). Consequences: the **worker now shows the same animated spinner heartbeat as the reviewer** (it was a static line), the `review --max` verdict and `--fix` output are colored consistently (and stay ANSI-free when piped / under `NO_COLOR`), and drifting glyphs (`▶`→`◐`, `●`→`✓`) and duplicate spinner frame sets are collapsed. (INT-2260)
 - **Multi-lens reviewer removed** — the opt-in multi-lens reviewer fan-out (PoC, shipped dormant in 0.10.0) is gone. A synthetic planted-defect A/B showed **zero detection uplift** over the single reviewer and **complete lens overlap** (every lens named every defect), so the 3× cost bought nothing. The reproducible A/B harness lives in `benchmarks/reviewLensAB.ts`. (INT-2230)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -77,8 +77,12 @@ openswarm review                 # Review the working-tree changes
 openswarm review --max           # Full-codebase audit: fan reviewer subagents over areas
                                  #   → report at .openswarm/audit/ + PM-synthesized Linear
                                  #   issues by default (≤10 cohesive, master + sub-issues)
-                                 #   --no-linear (report only), --issues-per-area (legacy spray),
-                                 #   --issues <id> (set parent), --fallback <adapter>, --out <file>
+openswarm review --max --fix     # after the audit, a worker per flagged area applies the
+                                 #   fixes in the working tree (review the diff, then commit)
+openswarm review --max --concurrency 8   # widen the fan-out — areas auto-split to fill the pool
+                                 # more --max flags: --no-linear (report only) · --issues-per-area
+                                 #   (legacy spray) · --issues <id> (set parent) · --fallback
+                                 #   <adapter> · --out <file> · --dry-run (print the plan)
 
 # Code Registry & BS Detector
 openswarm check --scan           # Scan repo → register all entities
@@ -272,6 +276,7 @@ openswarm dash                # open the web dashboard (:3847)
 - **BS Detector** — Built-in static analysis engine that detects bad code patterns (empty catch, hardcoded secrets, `as any`, etc.) with pipeline guard integration
 - **Autonomous Pipeline** — Cron-driven heartbeat fetches Linear issues, runs Worker/Reviewer pair loops, and updates issue state automatically
 - **Worker/Reviewer Pairs** — Multi-iteration code generation with automated review, testing, and documentation stages
+- **Codebase Audit (`review --max`)** — fans reviewer subagents out over directory-shaped areas (auto-split to fill `--concurrency`), aggregates a deduped verdict into a markdown report, and synthesizes ≤10 cohesive Linear issues via a PM agent. `--fix` sends a worker per flagged area to apply the fixes in the working tree. Language-agnostic; codex usage-limit aware with automatic `claude` fallback
 - **Decision Engine** — Scope validation, rate limiting, priority-based task selection, and workflow mapping
 - **Cognitive Memory** — LanceDB vector store with Xenova/multilingual-e5-base embeddings for long-term recall across sessions
 - **Repo Knowledge Loop** — workers learn each repository over time: task outcomes (success patterns, review-rejection pitfalls) are stored per-repo and recalled into the next worker prompt
@@ -498,65 +503,12 @@ the CLI (fire-and-forget with a short timeout, and failures are silently ignored
 
 ## Changelog
 
-### v0.8.1
-- **License** — relicensed to **MIT** (was GPL-3.0)
-- **Docs** — README overhauled for first-time users (`openswarm init` walkthrough, accurate adapter registry, latest-build models) and contributor health files added (CONTRIBUTING, Code of Conduct, Security policy, PR template)
+Full version history lives in **[CHANGELOG.md](CHANGELOG.md)** and the
+[GitHub Releases](https://github.com/unohee/OpenSwarm/releases) page.
 
-### v0.8.0
-- **Interactive `openswarm init` wizard** — Linear OAuth (PKCE) sign-in with arrow-key team/project picker, provider auto-detection, and a validated `config.yaml` (INT-1808)
-- **`openswarm doctor`** — one-shot environment diagnostics: Node version, native modules, provider CLIs, ports, and config discovery
-- **Linear OAuth login** — `openswarm auth login --provider linear` (PKCE, no API-key entry)
-- **CLI polish** — ASCII banner and colored output (NO_COLOR / non-TTY aware)
-- **Autonomy hardening** — dependency-order gating + Backlog parking (INT-1809), daemon self-modify guards (INT-1810), `jobProfiles` partial roles carried through to runtime (INT-1812), and an `init` symlink guard that refuses to overwrite the daemon's global config
-- **Fix** — codex adapter `--full-auto` → `--sandbox workspace-write` (codex 0.137 deprecation) (INT-1699)
-
-### v0.5.0
-- **Native Codex Responses-API adapter** (`codex-responses`) — ChatGPT OAuth, no CLI binary required; live model discovery via the OAuth backend
-- **Linear-optional autonomy** — `ITaskSource` abstraction + local SQLite task source; the autonomous runner no longer requires Linear
-- **Notifier abstraction** — Discord / Slack / Telegram / webhook
-- **Agentic loop tools** — `web_fetch` + `web_search`
-- **Planner cockpit TUI** — `/plan` decompose → approve → dispatch
-- **Loop maturity (INT-1679)** — bad-edit guard + reflection self-repair loop
-- **Conflict-free concurrency (INT-1610)** — blocker/dependency ordering for parallel workers; worker instructions + actions logged to issue comments
-
-### v0.4.0
-- **Benchmarks (L0–L6)** — difficulty rubric, model-routing benchmark, and a real SWE-bench harness
-- **Repo knowledge loop** — workers learn each repository across tasks (per-repo success patterns + review-rejection pitfalls recalled into prompts)
-- **OpenRouter agentic adapter** — native tool loop with harness hardening from SWE-bench findings
-- **LM Studio adapter** with auto model selection
-- **CLI** — `openswarm dash`, `--tree` / `--ci` flags for `check`
-
-### v0.3.0
-- **Code Registry**: `openswarm check --scan` scans repo, registers 1000+ entities across 8 languages (TS, Python, Go, Rust, Java, C, C++, C#) with test mapping, complexity scoring, and risk assessment
-- **BS Detector**: `openswarm check --bs` — built-in static analysis for bad code patterns, pipeline guard integration
-- **Local Model Support**: Ollama, LMStudio, llama.cpp via single `local` adapter with auto-detection
-- **GPT Adapter**: OpenAI models via OAuth PKCE flow
-- **Local Issue Tracker**: SQLite + GraphQL + Kanban web UI at `:3847/issues`
-- **CLI**: `openswarm check`, `openswarm annotate` commands
-
-### v0.2.2
-- `openswarm` without arguments now launches TUI chat directly
-
-### v0.2.1
-- Security: patched lodash, picomatch, rollup, undici, yaml vulnerabilities
-
-### v0.2.0
-- Published as `@intrect/openswarm` on npm
-- Extracted `@intrect/claude-driver` as standalone zero-dependency package
-- Autonomous runner hardening and multi-project orchestration
-- Task-state rehydration from Linear comments
-- `--verbose` flag for detailed execution logging
-- Codex adapter: dropped o-series model override
-
-### v0.1.0
-- Initial release
-- Worker/Reviewer pair pipeline
-- Claude Code CLI + Codex CLI adapters
-- Discord bot control
-- Linear integration
-- LanceDB cognitive memory
-- Web dashboard (port 3847)
-- Rich TUI chat interface
+Latest — **v0.11.0**: `review --max --fix` (a worker per flagged area applies the
+audit fixes in the working tree) and concurrency-saturating area distribution
+(areas auto-split to fill `--concurrency`). See CHANGELOG.md for the rest.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",

--- a/src/cli/reviewAudit.ts
+++ b/src/cli/reviewAudit.ts
@@ -14,6 +14,7 @@ import type { ReviewResult, RecommendedAction } from '../agents/agentPair.js';
 import type { AdapterName } from '../adapters/types.js';
 import { runPool } from '../support/concurrencyPool.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
+import { c, status } from '../support/colors.js';
 
 // Source extensions and test patterns mirror src/knowledge/scanner.ts. Kept
 // local (not imported) because those are unexported module consts; the audit
@@ -292,20 +293,26 @@ export function formatAuditReport(summary: AuditSummary, repoName: string, times
   return lines.join('\n');
 }
 
-/** Render the aggregate audit verdict for the terminal. Pure. */
+/**
+ * Render the aggregate audit verdict for the terminal. Glyphs + colors come from
+ * the shared status vocabulary (support/colors `status`), matching the AuditBoard
+ * — color is a no-op under NO_COLOR / non-TTY so the text stays clean. (INT-2260)
+ */
 export function formatAuditSummary(summary: AuditSummary): string {
+  // decision → shared status glyph (colored): approve ✓, revise ✎, reject ✗, error ⚠.
   const mark = (d: AuditAreaSummary['decision']) =>
-    d === 'approve' ? '✓' : d === 'revise' ? '✎' : d === 'reject' ? '✗' : '⚠';
+    d === 'approve' ? status.glyph('ok') : d === 'revise' ? status.glyph('revise') : d === 'reject' ? status.glyph('err') : status.glyph('warn');
   const lines: string[] = [];
 
   const approved = summary.areas.filter((a) => a.decision === 'approve').length;
   const revised = summary.areas.filter((a) => a.decision === 'revise').length;
   const rejected = summary.areas.filter((a) => a.decision === 'reject').length;
   lines.push(
-    `Codebase audit — ${summary.totalAreas} area(s): ${approved} ✓, ${revised} ✎ revise, ${rejected} ✗ reject` +
+    `Codebase audit — ${summary.totalAreas} area(s): ${approved} ${status.glyph('ok')}, ${revised} ${status.glyph('revise')} revise, ${rejected} ${status.glyph('err')} reject` +
       (summary.failed ? `  [${summary.failed} failed]` : ''),
   );
-  lines.push(`Verdict: ${summary.decision.toUpperCase()}`);
+  const verdictPaint = summary.decision === 'reject' ? c.red : summary.decision === 'revise' ? c.yellow : c.green;
+  lines.push(verdictPaint(`Verdict: ${summary.decision.toUpperCase()}`));
   lines.push('');
 
   for (const a of summary.areas) {

--- a/src/cli/reviewMaxCommand.tsx
+++ b/src/cli/reviewMaxCommand.tsx
@@ -29,6 +29,7 @@ import {
 import { AuditBoard } from '../tui/components/AuditBoard.js';
 import { resolveIssueFromBranch, ensureTaskSource, resolveProjectId } from './reviewCommand.js';
 import { synthesizeAuditIssues } from './auditPM.js';
+import { status } from '../support/colors.js';
 import type { AdapterName } from '../adapters/types.js';
 
 export interface ReviewMaxOptions {
@@ -191,7 +192,7 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
     const fallback = resolveFallbackAdapter(opts);
     if (fallback) {
       const pending = areas.filter((_, i) => run.results[i]?.error);
-      console.warn(`\n⚠ Codex usage limit hit — falling back to "${fallback}" for ${pending.length} remaining area(s)...`);
+      console.warn(`\n${status.warn(`Codex usage limit hit — falling back to "${fallback}" for ${pending.length} remaining area(s)...`)}`);
       const fbRun = await runMaxReview(
         pending,
         cwd,
@@ -214,7 +215,7 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
   if (run.rateLimit) {
     const skipped = run.summary.areas.filter((a) => a.decision === 'error').length;
     const when = run.rateLimit.resetsAt ? new Date(run.rateLimit.resetsAt * 1000).toLocaleString() : 'an unknown time';
-    console.warn(`\n⚠ Usage limit unresolved — ${skipped} area(s) still incomplete. ${run.rateLimit.message}`);
+    console.warn(`\n${status.warn(`Usage limit unresolved — ${skipped} area(s) still incomplete. ${run.rateLimit.message}`)}`);
     console.warn(`  Retry after ${when}${resolveFallbackAdapter(opts) ? ' (fallback adapter also exhausted)' : ', or set `--fallback <adapter>`'}.`);
   }
 
@@ -245,8 +246,8 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
         { concurrency, adapter: opts.adapter as AdapterName | undefined },
         {
           onProgress: (e) => {
-            if (e.type === 'done') console.log(`  ✓ ${e.label} — ${e.filesChanged} file(s) changed`);
-            else if (e.type === 'error') console.log(`  ✗ ${e.label} — ${e.error}`);
+            if (e.type === 'done') console.log(`  ${status.ok(`${e.label} — ${e.filesChanged} file(s) changed`)}`);
+            else if (e.type === 'error') console.log(`  ${status.err(`${e.label} — ${e.error}`)}`);
           },
         },
       );
@@ -340,8 +341,10 @@ async function filePmSynthesizedIssues(
     // No <repo>/openswarm.json mapping → issues get filed without a project (and
     // on a multi-team config, only the first team). Tell the user how to map it. (INT-2239)
     console.warn(
-      '⚠ No Linear project mapped for this repo (openswarm.json `linear.projectId` missing) — ' +
-        'issues will not be linked to a project. Run `openswarm add` here to map it.',
+      status.warn(
+        'No Linear project mapped for this repo (openswarm.json `linear.projectId` missing) — ' +
+          'issues will not be linked to a project. Run `openswarm add` here to map it.',
+      ),
     );
   }
 
@@ -380,12 +383,12 @@ async function filePmSynthesizedIssues(
         : await source.createTask(issue.title, issue.description, projectId);
       if ('identifier' in res) {
         filed++;
-        console.log(`  ✓ ${res.identifier}  ${issue.title}  (${issue.items.length} follow-up(s))`);
+        console.log(`  ${status.ok(`${res.identifier}  ${issue.title}  (${issue.items.length} follow-up(s))`)}`);
       } else {
-        console.warn(`  ✗ Could not create issue "${issue.title}": ${res.error}`);
+        console.warn(`  ${status.err(`Could not create issue "${issue.title}": ${res.error}`)}`);
       }
     } catch (e) {
-      console.warn(`  ✗ Could not create issue "${issue.title}": ${e instanceof Error ? e.message : String(e)}`);
+      console.warn(`  ${status.err(`Could not create issue "${issue.title}": ${e instanceof Error ? e.message : String(e)}`)}`);
     }
   }
 

--- a/src/cli/reviewProgress.test.ts
+++ b/src/cli/reviewProgress.test.ts
@@ -3,14 +3,15 @@ import { spinnerFrame, formatProgress, startReviewProgress, oneLine, truncateLin
 
 describe('spinnerFrame / formatProgress (INT-1963)', () => {
   it('cycles spinner frames and is safe for any tick', () => {
-    expect(spinnerFrame(0)).toBe('⠋');
-    expect(spinnerFrame(10)).toBe(spinnerFrame(0)); // wraps
+    // Single-sourced braille spinner from support/glyphs (8 frames). (INT-2260)
+    expect(spinnerFrame(0)).toBe('⣾');
+    expect(spinnerFrame(8)).toBe(spinnerFrame(0)); // wraps at frame count (8)
     expect(typeof spinnerFrame(-1)).toBe('string');
   });
 
   it('formats elapsed seconds and an optional activity note', () => {
-    expect(formatProgress(0, 3)).toBe('⠋ reviewing… 3s');
-    expect(formatProgress(0, 5, '🔧 read_file')).toBe('⠋ reviewing… 5s · 🔧 read_file');
+    expect(formatProgress(0, 3)).toBe('⣾ reviewing… 3s');
+    expect(formatProgress(0, 5, '🔧 read_file')).toBe('⣾ reviewing… 5s · 🔧 read_file');
   });
 });
 

--- a/src/cli/reviewProgress.ts
+++ b/src/cli/reviewProgress.ts
@@ -2,16 +2,14 @@
 // OpenSwarm - review progress indicator (INT-1963)
 // ============================================
 //
-// A live "still working" heartbeat for `openswarm review`, so a multi-second
-// reviewer run doesn't look frozen. The formatter is pure (unit-tested); the
-// runtime owns a timer + stderr writes (injectable for tests).
+// A live "still working" heartbeat for any multi-second CLI agent run (reviewer
+// AND worker), so it doesn't look frozen. The formatter is pure (unit-tested);
+// the runtime owns a timer + stderr writes (injectable for tests). The spinner
+// is single-sourced from support/glyphs so the CLI heartbeat matches the TUI
+// boards. (INT-2260)
 
-const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-
-/** Braille spinner frame for a tick. Pure. */
-export function spinnerFrame(tick: number): string {
-  return FRAMES[((tick % FRAMES.length) + FRAMES.length) % FRAMES.length];
-}
+export { spinnerFrame } from '../support/glyphs.js';
+import { spinnerFrame } from '../support/glyphs.js';
 
 /** Collapse newlines/whitespace runs to single spaces so a note stays one line. Pure. */
 export function oneLine(s: string): string {
@@ -68,9 +66,9 @@ export function truncateLine(s: string, width: number): string {
   return `${out}…`;
 }
 
-/** One progress line: `⠙ reviewing… 3s · 🔧 read_file`. Pure. */
-export function formatProgress(tick: number, elapsedSec: number, last?: string, width?: number): string {
-  const base = `${spinnerFrame(tick)} reviewing… ${elapsedSec}s`;
+/** One progress line: `⣾ reviewing… 3s · 🔧 read_file`. Pure. (label defaults to `reviewing…`) */
+export function formatProgress(tick: number, elapsedSec: number, last?: string, width?: number, label = 'reviewing…'): string {
+  const base = `${spinnerFrame(tick)} ${label} ${elapsedSec}s`;
   const line = last ? `${base} · ${last}` : base;
   return width ? truncateLine(line, width) : line;
 }
@@ -96,9 +94,11 @@ const CLEAR_LINE = '\r\x1b[2K';
 
 /**
  * Start a spinner heartbeat that re-renders every intervalMs until stop().
- * Returns handles to update the activity note and to stop. (INT-1963)
+ * `label` is the verb shown next to the spinner (`reviewing…`, `worker…`), so
+ * the same heartbeat serves every CLI agent stage. Returns handles to update the
+ * activity note and to stop. (INT-1963, INT-2260)
  */
-export function startReviewProgress(deps: ReviewProgressDeps = {}): ReviewProgress {
+export function startProgressHeartbeat(label: string, deps: ReviewProgressDeps = {}): ReviewProgress {
   const write = deps.write ?? ((s: string) => process.stderr.write(s));
   const now = deps.now ?? (() => Date.now());
   const setIntervalFn = deps.setIntervalFn ?? setInterval;
@@ -116,7 +116,7 @@ export function startReviewProgress(deps: ReviewProgressDeps = {}): ReviewProgre
   const render = () => {
     const elapsedSec = Math.max(0, Math.floor((now() - start) / 1000));
     // Single line, truncated to display width — a wide-char note must never wrap/stack. (INT-1966)
-    write(`${CLEAR_LINE}${formatProgress(tick, elapsedSec, last, maxCols)}`);
+    write(`${CLEAR_LINE}${formatProgress(tick, elapsedSec, last, maxCols, label)}`);
     tick += 1;
   };
 
@@ -132,4 +132,9 @@ export function startReviewProgress(deps: ReviewProgressDeps = {}): ReviewProgre
       write(CLEAR_LINE);
     },
   };
+}
+
+/** The reviewer's heartbeat — `startProgressHeartbeat` with the `reviewing…` label. */
+export function startReviewProgress(deps: ReviewProgressDeps = {}): ReviewProgress {
+  return startProgressHeartbeat('reviewing…', deps);
 }

--- a/src/runners/cliRunner.ts
+++ b/src/runners/cliRunner.ts
@@ -12,6 +12,8 @@ import type { TaskItem } from '../orchestration/decisionEngine.js';
 import type { PipelineStage, RoleConfig } from '../core/types.js';
 import { initLocale } from '../locale/index.js';
 import { expandPath } from '../core/config.js';
+import { startProgressHeartbeat, type ReviewProgress } from '../cli/reviewProgress.js';
+import { status } from '../support/colors.js';
 
 // Types
 
@@ -122,22 +124,34 @@ export async function runCli(options: CliRunOptions): Promise<void> {
 
   // 8. Attach event listeners for progress
   const stageStartTimes = new Map<string, number>();
+  // Every stage (worker included) gets the same animated braille heartbeat the
+  // reviewer has, so a running stage never looks frozen. On a non-TTY or in
+  // verbose mode (where each tool line is printed) we fall back to plain lines.
+  // (INT-2260)
+  const liveSpinner = !!process.stdout.isTTY && !options.verbose;
+  let heartbeat: ReviewProgress | null = null;
+  const stopHeartbeat = () => {
+    heartbeat?.stop();
+    heartbeat = null;
+  };
 
   pipeline.on('stage:start', ({ stage }: { stage: string }) => {
     stageStartTimes.set(stage, Date.now());
-    process.stdout.write(`  ~ ${stage}...`);
+    if (liveSpinner) heartbeat = startProgressHeartbeat(`${stage}…`, { write: (s) => process.stdout.write(s) });
+    else process.stdout.write(`  ~ ${stage}...\n`);
   });
 
   pipeline.on('stage:complete', ({ stage, result }: { stage: string; result: { success: boolean; duration: number } }) => {
-    const symbol = result.success ? 'v' : 'x';
+    stopHeartbeat();
     const duration = (result.duration / 1000).toFixed(1);
-    // Clear the "running" line and replace with result
-    process.stdout.write(`\r  ${symbol} ${stage} (${duration}s)\n`);
+    const line = `${stage} (${duration}s)`;
+    process.stdout.write(`  ${result.success ? status.ok(line) : status.err(line)}\n`);
   });
 
   pipeline.on('stage:fail', ({ stage, result }: { stage: string; result: { duration: number } }) => {
+    stopHeartbeat();
     const duration = (result.duration / 1000).toFixed(1);
-    process.stdout.write(`\r  x ${stage} (${duration}s) FAILED\n`);
+    process.stdout.write(`  ${status.err(`${stage} (${duration}s) FAILED`)}\n`);
   });
 
   pipeline.on('iteration:start', ({ iteration, maxIterations }: { iteration: number; maxIterations: number }) => {

--- a/src/support/colors.ts
+++ b/src/support/colors.ts
@@ -5,6 +5,8 @@
 // Honors NO_COLOR and non-TTY output (pipes/CI) — colors are stripped so logs
 // stay clean when redirected. Used by CLI commands (init, doctor, …).
 
+import { GLYPH, type StatusKind } from './glyphs.js';
+
 const useColor = !!process.stdout.isTTY && !process.env.NO_COLOR;
 
 const wrap =
@@ -28,4 +30,34 @@ export const c = {
     (r: number, g: number, b: number) =>
     (s: string): string =>
       useColor ? `\x1b[38;2;${r};${g};${b}m${s}\x1b[39m` : s,
+};
+
+/** Console color per status kind — the plain-output twin of theme.STATUS. */
+const STATUS_PAINT: Record<StatusKind, (s: string) => string> = {
+  running: c.cyan,
+  ok: c.green,
+  warn: c.yellow,
+  err: c.red,
+  revise: c.magenta,
+  info: c.blue,
+};
+
+/**
+ * Console status helpers — the plain-output adapter over the shared glyph
+ * vocabulary (support/glyphs GLYPH), mirroring the Ink <StatusIcon>. `status.ok(
+ * 'saved')` → a green `✓ saved` (stripped under NO_COLOR / non-TTY). Use these
+ * instead of hand-writing `console.log('✓ …')` so CLI output can't drift from
+ * the TUI. (INT-2260)
+ */
+export const status = {
+  /** Bare colored glyph (no trailing text), e.g. for inline use. */
+  glyph: (kind: StatusKind): string => STATUS_PAINT[kind](GLYPH[kind]),
+  /** `<glyph> <text>`, colored for the kind. */
+  line: (kind: StatusKind, text: string): string => STATUS_PAINT[kind](`${GLYPH[kind]} ${text}`),
+  ok: (text: string): string => STATUS_PAINT.ok(`${GLYPH.ok} ${text}`),
+  err: (text: string): string => STATUS_PAINT.err(`${GLYPH.err} ${text}`),
+  warn: (text: string): string => STATUS_PAINT.warn(`${GLYPH.warn} ${text}`),
+  revise: (text: string): string => STATUS_PAINT.revise(`${GLYPH.revise} ${text}`),
+  running: (text: string): string => STATUS_PAINT.running(`${GLYPH.running} ${text}`),
+  info: (text: string): string => STATUS_PAINT.info(`${GLYPH.info} ${text}`),
 };

--- a/src/support/glyphs.test.ts
+++ b/src/support/glyphs.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { GLYPH, SPINNER_FRAMES, spinnerFrame } from './glyphs.js';
+import { status } from './colors.js';
+
+describe('glyphs — single status vocabulary (INT-2260)', () => {
+  it('exposes one glyph per status kind', () => {
+    expect(GLYPH.running).toBe('◐');
+    expect(GLYPH.ok).toBe('✓');
+    expect(GLYPH.err).toBe('✗');
+    expect(GLYPH.warn).toBe('⚠');
+    expect(GLYPH.revise).toBe('✎');
+  });
+
+  it('spinnerFrame cycles and is safe for any tick', () => {
+    expect(spinnerFrame(0)).toBe(SPINNER_FRAMES[0]);
+    expect(spinnerFrame(SPINNER_FRAMES.length)).toBe(spinnerFrame(0)); // wraps
+    expect(typeof spinnerFrame(-1)).toBe('string');
+  });
+});
+
+describe('status console helper (INT-2260)', () => {
+  // vitest runs non-TTY, so `c` strips color — glyph+text stays plain and the
+  // console output matches the shared vocabulary without ANSI leaking into pipes.
+  it('prepends the shared glyph and stays plain when not a TTY', () => {
+    expect(status.ok('saved')).toBe('✓ saved');
+    expect(status.err('boom')).toBe('✗ boom');
+    expect(status.warn('careful')).toBe('⚠ careful');
+    expect(status.line('running', 'working')).toBe('◐ working');
+    expect(status.glyph('revise')).toBe('✎');
+  });
+});

--- a/src/support/glyphs.ts
+++ b/src/support/glyphs.ts
@@ -1,0 +1,33 @@
+// ============================================
+// OpenSwarm - Status glyph + spinner vocabulary (INT-2260)
+// ============================================
+//
+// The SINGLE source of truth for status glyphs and the braille spinner, shared
+// by both render targets: the Ink TUI (via theme.ts STATUS + <StatusIcon>/
+// <Spinner>) and plain console output (via support/colors.ts `status`). Every
+// view renders through one of those two adapters, so no component hand-rolls its
+// own glyph / frame set again — that drift is what left some views without a
+// spinner or with the wrong icon. Context-free on purpose: no Ink, no ANSI here.
+
+/** Semantic status kinds shared across every progress/verdict surface. */
+export type StatusKind = 'running' | 'ok' | 'warn' | 'err' | 'revise' | 'info';
+
+/** The one glyph vocabulary. Views reference these — never a literal. */
+export const GLYPH: Record<StatusKind, string> = {
+  running: '◐',
+  ok: '✓',
+  warn: '⚠',
+  err: '✗',
+  revise: '✎',
+  info: '•',
+};
+
+/** The one braille spinner. Both the CLI heartbeat and the Ink boards use it. */
+export const SPINNER_FRAMES = ['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷'] as const;
+
+const mod = (n: number, m: number): number => ((n % m) + m) % m;
+
+/** Braille spinner glyph for the given tick. Pure. */
+export function spinnerFrame(tick: number): string {
+  return SPINNER_FRAMES[mod(tick, SPINNER_FRAMES.length)];
+}

--- a/src/tui/components/AuditBoard.tsx
+++ b/src/tui/components/AuditBoard.tsx
@@ -7,8 +7,8 @@
 import { Box, Text } from 'ink';
 import { useState, useEffect } from 'react';
 import type { EventEmitter } from 'node:events';
-import { spinnerFrame } from '../loadingMessages.js';
-import { theme } from '../theme.js';
+import { theme, ICON } from '../theme.js';
+import { Spinner } from './Status.js';
 import type { AuditArea, AuditProgress } from '../../cli/reviewAudit.js';
 import type { ReviewResult } from '../../agents/agentPair.js';
 
@@ -28,7 +28,6 @@ export interface AuditBoardProps {
 const truncate = (s: string, n: number) => (s.length <= n ? s : `${s.slice(0, n - 1)}…`);
 
 export function AuditBoard({ areas, concurrency, events }: AuditBoardProps) {
-  const [tick, setTick] = useState(0);
   const [statuses, setStatuses] = useState<Record<string, AreaStatus>>(() =>
     Object.fromEntries(areas.map((a) => [a.label, { status: 'pending' as const }])),
   );
@@ -51,11 +50,6 @@ export function AuditBoard({ areas, concurrency, events }: AuditBoardProps) {
     };
   }, [events]);
 
-  useEffect(() => {
-    const t = setInterval(() => setTick((x) => x + 1), 120);
-    return () => clearInterval(t);
-  }, []);
-
   const entries = Object.values(statuses);
   const done = entries.filter((s) => s.status === 'done' || s.status === 'error').length;
   const running = Object.entries(statuses).filter(([, s]) => s.status === 'running');
@@ -67,28 +61,28 @@ export function AuditBoard({ areas, concurrency, events }: AuditBoardProps) {
   return (
     <Box flexDirection="column">
       <Text>
-        <Text color={theme.accent}>{spinnerFrame(tick)}</Text>
+        <Spinner />
         <Text bold>{` Codebase audit · ${done}/${areas.length} areas · concurrency ${concurrency}`}</Text>
       </Text>
       {running.map(([label, s]) => (
         <Text key={label} color={theme.dim}>
           {'  '}
-          <Text color={theme.accent}>{spinnerFrame(tick)}</Text>
+          <Spinner />
           {` ${label}`}
           {s.lastLog ? `  ${truncate(s.lastLog, 48)}` : ''}
         </Text>
       ))}
       <Text color={theme.dim}>
         {'  '}
-        <Text color={theme.ok}>{`✓ ${approved} done`}</Text>
+        <Text color={theme.ok}>{`${ICON.ok} ${approved} done`}</Text>
         {' · '}
-        <Text color={theme.accentAlt}>{`✎ ${revised} revise`}</Text>
+        <Text color={theme.accentAlt}>{`${ICON.revise} ${revised} revise`}</Text>
         {' · '}
-        <Text color={theme.err}>{`✗ ${rejected} reject`}</Text>
+        <Text color={theme.err}>{`${ICON.fail} ${rejected} reject`}</Text>
         {failed ? (
           <Text>
             {' · '}
-            <Text color={theme.warn}>{`⚠ ${failed} failed`}</Text>
+            <Text color={theme.warn}>{`${ICON.warn} ${failed} failed`}</Text>
           </Text>
         ) : null}
       </Text>

--- a/src/tui/components/StageTimeline.tsx
+++ b/src/tui/components/StageTimeline.tsx
@@ -2,11 +2,12 @@
 // Presentational: takes already-reduced stage entries (parity with the
 // dashboard's renderStages).
 import { Box, Text } from 'ink';
-import { theme } from '../theme.js';
+import { STATUS } from '../theme.js';
+import type { StatusKind } from '../../support/glyphs.js';
 import type { StageEntry } from '../pipelineEvents.js';
 
-const ICON: Record<StageEntry['status'], string> = { start: '▶', complete: '✓', fail: '✗' };
-const COLOR: Record<StageEntry['status'], string> = { start: theme.running, complete: theme.ok, fail: theme.err };
+// Single-sourced glyphs + colors (INT-2260): running → ◐, complete → ✓, fail → ✗.
+const KIND: Record<StageEntry['status'], StatusKind> = { start: 'running', complete: 'ok', fail: 'err' };
 
 export interface StageTimelineProps {
   stages: StageEntry[];
@@ -25,9 +26,10 @@ export function StageTimeline({ stages, max = 12 }: StageTimelineProps) {
           const dur = s.durationMs ? ` ${Math.round(s.durationMs / 1000)}s` : '';
           const model = s.model ? ` (${s.model})` : '';
           const decision = s.decision ? ` → ${s.decision}` : '';
+          const st = STATUS[KIND[s.status]];
           return (
-            <Text key={i} color={COLOR[s.status]}>
-              {`${ICON[s.status]} ${s.stage}${model}${dur}${decision}`}
+            <Text key={i} color={st.color}>
+              {`${st.icon} ${s.stage}${model}${dur}${decision}`}
             </Text>
           );
         })

--- a/src/tui/components/Status.tsx
+++ b/src/tui/components/Status.tsx
@@ -1,0 +1,35 @@
+// ============================================
+// OpenSwarm - Shared Ink status primitives (INT-2260)
+// ============================================
+//
+// The Ink adapter over the shared glyph vocabulary. Every board/tree/timeline
+// renders in-progress and terminal status through <Spinner> and <StatusIcon>,
+// so a "running / done / failed / revise" always looks the same and nothing is
+// left static or off-theme. The plain-console twin lives in support/colors
+// (`status`); both read the same GLYPH / theme.STATUS source.
+
+import { Text } from 'ink';
+import { useState, useEffect } from 'react';
+import { theme, STATUS } from '../theme.js';
+import { spinnerFrame } from '../../support/glyphs.js';
+import type { StatusKind } from '../../support/glyphs.js';
+
+/** A themed status glyph (◐ ✓ ✗ ⚠ ✎ •), colored per theme.STATUS. */
+export function StatusIcon({ kind }: { kind: StatusKind }) {
+  const s = STATUS[kind];
+  return <Text color={s.color}>{s.icon}</Text>;
+}
+
+/**
+ * A self-animating braille spinner — the one in-progress indicator. Drop it
+ * anywhere a running row/line needs to show life; it owns its own timer so
+ * callers don't each re-implement a tick.
+ */
+export function Spinner({ intervalMs = 120 }: { intervalMs?: number }) {
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const h = setInterval(() => setTick((t) => t + 1), intervalMs);
+    return () => clearInterval(h);
+  }, [intervalMs]);
+  return <Text color={theme.accent}>{spinnerFrame(tick)}</Text>;
+}

--- a/src/tui/components/SubagentTree.tsx
+++ b/src/tui/components/SubagentTree.tsx
@@ -1,11 +1,12 @@
 // SubagentTree — concurrent tasks as a per-worktree agent tree (S7).
 // Presentational: takes nodes built by buildSubagentTree.
 import { Box, Text } from 'ink';
-import { theme } from '../theme.js';
+import { STATUS } from '../theme.js';
+import type { StatusKind } from '../../support/glyphs.js';
 import type { TaskNode, TaskStatus } from '../subagentTree.js';
 
-const ICON: Record<TaskStatus, string> = { start: '◐', complete: '●', fail: '✗' };
-const COLOR: Record<TaskStatus, string> = { start: theme.running, complete: theme.ok, fail: theme.err };
+// Single-sourced glyphs + colors (INT-2260): running → ◐, complete → ✓, fail → ✗.
+const KIND: Record<TaskStatus, StatusKind> = { start: 'running', complete: 'ok', fail: 'err' };
 
 export interface SubagentTreeProps {
   tasks: TaskNode[];
@@ -25,7 +26,7 @@ export function SubagentTree({ tasks, max = 6, maxStages = 5 }: SubagentTreeProp
       ) : (
         shown.map((task) => (
           <Box key={task.taskId} flexDirection="column">
-            <Text color={COLOR[task.status]}>{`${ICON[task.status]} ${task.taskId.slice(0, 16)}`}</Text>
+            <Text color={STATUS[KIND[task.status]].color}>{`${STATUS[KIND[task.status]].icon} ${task.taskId.slice(0, 16)}`}</Text>
             {task.stages.slice(-maxStages).map((s, i) => (
               <Text key={i} dimColor>
                 {`   └ ${s.stage}${s.model ? ` (${s.model})` : ''} — ${s.status}`}

--- a/src/tui/loadingMessages.ts
+++ b/src/tui/loadingMessages.ts
@@ -23,14 +23,11 @@ export const LOADING_MESSAGES = [
   'Activating response circuits',
 ] as const;
 
-export const SPINNER_FRAMES = ['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷'] as const;
+// Spinner is single-sourced from support/glyphs (INT-2260); re-exported here for
+// the existing TUI importers (AuditBoard, WorkingIndicator).
+export { SPINNER_FRAMES, spinnerFrame } from '../support/glyphs.js';
 
 const mod = (n: number, m: number) => ((n % m) + m) % m;
-
-/** Braille spinner glyph for the given tick. */
-export function spinnerFrame(tick: number): string {
-  return SPINNER_FRAMES[mod(tick, SPINNER_FRAMES.length)];
-}
 
 /**
  * Loading line for a given tick. The message advances once per `periodMs`

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -1,8 +1,12 @@
 // ============================================
-// OpenSwarm - TUI theme (INT-1943)
+// OpenSwarm - TUI theme (INT-1943, INT-2260)
 // Single source of colors + glyphs for the Ink cockpit, so the chat-first
-// redesign stays visually consistent.
+// redesign stays visually consistent. Status glyphs + the spinner come from the
+// context-free `support/glyphs` so plain console output (support/colors `status`)
+// shares the exact same vocabulary — no view redeclares its own icons.
 // ============================================
+
+import { GLYPH, type StatusKind } from '../support/glyphs.js';
 
 export const theme = {
   accent: 'cyan',
@@ -20,17 +24,37 @@ export const theme = {
   borderActive: 'cyan',
 } as const;
 
+/** Non-status decoration glyphs + the shared status vocabulary (from GLYPH). */
 export const ICON = {
   user: '▸',
   assistant: '◆',
   system: '•',
   tool: '⦿',
-  ok: '✓',
-  fail: '✗',
-  running: '◐',
   prompt: '›',
   git: '⎇',
+  // Status glyphs — single-sourced from support/glyphs. `fail` kept as the
+  // established alias for the error glyph.
+  ok: GLYPH.ok,
+  fail: GLYPH.err,
+  running: GLYPH.running,
+  warn: GLYPH.warn,
+  revise: GLYPH.revise,
+  info: GLYPH.info,
 } as const;
+
+/**
+ * Status semantic → { glyph, Ink color token }. The one map the Ink status
+ * primitives (<StatusIcon>) read, so every board/tree/timeline colors and
+ * glyphs a "running / done / failed / revise" the same way.
+ */
+export const STATUS: Record<StatusKind, { icon: string; color: string }> = {
+  running: { icon: GLYPH.running, color: theme.running },
+  ok: { icon: GLYPH.ok, color: theme.ok },
+  warn: { icon: GLYPH.warn, color: theme.warn },
+  err: { icon: GLYPH.err, color: theme.err },
+  revise: { icon: GLYPH.revise, color: theme.accentAlt },
+  info: { icon: GLYPH.info, color: theme.info },
+};
 
 /** Gradient stops for the OpenSwarm wordmark (ink-gradient `colors`). */
 export const LOGO_GRADIENT = ['#22d3ee', '#3b82f6', '#a855f7'];


### PR DESCRIPTION
Release **v0.11.0**. Bundles the docs/version bump with the TUI/CLI status-consistency refactor.

## Included
- **`review --max --fix`** + concurrency-saturating area distribution (INT-2249, already on main via #183; documented here).
- **Unified CLI/TUI status design (INT-2260)** — single-sourced glyphs (`◐ ✓ ✗ ⚠ ✎`) + braille spinner (`src/support/glyphs.ts`), consumed by both the Ink TUI (`<StatusIcon>`/`<Spinner>` + `theme.STATUS`) and plain console (`status` in `src/support/colors.ts`). The **worker now shows the same animated spinner heartbeat as the reviewer** (was static), `review --max` verdict/`--fix` output is colored consistently (ANSI-free when piped), and drifting glyphs (`▶`→`◐`, `●`→`✓`) + duplicate spinner sets are collapsed.
- README: documents `--fix`/`--concurrency`, adds a Codebase Audit feature bullet, replaces the stale inline changelog with a pointer to CHANGELOG.md.
- package.json 0.10.2 → 0.11.0; CHANGELOG 0.11.0 entry (incl. #182 scheduler fix credit to @ag-linden).

## Verification
- typecheck / build / lint (0 errors) green.
- Full suite green except the 2 pre-existing `service.test.ts` failures (unrelated; fail on `main` too). +`glyphs.test.ts`, updated `reviewProgress.test.ts` for the unified spinner frames.
- Worker spinner confirmed live (braille heartbeat rotates in place); verdict output confirmed ANSI-free when piped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)