### PR TITLE
feat(ci): auto-release on version bump + CLI update notifier (INT-2270)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+# Auto-release on a version bump: when a merge to main changes package.json and
+# the version has no tag yet, gate → publish to npm → tag → GitHub release.
+# So the release flow is just "merge a version-bump PR". (INT-2270)
+#
+# Requires a repo secret NPM_TOKEN (npm automation token). GITHUB_TOKEN is
+# provided automatically for the tag + release.
+
+on:
+  push:
+    branches: [main]
+    paths: ['package.json']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  NODE_VERSION: '22'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version and whether it is already released
+        id: ver
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "v$VERSION already tagged — nothing to release."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Releasing v$VERSION."
+          fi
+
+      - uses: actions/setup-node@v4
+        if: steps.ver.outputs.exists == 'false'
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - if: steps.ver.outputs.exists == 'false'
+        run: npm ci
+
+      # Hard gates — a red one blocks the release.
+      - if: steps.ver.outputs.exists == 'false'
+        run: npm run lint
+      - if: steps.ver.outputs.exists == 'false'
+        run: npm run typecheck
+      - if: steps.ver.outputs.exists == 'false'
+        run: npm run build
+
+      # Advisory (matches ci.yml until the 2 known service.test failures are
+      # resolved — INT-2271). Promote to a hard gate once green.
+      - if: steps.ver.outputs.exists == 'false'
+        run: npm test
+        continue-on-error: true
+
+      - name: Publish to npm
+        if: steps.ver.outputs.exists == 'false'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag and GitHub release
+        if: steps.ver.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+          # Extract this version's CHANGELOG section for the release notes.
+          NOTES=$(awk -v v="## $VERSION" '$0 ~ "^"v" " {f=1; next} /^## / {f=0} f' CHANGELOG.md)
+          if [ -z "$NOTES" ]; then NOTES="Release v$VERSION"; fi
+          gh release create "v$VERSION" --title "v$VERSION" --notes "$NOTES"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import { runCli } from './runners/cliRunner.js';
 import { loadConfig, validateConfig, generateSampleConfig } from './core/config.js';
 import { loadEnvFile } from './core/envFile.js';
 import { initTelemetry, track } from './telemetry/telemetry.js';
+import { maybeNotifyUpdate } from './support/updateNotifier.js';
 
 // Load .env so CLI commands (e.g. `auth login --provider linear` reading
 // LINEAR_OAUTH_CLIENT_ID) see the same env the daemon does. Idempotent; never
@@ -673,4 +674,7 @@ program.action(launchChatTui);
 
 // Parse & Execute
 
+// Surface an "update available" notice (cached, TTY-only, never blocking on the
+// network for more than a moment) before dispatching the command. (INT-2270)
+await maybeNotifyUpdate(VERSION);
 program.parse();

