### PR TITLE
release: v0.12.0 — openswarm fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.12.0 — 2026-07-01
+
+### Added
+
+- **`openswarm fix`** — bring `review --max`'s fan-out to the objective checks. Runs the project's checks (lint / typecheck / build / test, resolved from `package.json` scripts; `--checks` to select a subset), groups the failures by file into areas, fans a **fix-worker out over each area**, then **re-runs the checks and repeats until green** (or the `--rounds` budget; default 3). Edits land in the working tree — you review the diff. Unlike `review --max --fix` (an LLM opinion, no re-verify), the checks are deterministic so the loop verifies its own work and converges; it stops on no-progress (same failures + no edits) and exits non-zero while red. `--concurrency <n>`, `--adapter <name>`. (INT-2267)
+
 ## 0.11.0 — 2026-07-01
 
 Wider, faster codebase audits — plus the audit can now fix what it finds.

--- a/README.md
+++ b/README.md
@@ -512,9 +512,8 @@ the CLI (fire-and-forget with a short timeout, and failures are silently ignored
 Full version history lives in **[CHANGELOG.md](CHANGELOG.md)** and the
 [GitHub Releases](https://github.com/unohee/OpenSwarm/releases) page.
 
-Latest — **v0.11.0**: `review --max --fix` (a worker per flagged area applies the
-audit fixes in the working tree) and concurrency-saturating area distribution
-(areas auto-split to fill `--concurrency`). See CHANGELOG.md for the rest.
+Latest — **v0.12.0**: `openswarm fix` — run the CI/test checks, fan a fix-worker
+out over the failures, and re-run until green. See CHANGELOG.md for the rest.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Release v0.12.0. Version bump + CHANGELOG for `openswarm fix` (INT-2267, merged via #185).

🤖 Generated with [Claude Code](https://claude.com/claude-code)