### PR TITLE
release: v0.14.0 — auto-release + update notifier + hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.14.0 — 2026-07-01
+
+### Added
+
+- **Auto-release on version bump** — a push to `main` that changes `package.json` now runs the gate (lint / typecheck / build) and automatically **publishes to npm + tags + creates a GitHub release** (notes sliced from this file). The release flow is just "merge a version-bump PR". Idempotent. Requires a repo secret `NPM_TOKEN`. (INT-2270)
+- **CLI update notifier** — when the running version is behind npm's latest, the CLI prints a two-line "update available" notice. 24h cached (`~/.openswarm/update-check.json`) so it's near-instant and non-blocking; skips non-TTY / CI / `--version` / `NO_UPDATE_NOTIFIER`. (INT-2270)
+
+### Changed
+
+- **`checkHandler` colors unified** onto the shared NO_COLOR/TTY-safe helper (`src/support/colors`), finishing the CLI/TUI status-consistency work — ~108 hand-rolled ANSI sites now go through `c` / `status`. Output is byte-identical when piped. (INT-2260)
+- **CI `test` job promoted to a hard gate** (the suite is green), and lint is now warning-free (36 → 0).
+
+### Fixed
+
+- **Stale `service.test.ts` provider-override tests** — the reapply lives inside the autonomous-start block; the tests drove it with a non-autonomous config. Fixed → the full suite is green (1315 passing). (INT-2271)
+- **`postbuild` `chmod +x dist/cli.js`** — a clean `rm -rf dist && build` no longer leaves the global CLI unexecutable ("permission denied").
+
 ## 0.13.0 — 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -512,9 +512,8 @@ the CLI (fire-and-forget with a short timeout, and failures are silently ignored
 Full version history lives in **[CHANGELOG.md](CHANGELOG.md)** and the
 [GitHub Releases](https://github.com/unohee/OpenSwarm/releases) page.
 
-Latest — **v0.13.0**: CLI agent runs (`run` / `fix` / `review --max`) now grow the
-per-repo knowledge memory, not just the daemon (`--no-learn` opts out). See
-CHANGELOG.md for the rest.
+Latest — **v0.14.0**: auto-release on version bump (merge → npm publish + tag +
+GitHub release) and a CLI update notifier. See CHANGELOG.md for the rest.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Release v0.14.0. Merging this version bump to main should trigger the new **auto-release** workflow (first dogfood): gate → npm publish → tag → GitHub release.

Bundles INT-2270 (auto-release + notifier), INT-2260 (checkHandler ANSI), INT-2271 (green suite), postbuild chmod, lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)