### PR TITLE
chore(release): v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.15.0 — 2026-07-02
+
+### Added
+
+- **`openswarm fix` is now multi-language** — check resolution auto-detects the project's ecosystem instead of requiring `package.json` scripts. First non-empty source wins: an explicit `"checks"` map in `openswarm.json` (key → shell command — the escape hatch for **any** language and for mixed repos), `package.json` scripts, `Cargo.toml` (**Rust**: `cargo check --all-targets` + `cargo test` by default; `clippy`/`build` via `--checks lint,build`), or **Python** markers (`ruff check .` / `mypy .` / `pytest`, each included only when the repo is configured for the tool; `--checks` bypasses the gating). Previously Rust/Python projects always exited with `No checks resolved`. (INT-2303)
+
 ## 0.14.0 — 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -514,8 +514,9 @@ the CLI (fire-and-forget with a short timeout, and failures are silently ignored
 Full version history lives in **[CHANGELOG.md](CHANGELOG.md)** and the
 [GitHub Releases](https://github.com/unohee/OpenSwarm/releases) page.
 
-Latest — **v0.14.0**: auto-release on version bump (merge → npm publish + tag +
-GitHub release) and a CLI update notifier. See CHANGELOG.md for the rest.
+Latest — **v0.15.0**: `openswarm fix` goes multi-language — auto-detects npm,
+Cargo (Rust), and Python (ruff/mypy/pytest) checks; any other toolchain via an
+`openswarm.json` `"checks"` map. See CHANGELOG.md for the rest.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.10.2",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.10.2",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Version bump 0.14.0 → 0.15.0. Merging this triggers the auto-release workflow (npm publish + tag + GitHub release).

- `openswarm fix` multi-language check resolution — Cargo/Python auto-detect + `openswarm.json` `checks` config (INT-2303, #193)

🤖 Generated with [Claude Code](https://claude.com/claude-code)