### PR TITLE
feat(engine): same-project parallel task selection — round-robin fill

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -196,6 +196,9 @@ export class AutonomousRunner {
       cooldownSeconds: config.cooldownSeconds,
       dryRun: config.dryRun,
       includeBacklog: config.includeBacklog,
+      // Same-project parallel selection only makes sense when the scheduler can
+      // actually run those tasks concurrently (worktree isolation). (INT-2318)
+      sameProjectParallel: (config.allowSameProjectConcurrent ?? true) && (config.worktreeMode ?? false),
     });
 
     // Initialize TaskScheduler

--- a/src/orchestration/decisionEngine.test.ts
+++ b/src/orchestration/decisionEngine.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isAllowedProjectPath, isUmbrellaIssue, type TaskItem } from './decisionEngine.js';
+import { isAllowedProjectPath, isUmbrellaIssue, selectTasksRoundRobin, type TaskItem } from './decisionEngine.js';
 
 // INT-1810 R2: parent/EPIC issues are umbrellas, not executable work. INT-1702 (tracking,
 // decomposed into sub-issues) and KT-300 ([EPIC] …) were wrongly picked for the worker.
@@ -44,5 +44,62 @@ describe('isAllowedProjectPath', () => {
 
   it('rejects broader parent paths when only a child repo is allowed', () => {
     expect(isAllowedProjectPath('/tmp', ['/tmp/allowed-repo'])).toBe(false);
+  });
+});
+
+describe('selectTasksRoundRobin (INT-2318)', () => {
+  const t = (id: string, project: string): TaskItem =>
+    task({ id, linearProject: { id: project, name: project } as TaskItem['linearProject'] });
+  const ok = () => true;
+  const wf = async () => ({}) as Awaited<ReturnType<Parameters<typeof selectTasksRoundRobin>[4]>>;
+
+  const sorted = [t('a1', 'A'), t('a2', 'A'), t('a3', 'A'), t('b1', 'B'), t('b2', 'B')];
+
+  it('one task per project per cycle when sameProjectParallel is off', async () => {
+    const { selected } = await selectTasksRoundRobin(sorted, 6, false, ok, wf);
+    expect(selected.map((s) => s.task.id)).toEqual(['a1', 'b1']);
+  });
+
+  it('fills remaining slots round-robin across projects when on', async () => {
+    const { selected } = await selectTasksRoundRobin(sorted, 6, true, ok, wf);
+    // pass 1: a1, b1 · pass 2: a2, b2 · pass 3: a3 — no project monopolizes early slots
+    expect(selected.map((s) => s.task.id)).toEqual(['a1', 'b1', 'a2', 'b2', 'a3']);
+  });
+
+  it('respects maxTasks', async () => {
+    const { selected } = await selectTasksRoundRobin(sorted, 3, true, ok, wf);
+    expect(selected.map((s) => s.task.id)).toEqual(['a1', 'b1', 'a2']);
+  });
+
+  it('counts rejected tasks as skipped and moves on within the same pass', async () => {
+    const { selected, skippedCount } = await selectTasksRoundRobin(
+      sorted, 6, true, (task) => task.id !== 'a1', wf,
+    );
+    expect(selected.map((s) => s.task.id)).toEqual(['a2', 'b1', 'a3', 'b2']);
+    expect(skippedCount).toBe(1);
+  });
+
+  it('counts workflow-mapping failures as skipped and never retries them', async () => {
+    let b1Calls = 0;
+    const { selected, skippedCount } = await selectTasksRoundRobin(
+      sorted, 6, true, ok,
+      async (task) => {
+        if (task.id === 'b1') { b1Calls++; return null; }
+        return wf();
+      },
+    );
+    expect(selected.map((s) => s.task.id)).toEqual(['a1', 'b2', 'a2', 'a3']);
+    expect(skippedCount).toBe(1);
+    expect(b1Calls).toBe(1);
+  });
+
+  it('falls back to projectPath then task id as the project key', async () => {
+    const byPath = [
+      task({ id: 'p1', projectPath: '/repo/x' }),
+      task({ id: 'p2', projectPath: '/repo/x' }),
+      task({ id: 'keyless' }),
+    ];
+    const { selected } = await selectTasksRoundRobin(byPath, 6, false, ok, wf);
+    expect(selected.map((s) => s.task.id)).toEqual(['p1', 'keyless']);
   });
 });

--- a/src/orchestration/decisionEngine.ts
+++ b/src/orchestration/decisionEngine.ts
@@ -201,6 +201,18 @@ export interface DecisionEngineConfig {
    * actionable, so moving an issue to Backlog stops the daemon picking it up.
    */
   includeBacklog?: boolean;
+
+  /**
+   * Allow selecting multiple tasks from the same project in one cycle
+   * (round-robin fill: every pass adds at most one task per project, so no
+   * project can monopolize the slots). Wire this from
+   * `allowSameProjectConcurrent && worktreeMode` — the scheduler only runs
+   * same-project tasks concurrently under worktree isolation, and the
+   * heartbeat's knowledge-graph conflict detection defers file-overlapping
+   * tasks within a project. Default false (one task per project per cycle).
+   * (INT-2318)
+   */
+  sameProjectParallel?: boolean;
 }
 
 // Constants
