### PR TITLE
feat(cli): openswarm fix — CI/test gate fan-out auto-fix until green (INT-2267)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ openswarm review --max --concurrency 8   # widen the fan-out — areas auto-spli
                                  #   (legacy spray) · --issues <id> (set parent) · --fallback
                                  #   <adapter> · --out <file> · --dry-run (print the plan)
 
+# CI / test gate auto-fix
+openswarm fix                    # Run the checks (lint/typecheck/build/test from package.json),
+                                 #   fan a fix-worker out over the failures, re-run until green
+openswarm fix --checks lint,test # only these checks · --concurrency <n> · --rounds <n> (default 3)
+
 # Code Registry & BS Detector
 openswarm check --scan           # Scan repo → register all entities
 openswarm check src/foo.ts       # File brief (entities, tests, risk)
@@ -277,6 +282,7 @@ openswarm dash                # open the web dashboard (:3847)
 - **Autonomous Pipeline** — Cron-driven heartbeat fetches Linear issues, runs Worker/Reviewer pair loops, and updates issue state automatically
 - **Worker/Reviewer Pairs** — Multi-iteration code generation with automated review, testing, and documentation stages
 - **Codebase Audit (`review --max`)** — fans reviewer subagents out over directory-shaped areas (auto-split to fill `--concurrency`), aggregates a deduped verdict into a markdown report, and synthesizes ≤10 cohesive Linear issues via a PM agent. `--fix` sends a worker per flagged area to apply the fixes in the working tree. Language-agnostic; codex usage-limit aware with automatic `claude` fallback
+- **CI / test gate auto-fix (`openswarm fix`)** — runs the project's objective checks (lint / typecheck / build / test), groups the failures by file into areas, fans a fix-worker out over each, then **re-runs the checks and repeats until green** (or the round budget). Deterministic convergence — unlike the review fix pass, it verifies its own work
 - **Decision Engine** — Scope validation, rate limiting, priority-based task selection, and workflow mapping
 - **Cognitive Memory** — LanceDB vector store with Xenova/multilingual-e5-base embeddings for long-term recall across sessions
 - **Repo Knowledge Loop** — workers learn each repository over time: task outcomes (success patterns, review-rejection pitfalls) are stored per-repo and recalled into the next worker prompt

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -296,6 +296,33 @@ program
     }
   });
 
+// openswarm fix — CI/test gate fan-out auto-fix (INT-2267)
+
+program
+  .command('fix')
+  .description('Run the CI/test checks and fan a fix-worker out over the failures, re-running until green')
+  .option('--path <path>', 'Project path (default: cwd)')
+  .option('--checks <list>', 'Comma list of checks (lint,type,build,test); default: all detected in package.json', (v) => v.split(',').map((s) => s.trim()).filter(Boolean))
+  .option('--concurrency <n>', 'Max fix workers in flight (default 4)', (v) => parseInt(v, 10))
+  .option('--rounds <n>', 'Max check → fix → re-check rounds (default 3)', (v) => parseInt(v, 10))
+  .option('--adapter <name>', 'Adapter override for the fix workers')
+  .action(async (opts: { path?: string; checks?: string[]; concurrency?: number; rounds?: number; adapter?: string }) => {
+    try {
+      const { runFixCommand } = await import('./cli/fixCommand.js');
+      const report = await runFixCommand({
+        path: opts.path,
+        checks: opts.checks,
+        concurrency: opts.concurrency,
+        rounds: opts.rounds,
+        adapter: opts.adapter as import('./adapters/types.js').AdapterName | undefined,
+      });
+      if (!report.green) process.exitCode = 1;
+    } catch (e) {
+      console.error(e instanceof Error ? e.message : String(e));
+      process.exitCode = 1;
+    }
+  });
+
 // openswarm exec <prompt>
 
 program

