### PR TITLE
feat(tui): summarize worker activity in pipeline tree

### DIFF
--- a/src/adapters/processRegistry.ts
+++ b/src/adapters/processRegistry.ts
@@ -75,6 +75,10 @@ export function registerProcess(info: ProcessInfo, proc: ChildProcess): void {
       type: 'process:exit',
       data: {
         pid: info.pid,
+        taskId: info.taskId,
+        stage: info.stage,
+        model: info.model,
+        projectPath: info.projectPath,
         exitCode: code,
         signal: signal,
         durationMs,
@@ -147,6 +151,10 @@ export function startHealthChecker(intervalMs = 30000): void {
           type: 'process:exit',
           data: {
             pid,
+            taskId: info.taskId,
+            stage: info.stage,
+            model: info.model,
+            projectPath: info.projectPath,
             exitCode: null,
             signal: null,
             durationMs,

--- a/src/agents/pairPipeline.test.ts
+++ b/src/agents/pairPipeline.test.ts
@@ -2,9 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkerOptions } from './worker.js';
 import type { ReviewerOptions } from './reviewer.js';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
 
 const runWorker = vi.fn();
 const runReviewer = vi.fn();
+const broadcastEvent = vi.fn();
 
 vi.mock('./worker.js', () => ({
   runWorker,
@@ -26,6 +28,10 @@ vi.mock('../knowledge/index.js', () => ({
 
 vi.mock('../memory/repoKnowledge.js', () => ({
   recallRepoKnowledge: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../core/eventHub.js', () => ({
+  broadcastEvent,
 }));
 
 describe('PairPipeline model selection', () => {
@@ -123,6 +129,29 @@ describe('PairPipeline model selection', () => {
     }));
     expect(runReviewer).toHaveBeenCalledWith(expect.objectContaining<Partial<ReviewerOptions>>({
       model: 'fallback-reviewer',
+    }));
+  });
+
+  it('emits rate-limit reset timestamps on failed stage events', async () => {
+    runWorker.mockRejectedValueOnce(new RateLimitError(1770000000, 'rate limited'));
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker'],
+      maxIterations: 1,
+      roles: {
+        worker: { enabled: true, model: 'fallback-worker', timeoutMs: 0 },
+      },
+    });
+
+    await pipeline.run(task(), process.cwd());
+
+    expect(broadcastEvent).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'pipeline:stage',
+      data: expect.objectContaining({
+        stage: 'worker',
+        status: 'fail',
+        rateLimitResetsAt: 1770000000000,
+      }),
     }));
   });
 });

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -835,6 +835,7 @@ export class PairPipeline extends EventEmitter {
         taskId: context.task.id, stage, status: 'fail',
         ...metadata,
         durationMs: stageResult.duration,
+        rateLimitResetsAt: error instanceof RateLimitError && error.resetsAt ? error.resetsAt * 1000 : undefined,
         error: error instanceof Error ? error.message : String(error),
       } });
       return stageResult;

--- a/src/core/eventHub.ts
+++ b/src/core/eventHub.ts
@@ -63,6 +63,7 @@ export type HubEvent =
       // Worker confidence-gate
       confidencePercent?: number;
       haltReason?: string;
+      rateLimitResetsAt?: number;
       // Errors
       error?: string;
     } }
@@ -77,7 +78,16 @@ export type HubEvent =
   | { type: 'monitor:checked'; data: { id: string; name: string; state: MonitorState; output?: string; checkCount: number } }
   | { type: 'monitor:stateChange'; data: { id: string; name: string; from: MonitorState; to: MonitorState; issueId?: string } }
   | { type: 'process:spawn'; data: { pid: number; taskId: string; stage: string; model?: string; projectPath: string } }
-  | { type: 'process:exit'; data: { pid: number; exitCode: number | null; signal: string | null; durationMs: number } }
+  | { type: 'process:exit'; data: {
+      pid: number;
+      taskId?: string;
+      stage?: string;
+      model?: string;
+      projectPath?: string;
+      exitCode: number | null;
+      signal: string | null;
+      durationMs: number;
+    } }
   | { type: 'conflict:detected'; data: { repo: string; prNumber: number; branch: string } }
   | { type: 'conflict:resolving'; data: { repo: string; prNumber: number; branch: string; attempt: number } }
   | { type: 'conflict:resolved'; data: { repo: string; prNumber: number; branch: string; filesResolved: number } }

--- a/src/tui/components/SubagentTree.tsx
+++ b/src/tui/components/SubagentTree.tsx
@@ -1,9 +1,11 @@
 // SubagentTree — concurrent tasks as a per-worktree agent tree (S7).
 // Presentational: takes nodes built by buildSubagentTree.
 import { Box, Text } from 'ink';
