### PR TITLE
Add verified metric evidence guard

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -103,6 +103,7 @@ autonomous:
     bsDetector: true        # blocks on critical code-smell patterns
     dependencyAntiPatternCheck: true  # block package recreation/version spoofing after import failures (INT-2388 #1)
     contractEvidenceCheck: true       # block self-referential contract tests without producer/consumer evidence (INT-2388 #2)
+    verifiedMetricEvidenceCheck: true # block verified evidence deletion / metric changes without distributions (INT-2388 #4)
     deadModuleCheck: true   # warn on new modules nothing imports/calls (INT-2388 #5)
     reformatCheck: true     # warn on reformat-only files / oversized diffs (INT-2388 #6)
 

--- a/src/agents/pipelineGuards.test.ts
+++ b/src/agents/pipelineGuards.test.ts
@@ -309,6 +309,213 @@ describe('pipelineGuards — INT-2388 deterministic guards', () => {
     });
   });
 
+  describe('verifiedMetricEvidenceCheck', () => {
+    it('blocks removing verified documentation without counter-evidence', async () => {
+      writeFileSync(join(repo, 'ARCHITECTURE.md'), 'KIS and pykrx parity is verified by 2026-06-28 sample.\n');
+      execFileSync('git', ['add', 'ARCHITECTURE.md'], { cwd: repo });
+      execFileSync('git', ['commit', '-m', 'add verified doc'], { cwd: repo });
+
+      writeFileSync(join(repo, 'ARCHITECTURE.md'), 'KIS and pykrx parity needs more study.\n');
+      const res = await runGuards(
+        mockWorker(['ARCHITECTURE.md']),
+        repo,
+        { verifiedMetricEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'verifiedMetricEvidence');
+      expect(issues.some(i => i.includes('ARCHITECTURE.md'))).toBe(true);
+      expect(res.allPassed).toBe(false);
+    });
+
+    it('allows removing verified documentation when counter-evidence is cited', async () => {
+      writeFileSync(join(repo, 'ARCHITECTURE.md'), 'The old parity claim is confirmed by sample A.\n');
+      execFileSync('git', ['add', 'ARCHITECTURE.md'], { cwd: repo });
+      execFileSync('git', ['commit', '-m', 'add confirmed doc'], { cwd: repo });
+
+      writeFileSync(join(repo, 'ARCHITECTURE.md'), 'The old parity claim is superseded.\n');
+      const res = await runGuards(
+        {
+          ...mockWorker(['ARCHITECTURE.md']),
+          output: 'ARCHITECTURE.md counter-evidence: remeasured 8 rows and disproves the old parity claim.',
+        },
+        repo,
+        { verifiedMetricEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'verifiedMetricEvidence');
+      expect(issues.length).toBe(0);
+      expect(res.allPassed).toBe(true);
+    });
+
+    it('does not accept a negative counter-evidence statement', async () => {
+      writeFileSync(join(repo, 'ARCHITECTURE.md'), 'The old parity claim is measured by sample A.\n');
+      execFileSync('git', ['add', 'ARCHITECTURE.md'], { cwd: repo });
+      execFileSync('git', ['commit', '-m', 'add measured doc'], { cwd: repo });
+
+      writeFileSync(join(repo, 'ARCHITECTURE.md'), 'The old parity claim is removed.\n');
+      const res = await runGuards(
+        {
+          ...mockWorker(['ARCHITECTURE.md']),
+          output: 'Counter-evidence was not found.',
+        },
+        repo,
+        { verifiedMetricEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'verifiedMetricEvidence');
+      expect(issues.some(i => i.includes('ARCHITECTURE.md'))).toBe(true);
+      expect(res.allPassed).toBe(false);
+    });
+
+    it('blocks score logic changes without before/after distribution evidence', async () => {
+      writeFileSync(join(repo, 'scoreGate.ts'), 'export const score = (x: number) => x > 10 ? 1 : 0;\n');
+      execFileSync('git', ['add', 'scoreGate.ts'], { cwd: repo });
+      execFileSync('git', ['commit', '-m', 'add score gate'], { cwd: repo });
+
+      writeFileSync(join(repo, 'scoreGate.ts'), 'export const score = (x: number) => x > 20 ? 1 : 0;\n');
+      const res = await runGuards(
+        mockWorker(['scoreGate.ts']),
+        repo,
+        { verifiedMetricEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'verifiedMetricEvidence');
+      expect(issues.some(i => i.includes('scoreGate.ts'))).toBe(true);
+      expect(res.allPassed).toBe(false);
+    });
+
+    it('does not block config/test terminology that mentions metric or gate', async () => {
+      writeFileSync(join(repo, 'config.example.yaml'), 'verifiedMetricEvidenceCheck: true\n');
+      writeFileSync(join(repo, 'guardTerminology.test.ts'), 'it("mentions score gate", () => {});\n');
+      const res = await runGuards(
+        mockWorker(['config.example.yaml', 'guardTerminology.test.ts']),
+        repo,
+        { verifiedMetricEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'verifiedMetricEvidence');
+      expect(issues.length).toBe(0);
+      expect(res.allPassed).toBe(true);
+    });
+
+    it('blocks threshold logic changes in non-metric-named source files', async () => {
+      writeFileSync(join(repo, 'strategy.ts'), 'export const decide = (score: number) => score > 10;\n');
+      execFileSync('git', ['add', 'strategy.ts'], { cwd: repo });
+      execFileSync('git', ['commit', '-m', 'add strategy'], { cwd: repo });
+
+      writeFileSync(join(repo, 'strategy.ts'), 'export const decide = (score: number) => score > 20;\n');
+      const res = await runGuards(
+        mockWorker(['strategy.ts']),
+        repo,
+        { verifiedMetricEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'verifiedMetricEvidence');
+      expect(issues.some(i => i.includes('strategy.ts'))).toBe(true);
+      expect(res.allPassed).toBe(false);
+    });
+
+    it('allows score logic changes with before/after distribution evidence', async () => {
+      writeFileSync(join(repo, 'metricRanker.ts'), 'export const rank = (score: number) => score * 1;\n');
+      execFileSync('git', ['add', 'metricRanker.ts'], { cwd: repo });
+      execFileSync('git', ['commit', '-m', 'add metric ranker'], { cwd: repo });
+
+      writeFileSync(join(repo, 'metricRanker.ts'), 'export const rank = (score: number) => score * 2;\n');
+      const res = await runGuards(
+        {
+          ...mockWorker(['metricRanker.ts']),
+          output: 'metricRanker.ts before/after distribution: changed 12 items, median delta +2.1, histogram attached.',
+        },
+        repo,
+        { verifiedMetricEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'verifiedMetricEvidence');
+      expect(issues.length).toBe(0);
+      expect(res.allPassed).toBe(true);
+    });
+
+    it('does not accept a negative before/after distribution statement', async () => {
+      writeFileSync(join(repo, 'metricRanker.ts'), 'export const rank = (score: number) => score * 1;\n');
+      execFileSync('git', ['add', 'metricRanker.ts'], { cwd: repo });
+      execFileSync('git', ['commit', '-m', 'add metric ranker'], { cwd: repo });
+
+      writeFileSync(join(repo, 'metricRanker.ts'), 'export const rank = (score: number) => score * 3;\n');
+      const res = await runGuards(
+        {
+          ...mockWorker(['metricRanker.ts']),
+          output: 'No before/after distribution was produced; delta unavailable.',
+        },
+        repo,
+        { verifiedMetricEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'verifiedMetricEvidence');
+      expect(issues.some(i => i.includes('metricRanker.ts'))).toBe(true);
+      expect(res.allPassed).toBe(false);
+    });
+
+    it('requires before/after evidence per changed metric file', async () => {
+      writeFileSync(join(repo, 'scoreGate.ts'), 'export const score = (x: number) => x > 10 ? 1 : 0;\n');
+      writeFileSync(join(repo, 'metricRanker.ts'), 'export const rank = (score: number) => score * 1;\n');
+      execFileSync('git', ['add', 'scoreGate.ts', 'metricRanker.ts'], { cwd: repo });
+      execFileSync('git', ['commit', '-m', 'add metric files'], { cwd: repo });
+
+      writeFileSync(join(repo, 'scoreGate.ts'), 'export const score = (x: number) => x > 20 ? 1 : 0;\n');
+      writeFileSync(join(repo, 'metricRanker.ts'), 'export const rank = (score: number) => score * 2;\n');
+      const res = await runGuards(
+        {
+          ...mockWorker(['scoreGate.ts', 'metricRanker.ts']),
+          output: 'metricRanker.ts before/after distribution: changed 12 items, median delta +2.1.',
+        },
+        repo,
+        { verifiedMetricEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'verifiedMetricEvidence');
+      expect(issues.some(i => i.includes('scoreGate.ts'))).toBe(true);
+      expect(issues.some(i => i.includes('metricRanker.ts'))).toBe(false);
+      expect(res.allPassed).toBe(false);
+    });
+
+    it('requires counter-evidence per verified doc removal', async () => {
+      writeFileSync(join(repo, 'A.md'), 'Claim A is verified.\n');
+      writeFileSync(join(repo, 'B.md'), 'Claim B is measured.\n');
+      execFileSync('git', ['add', 'A.md', 'B.md'], { cwd: repo });
+      execFileSync('git', ['commit', '-m', 'add evidence docs'], { cwd: repo });
+
+      writeFileSync(join(repo, 'A.md'), 'Claim A removed.\n');
+      writeFileSync(join(repo, 'B.md'), 'Claim B removed.\n');
+      const res = await runGuards(
+        {
+          ...mockWorker(['A.md', 'B.md']),
+          output: 'A.md counter-evidence: remeasured and disproves Claim A.',
+        },
+        repo,
+        { verifiedMetricEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'verifiedMetricEvidence');
+      expect(issues.some(i => i.includes('A.md'))).toBe(false);
+      expect(issues.some(i => i.includes('B.md'))).toBe(true);
+      expect(res.allPassed).toBe(false);
+    });
+
+    it('does not let basename-matched doc evidence clear another file', async () => {
+      mkdirSync(join(repo, 'docs', 'old'), { recursive: true });
+      mkdirSync(join(repo, 'docs', 'new'), { recursive: true });
+      writeFileSync(join(repo, 'docs', 'old', 'README.md'), 'Old claim is verified.\n');
+      writeFileSync(join(repo, 'docs', 'new', 'README.md'), 'New claim is measured.\n');
+      execFileSync('git', ['add', 'docs/old/README.md', 'docs/new/README.md'], { cwd: repo });
+      execFileSync('git', ['commit', '-m', 'add nested docs'], { cwd: repo });
+
+      writeFileSync(join(repo, 'docs', 'old', 'README.md'), 'Old claim removed.\n');
+      writeFileSync(join(repo, 'docs', 'new', 'README.md'), 'New claim removed.\n');
+      const res = await runGuards(
+        {
+          ...mockWorker(['docs/old/README.md', 'docs/new/README.md']),
+          output: 'docs/new/README.md counter-evidence: remeasured and disproves New claim.',
+        },
+        repo,
+        { verifiedMetricEvidenceCheck: true },
+      );
+      const issues = guardIssues(res, 'verifiedMetricEvidence');
+      expect(issues.some(i => i.includes('docs/old/README.md'))).toBe(true);
+      expect(issues.some(i => i.includes('docs/new/README.md'))).toBe(false);
+      expect(res.allPassed).toBe(false);
+    });
+  });
+
   describe('deadModuleCheck', () => {
     it('flags a new source module that nothing imports', async () => {
       writeFileSync(join(repo, 'orphanwidget.ts'), 'export function orphanwidget() { return 1; }\n');

--- a/src/agents/pipelineGuards.ts
+++ b/src/agents/pipelineGuards.ts
@@ -318,6 +318,39 @@ const EVIDENCE_FILE_REF_RE =
   /((?:\/|\.\/)?[\w./-]+\.(?:ts|tsx|js|jsx|py|go|rs|java|yaml|yml|json)):(\d+)\b/g;
 const CONTRACT_EVIDENCE_FILE_RE =
   /\.(ts|tsx|js|jsx|py|go|rs|java|yaml|yml|json)$/;
+const DOC_FILE_RE = /\.(md|mdx|txt|rst)$/;
+const VERIFIED_STATEMENT_RE = /\b(verified|confirmed|measured)\b/i;
+const COUNTER_EVIDENCE_RE = /\b(counter-?evidence|disproves?|invalidates?|supersedes?|retested|re-measured|remeasured)\b/i;
+const METRIC_FILE_RE = /(score|scorer|metric|gate|ranking|rank|report)/i;
+const METRIC_LOGIC_RE = /\b(score|metric|gate|threshold|weight|rank|ranking|percentile|quantile)\b/i;
+const METRIC_CODE_CHANGE_RE =
+  /\b(score|metric|gate|threshold|weight|rank|ranking|percentile|quantile)\b.*(=>|=|>|<|\+|-|\*|\/)|(=>|=|>|<|\+|-|\*|\/).*\b(score|metric|gate|threshold|weight|rank|ranking|percentile|quantile)\b/i;
+const GUARD_INFRA_FILE_RE = /(^|\/)(pipelineGuards|config|types)\.(ts|tsx|ya?ml)$/;
+const BEFORE_AFTER_RE = /\b(before\/after|before and after|distribution|histogram|moved|delta|changed\s+\d+|diff\s+distribution)\b/i;
+const NEGATIVE_EVIDENCE_RE =
+  /\b(no|not|without|missing|failed to|was not|not found|not produced|unavailable)\b.{0,60}\b(counter-?evidence|before\/after|before and after|distribution|delta|histogram)\b|\b(counter-?evidence|before\/after|before and after|distribution|delta|histogram)\b.{0,60}\b(not found|not produced|missing|unavailable)\b/i;
+const DISTRIBUTION_NUMERIC_RE =
+  /\b(changed\s+\d+|\d+\s+items?|median\s+delta|mean\s+delta|delta\s+[+-]?\d|histogram|p\d+|quantile)\b/i;
+
+function reportLinesForFile(reportText: string, filePath: string): string[] {
+  return reportText
+    .split('\n')
+    .filter(line => line.includes(filePath));
+}
+
+function hasFileScopedCounterEvidence(reportText: string, filePath: string): boolean {
+  return reportLinesForFile(reportText, filePath)
+    .some(line => COUNTER_EVIDENCE_RE.test(line) && !NEGATIVE_EVIDENCE_RE.test(line));
+}
+
+function hasFileScopedBeforeAfterEvidence(reportText: string, filePath: string): boolean {
+  return reportLinesForFile(reportText, filePath)
+    .some(line =>
+      BEFORE_AFTER_RE.test(line) &&
+      DISTRIBUTION_NUMERIC_RE.test(line) &&
+      !NEGATIVE_EVIDENCE_RE.test(line),
+    );
+}
 
 async function getAddedLinesForFile(projectPath: string, filePath: string, isNew: boolean): Promise<string> {
   try {
@@ -339,6 +372,23 @@ async function getAddedLinesForFile(projectPath: string, filePath: string, isNew
   if (!isNew) return '';
   try {
     return await readFile(join(projectPath, filePath), 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+async function getRemovedLinesForFile(projectPath: string, filePath: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['diff', '--unified=0', 'HEAD', '--', filePath],
+      { cwd: projectPath, timeout: 10_000 },
+    );
+    return stdout
+      .split('\n')
+      .filter(line => line.startsWith('-') && !line.startsWith('---'))
+      .map(line => line.slice(1))
+      .join('\n');
   } catch {
     return '';
   }
@@ -579,6 +629,58 @@ async function runContractEvidenceGuard(
 }
 
 /**
+ * Evidence preservation guard (INT-2388 defect #4): don't silently delete
+ * verified/confirmed/measured claims, and don't change score/metric/gating logic
+ * without before/after distribution evidence. Blocking, but narrow: it only
+ * fires on removed evidence wording or metric-like logic diffs.
+ */
+async function runVerifiedMetricEvidenceGuard(
+  workerResult: WorkerResult,
+  projectPath: string,
+): Promise<GuardResult> {
+  const guard = 'verifiedMetricEvidence';
+  const issues: string[] = [];
+  const reportText = `${workerResult.summary}\n${workerResult.output.slice(0, 8000)}\n${workerResult.error ?? ''}`;
+
+  try {
+    const details = await getWorkingDiffDetail(projectPath);
+
+    for (const d of details) {
+      const removedLines = await getRemovedLinesForFile(projectPath, d.file);
+      const addedLines = await getAddedLinesForFile(projectPath, d.file, d.isNew);
+
+      if (DOC_FILE_RE.test(d.file) && VERIFIED_STATEMENT_RE.test(removedLines) && !hasFileScopedCounterEvidence(reportText, d.file)) {
+        issues.push(
+          `[${d.file}] removes verified/confirmed/measured evidence wording without counter-evidence in the worker report.`,
+        );
+      }
+
+      const fileName = d.file.split('/').pop() ?? d.file;
+      const metricLikeFile = METRIC_FILE_RE.test(fileName);
+      const metricLikeDiff = METRIC_LOGIC_RE.test(`${addedLines}\n${removedLines}`);
+      const metricCodeChange = METRIC_CODE_CHANGE_RE.test(`${addedLines}\n${removedLines}`);
+      const codeFile = SOURCE_FILE_RE.test(d.file) && !TEST_FILE_RE.test(d.file) && !d.file.endsWith('.d.ts');
+      if (
+        codeFile &&
+        !GUARD_INFRA_FILE_RE.test(d.file) &&
+        (metricLikeFile || metricCodeChange) &&
+        metricLikeDiff &&
+        (addedLines || removedLines) &&
+        !hasFileScopedBeforeAfterEvidence(reportText, d.file)
+      ) {
+        issues.push(
+          `[${d.file}] changes score/metric/gate/ranking logic without before/after distribution evidence.`,
+        );
+      }
+    }
+  } catch (err) {
+    console.warn('[Guard:verifiedMetricEvidence] Error:', err);
+  }
+
+  return { passed: issues.length === 0, guard, issues, blocking: true };
+}
+
+/**
  * Reformat/scope guard (INT-2388 defect #6): flag reformat-only files (whose
  * diff vanishes under `git diff -w`) and unusually large diffs. Both inflate
  * cross-PR conflict surface and hide the real change. Non-blocking — advisory.
@@ -656,6 +758,10 @@ export async function runGuards(
 
   if (config.contractEvidenceCheck) {
     results.push(await runContractEvidenceGuard(workerResult, projectPath));
+  }
+
+  if (config.verifiedMetricEvidenceCheck) {
+    results.push(await runVerifiedMetricEvidenceGuard(workerResult, projectPath));
   }
 
   if (config.deadModuleCheck) {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -224,6 +224,7 @@ const PipelineGuardsConfigSchema = z.object({
   bsDetector: z.boolean().optional(),
   dependencyAntiPatternCheck: z.boolean().optional(),
   contractEvidenceCheck: z.boolean().optional(),
+  verifiedMetricEvidenceCheck: z.boolean().optional(),
   deadModuleCheck: z.boolean().optional(),
   reformatCheck: z.boolean().optional(),
 }).optional();

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -430,6 +430,8 @@ export interface PipelineGuardsConfig {
   dependencyAntiPatternCheck?: boolean;
   /** Block self-referential contract tests without producer/consumer evidence (INT-2388 #2). */
   contractEvidenceCheck?: boolean;
+  /** Block verified-evidence deletion and metric changes without before/after evidence (INT-2388 #4). */
+  verifiedMetricEvidenceCheck?: boolean;
   /** Flag newly-added source modules that nothing imports/calls (INT-2388 #5). */
   deadModuleCheck?: boolean;
   /** Flag reformat-only files and oversized diffs — scope creep (INT-2388 #6). */


### PR DESCRIPTION
## Summary
- add blocking verifiedMetricEvidence guard for INT-2391
- block removal of verified/confirmed/measured doc statements unless file-scoped counter-evidence is cited
- block score/metric/gate/ranking logic changes unless file-scoped before/after distribution evidence is cited
- cover negative evidence wording, config/test false positives, non-metric filenames, basename collisions, and per-file evidence requirements

## Verification
- npm test -- src/agents/pipelineGuards.test.ts
- npm run typecheck
- npm run lint
- openswarm review --path . → approve
- npm test (130 files / 1466 tests)
- npm run build

Linear: INT-2391