### PR TITLE
test(registry): cover INT-2302 regressions

### DIFF
--- a/src/cli/checkHandler.test.ts
+++ b/src/cli/checkHandler.test.ts
@@ -1,0 +1,49 @@
+import { mkdir, mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getStats = vi.fn();
+
+vi.mock('../registry/sqliteStore.js', () => ({
+  getRegistryStore: () => ({ getStats }),
+  closeRegistryStore: vi.fn(),
+}));
+
+describe('checkHandler', () => {
+  let tmp: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'openswarm-check-'));
+    originalCwd = process.cwd();
+    getStats.mockReset();
+    getStats.mockReturnValue({
+      total: 0,
+      deprecated: 0,
+      untested: 0,
+      highRisk: 0,
+      withWarnings: 0,
+      byKind: [],
+      byStatus: [],
+    });
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('scopes --stats to the current project when --project is omitted', async () => {
+    await mkdir(tmp, { recursive: true });
+    await writeFile(join(tmp, 'package.json'), JSON.stringify({ name: '@intrect/project-a' }), 'utf-8');
+    process.chdir(tmp);
+
+    const { handleCheck } = await import('./checkHandler.js');
+    await handleCheck(undefined, { stats: true });
+
+    expect(getStats).toHaveBeenCalledWith('project-a');
+  });
+});

--- a/src/registry/entityScanner.test.ts
+++ b/src/registry/entityScanner.test.ts
@@ -1,0 +1,56 @@
+import { mkdir, mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RegisterEntityInput } from './sqliteStore.js';
+
+const registered: RegisterEntityInput[] = [];
+
+vi.mock('./sqliteStore.js', () => ({
+  getRegistryStore: () => ({
+    listEntities: () => ({ entities: [], total: 0 }),
+    registerEntity: (input: RegisterEntityInput) => {
+      registered.push(input);
+      return { id: input.name };
+    },
+    updateEntity: vi.fn(),
+    changeEntityStatus: vi.fn(),
+  }),
+}));
+
+describe('entity scanner', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'openswarm-registry-'));
+    registered.length = 0;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  async function writeProjectFile(path: string, content: string): Promise<void> {
+    const fullPath = join(tmp, path);
+    await mkdir(join(fullPath, '..'), { recursive: true });
+    await writeFile(fullPath, content, 'utf-8');
+  }
+
+  it('maps Python test_ files to matching source entities', async () => {
+    await writeProjectFile('src/foo.py', 'def foo():\n    return 1\n');
+    await writeProjectFile('tests/test_foo.py', 'def test_foo():\n    assert foo() == 1\n');
+
+    const { scanRepository } = await import('./entityScanner.js');
+    const result = await scanRepository(tmp, 'test-project');
+
+    expect(result.testsMapped).toBe(1);
+    expect(registered).toContainEqual(expect.objectContaining({
+      projectId: 'test-project',
+      name: 'foo',
+      filePath: 'src/foo.py',
+      hasTests: true,
+      testFile: 'tests/test_foo.py',
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- add a regression test that `openswarm check --stats` scopes stats to the current project when `--project` is omitted
- add a registry scanner regression test for Python `test_*.py` files mapping to matching source entities

## Verification
- `npm test -- src/cli/checkHandler.test.ts src/registry/entityScanner.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- `openswarm review --path .` -> APPROVE

Linear: INT-2302