### PR TITLE
fix(knowledge): vendored dirs poison conflict detection

### DIFF
--- a/src/knowledge/analyzer.test.ts
+++ b/src/knowledge/analyzer.test.ts
@@ -107,6 +107,30 @@ describe('Knowledge Graph Analyzer', () => {
       expect(result.testFiles).toEqual([]);
     });
 
+    it('does not match short generic vendored filenames as substrings (INT-2320)', () => {
+      // a.py / run.py used to substring-match virtually every issue text,
+      // making the conflict detector see all task pairs as overlapping.
+      graph.addNode(mod('vendor/dns/a.py'));
+      graph.addNode(mod('vendor/tasks/run.py'));
+      graph.addNode(mod('vendor/requests/api.py'));
+
+      const result = analyzeIssueImpact(
+        graph,
+        'Harden the running audit pipeline',
+        'API change compatibility risk around a rapid rollout',
+      );
+
+      expect(result.directModules).not.toContain('vendor/dns/a.py'); // < 3 chars: never
+      expect(result.directModules).not.toContain('vendor/tasks/run.py'); // "running" is not "run"
+      // "API" appears as a standalone word → a legitimate boundary match
+      expect(result.directModules).toContain('vendor/requests/api.py');
+    });
+
+    it('still matches whole-word filenames at word boundaries (INT-2320)', () => {
+      const result = analyzeIssueImpact(graph, 'login: broken redirect', 'the login/ page 500s');
+      expect(result.directModules).toContain('src/auth/login.ts');
+    });
+
     it('estimates scope as "small" for <= 2 affected modules', () => {
       // token.ts + middleware.ts = 2 affected
       const result = analyzeIssueImpact(graph, 'Token issue');

--- a/src/knowledge/analyzer.ts
+++ b/src/knowledge/analyzer.ts
@@ -8,6 +8,19 @@ import type { ImpactAnalysis, ProjectSummary } from './types.js';
 
 // Issue Impact Analysis
 
+const escapeRegExp = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Whole-word match: `run` matches "fix run loop" but not "running" or
+ * "pruner". Raw substring matching made every short vendored filename
+ * (`a.py`, `run.py`, `api.py`) hit every issue, so the conflict detector saw
+ * all task pairs as overlapping. (INT-2320)
+ */
+function matchesWord(text: string, needle: string): boolean {
+  if (needle.length < 3) return false; // 1–2 char names match everything
+  return new RegExp(`(?:^|[^a-z0-9])${escapeRegExp(needle)}(?:$|[^a-z0-9])`).test(text);
+}
+
 /**
  * Analyze issue text to identify affected modules
  */
@@ -28,7 +41,7 @@ export function analyzeIssueImpact(
     const pathParts = mod.path.split('/');
 
     // Filename matching (e.g., "decisionEngine" → decisionEngine.ts)
-    if (text.includes(name.toLowerCase())) {
+    if (matchesWord(text, name.toLowerCase())) {
       directModules.push(mod.id);
       continue;
     }

--- a/src/knowledge/scanner.test.ts
+++ b/src/knowledge/scanner.test.ts
@@ -119,4 +119,16 @@ describe('knowledge scanner', () => {
       }
     }
   });
+
+  it('skips vendored third-party trees (INT-2320)', async () => {
+    await writeProjectFile('src/app.ts', 'export const app = 1;\n');
+    await writeProjectFile('google-cloud-sdk/lib/surface/run.py', 'x = 1\n');
+    await writeProjectFile('third_party/requests/api.py', 'x = 1\n');
+    await writeProjectFile('vendor/dns/a.py', 'x = 1\n');
+
+    const graph = await scanProject(tmp, 'test-project');
+    const ids = graph.getNodesByType('module').map(n => n.id);
+    expect(ids).toContain('src/app.ts');
+    expect(ids.filter(id => id.includes('google-cloud-sdk') || id.includes('third_party') || id.includes('vendor/'))).toEqual([]);
+  });
 });

--- a/src/knowledge/scanner.ts
+++ b/src/knowledge/scanner.ts
@@ -20,6 +20,10 @@ const SKIP_DIRS = new Set([
   // registry to 624650 entities (normal ~1,594) and the conflict detector then treated those
   // trash files as shared between unrelated issues → false conflicts.
   'trash', '.openswarm', 'htmlcov', '.ruff_cache', 'worktree',
+  // INT-2320: vendored third-party trees are not the repo's own code. Thousands of
+  // short generic filenames (a.py, run.py, api.py) poisoned issue-impact matching,
+  // so the conflict detector deferred every same-project task pair as "conflicting".
+  'google-cloud-sdk', 'third_party', 'vendor', 'vendors',
 ]);
 
 // Prefix-based skip: any directory name starting with these prefixes


### PR DESCRIPTION
## Summary

With #199's same-project parallel selection live, the KG conflict detector deferred 4/5 intrect-platform tasks as "conflicting" — the shared modules were entirely vendored `google-cloud-sdk/` files (`a.py`, `run.py`, `api.py`, …). Same failure family as the INT-1810 R3 `trash/` false conflicts. (INT-2320)

Two compounding causes, both fixed:
1. **Scanner** indexed vendored third-party trees → `SKIP_DIRS` now excludes `google-cloud-sdk` / `third_party` / `vendor` / `vendors`
2. **`analyzeIssueImpact`** matched filenames as raw substrings of issue text (1–2 char names matched everything; `run` matched "running") → filename matching now requires a whole-word boundary match and a minimum length of 3 (camelCase word-split and path-segment matching unchanged)

## Verification

- New tests: scanner skips vendored trees; analyzer rejects `a.py`/`run.py`-vs-"running" while keeping legitimate boundary matches (`api`, `login`)
- Full suite 1401 passed · oxlint 0 · tsc clean
- After merge: force a full rescan of the cached intrect-platform graph and verify the same 5 tasks enqueue without fake conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)