@@ -253,6 +265,67 @@ export function isActionableLinearState(linearState: string | undefined, include
   if (!linearState) return true; // unknown state → don't gate (conservative)
   if (!NON_ACTIONABLE_LINEAR_STATES.has(linearState)) return true;
   return linearState === 'Backlog' && includeBacklog === true;
+}
+
+/**
+ * Select up to `maxTasks` from the priority-sorted list, round-robin across
+ * projects: every pass adds at most one task per project, so no project can
+ * monopolize the slots and all bots stay active. With `sameProjectParallel`
+ * (scheduler worktree isolation + KG conflict detection downstream) later
+ * passes fill the remaining slots with additional tasks from the same
+ * projects; without it, selection stops after the first pass (one task per
+ * project per cycle). Tasks failing `validate`/`toWorkflow` are counted as
+ * skipped and never retried in later passes. Pure orchestration (deps
+ * injected) — unit-tested directly. (INT-2318)
+ */
+export async function selectTasksRoundRobin(
+  sorted: TaskItem[],
+  maxTasks: number,
+  sameProjectParallel: boolean,
+  validate: (task: TaskItem) => boolean,
+  toWorkflow: (task: TaskItem) => Promise<WorkflowConfig | null>,
+): Promise<{ selected: Array<{ task: TaskItem; workflow: WorkflowConfig }>; skippedCount: number }> {
+  const selected: Array<{ task: TaskItem; workflow: WorkflowConfig }> = [];
+  const seenIds = new Set<string>();
+  let skippedCount = 0;
+
+  const maxPasses = sameProjectParallel ? Math.max(1, maxTasks) : 1;
+  for (let pass = 0; pass < maxPasses && selected.length < maxTasks; pass++) {
+    const projectsThisPass = new Set<string>();
+    let addedThisPass = 0;
+
+    for (const task of sorted) {
+      if (selected.length >= maxTasks) break;
+      if (seenIds.has(task.id)) continue;
+
+      const projectKey = task.linearProject?.id || task.projectPath || task.id;
+      if (projectsThisPass.has(projectKey)) {
+        continue; // already picked a task for this project this pass
+      }
+
+      if (!validate(task)) {
+        skippedCount++;
+        seenIds.add(task.id);
+        continue;
+      }
+
+      const workflow = await toWorkflow(task);
+      if (!workflow) {
+        skippedCount++;
+        seenIds.add(task.id);
+        continue;
+      }
+
+      selected.push({ task, workflow });
+      seenIds.add(task.id);
+      projectsThisPass.add(projectKey);
+      addedThisPass++;
+    }
+
+    if (addedThisPass === 0) break; // nothing left to pick
+  }
+
+  return { selected, skippedCount };
 }
 
 // Engine State
@@ -462,39 +535,15 @@ export class DecisionEngine {
     const downstream = computeDownstreamCounts(tasks);
     const sorted = this.prioritizeTasks(executableTasks, downstream);
 
-    // 6. Select multiple tasks. One per project per cycle: the scheduler runs at
-    // most one worker per project, so selecting several from the same project just
-    // queues them and starves other projects. Spreading across projects keeps all
-    // bots active (the deferred same-project tasks get picked next cycle).
-    const selectedTasks: Array<{ task: TaskItem; workflow: WorkflowConfig }> = [];
-    const selectedProjects = new Set<string>();
-    let skippedCount = 0;
-
-    for (const task of sorted) {
-      if (selectedTasks.length >= maxTasks) break;
-
-      const projectKey = task.linearProject?.id || task.projectPath || task.id;
-      if (selectedProjects.has(projectKey)) {
-        continue; // already picked a task for this project this cycle
-      }
-
-      // Scope validation
-      const scopeCheck = this.validateScope(task);
-      if (!scopeCheck.valid) {
-        skippedCount++;
-        continue;
-      }
-
-      // Workflow mapping
-      const workflow = await this.taskToWorkflow(task);
-      if (!workflow) {
-        skippedCount++;
-        continue;
-      }
-
-      selectedTasks.push({ task, workflow });
-      selectedProjects.add(projectKey);
-    }
+    // 6. Select multiple tasks (round-robin across projects — see
+    // selectTasksRoundRobin). (INT-2318)
+    const { selected: selectedTasks, skippedCount } = await selectTasksRoundRobin(
+      sorted,
+      maxTasks,
+      !!this.config.sameProjectParallel,
+      (task) => this.validateScope(task).valid,
+      (task) => this.taskToWorkflow(task),
+    );
 
     if (selectedTasks.length === 0) {
       return {


### PR DESCRIPTION
## Summary

Only one agent ever ran per project (INT-2318). The serializer was **not the scheduler** — same-project concurrency has been supported under worktree isolation since INT-1975 (`allowSameProjectConcurrent`, default on) — but the DecisionEngine's hard one-task-per-project rule in heartbeat selection. Its justifying comment was stale, and it kept the heartbeat's KG file-conflict detection (`group.length > 1` branch) permanently dead.

- Selection extracted to the pure `selectTasksRoundRobin` and made **round-robin across projects**: every pass adds at most one task per project (fairness preserved — no project monopolizes slots); with `sameProjectParallel`, later passes fill remaining slots from the same projects
- Flag wired from `allowSameProjectConcurrent && worktreeMode` — selection only outpaces one-per-project when the scheduler can actually run those tasks concurrently
- File-overlapping tasks within a project are still deferred by the existing knowledge-graph conflict detection (that code path now actually runs)

## Verification

6 new unit tests (off/on ordering, maxTasks, skip accounting, no-retry of failed mappings, project-key fallback) · full suite 1398 passed · oxlint 0 · tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)