### PR TITLE
feat(daemon): remove the per-project 5h task cap

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -16,8 +16,6 @@ import {
   formatRetryTime,
   getDailyPaceInfo,
   recordProjectCompletion,
-  canProjectAcceptTask,
-  getProjectWindowCount,
   loadProjectSelection,
   saveProjectSelection,
   type TaskState,
@@ -976,15 +974,9 @@ export class AutonomousRunner {
         continue;
       }
 
-      // 프로젝트별 5시간 윈도우 cap 체크
-      const projName = task.linearProject?.name ?? 'unknown';
-      const perProjectCap = this.config.dailyTaskCap ?? 6;
-      if (!canProjectAcceptTask(projName, perProjectCap)) {
-        const count = getProjectWindowCount(projName);
-        this.syslog(`  ⏸ ${projName}: ${count}/${perProjectCap} tasks in 5h window — throttled`);
-        continue;
-      }
-
+      // Per-project 5h window cap (removed, INT-2317) — like the global pace
+      // gate above, throughput is governed by the cron schedule and the Linear
+      // rate limiter only. Completions are still recorded for cost telemetry.
       candidates.push({ task, projectPath });
     }
 

--- a/src/automation/runnerState.coverage.test.ts
+++ b/src/automation/runnerState.coverage.test.ts
@@ -61,16 +61,11 @@ describe('runnerState persistence and helpers', () => {
     }));
     vi.resetModules();
     mod = await import('./runnerState.js');
-    expect(mod.getProjectWindowCount('Alpha')).toBe(1);
-    expect(mod.canProjectAcceptTask('Alpha', 2)).toBe(true);
-    expect(mod.canProjectAcceptTask('Alpha', 1)).toBe(false);
-    expect(mod.getTotalWindowCount()).toBe(1);
+    // Cap helpers were removed with the per-project 5h cap (INT-2317) —
+    // the rolling-window prune is still observable via getDailyPaceInfo.
+    expect(mod.getDailyPaceInfo().projectCounts.Alpha).toBe(1);
 
     mod.recordProjectCompletion('Alpha', 1.25);
-    expect(mod.getProjectWindowCount('Alpha')).toBe(2);
-    expect(mod.canAcceptMoreTasks(3)).toBe(true);
-    expect(mod.getDailyCompletedCount()).toBe(2);
-    mod.incrementDailyCompleted();
     const info = mod.getDailyPaceInfo();
     expect(info.completedToday).toBe(2);
     expect(info.projectCounts.Alpha).toBe(2);

--- a/src/automation/runnerState.ts
+++ b/src/automation/runnerState.ts
@@ -120,15 +120,9 @@ function pruneOldEntries(entries: ProjectPaceEntry[]): ProjectPaceEntry[] {
   return entries.filter(e => new Date(e.completedAt).getTime() > cutoff);
 }
 
