### PR TITLE
Add dependency anti-pattern guard

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -101,6 +101,7 @@ autonomous:
     uncertaintyDetection: true
     registryCheck: true
     bsDetector: true        # blocks on critical code-smell patterns
+    dependencyAntiPatternCheck: true  # block package recreation/version spoofing after import failures (INT-2388 #1)
     deadModuleCheck: true   # warn on new modules nothing imports/calls (INT-2388 #5)
     reformatCheck: true     # warn on reformat-only files / oversized diffs (INT-2388 #6)
 

--- a/src/agents/pipelineGuards.test.ts
+++ b/src/agents/pipelineGuards.test.ts
@@ -32,6 +32,61 @@ describe('pipelineGuards — INT-2388 deterministic guards', () => {
     if (existsSync(repo)) rmSync(repo, { recursive: true, force: true });
   });
 
+  describe('dependencyAntiPatternCheck', () => {
+    it('blocks __version__ spoofing after an import failure', async () => {
+      writeFileSync(join(repo, 'thirdpartyshim.py'), '__version__ = "9.6.0"\n');
+      const res = await runGuards(
+        { ...mockWorker(['thirdpartyshim.py']), output: 'ModuleNotFoundError: No module named stonks' },
+        repo,
+        { dependencyAntiPatternCheck: true },
+      );
+      const issues = guardIssues(res, 'dependencyAntiPattern');
+      expect(issues.some(i => i.includes('thirdpartyshim.py') && i.includes('__version__'))).toBe(true);
+      expect(res.allPassed).toBe(false);
+    });
+
+    it('blocks new package scaffold after a module-not-found failure', async () => {
+      mkdirSync(join(repo, 'packages', 'missing-sdk'), { recursive: true });
+      writeFileSync(join(repo, 'packages', 'missing-sdk', 'package.json'), '{"name":"missing-sdk","version":"1.0.0"}\n');
+      const res = await runGuards(
+        { ...mockWorker(['packages/missing-sdk/package.json']), output: 'Cannot find module missing-sdk' },
+        repo,
+        { dependencyAntiPatternCheck: true },
+      );
+      const issues = guardIssues(res, 'dependencyAntiPattern');
+      expect(issues.some(i => i.includes('packages/missing-sdk/package.json'))).toBe(true);
+      expect(res.allPassed).toBe(false);
+    });
+
+    it('does not flag __version__ without a dependency failure signal', async () => {
+      writeFileSync(join(repo, 'ownedpkg.py'), '__version__ = "1.0.0"\n');
+      const res = await runGuards(
+        { ...mockWorker(['ownedpkg.py']), output: 'normal feature work' },
+        repo,
+        { dependencyAntiPatternCheck: true },
+      );
+      const issues = guardIssues(res, 'dependencyAntiPattern');
+      expect(issues.length).toBe(0);
+      expect(res.allPassed).toBe(true);
+    });
+
+    it('does not flag an existing __version__ when the diff only changes another line', async () => {
+      writeFileSync(join(repo, 'ownedpkg.py'), '__version__ = "1.0.0"\nexport const value = 1\n');
+      execFileSync('git', ['add', 'ownedpkg.py'], { cwd: repo });
+      execFileSync('git', ['commit', '-m', 'add owned package'], { cwd: repo });
+
+      writeFileSync(join(repo, 'ownedpkg.py'), '__version__ = "1.0.0"\nexport const value = 2\n');
+      const res = await runGuards(
+        { ...mockWorker(['ownedpkg.py']), output: 'ModuleNotFoundError: No module named stonks' },
+        repo,
+        { dependencyAntiPatternCheck: true },
+      );
+      const issues = guardIssues(res, 'dependencyAntiPattern');
+      expect(issues.length).toBe(0);
+      expect(res.allPassed).toBe(true);
+    });
+  });
+
   describe('deadModuleCheck', () => {
     it('flags a new source module that nothing imports', async () => {
       writeFileSync(join(repo, 'orphanwidget.ts'), 'export function orphanwidget() { return 1; }\n');

--- a/src/agents/pipelineGuards.ts
+++ b/src/agents/pipelineGuards.ts
@@ -4,6 +4,8 @@
 // ============================================
 
 import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { promisify } from 'node:util';
 import type { WorkerResult } from './agentPair.js';
 import type { PipelineGuardsConfig } from '../core/types.js';
@@ -306,6 +308,37 @@ async function runBsDetectorGuard(
 
 const SOURCE_FILE_RE = /\.(ts|tsx|js|jsx|py)$/;
 const TEST_FILE_RE = /\.(test|spec)\.[jt]sx?$|(^|\/)test_[^/]+\.py$|_test\.py$/;
+const DEPENDENCY_FAILURE_RE =
+  /\b(ModuleNotFoundError|ImportError|Cannot find module|ERR_MODULE_NOT_FOUND|No module named|PackageNotFoundError|missing dependency|not installed)\b/i;
+const VERSION_SPOOF_RE =
+  /(^|\n)\s*(?:export\s+const\s+)?__version__\s*[:=]/;
+const PACKAGE_SCAFFOLD_RE =
+  /(^|\/)(package\.json|pyproject\.toml|setup\.py|setup\.cfg)$/;
+
+async function getAddedLinesForFile(projectPath: string, filePath: string, isNew: boolean): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['diff', '--unified=0', 'HEAD', '--', filePath],
+      { cwd: projectPath, timeout: 10_000 },
+    );
+    const added = stdout
+      .split('\n')
+      .filter(line => line.startsWith('+') && !line.startsWith('+++'))
+      .map(line => line.slice(1))
+      .join('\n');
+    if (added) return added;
+  } catch {
+    // Fall through to untracked-new handling below.
+  }
+
+  if (!isNew) return '';
+  try {
+    return await readFile(join(projectPath, filePath), 'utf8');
+  } catch {
+    return '';
+  }
+}
 
 /**
  * Dead-module guard (INT-2388 defect #5): a newly-added source module that
@@ -365,6 +398,51 @@ async function runDeadModuleGuard(projectPath: string): Promise<GuardResult> {
   }
 
   return { passed: issues.length === 0, guard, issues, blocking: false };
+}
+
+/**
+ * Dependency anti-pattern guard (INT-2388 defect #1): if the worker reports an
+ * import/package failure, don't allow the fix to become "recreate the missing
+ * package" or "spoof its version". This is intentionally narrow and blocking:
+ * it fires only when a dependency-failure signal is paired with package-identity
+ * code or a new package scaffold in the diff.
+ */
+async function runDependencyAntiPatternGuard(
+  workerResult: WorkerResult,
+  projectPath: string,
+): Promise<GuardResult> {
+  const guard = 'dependencyAntiPattern';
+  const issues: string[] = [];
+  const reportText = `${workerResult.summary}\n${workerResult.output.slice(0, 8000)}\n${workerResult.error ?? ''}`;
+
+  if (!DEPENDENCY_FAILURE_RE.test(reportText)) {
+    return { passed: true, guard, issues, blocking: true };
+  }
+
+  try {
+    const details = await getWorkingDiffDetail(projectPath);
+
+    for (const d of details) {
+      if (d.isNew && PACKAGE_SCAFFOLD_RE.test(d.file)) {
+        issues.push(
+          `[${d.file}] dependency/import failure was reported, but the diff adds package scaffold. Fix the environment or document the blocker instead of recreating a third-party package.`,
+        );
+      }
+
+      if (!SOURCE_FILE_RE.test(d.file) || TEST_FILE_RE.test(d.file)) continue;
+
+      const addedLines = await getAddedLinesForFile(projectPath, d.file, d.isNew);
+      if (VERSION_SPOOF_RE.test(addedLines)) {
+        issues.push(
+          `[${d.file}] dependency/import failure was reported, but the diff defines __version__. Do not spoof package identity/version constants for code you do not own.`,
+        );
+      }
+    }
+  } catch (err) {
+    console.warn('[Guard:dependencyAntiPattern] Error:', err);
+  }
+
+  return { passed: issues.length === 0, guard, issues, blocking: true };
 }
 
 /**
@@ -437,6 +515,10 @@ export async function runGuards(
 
   if (config.bsDetector) {
     results.push(await runBsDetectorGuard(workerResult, projectPath));
+  }
+
+  if (config.dependencyAntiPatternCheck) {
+    results.push(await runDependencyAntiPatternGuard(workerResult, projectPath));
   }
 
   if (config.deadModuleCheck) {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -222,6 +222,7 @@ const PipelineGuardsConfigSchema = z.object({
   haltToLinear: z.boolean().optional(),
   registryCheck: z.boolean().optional(),
   bsDetector: z.boolean().optional(),
+  dependencyAntiPatternCheck: z.boolean().optional(),
   deadModuleCheck: z.boolean().optional(),
   reformatCheck: z.boolean().optional(),
 }).optional();

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -426,6 +426,8 @@ export interface PipelineGuardsConfig {
   haltToLinear: boolean;
   registryCheck: boolean;
   bsDetector: boolean;
+  /** Block dependency/import failure fixes that spoof package identity (INT-2388 #1). */
+  dependencyAntiPatternCheck?: boolean;
   /** Flag newly-added source modules that nothing imports/calls (INT-2388 #5). */
   deadModuleCheck?: boolean;
   /** Flag reformat-only files and oversized diffs — scope creep (INT-2388 #6). */


### PR DESCRIPTION
## Summary
- add blocking dependencyAntiPattern guard for INT-2389
- detect dependency/import failure reports paired with newly-added package scaffold or newly-added __version__ lines
- wire the guard through config schema, types, and sample config

## Verification
- npm test -- src/agents/pipelineGuards.test.ts
- npm run typecheck
- npm run lint
- npm test (130 files / 1444 tests)
- npm run build
- openswarm review --path . → approve

Linear: INT-2389