### PR TITLE
feat(tui): group pipeline agents by repository

### DIFF
--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -71,6 +71,8 @@ export interface PipelineConfig {
   guards?: Partial<PipelineGuardsConfig>;
   /** Optional job profiles for model selection */
   jobProfiles?: JobProfile[];
+  /** Runtime metadata used by observers such as the TUI pipeline tree. */
+  runMetadata?: PipelineRunMetadata;
   /** Skip tester if no code files (.ts/.js/.py etc.) changed (default: true) */
   skipTesterIfNoCodeChange?: boolean;
   /** Skip auditor if fewer than N files changed (default: 3) */
@@ -89,6 +91,15 @@ export interface PipelineConfig {
     impactAnalysis?: import('../knowledge/types.js').ImpactAnalysis;
     registrySnapshot?: Array<{ filePath: string; summary: string; highlights: string[] }>;
   };
+}
+
+export interface PipelineRunMetadata {
+  repository?: string;
+  projectPath?: string;
+  worktree?: string;
+  branch?: string;
+  issueIdentifier?: string;
+  title?: string;
 }
 
 export interface StageResult {
@@ -529,9 +540,10 @@ export class PairPipeline extends EventEmitter {
     const startTime = Date.now();
     const stageModel = overrides?.model ?? this.getModelForRole(stage, context.task);
     const prefix = context.taskPrefix;
+    const metadata = this.stageMetadata(context);
     console.log(`[${prefix}] Stage starting: ${stage}`);
     this.emit('stage:start', { stage, context, model: stageModel });
-    broadcastEvent({ type: 'pipeline:stage', data: { taskId: context.task.id, stage, status: 'start', model: stageModel } });
+    broadcastEvent({ type: 'pipeline:stage', data: { taskId: context.task.id, stage, status: 'start', model: stageModel, ...metadata } });
 
     if (this.config.verbose) {
       this.emit('log', { line: `[verbose] Stage: ${stage} | model: ${stageModel ?? 'default'} | iteration: ${context.currentIteration}` });
@@ -793,6 +805,7 @@ export class PairPipeline extends EventEmitter {
       }
       broadcastEvent({ type: 'pipeline:stage', data: {
         taskId: context.task.id, stage, status: 'complete',
+        ...metadata,
         model: costInfo?.model,
         inputTokens: costInfo?.inputTokens,
         outputTokens: costInfo?.outputTokens,
@@ -820,11 +833,25 @@ export class PairPipeline extends EventEmitter {
       this.emit('stage:fail', { stage, result: stageResult, context, error });
       broadcastEvent({ type: 'pipeline:stage', data: {
         taskId: context.task.id, stage, status: 'fail',
+        ...metadata,
         durationMs: stageResult.duration,
         error: error instanceof Error ? error.message : String(error),
       } });
       return stageResult;
     }
+  }
+
+  private stageMetadata(context: PipelineContext): PipelineRunMetadata {
+    const configured = this.config.runMetadata ?? {};
+    const projectPath = configured.projectPath ?? context.projectPath;
+    return {
+      repository: configured.repository ?? context.task.linearProject?.name ?? repoNameFromPath(projectPath),
+      projectPath,
+      worktree: configured.worktree ?? worktreeNameFromPath(projectPath),
+      branch: configured.branch,
+      issueIdentifier: configured.issueIdentifier ?? context.task.issueIdentifier ?? context.task.issueId,
+      title: configured.title ?? context.task.title,
+    };
   }
 
   /**
@@ -1314,6 +1341,7 @@ export function createPipelineFromConfig(
   jobProfiles?: JobProfile[],
   draftAnalysis?: PipelineConfig['draftAnalysis'],
   maxReflections?: number,
+  runMetadata?: PipelineRunMetadata,
 ): PairPipeline {
   const stages: PipelineStage[] = [];
 
@@ -1344,7 +1372,18 @@ export function createPipelineFromConfig(
     guards,
     jobProfiles,
     draftAnalysis,
+    runMetadata,
   });
+}
+
+function repoNameFromPath(projectPath?: string): string | undefined {
+  if (!projectPath) return undefined;
+  const normalized = projectPath.replace(/\/+$/, '').replace(/\/worktree\/[^/]+$/, '');
+  return normalized.split('/').pop();
+}
+
+function worktreeNameFromPath(projectPath?: string): string | undefined {
+  return projectPath?.match(/\/worktree\/([^/]+)\/?$/)?.[1];
 }
 
 // Helpers

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -6,7 +6,7 @@
 import { EmbedBuilder } from 'discord.js';
 import type { TaskItem, DecisionResult } from '../orchestration/decisionEngine.js';
 import type { ExecutorResult } from '../orchestration/workflow.js';
-import type { PipelineResult } from '../agents/pairPipeline.js';
+import type { PipelineResult, PipelineRunMetadata } from '../agents/pairPipeline.js';
 import type { DefaultRolesConfig, PipelineStage, JobProfile } from '../core/types.js';
 import { createPipelineFromConfig, buildTaskPrefix } from '../agents/pairPipeline.js';
 import type { WorkerResult, ReviewResult } from '../agents/agentPair.js';
@@ -55,6 +55,34 @@ import {
 // Notifier (outbound notifications — Discord/Slack/Telegram/webhook, INT-1576)
 
 let notifier: Notifier | null = null;
+
+interface PipelineMetadataTask {
+  id: string;
+  title: string;
+  issueId?: string;
+  issueIdentifier?: string;
+  linearProject?: { id?: string; name?: string };
+}
+
+function pipelineMetadata(task: PipelineMetadataTask, projectPath: string, worktreeInfo?: WorktreeInfo | null): PipelineRunMetadata {
+  const activePath = worktreeInfo?.worktreePath ?? projectPath;
+  return {
+    repository: task.linearProject?.name ?? repoNameFromPath(projectPath),
+    projectPath: activePath,
+    worktree: worktreeInfo?.issueId ?? worktreeNameFromPath(activePath),
+    branch: worktreeInfo?.branchName,
+    issueIdentifier: task.issueIdentifier ?? task.issueId,
+    title: task.title,
+  };
+}
+
+function repoNameFromPath(projectPath: string): string {
+  return projectPath.replace(/\/+$/, '').replace(/\/worktree\/[^/]+$/, '').split('/').pop() || projectPath;
+}
+
+function worktreeNameFromPath(projectPath: string): string | undefined {
+  return projectPath.match(/\/worktree\/([^/]+)\/?$/)?.[1];
+}
 
 export function setNotifier(n: Notifier): void {
   notifier = n;
@@ -302,7 +330,11 @@ export async function createSubIssuesWithDependencies(
   ctx: { reportToDiscord: (msg: string) => Promise<void> | void; scheduleNextHeartbeat?: () => void },
   taskId: string,
   dailyLimit: number,
+  projectPath?: string,
 ): Promise<boolean> {
+  const metadata = projectPath
+    ? pipelineMetadata({ ...task, id: taskId }, projectPath)
+    : {};
   const createdSubIssues: Array<{
     id: string;
     identifier: string;
@@ -352,7 +384,7 @@ export async function createSubIssuesWithDependencies(
 
   if (createdSubIssues.length === 0) {
     console.error('[AutonomousRunner] No sub-issues created');
-    broadcastEvent({ type: 'pipeline:stage', data: { taskId, stage: 'decompose', status: 'fail' } });
+    broadcastEvent({ type: 'pipeline:stage', data: { taskId, stage: 'decompose', status: 'fail', ...metadata } });
     return false;
   }
 
@@ -396,7 +428,7 @@ export async function createSubIssuesWithDependencies(
     totalMinutes: String(totalEstimatedMinutes),
   }));
 
-  broadcastEvent({ type: 'pipeline:stage', data: { taskId, stage: 'decompose', status: 'complete' } });
+  broadcastEvent({ type: 'pipeline:stage', data: { taskId, stage: 'decompose', status: 'complete', ...metadata } });
   // Log each sub-issue as a log line for the dashboard
   for (const s of createdSubIssues) {
     broadcastEvent({ type: 'log', data: { taskId, stage: 'decompose', line: `↳ ${s.identifier}: ${s.title}` } });
@@ -465,6 +497,7 @@ export async function decomposeTask(
   console.log(`[AutonomousRunner] Decomposing task: ${task.title}`);
 
   const taskId = task.issueId || task.id;
+  const metadata = pipelineMetadata(task, projectPath);
   const maxDepth = ctx.decompositionMaxDepth ?? 2;
   const maxChildren = ctx.decompositionMaxChildren ?? 5;
   const dailyLimit = ctx.decompositionDailyLimit ?? 20;
@@ -528,7 +561,7 @@ export async function decomposeTask(
     return false;
   }
 
-  broadcastEvent({ type: 'pipeline:stage', data: { taskId, stage: 'decompose', status: 'start' } });
+  broadcastEvent({ type: 'pipeline:stage', data: { taskId, stage: 'decompose', status: 'start', ...metadata } });
 
   await ctx.reportToDiscord(t('runner.decomposition.starting', {
     title: task.title,
@@ -577,7 +610,7 @@ export async function decomposeTask(
 
   if (!result.success) {
     console.error(`[AutonomousRunner] Planner failed: ${result.error}`);
-    broadcastEvent({ type: 'pipeline:stage', data: { taskId, stage: 'decompose', status: 'fail' } });
+    broadcastEvent({ type: 'pipeline:stage', data: { taskId, stage: 'decompose', status: 'fail', ...metadata } });
     return false;
   }
 
@@ -599,6 +632,7 @@ export async function decomposeTask(
     ctx,
     taskId,
     dailyLimit,
+    projectPath,
   );
 }
 
@@ -620,7 +654,8 @@ export async function executePipeline(
   if (ctx.enableDraftAnalysis !== false) {
     try {
       const taskId = task.issueIdentifier || task.issueId || task.id;
-      broadcastEvent({ type: 'pipeline:stage', data: { taskId, stage: 'draft', status: 'start' } });
+      const metadata = pipelineMetadata(task, projectPath);
+      broadcastEvent({ type: 'pipeline:stage', data: { taskId, stage: 'draft', status: 'start', ...metadata } });
 
       draftResult = await runDraftAnalysis({
         taskTitle: task.title,
@@ -631,7 +666,7 @@ export async function executePipeline(
         onLog: (line) => broadcastEvent({ type: 'log', data: { taskId, stage: 'draft', line } }),
       });
 
-      broadcastEvent({ type: 'pipeline:stage', data: { taskId, stage: 'draft', status: 'complete' } });
+      broadcastEvent({ type: 'pipeline:stage', data: { taskId, stage: 'draft', status: 'complete', durationMs: draftResult.durationMs, ...metadata } });
       console.log(`[AutonomousRunner] Draft: type=${draftResult.taskType}, files=${draftResult.relevantFiles.length}, ${draftResult.durationMs}ms`);
     } catch (err) {
       console.warn('[AutonomousRunner] Draft analysis failed (non-blocking):', err);
@@ -712,6 +747,7 @@ export async function executePipeline(
         registrySnapshot: draftResult.registrySnapshot,
       } : undefined,
       ctx.maxReflections,
+      pipelineMetadata(task, actualPath, worktreeInfo),
     );
 
     const taskPrefix = buildTaskPrefix(task, actualPath);

--- a/src/core/eventHub.ts
+++ b/src/core/eventHub.ts
@@ -27,6 +27,12 @@ export type HubEvent =
       taskId: string;
       stage: string;
       status: 'start' | 'complete' | 'fail';
+      repository?: string;
+      projectPath?: string;
+      worktree?: string;
+      branch?: string;
+      issueIdentifier?: string;
+      title?: string;
       model?: string;
       inputTokens?: number;
       outputTokens?: number;

--- a/src/tui/components/SubagentTree.tsx
+++ b/src/tui/components/SubagentTree.tsx
@@ -3,12 +3,13 @@
 import { Box, Text } from 'ink';
 import { STATUS } from '../theme.js';
 import type { StatusKind } from '../../support/glyphs.js';
-import type { TaskNode, TaskStatus } from '../subagentTree.js';
+import type { RepositoryNode, TaskStatus } from '../subagentTree.js';
 
 // Single-sourced glyphs + colors (INT-2260): running → ◐, complete → ✓, fail → ✗.
 const KIND: Record<TaskStatus, StatusKind> = { start: 'running', complete: 'ok', fail: 'err' };
 const STAGE_LABEL_MAX_CHARS = 80;
 const MODEL_LABEL_MAX_CHARS = 80;
+const NODE_LABEL_MAX_CHARS = 96;
 
 // eslint-disable-next-line no-control-regex
 const TERMINAL_ESCAPE_RE = /\x1b(?:\][^\x07]*(?:\x07|\x1b\\)|\[[0-?]*[ -/]*[@-~]|[@-Z\\-_])/g;
@@ -26,30 +27,50 @@ function clampLimit(value: number): number {
 }
 
 export interface SubagentTreeProps {
-  tasks: TaskNode[];
-  /** Max tasks shown (most recent). */
+  repositories: RepositoryNode[];
+  /** Max worktrees shown across each repository (most recent). */
   max?: number;
-  /** Max stage children shown per task. */
-  maxStages?: number;
+  /** Max role children shown per worktree. */
+  maxRoles?: number;
 }
 
-export function SubagentTree({ tasks, max = 6, maxStages = 5 }: SubagentTreeProps) {
-  const taskLimit = clampLimit(max);
-  const stageLimit = clampLimit(maxStages);
-  const shown = taskLimit === 0 ? [] : tasks.slice(-taskLimit);
+function formatDuration(ms: number | undefined): string | undefined {
+  if (ms == null) return undefined;
+  if (ms < 1000) return `${ms}ms`;
+  return `${Math.round(ms / 1000)}s`;
+}
+
+function worktreeLabel(task: RepositoryNode['worktrees'][number]): string {
+  const id = task.issueIdentifier ?? task.taskId;
+  const branch = task.branch ? ` ${task.branch}` : task.worktree ? ` worktree/${task.worktree}` : '';
+  const stage = task.currentStage ? ` ${task.currentStage}` : '';
+  const duration = formatDuration(task.durationMs);
+  const decision = task.decision ? ` ${task.decision}` : '';
+  const title = task.title ? ` ${task.title}` : '';
+  return sanitizeTerminalLabel(`${id}${branch}${stage}${duration ? ` ${duration}` : ''}${decision}${title}`, NODE_LABEL_MAX_CHARS);
+}
+
+export function SubagentTree({ repositories, max = 6, maxRoles = 5 }: SubagentTreeProps) {
+  const worktreeLimit = clampLimit(max);
+  const roleLimit = clampLimit(maxRoles);
   return (
     <Box flexDirection="column">
-      <Text bold>Agents (by task)</Text>
-      {shown.length === 0 ? (
+      <Text bold>Agents by repository</Text>
+      {repositories.length === 0 || worktreeLimit === 0 ? (
         <Text dimColor>(no active agents)</Text>
       ) : (
-        shown.map((task) => (
-          <Box key={task.taskId} flexDirection="column">
-            <Text color={STATUS[KIND[task.status]].color}>{`${STATUS[KIND[task.status]].icon} ${sanitizeTerminalLabel(task.taskId).slice(0, 16)}`}</Text>
-            {(stageLimit === 0 ? [] : task.stages.slice(-stageLimit)).map((s, i) => (
-              <Text key={i} dimColor>
-                {`   └ ${sanitizeTerminalLabel(s.stage, STAGE_LABEL_MAX_CHARS)}${s.model ? ` (${sanitizeTerminalLabel(s.model, MODEL_LABEL_MAX_CHARS)})` : ''} — ${s.status}`}
-              </Text>
+        repositories.map((repo) => (
+          <Box key={repo.repository} flexDirection="column">
+            <Text color={STATUS[KIND[repo.status]].color}>{`${STATUS[KIND[repo.status]].icon} ${sanitizeTerminalLabel(repo.repository, NODE_LABEL_MAX_CHARS)}`}</Text>
+            {repo.worktrees.slice(-worktreeLimit).map((task) => (
+              <Box key={`${repo.repository}:${task.taskId}`} flexDirection="column">
+                <Text dimColor>{`  └ ${worktreeLabel(task)} — ${task.status}`}</Text>
+                {(roleLimit === 0 ? [] : task.roles.slice(-roleLimit)).map((role, i) => (
+                  <Text key={i} dimColor>
+                    {`     └ ${sanitizeTerminalLabel(role.role, STAGE_LABEL_MAX_CHARS)}${role.model ? ` (${sanitizeTerminalLabel(role.model, MODEL_LABEL_MAX_CHARS)})` : ''} — ${role.status}${role.decision ? `/${role.decision}` : ''}`}
+                  </Text>
+                ))}
+              </Box>
             ))}
           </Box>
         ))

--- a/src/tui/panels/PipelinePanel.tsx
+++ b/src/tui/panels/PipelinePanel.tsx
@@ -28,7 +28,7 @@ export function PipelinePanel({ port }: PipelinePanelProps) {
         <Text color={live ? theme.ok : theme.dim}>{live ? '●' : '○'}</Text>
         <Text dimColor>{label}</Text>
       </Text>
-      <SubagentTree tasks={buildSubagentTree(stages)} />
+      <SubagentTree repositories={buildSubagentTree(stages)} />
       <Box marginTop={1}>
         <StageTimeline stages={stages} />
       </Box>

--- a/src/tui/pipelineEvents.test.ts
+++ b/src/tui/pipelineEvents.test.ts
@@ -12,9 +12,29 @@ describe('reducePipelineEvent (EPIC INT-1813 S5)', () => {
   it('appends pipeline:stage entries with their fields', () => {
     let s = initialPipelineState;
     s = reducePipelineEvent(s, stage({ status: 'start' }));
-    s = reducePipelineEvent(s, stage({ status: 'complete', model: 'gpt', durationMs: 3000, decision: 'approve' }));
+    s = reducePipelineEvent(s, stage({
+      status: 'complete',
+      model: 'gpt',
+      durationMs: 3000,
+      decision: 'approve',
+      repository: 'OpenSwarm',
+      projectPath: '/repo/worktree/INT-2367',
+      worktree: 'INT-2367',
+      branch: 'swarm/INT-2367-pipeline-tree',
+      issueIdentifier: 'INT-2367',
+      title: 'Pipeline tree',
+    }));
     expect(s.stages).toHaveLength(2);
-    expect(s.stages[1]).toMatchObject({ status: 'complete', model: 'gpt', decision: 'approve' });
+    expect(s.stages[1]).toMatchObject({
+      status: 'complete',
+      model: 'gpt',
+      decision: 'approve',
+      repository: 'OpenSwarm',
+      worktree: 'INT-2367',
+      branch: 'swarm/INT-2367-pipeline-tree',
+      issueIdentifier: 'INT-2367',
+      title: 'Pipeline tree',
+    });
   });
 
   it('appends log lines with a stage prefix', () => {

--- a/src/tui/pipelineEvents.ts
+++ b/src/tui/pipelineEvents.ts
@@ -10,6 +10,12 @@ export interface StageEntry {
   taskId: string;
   stage: string;
   status: 'start' | 'complete' | 'fail';
+  repository?: string;
+  projectPath?: string;
+  worktree?: string;
+  branch?: string;
+  issueIdentifier?: string;
+  title?: string;
   model?: string;
   durationMs?: number;
   costUsd?: number;
@@ -35,6 +41,12 @@ export function reducePipelineEvent(state: PipelineState, ev: HubEvent): Pipelin
       taskId: d.taskId,
       stage: d.stage,
       status: d.status,
+      repository: d.repository,
+      projectPath: d.projectPath,
+      worktree: d.worktree,
+      branch: d.branch,
+      issueIdentifier: d.issueIdentifier,
+      title: d.title,
       model: d.model,
       durationMs: d.durationMs,
       costUsd: d.costUsd,

--- a/src/tui/subagentTree.test.ts
+++ b/src/tui/subagentTree.test.ts
@@ -2,24 +2,32 @@ import { describe, it, expect } from 'vitest';
 import { buildSubagentTree } from './subagentTree.js';
 import type { StageEntry } from './pipelineEvents.js';
 
-const s = (taskId: string, stage: string, status: StageEntry['status']): StageEntry => ({ taskId, stage, status });
+const s = (taskId: string, stage: string, status: StageEntry['status'], over: Partial<StageEntry> = {}): StageEntry => ({
+  taskId,
+  stage,
+  status,
+  ...over,
+});
 
 describe('buildSubagentTree (EPIC INT-1813 S7)', () => {
-  it('groups stages by task into nodes', () => {
+  it('groups stages by repository and worktree into role nodes', () => {
     const tree = buildSubagentTree([
-      s('t1', 'worker', 'start'),
-      s('t2', 'worker', 'start'),
-      s('t1', 'reviewer', 'complete'),
+      s('t1', 'worker', 'start', { repository: 'OpenSwarm', worktree: 'INT-1', branch: 'swarm/INT-1' }),
+      s('t2', 'worker', 'start', { repository: 'OpenSwarm', worktree: 'INT-2', branch: 'swarm/INT-2' }),
+      s('t1', 'reviewer', 'complete', { repository: 'OpenSwarm', worktree: 'INT-1', branch: 'swarm/INT-1' }),
     ]);
-    expect(tree).toHaveLength(2);
-    const t1 = tree.find((n) => n.taskId === 't1')!;
-    expect(t1.stages.map((x) => x.stage)).toEqual(['worker', 'reviewer']);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].repository).toBe('OpenSwarm');
+    expect(tree[0].worktrees).toHaveLength(2);
+    const t1 = tree[0].worktrees.find((n) => n.taskId === 't1')!;
+    expect(t1.branch).toBe('swarm/INT-1');
+    expect(t1.roles.map((x) => x.role)).toEqual(['Worker', 'Reviewer']);
   });
 
   it('rolls up status: fail dominates, all-complete completes, else running', () => {
-    expect(buildSubagentTree([s('t', 'a', 'complete'), s('t', 'b', 'fail')])[0].status).toBe('fail');
-    expect(buildSubagentTree([s('t', 'a', 'complete'), s('t', 'b', 'complete')])[0].status).toBe('complete');
-    expect(buildSubagentTree([s('t', 'a', 'complete'), s('t', 'b', 'start')])[0].status).toBe('start');
+    expect(buildSubagentTree([s('t', 'a', 'complete'), s('t', 'b', 'fail')])[0].worktrees[0].status).toBe('fail');
+    expect(buildSubagentTree([s('t', 'a', 'complete'), s('t', 'b', 'complete')])[0].worktrees[0].status).toBe('complete');
+    expect(buildSubagentTree([s('t', 'a', 'complete'), s('t', 'b', 'start')])[0].worktrees[0].status).toBe('start');
   });
 
   it('rolls up from the latest status for each stage', () => {
@@ -30,8 +38,72 @@ describe('buildSubagentTree (EPIC INT-1813 S7)', () => {
       s('t', 'reviewer', 'complete'),
     ]);
 
-    expect(tree[0].status).toBe('complete');
-    expect(tree[0].stages.map((x) => `${x.stage}:${x.status}`)).toEqual(['worker:complete', 'reviewer:complete']);
+    expect(tree[0].worktrees[0].status).toBe('complete');
+    expect(tree[0].worktrees[0].roles.map((x) => `${x.role}:${x.status}`)).toEqual(['Worker:complete', 'Reviewer:complete']);
+  });
+
+  it('infers repository and worktree from projectPath when event metadata is sparse', () => {
+    const tree = buildSubagentTree([
+      s('INT-2367-task', 'draft', 'complete', {
+        projectPath: '/Users/u/dev/OpenSwarm/worktree/INT-2367',
+        issueIdentifier: 'INT-2367',
+        title: 'Pipeline tab tree',
+      }),
+    ]);
+
+    expect(tree[0].repository).toBe('OpenSwarm');
+    expect(tree[0].worktrees[0]).toMatchObject({
+      worktree: 'INT-2367',
+      issueIdentifier: 'INT-2367',
+      title: 'Pipeline tab tree',
+      currentStage: 'Drafter',
+    });
+  });
+
+  it('keeps draft and worktree events for the same issue in one node', () => {
+    const tree = buildSubagentTree([
+      s('INT-2367', 'draft', 'complete', {
+        repository: 'OpenSwarm',
+        projectPath: '/Users/u/dev/OpenSwarm',
+        issueIdentifier: 'INT-2367',
+        title: 'Pipeline tab tree',
+      }),
+      s('linear-uuid', 'worker', 'start', {
+        repository: 'OpenSwarm',
+        projectPath: '/Users/u/dev/OpenSwarm/worktree/linear-uuid',
+        worktree: 'linear-uuid',
+        branch: 'swarm/INT-2367-pipeline-tree',
+        issueIdentifier: 'INT-2367',
+        title: 'Pipeline tab tree',
+      }),
+      s('linear-uuid', 'reviewer', 'complete', {
+        repository: 'OpenSwarm',
+        projectPath: '/Users/u/dev/OpenSwarm/worktree/linear-uuid',
+        worktree: 'linear-uuid',
+        branch: 'swarm/INT-2367-pipeline-tree',
+        issueIdentifier: 'INT-2367',
+        title: 'Pipeline tab tree',
+      }),
+    ]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].worktrees).toHaveLength(1);
+    expect(tree[0].worktrees[0].roles.map((role) => role.role)).toEqual(['Drafter', 'Worker', 'Reviewer']);
+    expect(tree[0].worktrees[0]).toMatchObject({
+      issueIdentifier: 'INT-2367',
+      branch: 'swarm/INT-2367-pipeline-tree',
+      worktree: 'linear-uuid',
+    });
+  });
+
+  it('orders worktrees by their latest event for max display limits', () => {
+    const tree = buildSubagentTree([
+      s('INT-1', 'worker', 'start', { repository: 'OpenSwarm', issueIdentifier: 'INT-1' }),
+      s('INT-2', 'worker', 'start', { repository: 'OpenSwarm', issueIdentifier: 'INT-2' }),
+      s('INT-1', 'reviewer', 'complete', { repository: 'OpenSwarm', issueIdentifier: 'INT-1' }),
+    ]);
+
+    expect(tree[0].worktrees.map((node) => node.issueIdentifier)).toEqual(['INT-2', 'INT-1']);
   });
 
   it('returns an empty tree for no stages', () => {

--- a/src/tui/subagentTree.test.tsx
+++ b/src/tui/subagentTree.test.tsx
@@ -6,19 +6,31 @@ import type { StageEntry } from './pipelineEvents.js';
 
 describe('SubagentTree component (EPIC INT-1813 S7)', () => {
   it('renders an empty state', () => {
-    expect(render(<SubagentTree tasks={[]} />).lastFrame()).toContain('no active agents');
+    expect(render(<SubagentTree repositories={[]} />).lastFrame()).toContain('no active agents');
   });
 
-  it('renders a task node with its stage children', () => {
+  it('renders repository, worktree and role nodes', () => {
     const stages: StageEntry[] = [
-      { taskId: 'INT-1940-x', stage: 'worker', status: 'complete', model: 'gpt-5.2-codex' },
-      { taskId: 'INT-1940-x', stage: 'reviewer', status: 'start' },
+      {
+        taskId: 'INT-2367-x',
+        stage: 'worker',
+        status: 'complete',
+        model: 'gpt-5.2-codex',
+        repository: 'OpenSwarm',
+        worktree: 'INT-2367',
+        branch: 'swarm/INT-2367-pipeline-tree',
+        issueIdentifier: 'INT-2367',
+        title: 'Pipeline tab tree',
+      },
+      { taskId: 'INT-2367-x', stage: 'reviewer', status: 'start', repository: 'OpenSwarm', worktree: 'INT-2367' },
     ];
-    const f = render(<SubagentTree tasks={buildSubagentTree(stages)} />).lastFrame()!;
-    expect(f).toContain('Agents (by task)');
-    expect(f).toContain('INT-1940-x');
-    expect(f).toContain('worker');
-    expect(f).toContain('reviewer');
+    const f = render(<SubagentTree repositories={buildSubagentTree(stages)} />).lastFrame()!;
+    expect(f).toContain('Agents by repository');
+    expect(f).toContain('OpenSwarm');
+    expect(f).toContain('INT-2367');
+    expect(f).toContain('swarm/INT-2367-pipeline-tree');
+    expect(f).toContain('Worker');
+    expect(f).toContain('Reviewer');
   });
 
   it('honors zero display limits', () => {
@@ -26,11 +38,11 @@ describe('SubagentTree component (EPIC INT-1813 S7)', () => {
       { taskId: 'INT-1940-x', stage: 'worker', status: 'complete', model: 'gpt-5.2-codex' },
     ];
 
-    expect(render(<SubagentTree tasks={buildSubagentTree(stages)} max={0} />).lastFrame()).toContain('no active agents');
+    expect(render(<SubagentTree repositories={buildSubagentTree(stages)} max={0} />).lastFrame()).toContain('no active agents');
 
-    const f = render(<SubagentTree tasks={buildSubagentTree(stages)} maxStages={0} />).lastFrame()!;
-    expect(f).toContain('INT-1940-x');
-    expect(f).not.toContain('worker');
+    const f = render(<SubagentTree repositories={buildSubagentTree(stages)} maxRoles={0} />).lastFrame()!;
+    expect(f).toContain('INT-1940');
+    expect(f).not.toContain('(gpt-5.2-codex)');
   });
 
   it('strips terminal control sequences from labels before rendering', () => {
@@ -43,9 +55,9 @@ describe('SubagentTree component (EPIC INT-1813 S7)', () => {
       },
     ];
 
-    const f = render(<SubagentTree tasks={buildSubagentTree(stages)} />).lastFrame()!;
-    expect(f).toContain('INT-1940-x');
-    expect(f).toContain('worker');
+    const f = render(<SubagentTree repositories={buildSubagentTree(stages)} />).lastFrame()!;
+    expect(f).toContain('INT-1940');
+    expect(f).toContain('Worker');
     expect(f).toContain('gpt');
     expect(f).not.toContain('\x1b');
     expect(f).not.toContain('AAAA');

--- a/src/tui/subagentTree.ts
+++ b/src/tui/subagentTree.ts
@@ -1,35 +1,90 @@
 // ============================================
 // OpenSwarm - Subagent tree (EPIC INT-1813 S7 / INT-1940)
-// Pure grouping of pipeline stage entries into a per-task (per-worktree) tree —
-// the Claude-Code-subagent view of concurrent runs. Derived from the existing
-// taskId-keyed events (each worktree task = one node, its stages = children), so
-// no new backend event stream is required to surface the tree.
+// Pure grouping of pipeline stage entries into a repository → worktree → role tree.
 // ============================================
 
 import type { StageEntry } from './pipelineEvents.js';
 
 export type TaskStatus = 'start' | 'complete' | 'fail';
 
-export interface TaskNode {
+export interface RoleNode {
+  role: string;
+  status: TaskStatus;
+  model?: string;
+  durationMs?: number;
+  decision?: 'approve' | 'revise' | 'reject';
+  summary?: string;
+}
+
+export interface WorktreeNode {
   taskId: string;
-  stages: StageEntry[];
+  issueIdentifier?: string;
+  title?: string;
+  branch?: string;
+  worktree?: string;
+  currentStage?: string;
+  durationMs?: number;
+  decision?: 'approve' | 'revise' | 'reject';
+  roles: RoleNode[];
   /** Rolled-up status: fail if any stage failed, complete if all complete, else running. */
   status: TaskStatus;
 }
 
-export function buildSubagentTree(stages: StageEntry[]): TaskNode[] {
-  const byTask = new Map<string, StageEntry[]>();
+export interface RepositoryNode {
+  repository: string;
+  projectPath?: string;
+  worktrees: WorktreeNode[];
+  status: TaskStatus;
+}
+
+export function buildSubagentTree(stages: StageEntry[]): RepositoryNode[] {
+  const byRepository = new Map<string, Map<string, StageEntry[]>>();
   for (const s of stages) {
-    const arr = byTask.get(s.taskId);
-    if (arr) arr.push(s);
-    else byTask.set(s.taskId, [s]);
+    const repository = s.repository ?? repoNameFromPath(s.projectPath) ?? 'unknown repository';
+    const worktreeKey = s.issueIdentifier ?? inferIssueIdentifier(s.taskId) ?? s.taskId ?? s.worktree ?? s.branch;
+    const repo = byRepository.get(repository) ?? new Map<string, StageEntry[]>();
+    const arr = repo.get(worktreeKey);
+    if (arr) {
+      arr.push(s);
+      repo.delete(worktreeKey);
+      repo.set(worktreeKey, arr);
+    } else {
+      repo.set(worktreeKey, [s]);
+    }
+    byRepository.set(repository, repo);
   }
-  return [...byTask.entries()].map(([taskId, taskStages]) => {
-    const latestStages = latestByStage(taskStages);
+
+  return [...byRepository.entries()].map(([repository, worktreeMap]) => {
+    const worktrees = [...worktreeMap.values()].map((worktreeStages) => {
+      const latestStages = latestByStage(worktreeStages);
+      const latest = latestStages[latestStages.length - 1];
+      const roles = latestStages.map((stage) => ({
+        role: displayRole(stage.stage),
+        status: stage.status,
+        model: stage.model,
+        durationMs: stage.durationMs,
+        decision: stage.decision,
+        summary: stage.summary,
+      }));
+      const withMetadata = [...latestStages].reverse();
+      return {
+        taskId: latest?.taskId ?? worktreeStages[0]?.taskId ?? 'unknown-task',
+        issueIdentifier: firstDefined(withMetadata, (stage) => stage.issueIdentifier) ?? inferIssueIdentifier(latest?.taskId) ?? latest?.taskId,
+        title: firstDefined(withMetadata, (stage) => stage.title),
+        branch: firstDefined(withMetadata, (stage) => stage.branch),
+        worktree: firstDefined(withMetadata, (stage) => stage.worktree) ?? worktreeNameFromPath(latest?.projectPath),
+        currentStage: latest ? displayRole(latest.stage) : undefined,
+        durationMs: latest?.durationMs,
+        decision: findLast(latestStages, (stage) => Boolean(stage.decision))?.decision,
+        roles,
+        status: rollUp(latestStages),
+      };
+    });
     return {
-      taskId,
-      stages: latestStages,
-      status: rollUp(latestStages),
+      repository,
+      projectPath: worktrees.map((w) => w.worktree).find(Boolean) ? undefined : latestProjectPath(worktreeMap),
+      worktrees,
+      status: rollUp(worktrees.flatMap((w) => w.roles.map((role) => ({ status: role.status } as StageEntry)))),
     };
   });
 }
@@ -47,4 +102,48 @@ function rollUp(stages: StageEntry[]): TaskStatus {
   if (stages.some((s) => s.status === 'fail')) return 'fail';
   if (stages.length > 0 && stages.every((s) => s.status === 'complete')) return 'complete';
   return 'start';
+}
+
+function displayRole(stage: string): string {
+  if (stage === 'draft') return 'Drafter';
+  if (stage === 'decompose') return 'Planner';
+  return stage.charAt(0).toUpperCase() + stage.slice(1);
+}
+
+function repoNameFromPath(projectPath?: string): string | undefined {
+  if (!projectPath) return undefined;
+  const normalized = projectPath.replace(/\/+$/, '');
+  const beforeWorktree = normalized.replace(/\/worktree\/[^/]+$/, '');
+  return beforeWorktree.split('/').pop();
+}
+
+function worktreeNameFromPath(projectPath?: string): string | undefined {
+  return projectPath?.match(/\/worktree\/([^/]+)\/?$/)?.[1];
+}
+
+function inferIssueIdentifier(taskId?: string): string | undefined {
+  return taskId?.match(/[A-Z]+-\d+/)?.[0];
+}
+
+function firstDefined<T>(items: StageEntry[], select: (item: StageEntry) => T | undefined): T | undefined {
+  for (const item of items) {
+    const value = select(item);
+    if (value !== undefined && value !== '') return value;
+  }
+  return undefined;
+}
+
+function latestProjectPath(worktreeMap: Map<string, StageEntry[]>): string | undefined {
+  for (const stages of worktreeMap.values()) {
+    const latest = findLast(stages, (stage) => Boolean(stage.projectPath));
+    if (latest?.projectPath) return latest.projectPath;
+  }
+  return undefined;
+}
+
+function findLast<T>(items: T[], predicate: (item: T) => boolean): T | undefined {
+  for (let i = items.length - 1; i >= 0; i--) {
+    if (predicate(items[i])) return items[i];
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Summary
- extend `pipeline:stage` events with repository/project/worktree/branch/issue metadata from runner and PairPipeline producers
- rebuild the Pipeline tab agent tree as Repository -> Worktree/branch -> Role instead of task-only grouping
- preserve stable grouping across draft-before-worktree and worker/reviewer-after-worktree events
- keep recent worktree ordering based on latest event updates and sanitize/truncate terminal labels

## Verification
- `npm test -- src/tui/subagentTree.test.ts src/tui/subagentTree.test.tsx src/tui/pipelineEvents.test.ts src/tui/pipelinePanel.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- `openswarm review --path .` -> APPROVE after addressing the initial grouping/recent-order findings

Linear: INT-2367