--- a/src/cli/fixCommand.test.ts
+++ b/src/cli/fixCommand.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  resolveChecks,
+  parseFailingFiles,
+  deriveFixAreas,
+  buildFixCheckTask,
+  runFixCommand,
+  type Check,
+  type CheckOutcome,
+  type FixArea,
+} from './fixCommand.js';
+
+describe('resolveChecks (INT-2267)', () => {
+  const scripts = { lint: 'oxlint src/', typecheck: 'tsc --noEmit', build: 'tsc', test: 'vitest run', dev: 'x' };
+
+  it('defaults to the standard checks that have a script, in order', () => {
+    expect(resolveChecks(scripts).map((c) => c.key)).toEqual(['lint', 'typecheck', 'build', 'test']);
+  });
+
+  it('maps requested keys (incl. the `type` alias) and drops unknown/missing', () => {
+    expect(resolveChecks(scripts, ['type', 'test', 'nope']).map((c) => c.key)).toEqual(['typecheck', 'test']);
+  });
+
+  it('resolves to `npm run <script>`', () => {
+    expect(resolveChecks(scripts, ['lint'])[0]).toEqual({ key: 'lint', program: 'npm', args: ['run', 'lint'] });
+  });
+
+  it('drops a requested check with no matching script', () => {
+    expect(resolveChecks({ test: 'vitest' }, ['lint', 'test']).map((c) => c.key)).toEqual(['test']);
+  });
+});
+
+describe('parseFailingFiles (INT-2267)', () => {
+  it('extracts paths from tsc / vitest / eslint output and dedupes', () => {
+    const out = [
+      'src/cli/fixCommand.ts(12,5): error TS2322: bad',
+      ' FAIL  src/cli/fixCommand.test.ts > x',
+      'src/cli/fixCommand.ts:40:1  error  no-unused',
+      './lib/util.py:3: E501',
+    ].join('\n');
+    const files = parseFailingFiles(out).sort();
+    expect(files).toEqual(['lib/util.py', 'src/cli/fixCommand.test.ts', 'src/cli/fixCommand.ts']);
+  });
+
+  it('ignores absolute paths and non-source text', () => {
+    expect(parseFailingFiles('all good, no files here')).toEqual([]);
+    expect(parseFailingFiles('/usr/lib/node/x.js failed')).toEqual([]);
+  });
+});
+
+describe('deriveFixAreas (INT-2267)', () => {
+  const oc = (key: string, files: string[], output = 'boom'): CheckOutcome => ({ key, passed: false, output, files });
+
+  it('partitions blamed files into areas and attaches relevant failures', () => {
+    const areas = deriveFixAreas([oc('typecheck', ['src/a/x.ts', 'src/b/y.ts'])], 4, 12);
+    expect(areas.length).toBeGreaterThanOrEqual(1);
+    expect(areas.flatMap((a) => a.files).sort()).toEqual(['src/a/x.ts', 'src/b/y.ts']);
+    expect(areas[0].failures.join('')).toContain('[typecheck]');
+  });
+
+  it('makes a check:<key> area for a failing check with no parseable files', () => {
+    const areas = deriveFixAreas([oc('build', [], 'Error: config broken')], 4, 12);
+    expect(areas).toHaveLength(1);
+    expect(areas[0].label).toBe('check:build');
+    expect(areas[0].files).toEqual([]);
+    expect(areas[0].failures[0]).toContain('config broken');
+  });
+});
+
+describe('buildFixCheckTask (INT-2267)', () => {
+  const area: FixArea = { label: 'src/a', dir: 'src/a', files: ['src/a/x.ts'], failures: ['[typecheck]\nTS2322'] };
+  const checks: Check[] = [{ key: 'typecheck', program: 'npm', args: ['run', 'typecheck'] }];
+
+  it('scopes to the files, includes the failure, and forbids cheating', () => {
+    const t = buildFixCheckTask(area, checks);
+    expect(t).toContain('src/a/x.ts');
+    expect(t).toContain('TS2322');
+    expect(t).toContain('npm run typecheck');
+    expect(t.toLowerCase()).toContain('do not');
+  });
+});
+
+describe('runFixCommand loop (INT-2267)', () => {
+  const checks: Check[] = [{ key: 'test', program: 'npm', args: ['run', 'test'] }];
+  const silent = { log: () => {}, exists: () => true, checks };
+
+  it('returns green without fixing when everything passes', async () => {
+    const runFixWorker = vi.fn();
+    const report = await runFixCommand(
+      { rounds: 3 },
+      { ...silent, runCheck: async () => ({ passed: true, output: '' }), runFixWorker },
+    );
+    expect(report.green).toBe(true);
+    expect(report.reason).toBe('green');
+    expect(runFixWorker).not.toHaveBeenCalled();
+  });
+
+  it('converges: fail → fix → pass', async () => {
+    let pass = false;
+    const runFixWorker = vi.fn(async () => {
+      pass = true; // the fix makes the next check pass
+      return { success: true, filesChanged: ['src/a/x.ts'] };
+    });
+    const report = await runFixCommand(
+      { rounds: 3 },
+      { ...silent, runCheck: async () => ({ passed: pass, output: 'src/a/x.ts:1 fail' }), runFixWorker },
+    );
+    expect(report.green).toBe(true);
+    expect(runFixWorker).toHaveBeenCalledTimes(1);
+    expect(report.rounds).toHaveLength(2);
+  });
+
+  it('stops on no progress (same failures, no edits)', async () => {
+    const report = await runFixCommand(
+      { rounds: 5 },
+      {
+        ...silent,
+        runCheck: async () => ({ passed: false, output: 'src/a/x.ts:1 fail' }),
+        runFixWorker: async () => ({ success: false, filesChanged: [] }),
+      },
+    );
+    expect(report.green).toBe(false);
+    expect(report.reason).toBe('no-progress');
+  });
+
+  it('gives up after the round budget when it keeps editing but never passes', async () => {
+    const report = await runFixCommand(
+      { rounds: 2 },
+      {
+        ...silent,
+        runCheck: async () => ({ passed: false, output: 'src/a/x.ts:1 fail' }),
+        runFixWorker: async () => ({ success: true, filesChanged: ['src/a/x.ts'] }),
+      },
+    );
+    expect(report.green).toBe(false);
+    expect(report.reason).toBe('out-of-rounds');
+  });
+
+  it('reports no-checks when nothing resolves', async () => {
+    const report = await runFixCommand({}, { log: () => {}, checks: [] });
+    expect(report.reason).toBe('no-checks');
+  });
+});

