### PR TITLE
release: v0.13.0 — CLI agent runs grow repo knowledge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.13.0 — 2026-07-01
+
+### Added
+
+- **CLI agent runs now grow repo knowledge** — `openswarm run`, `openswarm fix`, and `openswarm review --max` record into the per-repo knowledge memory (previously only the autonomous daemon did). A standalone run makes the codebase memory grow and gets recalled into the next worker/reviewer prompt: `run` records the task outcome (success pattern / review-rejection pitfall), `fix` records what made the checks pass, and `review --max` records the verdict + top follow-ups as **one capped constraint** (≤10, so hundreds of findings can't flood the memory). Default on; `--no-learn` opts out per command for throwaway/exploratory runs. (INT-2268)
+
 ## 0.12.0 — 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -512,8 +512,9 @@ the CLI (fire-and-forget with a short timeout, and failures are silently ignored
 Full version history lives in **[CHANGELOG.md](CHANGELOG.md)** and the
 [GitHub Releases](https://github.com/unohee/OpenSwarm/releases) page.
 
-Latest — **v0.12.0**: `openswarm fix` — run the CI/test checks, fan a fix-worker
-out over the failures, and re-run until green. See CHANGELOG.md for the rest.
+Latest — **v0.13.0**: CLI agent runs (`run` / `fix` / `review --max`) now grow the
+per-repo knowledge memory, not just the daemon (`--no-learn` opts out). See
+CHANGELOG.md for the rest.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Release v0.13.0. Version bump + CHANGELOG for INT-2268 (merged via #187).

🤖 Generated with [Claude Code](https://claude.com/claude-code)