+import { useEffect, useState } from 'react';
 import { STATUS } from '../theme.js';
 import type { StatusKind } from '../../support/glyphs.js';
 import type { RepositoryNode, TaskStatus } from '../subagentTree.js';
+import { spinnerFrame } from '../loadingMessages.js';
 
 // Single-sourced glyphs + colors (INT-2260): running → ◐, complete → ✓, fail → ✗.
 const KIND: Record<TaskStatus, StatusKind> = { start: 'running', complete: 'ok', fail: 'err' };
@@ -53,6 +55,14 @@ function worktreeLabel(task: RepositoryNode['worktrees'][number]): string {
 export function SubagentTree({ repositories, max = 6, maxRoles = 5 }: SubagentTreeProps) {
   const worktreeLimit = clampLimit(max);
   const roleLimit = clampLimit(maxRoles);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!repositories.some((repo) => repo.worktrees.some((task) => task.roles.some((role) => role.status === 'start')))) return;
+    const timer = setInterval(() => setTick((value) => value + 1), 120);
+    return () => clearInterval(timer);
+  }, [repositories]);
+
   return (
     <Box flexDirection="column">
       <Text bold>Agents by repository</Text>
@@ -67,7 +77,7 @@ export function SubagentTree({ repositories, max = 6, maxRoles = 5 }: SubagentTr
                 <Text dimColor>{`  └ ${worktreeLabel(task)} — ${task.status}`}</Text>
                 {(roleLimit === 0 ? [] : task.roles.slice(-roleLimit)).map((role, i) => (
                   <Text key={i} dimColor>
-                    {`     └ ${sanitizeTerminalLabel(role.role, STAGE_LABEL_MAX_CHARS)}${role.model ? ` (${sanitizeTerminalLabel(role.model, MODEL_LABEL_MAX_CHARS)})` : ''} — ${role.status}${role.decision ? `/${role.decision}` : ''}`}
+                    {`     └ ${role.status === 'start' ? spinnerFrame(tick) : ''} ${sanitizeTerminalLabel(role.role, STAGE_LABEL_MAX_CHARS)}${role.model ? ` (${sanitizeTerminalLabel(role.model, MODEL_LABEL_MAX_CHARS)})` : ''} — ${role.status}${role.activity ? ` · ${sanitizeTerminalLabel(role.activity, STAGE_LABEL_MAX_CHARS)}` : ''}${role.rateLimitResetsAt ? ` · reset ${new Date(role.rateLimitResetsAt).toISOString()}` : ''}${role.decision ? `/${role.decision}` : ''}`}
                   </Text>
                 ))}
               </Box>

--- a/src/tui/pipelineEvents.test.ts
+++ b/src/tui/pipelineEvents.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { reducePipelineEvent, initialPipelineState, MAX_STAGES, MAX_LOGS } from './pipelineEvents.js';
+import { classifyActivity, reducePipelineEvent, initialPipelineState, MAX_STAGES, MAX_LOGS } from './pipelineEvents.js';
 import type { HubEvent } from '../core/eventHub.js';
 
 const stage = (over: Record<string, unknown> = {}): HubEvent => ({
@@ -7,6 +7,14 @@ const stage = (over: Record<string, unknown> = {}): HubEvent => ({
   data: { taskId: 't1', stage: 'worker', status: 'start', ...over },
 }) as HubEvent;
 const log = (line: string): HubEvent => ({ type: 'log', data: { taskId: 't1', stage: 'worker', line } });
+const processSpawn = (over: Record<string, unknown> = {}): HubEvent => ({
+  type: 'process:spawn',
+  data: { pid: 1, taskId: 't1', stage: 'worker', projectPath: '/repo', ...over },
+}) as HubEvent;
+const processExit = (over: Record<string, unknown> = {}): HubEvent => ({
+  type: 'process:exit',
+  data: { pid: 1, taskId: 't1', stage: 'worker', exitCode: 0, signal: null, durationMs: 1000, ...over },
+}) as HubEvent;
 
 describe('reducePipelineEvent (EPIC INT-1813 S5)', () => {
   it('appends pipeline:stage entries with their fields', () => {
@@ -40,6 +48,43 @@ describe('reducePipelineEvent (EPIC INT-1813 S5)', () => {
   it('appends log lines with a stage prefix', () => {
     const s = reducePipelineEvent(initialPipelineState, log('hello'));
     expect(s.logs).toEqual(['[worker] hello']);
+  });
+
+  it('updates the running stage with compact activity from logs', () => {
+    let s = reducePipelineEvent(initialPipelineState, stage({ status: 'start' }));
+    s = reducePipelineEvent(s, log('🔧 read_file src/app.ts'));
+    expect(s.stages[0]).toMatchObject({ activity: 'tool: read_file' });
+
+    s = reducePipelineEvent(s, log('reasoning about next patch'));
+    expect(s.stages[0]).toMatchObject({ activity: 'thinking' });
+  });
+
+  it('clears process waiting activity only for the matching task and stage', () => {
+    let s = initialPipelineState;
+    s = reducePipelineEvent(s, stage({ taskId: 't1', stage: 'worker', status: 'start' }));
+    s = reducePipelineEvent(s, stage({ taskId: 't2', stage: 'worker', status: 'start' }));
+    s = reducePipelineEvent(s, processSpawn({ taskId: 't1', stage: 'worker' }));
+    s = reducePipelineEvent(s, processSpawn({ taskId: 't2', stage: 'worker' }));
+    s = reducePipelineEvent(s, processExit({ taskId: 't1', stage: 'worker' }));
+
+    expect(s.stages.find((entry) => entry.taskId === 't1')?.activity).toBeUndefined();
+    expect(s.stages.find((entry) => entry.taskId === 't2')?.activity).toBe('waiting');
+  });
+
+  it('shows rate-limit activity only when sourced from real event data', () => {
+    let s = reducePipelineEvent(initialPipelineState, stage({ status: 'start' }));
+    s = reducePipelineEvent(s, stage({ status: 'fail', error: '429 rate limit exceeded', rateLimitResetsAt: 1770000000000 }));
+    expect(s.stages[1]).toMatchObject({ activity: 'rate-limited', rateLimitResetsAt: 1770000000000 });
+
+    const clean = reducePipelineEvent(initialPipelineState, stage({ status: 'complete' }));
+    expect(clean.stages[0].rateLimitResetsAt).toBeUndefined();
+  });
+
+  it('classifies supported activity without inventing unknown quota values', () => {
+    expect(classifyActivity('tool: apply_patch')).toBe('tool: apply_patch');
+    expect(classifyActivity('Checking repository state')).toBe('thinking');
+    expect(classifyActivity('quota will reset soon')).toBe('rate-limited');
+    expect(classifyActivity('ordinary log line')).toBeUndefined();
   });
 
   it('ignores unrelated events (returns the same state)', () => {

--- a/src/tui/pipelineEvents.ts
+++ b/src/tui/pipelineEvents.ts
@@ -21,6 +21,8 @@ export interface StageEntry {
   costUsd?: number;
   decision?: 'approve' | 'revise' | 'reject';
   summary?: string;
+  activity?: string;
+  rateLimitResetsAt?: number;
 }
 
 export interface PipelineState {
@@ -52,11 +54,75 @@ export function reducePipelineEvent(state: PipelineState, ev: HubEvent): Pipelin
       costUsd: d.costUsd,
       decision: d.decision,
       summary: d.summary,
+      activity: d.status === 'start' ? 'waiting' : activityFromStage(d.error),
+      rateLimitResetsAt: d.rateLimitResetsAt,
     };
     return { ...state, stages: [...state.stages, entry].slice(-MAX_STAGES) };
   }
   if (ev.type === 'log') {
-    return { ...state, logs: [...state.logs, `[${ev.data.stage}] ${ev.data.line}`].slice(-MAX_LOGS) };
+    const activity = classifyActivity(ev.data.line);
+    return {
+      ...state,
+      stages: activity
+        ? updateLatestActivity(state.stages, ev.data.taskId, ev.data.stage, activity)
+        : state.stages,
+      logs: [...state.logs, `[${ev.data.stage}] ${ev.data.line}`].slice(-MAX_LOGS),
+    };
+  }
+  if (ev.type === 'process:spawn') {
+    return {
+      ...state,
+      stages: updateLatestActivity(state.stages, ev.data.taskId, ev.data.stage, 'waiting', ev.data.model),
+    };
+  }
+  if (ev.type === 'process:exit') {
+    if (!ev.data.taskId || !ev.data.stage) return state;
+    return {
+      ...state,
+      stages: state.stages.map((stage) => stage.taskId === ev.data.taskId && stage.stage === ev.data.stage && stage.activity === 'waiting'
+        ? { ...stage, activity: undefined }
+        : stage),
+    };
   }
   return state;
+}
+
+export function classifyActivity(line: string): string | undefined {
+  const text = line.trim();
+  const lower = text.toLowerCase();
+  if (/\b(rate[-\s]?limit|quota|429)\b/.test(lower)) return 'rate-limited';
+  const tool = text.match(/(?:tool[:\s]+|🔧\s*)([a-zA-Z_][\w-]*)/);
+  if (tool) return `tool: ${tool[1]}`;
+  if (/\b(apply_patch|read_file|write_file|edit_file|bash|shell|rg|grep)\b/.test(lower)) {
+    const matched = lower.match(/\b(apply_patch|read_file|write_file|edit_file|bash|shell|rg|grep)\b/);
+    return matched ? `tool: ${matched[1]}` : 'tool';
+  }
+  if (/\b(reasoning|thinking|analyzing|checking|planning)\b/.test(lower) || text.startsWith('💭')) return 'thinking';
+  if (/\b(waiting|pending|queued)\b/.test(lower)) return 'waiting';
+  return undefined;
+}
+
+function activityFromStage(error: string | undefined): string | undefined {
+  return error ? classifyActivity(error) : undefined;
+}
+
+function updateLatestActivity(
+  stages: StageEntry[],
+  taskId: string,
+  stageName: string,
+  activity: string,
+  model?: string,
+): StageEntry[] {
+  for (let i = stages.length - 1; i >= 0; i--) {
+    const stage = stages[i];
+    if (stage.taskId !== taskId || stage.stage !== stageName || stage.status !== 'start') continue;
+    const next = stages.slice();
+    next[i] = {
+      ...stage,
+      activity,
+      model: stage.model ?? model,
+    };
+    return next;
+  }
+  return stages;
 }

--- a/src/tui/subagentTree.test.tsx
+++ b/src/tui/subagentTree.test.tsx
@@ -33,6 +33,34 @@ describe('SubagentTree component (EPIC INT-1813 S7)', () => {
     expect(f).toContain('Reviewer');
   });
 
+  it('renders compact running activity and real rate-limit reset data', () => {
+    const stages: StageEntry[] = [
+      {
+        taskId: 'INT-2368-x',
+        stage: 'worker',
+        status: 'start',
+        repository: 'OpenSwarm',
+        issueIdentifier: 'INT-2368',
+        activity: 'tool: apply_patch',
+        model: 'codex',
+      },
+      {
+        taskId: 'INT-2368-x',
+        stage: 'reviewer',
+        status: 'fail',
+        repository: 'OpenSwarm',
+        issueIdentifier: 'INT-2368',
+        activity: 'rate-limited',
+        rateLimitResetsAt: 1770000000000,
+      },
+    ];
+
+    const f = render(<SubagentTree repositories={buildSubagentTree(stages)} />).lastFrame()!;
+    expect(f).toContain('tool: apply_patch');
+    expect(f).toContain('rate-limited');
+    expect(f).toContain('reset 2026-');
+  });
+
   it('honors zero display limits', () => {
     const stages: StageEntry[] = [
       { taskId: 'INT-1940-x', stage: 'worker', status: 'complete', model: 'gpt-5.2-codex' },

--- a/src/tui/subagentTree.ts
+++ b/src/tui/subagentTree.ts
@@ -14,6 +14,8 @@ export interface RoleNode {
   durationMs?: number;
   decision?: 'approve' | 'revise' | 'reject';
   summary?: string;
+  activity?: string;
+  rateLimitResetsAt?: number;
 }
 
 export interface WorktreeNode {
@@ -65,6 +67,8 @@ export function buildSubagentTree(stages: StageEntry[]): RepositoryNode[] {
         durationMs: stage.durationMs,
         decision: stage.decision,
         summary: stage.summary,
+        activity: stage.activity,
+        rateLimitResetsAt: stage.rateLimitResetsAt,
       }));
       const withMetadata = [...latestStages].reverse();
       return {


### PR DESCRIPTION
## Summary
- derive compact activity states from existing pipeline logs and process lifecycle events (`thinking`, `tool: ...`, `waiting`, `rate-limited`)
- render running role rows with a braille spinner and compact activity text in the repository pipeline tree
- include real process task/stage metadata on `process:exit` so waiting state clears only for the matching role
- pass real `RateLimitError.resetsAt` values through stage fail events; omit reset display when no source exists

## Verification
- `npm test -- src/tui/pipelineEvents.test.ts src/tui/subagentTree.test.ts src/tui/subagentTree.test.tsx src/agents/pairPipeline.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- `openswarm review --path .` -> APPROVE after fixing process-exit and rate-limit producer wiring

Linear: INT-2368