--- a/src/support/updateNotifier.test.ts
+++ b/src/support/updateNotifier.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import { isNewer, shouldSkip, maybeNotifyUpdate } from './updateNotifier.js';
+
+describe('isNewer (INT-2270)', () => {
+  it('compares semver numerically', () => {
+    expect(isNewer('0.13.0', '0.12.0')).toBe(true);
+    expect(isNewer('0.12.1', '0.12.0')).toBe(true);
+    expect(isNewer('1.0.0', '0.99.99')).toBe(true);
+    expect(isNewer('0.12.0', '0.12.0')).toBe(false);
+    expect(isNewer('0.11.9', '0.12.0')).toBe(false);
+  });
+  it('ignores pre-release tags', () => {
+    expect(isNewer('0.13.0-beta.1', '0.13.0')).toBe(false);
+  });
+});
+
+describe('shouldSkip (INT-2270)', () => {
+  const tty = true;
+  it('skips non-TTY, CI, opt-out, and meta commands', () => {
+    expect(shouldSkip(['n', 'c', 'run'], {}, false)).toBe(true); // non-TTY
+    expect(shouldSkip(['n', 'c', 'run'], { CI: '1' }, tty)).toBe(true);
+    expect(shouldSkip(['n', 'c', 'run'], { NO_UPDATE_NOTIFIER: '1' }, tty)).toBe(true);
+    expect(shouldSkip(['n', 'c', '--version'], {}, tty)).toBe(true);
+    expect(shouldSkip(['n', 'c', 'review', '--help'], {}, tty)).toBe(true);
+  });
+  it('does not skip a normal interactive command', () => {
+    expect(shouldSkip(['n', 'c', 'run', 'do a thing'], {}, tty)).toBe(false);
+    expect(shouldSkip(['n', 'c'], {}, tty)).toBe(false); // default TUI
+  });
+});
+
+describe('maybeNotifyUpdate (INT-2270)', () => {
+  const base = { argv: ['n', 'c', 'run'], env: {} as NodeJS.ProcessEnv, isTTY: true };
+
+  it('notifies from a fresh cache without fetching', async () => {
+    const write = vi.fn();
+    const fetchLatest = vi.fn();
+    await maybeNotifyUpdate('0.12.0', {
+      ...base,
+      readCache: () => ({ latest: '0.13.0', checkedAt: 1000 }),
+      now: () => 1000 + 60_000, // 1 min later — fresh
+      fetchLatest,
+      write,
+    });
+    expect(fetchLatest).not.toHaveBeenCalled();
+    expect(write).toHaveBeenCalledOnce();
+    expect(write.mock.calls[0][0]).toContain('0.13.0');
+  });
+
+  it('fetches when the cache is stale, writes it, and notifies', async () => {
+    const write = vi.fn();
+    const writeCache = vi.fn();
+    await maybeNotifyUpdate('0.12.0', {
+      ...base,
+      readCache: () => ({ latest: '0.12.0', checkedAt: 0 }),
+      now: () => 999_999_999, // far future — stale
+      fetchLatest: async () => '0.13.0',
+      writeCache,
+      write,
+    });
+    expect(writeCache).toHaveBeenCalledWith({ latest: '0.13.0', checkedAt: 999_999_999 });
+    expect(write).toHaveBeenCalledOnce();
+  });
+
+  it('does not notify when already on the latest', async () => {
+    const write = vi.fn();
+    await maybeNotifyUpdate('0.13.0', {
+      ...base,
+      readCache: () => ({ latest: '0.13.0', checkedAt: 1000 }),
+      now: () => 1001,
+      write,
+    });
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('backs off (stamps the cache) when the fetch fails', async () => {
+    const writeCache = vi.fn();
+    const write = vi.fn();
+    await maybeNotifyUpdate('0.12.0', {
+      ...base,
+      readCache: () => null,
+      now: () => 5000,
+      fetchLatest: async () => null, // registry error
+      writeCache,
+      write,
+    });
+    expect(writeCache).toHaveBeenCalledWith({ latest: '0.12.0', checkedAt: 5000 });
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when skipped (non-TTY)', async () => {
+    const fetchLatest = vi.fn();
+    const write = vi.fn();
+    await maybeNotifyUpdate('0.12.0', { ...base, isTTY: false, fetchLatest, write });
+    expect(fetchLatest).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+  });
+});

--- a/src/support/updateNotifier.ts
+++ b/src/support/updateNotifier.ts
@@ -1,0 +1,135 @@
+// ============================================
+// OpenSwarm - Update notifier (INT-2270)
+// ============================================
+//
+// Tell a user on an older version that a newer one is on npm. Reads a 24h cache
+// (~/.openswarm/update-check.json) so almost every run is instant; at most once
+// a day it does a short-timeout registry fetch. Silent on any error, non-TTY,
+// CI, `--version`/`--help`, or `NO_UPDATE_NOTIFIER` — it must never slow down or
+// break the CLI. The network/fs/clock are injectable for tests.
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { c } from './colors.js';
+
+const PKG = '@intrect/openswarm';
+const DAY_MS = 24 * 60 * 60 * 1000;
+const CACHE_PATH = join(homedir(), '.openswarm', 'update-check.json');
+
+interface UpdateCache {
+  latest: string;
+  checkedAt: number;
+}
+
+/** Numeric semver compare (pre-release tags ignored). `latest` strictly newer? Pure. */
+export function isNewer(latest: string, current: string): boolean {
+  const parse = (v: string) => v.split('-')[0].split('.').map((n) => parseInt(n, 10) || 0);
+  const a = parse(latest);
+  const b = parse(current);
+  for (let i = 0; i < 3; i++) {
+    if ((a[i] ?? 0) > (b[i] ?? 0)) return true;
+    if ((a[i] ?? 0) < (b[i] ?? 0)) return false;
+  }
+  return false;
+}
+
+/** Skip the check for non-interactive, CI, opted-out, or meta/help invocations. Pure. */
+export function shouldSkip(argv: string[], env: NodeJS.ProcessEnv, isTTY: boolean): boolean {
+  if (!isTTY) return true;
+  if (env.CI || env.NO_UPDATE_NOTIFIER || env.OPENSWARM_NO_UPDATE_NOTIFIER) return true;
+  const args = argv.slice(2);
+  const META = new Set(['--version', '-V', '--help', '-h', 'help', 'completion']);
+  if (args.some((a) => META.has(a))) return true;
+  return false;
+}
+
+/** Fetch the latest published version from the npm registry (short timeout). */
+async function fetchLatest(timeoutMs = 1200): Promise<string | null> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${PKG}/latest`, { signal: ctrl.signal });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { version?: unknown };
+    return typeof body.version === 'string' ? body.version : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function readCache(): UpdateCache | null {
+  try {
+    const obj = JSON.parse(readFileSync(CACHE_PATH, 'utf8'));
+    return typeof obj?.latest === 'string' && typeof obj?.checkedAt === 'number' ? obj : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(cache: UpdateCache): void {
+  try {
+    mkdirSync(dirname(CACHE_PATH), { recursive: true });
+    writeFileSync(CACHE_PATH, JSON.stringify(cache));
+  } catch {
+    // Cache is best-effort; a read-only home must not break the CLI.
+  }
+}
+
+/** The two-line notice, styled with the shared console colors. Pure. */
+export function formatUpdateNotice(current: string, latest: string): string {
+  return (
+    `\n  ${c.dim('Update available')} ${c.dim(current)} ${c.dim('→')} ${c.green(latest)}\n` +
+    `  Run ${c.cyan(`npm i -g ${PKG}`)} to update.\n`
+  );
+}
+
+export interface NotifierDeps {
+  fetchLatest?: (timeoutMs?: number) => Promise<string | null>;
+  readCache?: () => UpdateCache | null;
+  writeCache?: (cache: UpdateCache) => void;
+  now?: () => number;
+  write?: (s: string) => void;
+  argv?: string[];
+  env?: NodeJS.ProcessEnv;
+  isTTY?: boolean;
+}
+
+/**
+ * Print an "update available" notice if the running version is behind the latest
+ * on npm. Uses the 24h cache; only fetches when the cache is stale (and backs off
+ * — stamping checkedAt even on a failed fetch — so it never refetches every run).
+ * Never throws. (INT-2270)
+ */
+export async function maybeNotifyUpdate(current: string, deps: NotifierDeps = {}): Promise<void> {
+  try {
+    const argv = deps.argv ?? process.argv;
+    const env = deps.env ?? process.env;
+    const isTTY = deps.isTTY ?? !!process.stdout.isTTY;
+    if (shouldSkip(argv, env, isTTY)) return;
+
+    const now = deps.now ?? (() => Date.now());
+    const read = deps.readCache ?? readCache;
+    const write = deps.writeCache ?? writeCache;
+    const fetchFn = deps.fetchLatest ?? fetchLatest;
+    const out = deps.write ?? ((s: string) => process.stderr.write(s));
+
+    const cache = read();
+    let latest = cache?.latest ?? null;
+    const fresh = cache != null && now() - cache.checkedAt < DAY_MS;
+
+    if (!fresh) {
+      const fetched = await fetchFn();
+      // Back off even on failure (reuse the last known latest, or the current
+      // version) so a registry hiccup doesn't make every run hit the network.
+      write({ latest: fetched ?? latest ?? current, checkedAt: now() });
+      if (fetched) latest = fetched;
+    }
+
+    if (latest && isNewer(latest, current)) out(formatUpdateNotice(current, latest));
+  } catch {
+    // A notifier must never break the CLI.
+  }
+}


### PR DESCRIPTION
Two requested features: releases fire from a merge, and users on old versions get told.

## Auto-release — `.github/workflows/release.yml`
Triggers on a push to `main` that changes `package.json`. Reads the version; if `v<version>` isn't already tagged, runs **lint / typecheck / build** (hard gates) + **test** (advisory — matches `ci.yml` until INT-2271), then **`npm publish` + git tag + a GitHub release** with notes sliced from `CHANGELOG.md`. Idempotent (skips an already-released version).

**→ The release flow becomes: merge a version-bump PR.** No more manual publish/tag/release.

⚠️ **Requires a repo secret `NPM_TOKEN`** (npm automation token). `GITHUB_TOKEN` is automatic. Without the secret, publish fails but nothing else breaks.

## Update notifier — `src/support/updateNotifier.ts`
On CLI start, if the running version is behind npm's `latest`, prints a two-line notice to stderr (shared colors). A 24h cache (`~/.openswarm/update-check.json`) keeps almost every run instant; at most once a day a ≤1.2s registry fetch that backs off on failure. Skips non-TTY / CI / `--version`|`--help` / `NO_UPDATE_NOTIFIER`. Never throws or blocks the CLI.

```
  Update available 0.12.0 → 0.13.0
  Run npm i -g @intrect/openswarm to update.
```

## Verification
- typecheck / build / lint (0 errors) green.
- +9 notifier tests (isNewer, skip conditions, fresh-cache / stale-fetch / no-update / backoff).
- CLI smoke: `--version` instant (notifier skipped), notice renders correctly.
- The 2 pre-existing `service.test.ts` failures are split out as **INT-2271** (the release workflow keeps test advisory until they're green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)