### PR TITLE
feat(memory): CLI agent runs grow repo knowledge (run/fix/review --max) (INT-2268)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,6 +57,7 @@ program
   .option('--worker-only', 'Worker only, no review')
   .option('--max-iterations <n>', 'Max retry iterations', parseInt)
   .option('-v, --verbose', 'Enable detailed execution logging')
+  .option('--no-learn', 'Do not record this run into the repo knowledge memory')
   .action(async (task: string, opts: {
     path?: string;
     model?: string;
@@ -64,6 +65,7 @@ program
     workerOnly?: boolean;
     maxIterations?: number;
     verbose?: boolean;
+    learn?: boolean;
   }) => {
     await runCli({
       task,
@@ -73,6 +75,7 @@ program
       workerOnly: opts.workerOnly,
       maxIterations: opts.maxIterations,
       verbose: opts.verbose,
+      learn: opts.learn,
     });
   });
 
@@ -259,10 +262,11 @@ program
   .option('--fallback <adapter>', 'For --max: retry usage-limited areas on this adapter (default: claude for codex)')
   .option('--no-fallback', 'For --max: disable the automatic usage-limit fallback')
   .option('--fix', 'For --max: apply the reviewer fixes to each flagged area (working tree only, no commit)')
+  .option('--no-learn', 'For --max: do not record the audit findings into the repo knowledge memory')
   .action(async (opts: {
     path?: string; issues?: string | boolean; issuesPerArea?: string | boolean; file?: string | boolean; adapter?: string; debug?: boolean;
     max?: boolean; concurrency?: number; maxFilesPerArea?: number; yes?: boolean; dryRun?: boolean;
-    out?: string; linear?: boolean; fallback?: string | boolean; fix?: boolean;
+    out?: string; linear?: boolean; fallback?: string | boolean; fix?: boolean; learn?: boolean;
   }) => {
     try {
       if (opts.max) {
@@ -283,6 +287,7 @@ program
           fallbackAdapter: typeof opts.fallback === 'string' ? opts.fallback : undefined,
           noFallback: opts.fallback === false,
           fix: opts.fix,
+          learn: opts.learn,
         });
         if (result && result.decision === 'reject') process.exitCode = 1;
         return;
@@ -306,7 +311,8 @@ program
   .option('--concurrency <n>', 'Max fix workers in flight (default 4)', (v) => parseInt(v, 10))
   .option('--rounds <n>', 'Max check → fix → re-check rounds (default 3)', (v) => parseInt(v, 10))
   .option('--adapter <name>', 'Adapter override for the fix workers')
-  .action(async (opts: { path?: string; checks?: string[]; concurrency?: number; rounds?: number; adapter?: string }) => {
+  .option('--no-learn', 'Do not record a successful fix into the repo knowledge memory')
+  .action(async (opts: { path?: string; checks?: string[]; concurrency?: number; rounds?: number; adapter?: string; learn?: boolean }) => {
     try {
       const { runFixCommand } = await import('./cli/fixCommand.js');
       const report = await runFixCommand({
@@ -315,6 +321,7 @@ program
         concurrency: opts.concurrency,
         rounds: opts.rounds,
         adapter: opts.adapter as import('./adapters/types.js').AdapterName | undefined,
+        learn: opts.learn,
       });
       if (!report.green) process.exitCode = 1;
     } catch (e) {

--- a/src/cli/fixCommand.test.ts
+++ b/src/cli/fixCommand.test.ts
@@ -82,7 +82,7 @@ describe('buildFixCheckTask (INT-2267)', () => {
 
 describe('runFixCommand loop (INT-2267)', () => {
   const checks: Check[] = [{ key: 'test', program: 'npm', args: ['run', 'test'] }];
-  const silent = { log: () => {}, exists: () => true, checks };
+  const silent = { log: () => {}, exists: () => true, checks, recordOutcome: async () => {} };
 
   it('returns green without fixing when everything passes', async () => {
     const runFixWorker = vi.fn();
@@ -139,5 +139,48 @@ describe('runFixCommand loop (INT-2267)', () => {
   it('reports no-checks when nothing resolves', async () => {
     const report = await runFixCommand({}, { log: () => {}, checks: [] });
     expect(report.reason).toBe('no-checks');
+  });
+
+  it('records the outcome into repo knowledge on green after edits (INT-2268)', async () => {
+    let pass = false;
+    const recordOutcome = vi.fn(async () => {});
+    await runFixCommand(
+      { rounds: 3 },
+      {
+        ...silent,
+        recordOutcome,
+        runCheck: async () => ({ passed: pass, output: 'src/a/x.ts:1 fail' }),
+        runFixWorker: async () => {
+          pass = true;
+          return { success: true, filesChanged: ['src/a/x.ts'] };
+        },
+      },
+    );
+    expect(recordOutcome).toHaveBeenCalledTimes(1);
+    expect(recordOutcome.mock.calls[0][0].filesChanged).toEqual(['src/a/x.ts']);
+  });
+
+  it('does not record when already green (nothing was edited)', async () => {
+    const recordOutcome = vi.fn(async () => {});
+    await runFixCommand({ rounds: 3 }, { ...silent, recordOutcome, runCheck: async () => ({ passed: true, output: '' }) });
+    expect(recordOutcome).not.toHaveBeenCalled();
+  });
+
+  it('does not record when --no-learn (learn: false)', async () => {
+    let pass = false;
+    const recordOutcome = vi.fn(async () => {});
+    await runFixCommand(
+      { rounds: 3, learn: false },
+      {
+        ...silent,
+        recordOutcome,
+        runCheck: async () => ({ passed: pass, output: 'src/a/x.ts:1 fail' }),
+        runFixWorker: async () => {
+          pass = true;
+          return { success: true, filesChanged: ['src/a/x.ts'] };
+        },
+      },
+    );
+    expect(recordOutcome).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/fixCommand.ts
+++ b/src/cli/fixCommand.ts
@@ -164,6 +164,8 @@ export interface FixOptions {
   maxFilesPerArea?: number;
   timeoutMs?: number;
   signal?: AbortSignal;
+  /** Record a successful fix into repo knowledge (default true; --no-learn opts out). (INT-2268) */
+  learn?: boolean;
 }
 
 export interface FixDeps {
@@ -175,6 +177,8 @@ export interface FixDeps {
   checks?: Check[];
   /** File-existence predicate (tests). Default fs.existsSync under cwd. */
   exists?: (relPath: string, cwd: string) => boolean;
+  /** Record a green fix into repo knowledge. Default writes via recordTaskOutcome; tests pass a noop. */
+  recordOutcome?: (info: { taskTitle: string; filesChanged: string[]; summary: string }) => Promise<void>;
   log?: (line: string) => void;
 }
 
@@ -253,6 +257,16 @@ export async function runFixCommand(opts: FixOptions = {}, deps: FixDeps = {}): 
   const runCheck = deps.runCheck ?? defaultRunCheck;
   const runFixWorker = deps.runFixWorker ?? ((area, checks, onLog) => defaultRunFixWorker(area, checks, cwd, opts, onLog));
   const checks = deps.checks ?? resolveChecks(readScripts(cwd), opts.checks);
+  const recordOutcome =
+    deps.recordOutcome ??
+    (async (info) => {
+      const { recordTaskOutcome } = await import('../memory/repoKnowledge.js');
+      await recordTaskOutcome(cwd, {
+        taskTitle: info.taskTitle,
+        workerResult: { filesChanged: info.filesChanged, commands: [], summary: info.summary },
+        derivedFrom: 'cli:fix',
+      });
+    });
 
   if (!checks.length) {
     log(status.warn('No checks resolved — add lint/typecheck/build/test scripts to package.json, or pass --checks.'));
@@ -272,6 +286,16 @@ export async function runFixCommand(opts: FixOptions = {}, deps: FixDeps = {}): 
     if (!failing.length) {
       rounds.push({ round, outcomes, filesChanged: [] });
       log(`\n${status.ok(`All ${checks.length} check(s) passing.`)}`);
+      // Learn: record what made the checks pass (skipped when nothing was edited —
+      // an already-green repo has nothing to learn). (INT-2268)
+      const changed = [...new Set(rounds.flatMap((r) => r.filesChanged))];
+      if (opts.learn !== false && changed.length) {
+        await recordOutcome({
+          taskTitle: `Fixed checks: ${checks.map((ch) => ch.key).join(', ')}`,
+          filesChanged: changed,
+          summary: `Made ${checks.map((ch) => ch.key).join(', ')} pass after ${round} round(s).`,
+        }).catch(() => {});
+      }
       return { green: true, rounds, reason: 'green' };
     }
 

--- a/src/cli/reviewMaxCommand.tsx
+++ b/src/cli/reviewMaxCommand.tsx
@@ -59,6 +59,8 @@ export interface ReviewMaxOptions {
   noFallback?: boolean;
   /** Apply the reviewer's fixes to each non-approve area (working tree only). (INT-2249) */
   fix?: boolean;
+  /** Record the audit findings into repo knowledge (default true; --no-learn opts out). (INT-2268) */
+  learn?: boolean;
 }
 
 /**
@@ -272,6 +274,18 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
     await filePmSynthesizedIssues(cwd, opts, run.summary, report, ts);
   } else if (run.summary.recommendedActions.length) {
     console.log(`\n${run.summary.recommendedActions.length} follow-up(s) — captured in the report (--no-linear).`);
+  }
+
+  // (5) Learn: record the audit's top findings as one repo constraint so the
+  // next worker/reviewer knows this repo's known pitfalls. One memory (capped),
+  // not one-per-finding. (INT-2268)
+  if (opts.learn !== false && run.summary.recommendedActions.length) {
+    try {
+      const { recordAuditFindings } = await import('../memory/repoKnowledge.js');
+      await recordAuditFindings(cwd, { decision: run.summary.decision, recommendedActions: run.summary.recommendedActions });
+    } catch {
+      // recordAuditFindings is already non-throwing.
+    }
   }
 
   return { decision: run.summary.decision };

--- a/src/memory/repoKnowledge.ts
+++ b/src/memory/repoKnowledge.ts
@@ -12,7 +12,7 @@
 import { realpathSync } from 'node:fs';
 import path from 'node:path';
 import { saveMemory, searchMemorySafe } from './memoryCore.js';
-import type { WorkerResult } from '../agents/agentPair.js';
+import type { WorkerResult, RecommendedAction } from '../agents/agentPair.js';
 
 /**
  * Normalize a project path into a stable repo key. The LanceDB repo filter is
@@ -164,5 +164,40 @@ export async function recordTaskOutcome(
   } catch (err) {
     // Memory write failures must never stop the pipeline
     console.warn('[RepoKnowledge] recordTaskOutcome failed (non-critical):', err);
+  }
+}
+
+/**
+ * Record the outcome of a `review --max` audit as ONE repo constraint — the
+ * verdict plus the top follow-ups, so the next worker/reviewer knows this repo's
+ * known pitfalls. Capped at 10 actions on purpose: an audit can surface hundreds
+ * of findings and storing each would flood the repo memory. Non-critical.
+ * (INT-2268)
+ */
+export async function recordAuditFindings(
+  projectPath: string,
+  summary: { decision: string; recommendedActions: RecommendedAction[] },
+  stamp?: string,
+): Promise<void> {
+  try {
+    if (!summary.recommendedActions.length) return;
+    const repo = repoKey(projectPath);
+    const top = summary.recommendedActions.slice(0, 10);
+    const when = stamp ?? new Date().toISOString().slice(0, 10);
+    const body = [
+      `Codebase audit verdict: ${summary.decision.toUpperCase()} (${when}).`,
+      `Known issues / follow-ups to be aware of in this repo:`,
+      ...top.map((a) => `- [${a.type}] ${a.title}${a.location ? ` (${a.location})` : ''}`),
+      summary.recommendedActions.length > top.length ? `(+${summary.recommendedActions.length - top.length} more — see the audit report)` : '',
+    ]
+      .filter(Boolean)
+      .join('\n');
+    await saveMemory('constraint', repo, `Audit findings (${when})`, body, {
+      derivedFrom: 'cli:review-max',
+      isVerified: true,
+      skipDistillation: true,
+    });
+  } catch (err) {
+    console.warn('[RepoKnowledge] recordAuditFindings failed (non-critical):', err);
   }
 }

--- a/src/runners/cliRunner.ts
+++ b/src/runners/cliRunner.ts
@@ -25,6 +25,8 @@ export interface CliRunOptions {
   workerOnly?: boolean;
   maxIterations?: number;
   verbose?: boolean;
+  /** Record the outcome into repo knowledge (default true; --no-learn opts out). (INT-2268) */
+  learn?: boolean;
 }
 
 // Helpers
@@ -194,6 +196,26 @@ export async function runCli(options: CliRunOptions): Promise<void> {
 
   // 10. Format & print result
   printResult(result);
+
+  // 10.5. Learn: record the outcome into repo knowledge so a standalone `run`
+  // grows the codebase memory like the daemon does (default on; --no-learn opts
+  // out for throwaway/exploratory runs). Non-critical. (INT-2268)
+  if (options.learn !== false) {
+    try {
+      const { recordTaskOutcome } = await import('../memory/repoKnowledge.js');
+      await recordTaskOutcome(projectPath, {
+        taskTitle: options.task,
+        workerResult: result.workerResult
+          ? { filesChanged: result.workerResult.filesChanged, commands: result.workerResult.commands, summary: result.workerResult.summary }
+          : null,
+        rejectionFeedback: result.finalStatus === 'rejected' ? result.reviewResult?.feedback : undefined,
+        iterations: result.iterations,
+        derivedFrom: 'cli:run',
+      });
+    } catch {
+      // recordTaskOutcome is already non-throwing; belt-and-suspenders.
+    }
+  }
 
   // 11. Exit code
   process.exit(result.success ? 0 : 1);


### PR DESCRIPTION
## Why
The repo knowledge write path (`recordTaskOutcome`) was wired **only into the autonomous daemon**, so standalone CLI agent runs *read* repo knowledge (recall into the worker prompt) but never *grew* it. This closes that gap.

## What
All three CLI agent paths now record into repo knowledge — **default on**, `--no-learn` to opt out:
- **`run`** (cliRunner) — `recordTaskOutcome` after the pipeline: success → `system_pattern`, reviewer reject → `constraint`. `derivedFrom: cli:run`.
- **`fix`** (fixCommand) — on green with edits, records what made the checks pass. Injectable `recordOutcome` (tests noop); skipped when already green.
- **`review --max`** — new `recordAuditFindings`: the verdict + top follow-ups as **ONE** repo constraint (capped at 10, not one-per-finding) so an audit's hundreds of findings can't flood the memory.

## Pollution guards
- `recordTaskOutcome` already only writes on success+files-changed or a rejection (no-op otherwise).
- `review --max` capped to one memory.
- `--no-learn` for exploratory / dirty-tree runs.

## Not a silent no-op — verified
`saveMemory` lazily calls `initDatabase()`, so CLI context persists without extra init. Verified end-to-end: `recordAuditFindings` → `searchRepoMemoryText` round-trips the exact constraint (`[constraint] Audit findings … null deref in parseUser (src/x.ts:5)`).

## Verification
- typecheck / build / lint (0 errors) green.
- +3 tests (records on green+edits, not on already-green, not with `--no-learn`).
- Full suite: only the 2 pre-existing `service.test.ts` failures remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)