### PR TITLE
fix(worktree): run gh with the worktree cwd — PRs were never created off-repo

### DIFF
--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -18,9 +18,16 @@ async function git(cwd: string, ...args: string[]): Promise<string> {
   return stdout;
 }
 
-/** Safe gh command execution (no shell) */
-async function gh(...args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync('gh', args);
+/**
+ * Safe gh command execution (no shell). `cwd` must be inside the target repo —
+ * gh infers the repository from the working directory, and the daemon's own
+ * cwd is typically NOT a git repo (e.g. started from $HOME), which made every
+ * `gh pr create` here die with "fatal: not a git repository" while the push
+ * (which does pass a cwd) succeeded — completed work stranded on remote
+ * branches with no PR. (INT-2321)
+ */
+async function gh(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('gh', args, { cwd });
   return stdout;
 }
 
@@ -164,7 +171,7 @@ export async function commitAndCreatePR(
   console.log(`[Worktree] Pushed branch ${branchName}`);
 
   // If PR already exists, just return the URL
-  const existing = await gh('pr', 'list', '--head', branchName, '--state', 'open', '--json', 'url', '--jq', '.[0].url')
+  const existing = await gh(worktreePath, 'pr', 'list', '--head', branchName, '--state', 'open', '--json', 'url', '--jq', '.[0].url')
     .catch((e) => { console.warn(`[Worktree] PR list check failed for ${branchName}:`, e); return ''; });
 
   if (existing.trim()) {
@@ -184,7 +191,7 @@ export async function commitAndCreatePR(
     '🤖 Generated with [OpenSwarm](https://github.com/Intrect-io/OpenSwarm)',
   ].join('\n');
 
-  const prUrl = await gh('pr', 'create', '--head', branchName, '--base', 'main', '--title', title, '--body', prBody);
+  const prUrl = await gh(worktreePath, 'pr', 'create', '--head', branchName, '--base', 'main', '--title', title, '--body', prBody);
 
   const url = prUrl.trim();
   console.log(`[Worktree] PR created: ${url}`);


### PR DESCRIPTION
## Summary

The `gh` helper in `worktreeManager` ran with the **daemon's own cwd** — typically not a git repository (the daemon starts from `$HOME`). `gh` infers the target repository from the working directory, so every `gh pr list` / `gh pr create` in `commitAndCreatePR` died with `fatal: not a git repository`, while the branch push (which does pass a cwd) succeeded. Result: completed tasks stranded on remote branches with no PR — 80 recorded failures in the daemon log; the only historical successes were when the daemon's cwd happened to coincide with the target repo. (INT-2321)

`gh` now takes an explicit `cwd` (mirroring the `git` helper) and runs inside the task's worktree. The `github.ts` call sites are unaffected — they always pass `-R <repo>`.

## Verification

- tsc clean · oxlint 0 · full suite green
- Post-merge live check: restart the daemon and confirm the next completed task opens a PR (plus manually open PRs for the 3 currently-stranded branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)