### PR TITLE
Normalize project cancellation paths

### DIFF
--- a/src/orchestration/taskScheduler.cancel.test.ts
+++ b/src/orchestration/taskScheduler.cancel.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
 import { TaskScheduler } from './taskScheduler.js';
 import type { TaskItem } from './decisionEngine.js';
 import type { PipelineResult } from '../agents/pairPipeline.js';
@@ -56,6 +58,22 @@ describe('TaskScheduler cancellation', () => {
     expect(n).toBe(1);
     expect(a.wasAborted()).toBe(true);
     expect(b.wasAborted()).toBe(false);
+  });
+
+  it('cancelProjectTasks matches home-expanded project paths', () => {
+    const d = deferredExecutor();
+    sched.startTask(task('home'), resolve(homedir(), 'dev/WAVE'), d.exec);
+    const n = sched.cancelProjectTasks('~/dev/WAVE');
+    expect(n).toBe(1);
+    expect(d.wasAborted()).toBe(true);
+  });
+
+  it('cancelProjectTasks matches relative project paths', () => {
+    const d = deferredExecutor();
+    sched.startTask(task('relative'), resolve(process.cwd(), 'relative-WAVE'), d.exec);
+    const n = sched.cancelProjectTasks('./relative-WAVE');
+    expect(n).toBe(1);
+    expect(d.wasAborted()).toBe(true);
   });
 
   it("a cancelled result is not counted as failed", async () => {

--- a/src/orchestration/taskScheduler.ts
+++ b/src/orchestration/taskScheduler.ts
@@ -4,11 +4,17 @@
 // ============================================
 
 import { EventEmitter } from 'node:events';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
 import type { TaskItem } from './decisionEngine.js';
 import type { PipelineResult } from '../agents/pairPipeline.js';
 
 function normalizeProjectPath(path: string): string {
-  const normalized = path.replace(/\\/g, '/').replace(/\/+$/g, '');
+  const slashed = path.replace(/\\/g, '/');
+  const expanded = slashed === '~' || slashed.startsWith('~/')
+    ? `${homedir()}${slashed.slice(1)}`
+    : slashed;
+  const normalized = resolve(expanded).replace(/\\/g, '/').replace(/\/+$/g, '');
   return normalized || '/';
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the optional note on #182.

This makes project cancellation path matching tolerant of equivalent path representations before applying the exact-or-descendant boundary check.

Changes:

- expand `~` in scheduler cancellation paths
- resolve relative paths before comparison
- keep the existing slash normalization and trailing-slash trimming
- add regression coverage for home-expanded and relative disable paths

## Related issue

Follow-up to #182.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Docs

## Validation

- [x] `npm test -- src/orchestration/taskScheduler.cancel.test.ts`
- [x] `npm test -- src/orchestration/taskScheduler.cancel.test.ts src/orchestration/taskScheduler.concurrency.test.ts`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] `npm test` passes

Local full `npm test` still has unrelated environment/timing failures outside this scheduler change. The autonomous runner files passed when reproduced standalone; `src/tui/components/AuditBoard.test.tsx` still fails locally on the errored-area tally expectation.