--- a/src/cli/fixCommand.ts
+++ b/src/cli/fixCommand.ts
@@ -1,0 +1,305 @@
+// ============================================
+// OpenSwarm - `openswarm fix` — CI/test gate fan-out auto-fix (INT-2267)
+// ============================================
+//
+// Run the project's objective checks (lint / typecheck / build / test), group
+// the failures by file into areas, fan a fix-worker out over each area (same
+// concurrency machinery as `review --max`), then RE-RUN the checks and repeat
+// until green or the round budget runs out. Unlike `review --max --fix` (an LLM
+// opinion, no re-verify), the checks are deterministic so the loop can actually
+// converge. Edits land in the working tree — the user reviews the diff.
+//
+// Pure pieces (resolveChecks / parseFailingFiles / deriveFixAreas /
+// buildFixCheckTask) are unit-tested; the orchestration shell wires spawn +
+// runWorker + the concurrency pool (all injectable).
+
+import { execFile } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { balanceAreasToConcurrency } from './reviewAudit.js';
+import { runPool } from '../support/concurrencyPool.js';
+import { startProgressHeartbeat } from './reviewProgress.js';
+import { status, c } from '../support/colors.js';
+import type { AdapterName } from '../adapters/types.js';
+
+/** A resolvable objective check (`npm run lint`, `npm test`, …). */
+export interface Check {
+  key: string;
+  program: string;
+  args: string[];
+}
+
+/** The result of running one check, with the source files its output blamed. */
+export interface CheckOutcome {
+  key: string;
+  passed: boolean;
+  output: string;
+  files: string[];
+}
+
+/** One fix unit: a directory-shaped area plus the failing-check output for it. */
+export interface FixArea {
+  label: string;
+  dir: string;
+  files: string[];
+  failures: string[];
+}
+
+/** The named checks `--checks` understands, mapped to a package.json script. */
+const KNOWN_CHECKS: Record<string, string> = {
+  lint: 'lint',
+  type: 'typecheck',
+  typecheck: 'typecheck',
+  build: 'build',
+  test: 'test',
+};
+const DEFAULT_ORDER = ['lint', 'typecheck', 'build', 'test'];
+
+/**
+ * Resolve named checks to `npm run <script>` commands using the repo's
+ * package.json scripts. `requested` is the `--checks` list (keys); when omitted,
+ * every default check that has a script is used. Unknown/missing scripts are
+ * dropped. Pure.
+ */
+export function resolveChecks(scripts: Record<string, string>, requested?: string[]): Check[] {
+  const keys = requested?.length
+    ? requested.map((k) => KNOWN_CHECKS[k.trim()] ?? k.trim())
+    : DEFAULT_ORDER.filter((k) => k in scripts);
+  const seen = new Set<string>();
+  const checks: Check[] = [];
+  for (const script of keys) {
+    if (seen.has(script) || !(script in scripts)) continue;
+    seen.add(script);
+    checks.push({ key: script, program: 'npm', args: ['run', script] });
+  }
+  return checks;
+}
+
+/** Read `<cwd>/package.json` scripts (empty when absent/unparseable). */
+export function readScripts(cwd: string): Record<string, string> {
+  try {
+    const pkg = JSON.parse(readFileSync(join(cwd, 'package.json'), 'utf8'));
+    return pkg.scripts && typeof pkg.scripts === 'object' ? pkg.scripts : {};
+  } catch {
+    return {};
+  }
+}
+
+const SOURCE_EXT = 'tsx?|jsx?|mjs|cjs|py|rs|go|java|kt|kts|scala|rb|php|swift|c|cc|cpp|cxx|h|hpp|cs|ex|exs|lua|jl|zig|nim';
+const FILE_RE = new RegExp(String.raw`(?:^|[\s('"\`])((?:[\w.\-]+\/)*[\w.\-]+\.(?:${SOURCE_EXT}))`, 'g');
+
+/**
+ * Extract repo-relative source file paths mentioned in check output — the files
+ * to hand the fix worker. Language-agnostic: matches any path ending in a source
+ * extension (tsc `file.ts(1,2)`, vitest `FAIL file.test.ts`, eslint `file:1:1`,
+ * pytest `file.py::test`). Pure; caller filters to files that exist. Deduped,
+ * `./` stripped.
+ */
+export function parseFailingFiles(output: string): string[] {
+  const out = new Set<string>();
+  for (const m of output.matchAll(FILE_RE)) {
+    let p = m[1];
+    while (p.startsWith('./')) p = p.slice(2);
+    if (p && !p.startsWith('/')) out.add(p);
+  }
+  return [...out];
+}
+
+const truncate = (s: string, n: number): string => (s.length <= n ? s : `…${s.slice(-n)}`);
+
+/**
+ * Group failing checks into fix areas. Files blamed across the failing checks
+ * are partitioned into directory areas (sized to fill the pool); each area
+ * carries the check output relevant to its files. A failing check whose output
+ * has no parseable file (e.g. a bare build error) becomes its own `check:<key>`
+ * area with the raw output. Pure.
+ */
+export function deriveFixAreas(failing: CheckOutcome[], concurrency: number, maxFilesPerArea = 8): FixArea[] {
+  const areas: FixArea[] = [];
+  const allFiles = [...new Set(failing.flatMap((f) => f.files))];
+
+  if (allFiles.length) {
+    for (const a of balanceAreasToConcurrency(allFiles, concurrency, maxFilesPerArea)) {
+      const relevant = failing.filter((f) => f.files.some((file) => a.files.includes(file)));
+      const src = relevant.length ? relevant : failing;
+      areas.push({
+        label: a.label,
+        dir: a.dir,
+        files: a.files,
+        failures: src.map((f) => `[${f.key}]\n${truncate(f.output, 3000)}`),
+      });
+    }
+  }
+
+  for (const f of failing.filter((f) => f.files.length === 0)) {
+    areas.push({ label: `check:${f.key}`, dir: '.', files: [], failures: [`[${f.key}]\n${truncate(f.output, 3000)}`] });
+  }
+  return areas;
+}
+
+/** Build the fix worker's task: the failing output + a hard "verify, don't cheat" rule. */
+export function buildFixCheckTask(area: FixArea, checks: Check[]): string {
+  const verify = checks.map((c) => `${c.program} ${c.args.join(' ')}`).join(' && ');
+  return [
+    `The project's checks are failing. Apply the MINIMAL edits needed to make them pass.`,
+    area.files.length
+      ? `Files in scope (edit only these — the failures are theirs):\n${area.files.map((f) => `- ${f}`).join('\n')}`
+      : `No single file scope — find and fix the root cause of the failure below.`,
+    ``,
+    `Failing check output:`,
+    ...area.failures.map((f) => '```\n' + f + '\n```'),
+    ``,
+    `Re-run \`${verify}\` to confirm before finishing. Do NOT weaken, skip, or delete tests/checks to make them pass — fix the actual cause.`,
+  ].join('\n');
+}
+
+// ── Orchestration ────────────────────────────────────────────────────────────
+
+export interface FixOptions {
+  path?: string;
+  checks?: string[];
+  concurrency?: number;
+  rounds?: number;
+  adapter?: AdapterName;
+  maxFilesPerArea?: number;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+export interface FixDeps {
+  /** Run one check → {passed, output}. Default spawns the command. Injectable. */
+  runCheck?: (check: Check, cwd: string) => Promise<{ passed: boolean; output: string }>;
+  /** Apply one area's fixes → {success, filesChanged}. Default spawns a worker. Injectable. */
+  runFixWorker?: (area: FixArea, checks: Check[], onLog: (l: string) => void) => Promise<{ success: boolean; filesChanged: string[] }>;
+  /** Override the resolved checks (tests). */
+  checks?: Check[];
+  /** File-existence predicate (tests). Default fs.existsSync under cwd. */
+  exists?: (relPath: string, cwd: string) => boolean;
+  log?: (line: string) => void;
+}
+
+export interface RoundReport {
+  round: number;
+  outcomes: CheckOutcome[];
+  filesChanged: string[];
+}
+export interface FixReport {
+  green: boolean;
+  rounds: RoundReport[];
+  reason?: 'green' | 'out-of-rounds' | 'no-progress' | 'no-checks';
+}
+
+/** Default check runner: spawn the command, capture combined output, pass = exit 0. */
+async function defaultRunCheck(check: Check, cwd: string): Promise<{ passed: boolean; output: string }> {
+  return new Promise((resolve) => {
+    execFile(check.program, check.args, { cwd, maxBuffer: 32 * 1024 * 1024 }, (err, stdout, stderr) => {
+      resolve({ passed: !err, output: `${stdout ?? ''}${stderr ?? ''}` });
+    });
+  });
+}
+
+async function defaultRunFixWorker(
+  area: FixArea,
+  checks: Check[],
+  cwd: string,
+  opts: FixOptions,
+  onLog: (l: string) => void,
+): Promise<{ success: boolean; filesChanged: string[] }> {
+  const { runWorker } = await import('../agents/worker.js');
+  const r = await runWorker({
+    taskTitle: `Fix failing checks: ${area.label}`,
+    taskDescription: buildFixCheckTask(area, checks),
+    projectPath: cwd,
+    adapterName: opts.adapter,
+    timeoutMs: opts.timeoutMs,
+    nudgeMaxOnNoEdit: 1,
+    signal: opts.signal,
+    onLog,
+  });
+  return { success: r.success, filesChanged: r.filesChanged };
+}
+
+/** Run every check (sequentially — they contend for CPU/FS), blaming files from output. */
+async function runAllChecks(
+  checks: Check[],
+  cwd: string,
+  runCheck: NonNullable<FixDeps['runCheck']>,
+  exists: (p: string, cwd: string) => boolean,
+  log: (l: string) => void,
+): Promise<CheckOutcome[]> {
+  const outcomes: CheckOutcome[] = [];
+  for (const check of checks) {
+    const tty = !!process.stderr.isTTY;
+    const hb = tty ? startProgressHeartbeat(`${check.key}…`) : null;
+    const { passed, output } = await runCheck(check, cwd);
+    hb?.stop();
+    const files = passed ? [] : parseFailingFiles(output).filter((f) => exists(f, cwd));
+    outcomes.push({ key: check.key, passed, output, files });
+    log(passed ? `  ${status.ok(check.key)}` : `  ${status.err(`${check.key} — ${files.length} file(s)`)}`);
+  }
+  return outcomes;
+}
+
+/**
+ * Run checks → fan out fixes → re-run, until green or the round/progress budget
+ * is spent. Returns a structured report; the CLI turns it into an exit code.
+ */
+export async function runFixCommand(opts: FixOptions = {}, deps: FixDeps = {}): Promise<FixReport> {
+  const cwd = opts.path ?? process.cwd();
+  const concurrency = Math.max(1, opts.concurrency ?? 4);
+  const maxRounds = Math.max(1, opts.rounds ?? 3);
+  const log = deps.log ?? ((l: string) => console.log(l));
+  const exists = deps.exists ?? ((p, base) => existsSync(join(base, p)));
+  const runCheck = deps.runCheck ?? defaultRunCheck;
+  const runFixWorker = deps.runFixWorker ?? ((area, checks, onLog) => defaultRunFixWorker(area, checks, cwd, opts, onLog));
+  const checks = deps.checks ?? resolveChecks(readScripts(cwd), opts.checks);
+
+  if (!checks.length) {
+    log(status.warn('No checks resolved — add lint/typecheck/build/test scripts to package.json, or pass --checks.'));
+    return { green: false, rounds: [], reason: 'no-checks' };
+  }
+
+  log(c.bold(`\nRunning ${checks.length} check(s): ${checks.map((ch) => ch.key).join(', ')} · concurrency ${concurrency} · up to ${maxRounds} round(s)\n`));
+
+  const rounds: RoundReport[] = [];
+  let prevFailKey = '';
+
+  for (let round = 1; round <= maxRounds; round++) {
+    log(c.dim(`── round ${round}/${maxRounds} ──`));
+    const outcomes = await runAllChecks(checks, cwd, runCheck, exists, log);
+    const failing = outcomes.filter((o) => !o.passed);
+
+    if (!failing.length) {
+      rounds.push({ round, outcomes, filesChanged: [] });
+      log(`\n${status.ok(`All ${checks.length} check(s) passing.`)}`);
+      return { green: true, rounds, reason: 'green' };
+    }
+
+    if (round === maxRounds) {
+      rounds.push({ round, outcomes, filesChanged: [] });
+      break;
+    }
+
+    const areas = deriveFixAreas(failing, concurrency, opts.maxFilesPerArea);
+    log(`\nFixing ${failing.length} failing check(s) across ${areas.length} area(s)...`);
+    const settled = await runPool(areas, concurrency, async (area) => {
+      const r = await runFixWorker(area, checks, () => {});
+      log(r.filesChanged.length ? `  ${status.ok(`${area.label} — ${r.filesChanged.length} file(s)`)}` : `  ${status.warn(`${area.label} — no edit`)}`);
+      return r;
+    });
+    const filesChanged = [...new Set(settled.flatMap((s) => s.value?.filesChanged ?? []))];
+    rounds.push({ round, outcomes, filesChanged });
+
+    const failKey = failing.map((f) => f.key).sort().join(',');
+    if (failKey === prevFailKey && filesChanged.length === 0) {
+      log(`\n${status.warn('No progress this round (same failures, no edits) — stopping.')}`);
+      return { green: false, rounds, reason: 'no-progress' };
+    }
+    prevFailKey = failKey;
+  }
+
+  const lastFailing = rounds.at(-1)?.outcomes.filter((o) => !o.passed) ?? [];
+  log(`\n${status.err(`Still failing after ${maxRounds} round(s): ${lastFailing.map((o) => o.key).join(', ')}.`)}`);
+  log(c.dim('Changes are in the working tree — review the diff.'));
+  return { green: false, rounds, reason: 'out-of-rounds' };
+}


### PR DESCRIPTION
## Summary
Brings `review --max`'s fan-out to the **objective checks**. Test runners and linters already parallelize, so the value isn't fanning out the *checks* — it's fanning out a **fix-worker per failing area** and, unlike the review fix pass, **re-running the deterministic checks until they actually pass**.

```
openswarm fix [--checks lint,type,build,test] [--concurrency N] [--rounds 3] [--adapter …]
```

1. Resolve checks from `package.json` scripts; run them.
2. Parse blamed source files from each failing check's output (language-agnostic regex — handles tsc / vitest / eslint / pytest shapes), group by directory into pool-sized areas (`balanceAreasToConcurrency`).
3. Fan a fix-worker out over each area (`runWorker`) with the failure output + file scope + a hard "don't weaken/skip/delete checks" rule. Edits land in the **working tree** (review the diff).
4. Re-run the checks. Stop when **green**, on **no-progress** (same failures + no edits), or after `--rounds`. Exit 1 while red.

Deterministic convergence is the key difference from `review --max --fix` (which is an LLM opinion and doesn't re-verify).

## New / changed
- `src/cli/fixCommand.ts` — pure `resolveChecks` / `parseFailingFiles` / `deriveFixAreas` / `buildFixCheckTask` + the injectable `runFixCommand` loop.
- `src/cli.ts` — `fix` command registration.
- README — CLI block + feature bullet.
- Reuses the review fan-out machinery and the shared status/spinner primitives (INT-2260).

## Verification
- typecheck / build / lint (0 errors) green.
- +14 unit tests (check resolution, file parsing, area derivation, prompt, and the convergence loop via injected deps — green / fail→fix→pass / no-progress / out-of-rounds / no-checks).
- Green path (`fix --checks lint`) and failing path (temp repo, `--rounds 1`) smoke-tested end-to-end with **zero agent cost**.
- Full suite: only the 2 pre-existing `service.test.ts` failures remain (unrelated).

## Follow-ups (noted, out of scope)
- Non-JS check resolution via `openswarm.json` `checks` config.
- A live Ink board for the fix rounds (currently console + shared `status`).
- A shared fan-out abstraction unifying `review --max` and `fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)