### PR TITLE
fix(scheduler): empty-path guard in normalizeProjectPath (follow-up to #192)

### DIFF
--- a/src/orchestration/taskScheduler.cancel.test.ts
+++ b/src/orchestration/taskScheduler.cancel.test.ts
@@ -76,6 +76,14 @@ describe('TaskScheduler cancellation', () => {
     expect(d.wasAborted()).toBe(true);
   });
 
+  it('cancelProjectTasks with an empty/blank path cancels nothing (not cwd)', () => {
+    const d = deferredExecutor();
+    sched.startTask(task('cwd-task'), resolve(process.cwd(), 'some-repo'), d.exec);
+    expect(sched.cancelProjectTasks('')).toBe(0);
+    expect(sched.cancelProjectTasks('   ')).toBe(0);
+    expect(d.wasAborted()).toBe(false);
+  });
+
   it("a cancelled result is not counted as failed", async () => {
     const d = deferredExecutor();
     const events: string[] = [];

--- a/src/orchestration/taskScheduler.ts
+++ b/src/orchestration/taskScheduler.ts
@@ -10,6 +10,10 @@ import type { TaskItem } from './decisionEngine.js';
 import type { PipelineResult } from '../agents/pairPipeline.js';
 
 function normalizeProjectPath(path: string): string {
+  // Guard: resolve('') returns process.cwd(), so an accidental empty-string
+  // cancellation would match every task under the daemon's cwd. Keep the
+  // pre-#192 no-op behavior ('/' matches nothing in practice) instead.
+  if (!path.trim()) return '/';
   const slashed = path.replace(/\\/g, '/');
   const expanded = slashed === '~' || slashed.startsWith('~/')
     ? `${homedir()}${slashed.slice(1)}`


### PR DESCRIPTION
Follow-up to #192 (as noted in its review): `resolve('')` returns `process.cwd()`, so an accidental empty-string `cancelProjectTasks('')` would cancel every task under the daemon's cwd. Blank input now normalizes to `'/'` (the pre-#192 behavior — matches nothing in practice).

- One-line guard + regression test ('' and '   ' cancel 0 tasks, running task untouched)
- Verified: orchestration suite green, tsc clean, lint 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)