### PR TITLE
chore(release): v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.17.1 — 2026-07-02
+
+### Fixed
+
+- **Worktree PRs are actually created now** — the `gh` helper in `worktreeManager` ran with the daemon's own cwd (typically not a git repository, e.g. `$HOME`), so every `gh pr list` / `gh pr create` after a completed task died with `fatal: not a git repository` while the branch push succeeded — completed work stranded on remote branches with no PR (80 recorded failures; the only successes were when the daemon's cwd happened to be the target repo). `gh` now runs inside the task's worktree, mirroring the `git` helper. (INT-2327, #202)
+
 ## 0.17.0 — 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -514,10 +514,11 @@ the CLI (fire-and-forget with a short timeout, and failures are silently ignored
 Full version history lives in **[CHANGELOG.md](CHANGELOG.md)** and the
 [GitHub Releases](https://github.com/unohee/OpenSwarm/releases) page.
 
-Latest — **v0.17.0**: same-project parallel agents — round-robin task selection
-fills all worker slots (worktree-isolated, KG conflict detection defers real file
-overlaps), the per-project 5h task cap is gone, and vendored trees no longer
-poison conflict detection. See CHANGELOG.md for the rest.
+Latest — **v0.17.1**: worktree PRs are actually created now — `gh` used to run
+outside the repo and silently strand completed work on remote branches. Plus
+v0.17.0's same-project parallel agents (round-robin selection, worktree-isolated,
+KG conflict detection) and the removal of the per-project 5h task cap. See
+CHANGELOG.md for the rest.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Version bump 0.17.0 → 0.17.1. Merging triggers the auto-release workflow (npm publish + tag + GitHub release).

- fix(worktree): run gh with the worktree cwd — completed tasks stranded work on remote branches with no PR (INT-2327, #202)

🤖 Generated with [Claude Code](https://claude.com/claude-code)