### PR TITLE
Add contract evidence guard

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -102,6 +102,7 @@ autonomous:
     registryCheck: true
     bsDetector: true        # blocks on critical code-smell patterns
     dependencyAntiPatternCheck: true  # block package recreation/version spoofing after import failures (INT-2388 #1)
+    contractEvidenceCheck: true       # block self-referential contract tests without producer/consumer evidence (INT-2388 #2)
     deadModuleCheck: true   # warn on new modules nothing imports/calls (INT-2388 #5)
     reformatCheck: true     # warn on reformat-only files / oversized diffs (INT-2388 #6)
 

--- a/src/agents/pipelineGuards.test.ts
+++ b/src/agents/pipelineGuards.test.ts
@@ -87,6 +87,228 @@ describe('pipelineGuards — INT-2388 deterministic guards', () => {
     });
   });
 
+  describe('contractEvidenceCheck', () => {
+    it('blocks a self-referential contract literal introduced only in a test', async () => {
+      writeFileSync(
+        join(repo, 'contract.test.ts'),
+        "import { expect, it } from 'vitest';\nit('uses key', () => expect('foreign_summary:').toBe('foreign_summary:'));\n",
+      );
+      const res = await runGuards(
+        mockWorker(['contract.test.ts']),
+        repo,
+        { contractEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'contractEvidence');
+      expect(issues.some(i => i.includes('foreign_summary:'))).toBe(true);
+      expect(res.allPassed).toBe(false);
+    });
+
+    it('allows a contract literal that already exists in HEAD producer code', async () => {
+      writeFileSync(join(repo, 'publisher.ts'), "export const KEY_PREFIX = 'stockapi:foreign_summary:';\n");
+      execFileSync('git', ['add', 'publisher.ts'], { cwd: repo });
+      execFileSync('git', ['commit', '-m', 'add publisher contract'], { cwd: repo });
+
+      writeFileSync(
+        join(repo, 'contract.test.ts'),
+        "import { expect, it } from 'vitest';\nit('uses real key', () => expect('stockapi:foreign_summary:').toBeTruthy());\n",
+      );
+      const res = await runGuards(
+        mockWorker(['contract.test.ts']),
+        repo,
+        { contractEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'contractEvidence');
+      expect(issues.length).toBe(0);
+      expect(res.allPassed).toBe(true);
+    });
+
+    it('allows contract evidence from HEAD JSON schema files', async () => {
+      writeFileSync(join(repo, 'schema.json'), '{"required":["foreign_net_buy"]}\n');
+      execFileSync('git', ['add', 'schema.json'], { cwd: repo });
+      execFileSync('git', ['commit', '-m', 'add wire schema'], { cwd: repo });
+
+      writeFileSync(
+        join(repo, 'contract.test.ts'),
+        "import { expect, it } from 'vitest';\nit('uses schema field', () => expect('foreign_net_buy').toBeTruthy());\n",
+      );
+      const res = await runGuards(
+        mockWorker(['contract.test.ts']),
+        repo,
+        { contractEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'contractEvidence');
+      expect(issues.length).toBe(0);
+      expect(res.allPassed).toBe(true);
+    });
+
+    it('allows a new contract literal when worker evidence cites a measured command sample', async () => {
+      writeFileSync(
+        join(repo, 'contract.test.ts'),
+        "import { expect, it } from 'vitest';\nit('uses measured key', () => expect('stockapi:foreign_summary:').toBeTruthy());\n",
+      );
+      const res = await runGuards(
+        {
+          ...mockWorker(['contract.test.ts']),
+          output: 'redis-cli measured output sample: stockapi:foreign_summary:005930 -> {"ok":true}',
+        },
+        repo,
+        { contractEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'contractEvidence');
+      expect(issues.length).toBe(0);
+      expect(res.allPassed).toBe(true);
+    });
+
+    it('does not accept producer code added in the same diff as independent evidence', async () => {
+      mkdirSync(join(repo, 'src', 'cache'), { recursive: true });
+      writeFileSync(join(repo, 'src', 'cache', 'foreign.py'), "KEY_PREFIX = 'stockapi:foreign_summary:'\n");
+      writeFileSync(
+        join(repo, 'contract.test.ts'),
+        "import { expect, it } from 'vitest';\nit('uses same-diff key', () => expect('stockapi:foreign_summary:').toBeTruthy());\n",
+      );
+      const res = await runGuards(
+        {
+          ...mockWorker(['src/cache/foreign.py', 'contract.test.ts']),
+          output: 'Evidence: src/cache/foreign.py:1 contains stockapi:foreign_summary:',
+        },
+        repo,
+        { contractEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'contractEvidence');
+      expect(issues.some(i => i.includes('stockapi:foreign_summary:'))).toBe(true);
+      expect(res.allPassed).toBe(false);
+    });
+
+    it('does not accept same-diff producer evidence with dot-relative or absolute paths', async () => {
+      mkdirSync(join(repo, 'src', 'cache'), { recursive: true });
+      writeFileSync(join(repo, 'src', 'cache', 'foreign.py'), "KEY_PREFIX = 'stockapi:foreign_summary:'\n");
+      writeFileSync(
+        join(repo, 'contract.test.ts'),
+        "import { expect, it } from 'vitest';\nit('uses same-diff key', () => expect('stockapi:foreign_summary:').toBeTruthy());\n",
+      );
+
+      for (const citedPath of ['./src/cache/foreign.py', join(repo, 'src', 'cache', 'foreign.py')]) {
+        const res = await runGuards(
+          {
+            ...mockWorker(['src/cache/foreign.py', 'contract.test.ts']),
+            output: `Evidence: ${citedPath}:1 contains stockapi:foreign_summary:`,
+          },
+          repo,
+          { contractEvidenceCheck: true },
+        );
+        const issues = guardIssues(res, 'contractEvidence');
+        expect(issues.some(i => i.includes('stockapi:foreign_summary:'))).toBe(true);
+        expect(res.allPassed).toBe(false);
+      }
+    });
+
+    it('does not accept project-external file references as contract evidence', async () => {
+      const outside = join(tmpdir(), `openswarm-outside-contract-${process.pid}-${Date.now()}.py`);
+      writeFileSync(outside, "KEY_PREFIX = 'stockapi:foreign_summary:'\n");
+      writeFileSync(
+        join(repo, 'contract.test.ts'),
+        "import { expect, it } from 'vitest';\nit('uses key', () => expect('stockapi:foreign_summary:').toBeTruthy());\n",
+      );
+      try {
+        const res = await runGuards(
+          {
+            ...mockWorker(['contract.test.ts']),
+            output: `Evidence: ${outside}:1 contains stockapi:foreign_summary:`,
+          },
+          repo,
+          { contractEvidenceCheck: true },
+        );
+        const issues = guardIssues(res, 'contractEvidence');
+        expect(issues.some(i => i.includes('stockapi:foreign_summary:'))).toBe(true);
+        expect(res.allPassed).toBe(false);
+      } finally {
+        rmSync(outside, { force: true });
+      }
+    });
+
+    it('does not accept parent-relative external file references as contract evidence', async () => {
+      const parentOutside = join(repo, '..', `outside-contract-${process.pid}-${Date.now()}.py`);
+      writeFileSync(parentOutside, "KEY_PREFIX = 'stockapi:foreign_summary:'\n");
+      writeFileSync(
+        join(repo, 'contract.test.ts'),
+        "import { expect, it } from 'vitest';\nit('uses key', () => expect('stockapi:foreign_summary:').toBeTruthy());\n",
+      );
+      try {
+        const res = await runGuards(
+          {
+            ...mockWorker(['contract.test.ts']),
+            output: `Evidence: ../${parentOutside.split('/').pop()}:1 contains stockapi:foreign_summary:`,
+          },
+          repo,
+          { contractEvidenceCheck: true },
+        );
+        const issues = guardIssues(res, 'contractEvidence');
+        expect(issues.some(i => i.includes('stockapi:foreign_summary:'))).toBe(true);
+        expect(res.allPassed).toBe(false);
+      } finally {
+        rmSync(parentOutside, { force: true });
+      }
+    });
+
+    it('does not treat HEAD test-only literals as producer evidence', async () => {
+      writeFileSync(
+        join(repo, 'old-contract.test.ts'),
+        "import { expect, it } from 'vitest';\nit('old invented key', () => expect('invented_prefix:').toBeTruthy());\n",
+      );
+      execFileSync('git', ['add', 'old-contract.test.ts'], { cwd: repo });
+      execFileSync('git', ['commit', '-m', 'add old test-only contract'], { cwd: repo });
+
+      writeFileSync(
+        join(repo, 'contract.test.ts'),
+        "import { expect, it } from 'vitest';\nit('reuses invented key', () => expect('invented_prefix:').toBeTruthy());\n",
+      );
+      const res = await runGuards(
+        mockWorker(['contract.test.ts']),
+        repo,
+        { contractEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'contractEvidence');
+      expect(issues.some(i => i.includes('invented_prefix:'))).toBe(true);
+      expect(res.allPassed).toBe(false);
+    });
+
+    it('does not accept vague worker output as contract evidence', async () => {
+      writeFileSync(
+        join(repo, 'contract.test.ts'),
+        "import { expect, it } from 'vitest';\nit('uses key', () => expect('stockapi:foreign_summary:').toBeTruthy());\n",
+      );
+      const res = await runGuards(
+        {
+          ...mockWorker(['contract.test.ts']),
+          output: 'The producer uses stockapi:foreign_summary: and the consumer is aligned.',
+        },
+        repo,
+        { contractEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'contractEvidence');
+      expect(issues.some(i => i.includes('stockapi:foreign_summary:'))).toBe(true);
+      expect(res.allPassed).toBe(false);
+    });
+
+    it('does not accept the changed test file itself as contract evidence', async () => {
+      writeFileSync(
+        join(repo, 'contract.test.ts'),
+        "import { expect, it } from 'vitest';\nit('uses key', () => expect('stockapi:foreign_summary:').toBeTruthy());\n",
+      );
+      const res = await runGuards(
+        {
+          ...mockWorker(['contract.test.ts']),
+          output: 'Evidence: contract.test.ts:2 contains stockapi:foreign_summary:',
+        },
+        repo,
+        { contractEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'contractEvidence');
+      expect(issues.some(i => i.includes('stockapi:foreign_summary:'))).toBe(true);
+      expect(res.allPassed).toBe(false);
+    });
+  });
+
   describe('deadModuleCheck', () => {
     it('flags a new source module that nothing imports', async () => {
       writeFileSync(join(repo, 'orphanwidget.ts'), 'export function orphanwidget() { return 1; }\n');

--- a/src/agents/pipelineGuards.ts
+++ b/src/agents/pipelineGuards.ts
@@ -5,7 +5,7 @@
 
 import { execFile } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { isAbsolute, join, normalize, relative, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import type { WorkerResult } from './agentPair.js';
 import type { PipelineGuardsConfig } from '../core/types.js';
@@ -314,6 +314,10 @@ const VERSION_SPOOF_RE =
   /(^|\n)\s*(?:export\s+const\s+)?__version__\s*[:=]/;
 const PACKAGE_SCAFFOLD_RE =
   /(^|\/)(package\.json|pyproject\.toml|setup\.py|setup\.cfg)$/;
+const EVIDENCE_FILE_REF_RE =
+  /((?:\/|\.\/)?[\w./-]+\.(?:ts|tsx|js|jsx|py|go|rs|java|yaml|yml|json)):(\d+)\b/g;
+const CONTRACT_EVIDENCE_FILE_RE =
+  /\.(ts|tsx|js|jsx|py|go|rs|java|yaml|yml|json)$/;
 
 async function getAddedLinesForFile(projectPath: string, filePath: string, isNew: boolean): Promise<string> {
   try {
@@ -338,6 +342,95 @@ async function getAddedLinesForFile(projectPath: string, filePath: string, isNew
   } catch {
     return '';
   }
+}
+
+function extractStringLiterals(text: string): string[] {
+  const literals = new Set<string>();
+  const re = /['"`]([^'"`\n]{3,120})['"`]/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text))) {
+    literals.add(match[1]);
+  }
+  return [...literals];
+}
+
+function isContractLiteral(literal: string, addedLines: string): boolean {
+  if (literal.startsWith('/api/')) return true;
+  if (/^[a-zA-Z0-9_.-]{3,}:/.test(literal)) return true;
+  if (
+    /^[a-z][a-z0-9]+(?:_[a-z0-9]+)+$/.test(literal) &&
+    /\b(expect|assert|field|schema|payload|json|contract)\b/i.test(addedLines)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+async function literalExistsInHeadSource(projectPath: string, literal: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['grep', '-F', '-l', literal, 'HEAD', '--', '.'],
+      { cwd: projectPath, timeout: 10_000 },
+    );
+    return stdout
+      .split('\n')
+      .filter(Boolean)
+      .map(line => line.replace(/^HEAD:/, ''))
+      .some(file => CONTRACT_EVIDENCE_FILE_RE.test(file) && !TEST_FILE_RE.test(file));
+  } catch {
+    return false;
+  }
+}
+
+function normalizeEvidencePath(projectPath: string, filePath: string): string | null {
+  const cleaned = normalize(filePath).replace(/\\/g, '/').replace(/^\.\//, '');
+  const absolute = isAbsolute(cleaned) ? cleaned : resolve(projectPath, cleaned);
+  const rel = normalize(relative(projectPath, absolute)).replace(/\\/g, '/');
+  if (rel.startsWith('../') || rel === '..' || isAbsolute(rel)) return null;
+  return rel;
+}
+
+async function hasExternalContractEvidence(
+  workerResult: WorkerResult,
+  projectPath: string,
+  literal: string,
+  excludedFiles: Set<string>,
+): Promise<boolean> {
+  const text = `${workerResult.summary}\n${workerResult.output.slice(0, 8000)}\n${workerResult.error ?? ''}`;
+  const fileRefs = new Map<string, Set<number>>();
+  let match: RegExpExecArray | null;
+  while ((match = EVIDENCE_FILE_REF_RE.exec(text))) {
+    const normalized = normalizeEvidencePath(projectPath, match[1]);
+    if (!normalized) continue;
+    const lineNo = parseInt(match[2], 10);
+    const lines = fileRefs.get(normalized) ?? new Set<number>();
+    if (Number.isFinite(lineNo)) lines.add(lineNo);
+    fileRefs.set(normalized, lines);
+  }
+
+  for (const [file, lineNos] of fileRefs) {
+    if (excludedFiles.has(file) || !CONTRACT_EVIDENCE_FILE_RE.test(file) || TEST_FILE_RE.test(file)) continue;
+    try {
+      const content = await readFile(join(projectPath, file), 'utf8');
+      const lines = content.split('\n');
+      for (const lineNo of lineNos) {
+        const start = Math.max(0, lineNo - 3);
+        const end = Math.min(lines.length, lineNo + 2);
+        if (lines.slice(start, end).some(line => line.includes(literal))) return true;
+      }
+    } catch {
+      // Missing cited files do not count as evidence.
+    }
+  }
+
+  return text
+    .split('\n')
+    .some(line =>
+      line.includes(literal) &&
+      /\b(redis-cli|curl)\b/i.test(line) &&
+      /\b(output|sample|measured|actual|returned|observed)\b/i.test(line),
+    );
 }
 
 /**
@@ -446,6 +539,46 @@ async function runDependencyAntiPatternGuard(
 }
 
 /**
+ * Contract evidence guard (INT-2388 defect #2): a test that introduces a Redis
+ * key prefix, API route, or wire-field literal proves nothing if that literal is
+ * only invented inside the same diff. For new/changed tests, require the literal
+ * to already exist in HEAD or be backed by worker evidence (file:line, producer,
+ * consumer, redis-cli/curl/measured output).
+ */
+async function runContractEvidenceGuard(
+  workerResult: WorkerResult,
+  projectPath: string,
+): Promise<GuardResult> {
+  const guard = 'contractEvidence';
+  const issues: string[] = [];
+
+  try {
+    const details = await getWorkingDiffDetail(projectPath);
+    const changedTests = details.filter(d => TEST_FILE_RE.test(d.file));
+    const changedFiles = new Set(details.map(d => d.file));
+
+    for (const d of changedTests) {
+      const addedLines = await getAddedLinesForFile(projectPath, d.file, d.isNew);
+      const literals = extractStringLiterals(addedLines)
+        .filter(literal => isContractLiteral(literal, addedLines));
+
+      for (const literal of literals) {
+        const knownInHead = await literalExistsInHeadSource(projectPath, literal);
+        if (knownInHead || await hasExternalContractEvidence(workerResult, projectPath, literal, changedFiles)) continue;
+
+        issues.push(
+          `[${d.file}] test adds contract literal "${literal}" but it is not present in HEAD and no producer/consumer evidence was cited. Avoid self-referential contract tests.`,
+        );
+      }
+    }
+  } catch (err) {
+    console.warn('[Guard:contractEvidence] Error:', err);
+  }
+
+  return { passed: issues.length === 0, guard, issues, blocking: true };
+}
+
+/**
  * Reformat/scope guard (INT-2388 defect #6): flag reformat-only files (whose
  * diff vanishes under `git diff -w`) and unusually large diffs. Both inflate
  * cross-PR conflict surface and hide the real change. Non-blocking — advisory.
@@ -519,6 +652,10 @@ export async function runGuards(
 
   if (config.dependencyAntiPatternCheck) {
     results.push(await runDependencyAntiPatternGuard(workerResult, projectPath));
+  }
+
+  if (config.contractEvidenceCheck) {
+    results.push(await runContractEvidenceGuard(workerResult, projectPath));
   }
 
   if (config.deadModuleCheck) {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -223,6 +223,7 @@ const PipelineGuardsConfigSchema = z.object({
   registryCheck: z.boolean().optional(),
   bsDetector: z.boolean().optional(),
   dependencyAntiPatternCheck: z.boolean().optional(),
+  contractEvidenceCheck: z.boolean().optional(),
   deadModuleCheck: z.boolean().optional(),
   reformatCheck: z.boolean().optional(),
 }).optional();

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -428,6 +428,8 @@ export interface PipelineGuardsConfig {
   bsDetector: boolean;
   /** Block dependency/import failure fixes that spoof package identity (INT-2388 #1). */
   dependencyAntiPatternCheck?: boolean;
+  /** Block self-referential contract tests without producer/consumer evidence (INT-2388 #2). */
+  contractEvidenceCheck?: boolean;
   /** Flag newly-added source modules that nothing imports/calls (INT-2388 #5). */
   deadModuleCheck?: boolean;
   /** Flag reformat-only files and oversized diffs — scope creep (INT-2388 #6). */


### PR DESCRIPTION
## Summary
- add blocking contractEvidence guard for INT-2390
- detect contract-like literals introduced in tests and require independent evidence
- accept evidence only from HEAD source/schema files, changed-file-excluded file:line refs, or command-backed measured redis-cli/curl samples
- cover self-referential, same-diff producer, path normalization, and project-boundary bypass cases

## Verification
- npm test -- src/agents/pipelineGuards.test.ts
- npm run typecheck
- npm run lint
- npm test (130 files / 1455 tests)
- npm run build
- openswarm review --path .: earlier revise findings fixed; final rerun hit internal Codex timeout after no result

Linear: INT-2390