-export function getProjectWindowCount(projectName: string): number {
-  const state = ensurePaceLoaded();
-  const entries = state.projects[projectName] ?? [];
-  return pruneOldEntries(entries).length;
-}
-
-export function canProjectAcceptTask(projectName: string, cap: number): boolean {
-  return getProjectWindowCount(projectName) < cap;
-}
+// Cap helpers (getProjectWindowCount / canProjectAcceptTask / getTotalWindowCount)
+// were removed with the per-project 5h cap (INT-2317). Completion recording stays
+// below — daily-pace.json remains useful as a cost/throughput telemetry trail.
 
 export function recordProjectCompletion(projectName: string, costUsd?: number): void {
   const state = ensurePaceLoaded();
@@ -138,15 +132,6 @@ export function recordProjectCompletion(projectName: string, costUsd?: number): 
   state.updatedAt = new Date().toISOString();
   savePace();
   console.log(`[Pace] ${projectName}: ${state.projects[projectName].length} tasks in 5h window`);
-}
-
-export function getTotalWindowCount(): number {
-  const state = ensurePaceLoaded();
-  let total = 0;
-  for (const entries of Object.values(state.projects)) {
-    total += pruneOldEntries(entries).length;
-  }
-  return total;
 }
 
 export function getDailyPaceInfo(): DailyPaceState {
@@ -166,17 +151,6 @@ export function getDailyPaceInfo(): DailyPaceState {
   }
 
   return { completedToday: totalToday, dateKey: today, lastCompletionAt: lastCompletion, projectCounts };
-}
-
-// 하위 호환 래퍼
-export function getDailyCompletedCount(): number {
-  return getTotalWindowCount();
-}
-export function incrementDailyCompleted(): void {
-  // no-op — recordProjectCompletion으로 대체
-}
-export function canAcceptMoreTasks(cap: number): boolean {
-  return getTotalWindowCount() < cap;
 }
 
 export interface TaskState {

--- a/src/automation/runnerTypes.ts
+++ b/src/automation/runnerTypes.ts
@@ -39,8 +39,6 @@ export interface AutonomousConfig {
   guards?: Partial<import('../core/types.js').PipelineGuardsConfig>;
   /** Max objective self-repair attempts (lint/bs/test) before giving up (default: 3) */
   maxReflections?: number;
-  /** Per-project task cap in 5h rolling window (default: 6) */
-  dailyTaskCap?: number;
   /** Cooldown between task completions in ms (default: 1800000 = 30min) */
   interTaskCooldownMs?: number;
   jobProfiles?: JobProfile[];

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -260,8 +260,6 @@ const AutonomousConfigSchema = z.object({
   guards: PipelineGuardsConfigSchema,
   /** Max objective self-repair attempts (lint/bs/test) before giving up */
   maxReflections: z.number().min(1).max(10).default(3),
-  /** Daily task completion cap (default: 6) */
-  dailyTaskCap: z.number().min(1).max(50).default(6),
   /** Cooldown between task completions in ms (default: 1800000 = 30min) */
   interTaskCooldownMs: z.number().min(0).default(1800000),
 }).optional();
@@ -561,7 +559,6 @@ function transformConfig(raw: RawConfig): SwarmConfig {
       allowSameProjectConcurrent: raw.autonomous.allowSameProjectConcurrent,
       guards: raw.autonomous.guards,
       maxReflections: raw.autonomous.maxReflections,
-      dailyTaskCap: raw.autonomous.dailyTaskCap,
       interTaskCooldownMs: raw.autonomous.interTaskCooldownMs,
       // jobProfiles was validated by the schema but dropped here, so per-task
       // model selection silently fell back to defaultRoles. Carry it through.

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -232,8 +232,6 @@ export async function startService(config: SwarmConfig): Promise<void> {
       guards: config.autonomous.guards,
       // Bad-edit / reflection self-repair budget
       maxReflections: config.autonomous.maxReflections,
-      // Daily pace control
-      dailyTaskCap: config.autonomous.dailyTaskCap ?? 6,
       interTaskCooldownMs: config.autonomous.interTaskCooldownMs ?? 1_800_000,
       jobProfiles: config.autonomous.jobProfiles,
     });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -478,8 +478,6 @@ export type AutonomousStartupConfig = {
    * Default: 3.
    */
   maxReflections?: number;
-  /** Daily task completion cap (default: 6) */
-  dailyTaskCap?: number;
   /** Cooldown between task completions in ms (default: 1800000 = 30min) */
   interTaskCooldownMs?: number;
   /** Job profiles used to select models based on task traits */


### PR DESCRIPTION
## Summary

The global pace gate was removed earlier by design ("Pace: unrestricted (cron only)") but the **per-project 5h rolling-window cap** (`dailyTaskCap`, default 6) survived — today it silently stalled Intrect-platform for ~4h after a burst of 8 completions, with an idle scheduler and no error (`⏸ 8/6 tasks in 5h window — throttled` each heartbeat). INT-2317.

- Remove the throttle check from the heartbeat candidate loop
- Remove the cap helpers + dead backward-compat wrappers (zero production callers)
- Remove the `dailyTaskCap` config field (stale keys in existing configs are stripped by zod)
- Keep `recordProjectCompletion` / `daily-pace.json` (cost/throughput telemetry) and `getDailyPaceInfo` (dashboard)

Throughput is now governed only by the cron schedule and the Linear rate limiter.

## Verification

Full suite 1392 passed · oxlint 0 · tsc clean. `grep dailyTaskCap` → only historical comments remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)