### PR TITLE
Enrich TUI monitor tables

### DIFF
--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -537,6 +537,7 @@ export async function startWebServer(port: number = 3847): Promise<void> {
           return {
             path: p,
             name: dirName,
+            linearProject: info?.name,
             enabled: enabledPaths.has(p),
             pinned: pinnedProjects.has(p),
             running: info?.running ?? [],

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -77,7 +77,7 @@ export function App({ version, provider, model, port, cwd, branch, initialTab = 
         ) : activeTab.id === 'logs' ? (
           <LogsPanel port={port} />
         ) : activeTab.id in MONITOR_FETCHERS ? (
-          <MonitorPanel port={port} fetcher={MONITOR_FETCHERS[activeTab.id as keyof typeof MONITOR_FETCHERS]} />
+          <MonitorPanel port={port} fetcher={MONITOR_FETCHERS[activeTab.id as keyof typeof MONITOR_FETCHERS]} terminalWidth={columns} />
         ) : (
           <Text>{`${activeTab.label} — not yet implemented.`}</Text>
         )}

--- a/src/tui/components/DataTable.tsx
+++ b/src/tui/components/DataTable.tsx
@@ -1,26 +1,45 @@
 // DataTable — minimal column-aligned table for the monitor tabs (S6).
 // Hand-rolled (no ink-table) to avoid peer-version risk on ink 7 / react 19.
 import { Box, Text } from 'ink';
-import { displayWidth } from '../../cli/reviewProgress.js';
+import { displayWidth, truncateLine } from '../../cli/reviewProgress.js';
 import type { Table } from '../monitorRows.js';
 
 export interface DataTableProps extends Table {
   empty?: string;
+  maxCellWidth?: number;
+  terminalWidth?: number;
 }
 
-export function DataTable({ columns, rows, empty }: DataTableProps) {
+export function DataTable({ columns, rows, empty, maxCellWidth = 28, terminalWidth }: DataTableProps) {
   if (rows.length === 0) {
     return <Text dimColor>{empty ?? '(no data)'}</Text>;
   }
-  const widths = columns.map((c, i) =>
-    Math.max(displayWidth(c), ...rows.map((r) => displayWidth(r[i] ?? ''))),
+  const visibleColumnCount = terminalWidth
+    ? Math.max(1, Math.min(columns.length, terminalWidth))
+    : columns.length;
+  const rawColumns = columns.slice(0, visibleColumnCount);
+  const separatorWidth = terminalWidth && visibleColumnCount > 1
+    ? Math.max(0, Math.min(2, Math.floor((terminalWidth - visibleColumnCount) / (visibleColumnCount - 1))))
+    : 2;
+  const separator = ' '.repeat(separatorWidth);
+  const gapWidth = Math.max(0, visibleColumnCount - 1) * separatorWidth;
+  const availableCellWidth = terminalWidth ? Math.max(1, terminalWidth - gapWidth) : undefined;
+  const columnCount = Math.max(1, visibleColumnCount);
+  const cellWidth = availableCellWidth
+    ? Math.max(1, Math.min(maxCellWidth, Math.floor(availableCellWidth / columnCount)))
+    : maxCellWidth;
+  const clip = (value: string) => truncateLine(value, cellWidth);
+  const clippedColumns = rawColumns.map(clip);
+  const clippedRows = rows.map((row) => rawColumns.map((_, i) => clip(row[i] ?? '')));
+  const widths = clippedColumns.map((c, i) =>
+    Math.max(displayWidth(c), ...clippedRows.map((r) => displayWidth(r[i] ?? ''))),
   );
   const fmt = (cells: string[]) =>
-    cells.map((cell, i) => `${cell ?? ''}${' '.repeat(Math.max(0, widths[i] - displayWidth(cell ?? '')))}`).join('  ');
+    cells.map((cell, i) => `${cell ?? ''}${' '.repeat(Math.max(0, widths[i] - displayWidth(cell ?? '')))}`).join(separator);
   return (
     <Box flexDirection="column">
-      <Text bold>{fmt(columns)}</Text>
-      {rows.map((r, i) => (
+      <Text bold>{fmt(clippedColumns)}</Text>
+      {clippedRows.map((r, i) => (
         <Text key={i}>{fmt(r)}</Text>
       ))}
     </Box>

--- a/src/tui/dataTable.test.tsx
+++ b/src/tui/dataTable.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from 'ink-testing-library';
+import { displayWidth } from '../cli/reviewProgress.js';
 import { DataTable } from './components/DataTable.js';
 
 describe('DataTable (EPIC INT-1813 S6)', () => {
@@ -15,5 +16,46 @@ describe('DataTable (EPIC INT-1813 S6)', () => {
     expect(f).toContain('NAME');
     expect(f).toContain('alpha');
     expect(f).toContain('beta');
+  });
+
+  it('truncates long cells to keep terminal layout bounded', () => {
+    const f = render(
+      <DataTable columns={['TITLE']} rows={[[`x`.repeat(30)]]} maxCellWidth={10} />,
+    ).lastFrame()!;
+    expect(f).toContain('xxxxxxxxx…');
+    expect(f).not.toContain('x'.repeat(30));
+  });
+
+  it('truncates wide characters by terminal columns', () => {
+    const f = render(
+      <DataTable columns={['TITLE']} rows={[['작업상태확인']]} maxCellWidth={7} />,
+    ).lastFrame()!;
+    expect(f).toContain('작업상…');
+    expect(f).not.toContain('작업상태확인');
+  });
+
+  it('keeps rendered rows within the terminal width', () => {
+    const f = render(
+      <DataTable
+        columns={['FIRST', 'SECOND', 'THIRD']}
+        rows={[['alpha-alpha-alpha', 'beta-beta-beta', 'gamma-gamma-gamma']]}
+        maxCellWidth={20}
+        terminalWidth={24}
+      />,
+    ).lastFrame()!;
+    for (const line of f.split('\n')) {
+      expect(displayWidth(line)).toBeLessThanOrEqual(24);
+    }
+  });
+
+  it('keeps a wide monitor table within a narrow terminal width', () => {
+    const columns = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'];
+    const row = columns.map((c) => `${c}${c}${c}${c}${c}`);
+    const f = render(
+      <DataTable columns={columns} rows={[row]} maxCellWidth={20} terminalWidth={24} />,
+    ).lastFrame()!;
+    for (const line of f.split('\n')) {
+      expect(displayWidth(line)).toBeLessThanOrEqual(24);
+    }
   });
 });

--- a/src/tui/monitorRows.test.ts
+++ b/src/tui/monitorRows.test.ts
@@ -9,34 +9,55 @@ import {
 describe('monitorRows (EPIC INT-1813 S6)', () => {
   it('projectsToTable maps enabled flag and run/queue counts', () => {
     const t = projectsToTable([
-      { name: 'A', path: '/a', enabled: true, running: ['x'], queued: [] },
+      {
+        name: 'A',
+        linearProject: 'Linear A',
+        path: '/Users/u/dev/A',
+        enabled: true,
+        running: [{ id: '1', title: 'active worker task' }],
+        queued: [],
+        pending: [{ id: '2', title: 'todo', issueIdentifier: 'INT-2', linearState: 'Todo' }],
+        git: { branch: 'main', hasChanges: true, uncommittedFiles: 2, ahead: 1 },
+      },
       { name: 'B', path: '/b', enabled: false },
     ]);
-    expect(t.columns).toEqual(['', 'PROJECT', 'RUN', 'QUEUE']);
-    expect(t.rows[0]).toEqual(['●', 'A', '1', '0']);
-    expect(t.rows[1]).toEqual(['○', 'B', '0', '0']);
+    expect(t.columns).toEqual(['', 'PROJECT', 'PATH', 'GIT/WT', 'LINEAR', 'RUN', 'QUEUE', 'PEND', 'LAST']);
+    expect(t.rows[0]).toEqual(['●', 'A', '…/dev/A', 'main +2 ↑1', 'Linear A', '1', '0', '1', 'run active worker task']);
+    expect(t.rows[1]).toEqual(['○', 'B', '/b', '', '', '0', '0', '0', '']);
   });
 
   it('pipelineToTable joins task:started titles to stage rows, newest first', () => {
     const t = pipelineToTable([
       { type: 'task:started', data: { taskId: 't1', issueIdentifier: 'INT-9' } },
-      { type: 'pipeline:stage', data: { taskId: 't1', stage: 'worker', status: 'start', model: 'gpt-5.2-codex' } },
-      { type: 'pipeline:stage', data: { taskId: 't1', stage: 'reviewer', status: 'complete' } },
+      { type: 'pipeline:stage', data: { taskId: 't1', stage: 'worker', status: 'start', model: 'gpt-5.2-codex', repository: 'OpenSwarm' } },
+      { type: 'pipeline:stage', data: { taskId: 't1', stage: 'reviewer', status: 'complete', durationMs: 5000, decision: 'approve', summary: 'review accepted the changes' } },
     ]);
     expect(t.rows[0][0]).toBe('INT-9');
-    expect(t.rows[0][1]).toBe('reviewer'); // newest first
-    expect(t.rows[1][1]).toBe('worker');
-    expect(t.rows[1][2]).toBe('5.2-codex'); // model shortened
+    expect(t.rows[0][2]).toBe('reviewer'); // newest first
+    expect(t.rows[0][4]).toBe('● complete/approve');
+    expect(t.rows[0][5]).toBe('5s');
+    expect(t.rows[0][6]).toBe('review accepted the cha…');
+    expect(t.rows[1][2]).toBe('worker');
+    expect(t.rows[1][3]).toBe('5.2-codex'); // model shortened
+    expect(t.rows[1][6]).toBe('');
   });
 
   it('stuckToTable tags stuck vs failed and truncates long text', () => {
     const t = stuckToTable(
-      [{ identifier: 'INT-1', title: 'short', reason: 'no retry', priority: 1 }],
-      [{ identifier: 'INT-2', title: 'x'.repeat(60), reason: 'boom', priority: 3 }],
+      [{ identifier: 'INT-1', title: 'short', reason: 'no retry', priority: 1, project: { name: 'OpenSwarm' }, stuckDays: 8 }],
+      [{
+        identifier: 'INT-2',
+        title: 'x'.repeat(60),
+        reason: 'boom',
+        priority: 3,
+        labels: ['failed'],
+        comments: [{ body: 'worker failed after repeated timeout', createdAt: '2026-01-02T00:00:00.000Z' }],
+      }],
     );
-    expect(t.rows[0]).toEqual(['stuck', 'INT-1', 'short', 'urgent', 'no retry']);
+    expect(t.rows[0]).toEqual(['stuck', 'INT-1', 'short', 'urgent', 'OpenSwarm', 'no retry', '8d stale']);
     expect(t.rows[1][0]).toBe('failed');
     expect(t.rows[1][2].endsWith('…')).toBe(true);
+    expect(t.rows[1][6]).toBe('worker failed after rep…');
   });
 
   it('issuesToTable maps title/status/priority', () => {

--- a/src/tui/monitorRows.ts
+++ b/src/tui/monitorRows.ts
@@ -11,22 +11,89 @@ export interface Table {
 
 export interface ApiProject {
   name: string;
+  linearProject?: string;
   path: string;
   enabled: boolean;
-  running?: string[];
-  queued?: string[];
+  running?: ApiTaskSummary[];
+  queued?: ApiTaskSummary[];
+  pending?: ApiTaskSummary[];
+  git?: {
+    branch?: string;
+    hasChanges?: boolean;
+    uncommittedFiles?: number;
+    ahead?: number;
+    behind?: number;
+  } | null;
+  prs?: Array<{ number: number; branch: string; title: string; updatedAt?: string }>;
+}
+
+interface ApiTaskSummary {
+  id: string;
+  title: string;
+  priority?: number | string;
+  issueIdentifier?: string;
+  linearState?: string;
 }
 
 export function projectsToTable(projects: ApiProject[]): Table {
   return {
-    columns: ['', 'PROJECT', 'RUN', 'QUEUE'],
+    columns: ['', 'PROJECT', 'PATH', 'GIT/WT', 'LINEAR', 'RUN', 'QUEUE', 'PEND', 'LAST'],
     rows: projects.map((p) => [
       p.enabled ? '●' : '○',
       p.name,
+      compactPath(p.path),
+      gitSummary(p),
+      p.linearProject ?? '',
       String(p.running?.length ?? 0),
       String(p.queued?.length ?? 0),
+      String(p.pending?.length ?? 0),
+      latestProjectActivity(p),
     ]),
   };
+}
+
+function compactPath(path: string): string {
+  const parts = path.split('/').filter(Boolean);
+  return parts.length <= 2 ? path : `…/${parts.slice(-2).join('/')}`;
+}
+
+function gitSummary(p: ApiProject): string {
+  const git = p.git;
+  const branch = git?.branch ?? (p.prs?.[0]?.branch);
+  if (!branch) return '';
+  const dirty = git?.hasChanges ? ` +${git.uncommittedFiles ?? 0}` : '';
+  const sync = `${git?.ahead ? ` ↑${git.ahead}` : ''}${git?.behind ? ` ↓${git.behind}` : ''}`;
+  return `${branch}${dirty}${sync}`;
+}
+
+function latestProjectActivity(p: ApiProject): string {
+  const running = p.running?.[0];
+  if (running) return `run ${truncate(running.title || running.id, 18)}`;
+  const queued = p.queued?.[0];
+  if (queued) return `queue ${truncate(queued.title || queued.id, 16)}`;
+  const pending = p.pending?.[0];
+  if (pending) return `${pending.linearState ?? 'Todo'} ${pending.issueIdentifier ?? pending.id}`;
+  const pr = p.prs?.[0];
+  if (pr) return `PR #${pr.number}`;
+  return '';
+}
+
+function shortModel(model: string | undefined): string {
+  return model ? model.split('-').slice(-2).join('-') : '';
+}
+
+function elapsed(ms: number | undefined): string {
+  if (!ms) return '';
+  if (ms < 1000) return `${ms}ms`;
+  return `${Math.round(ms / 1000)}s`;
+}
+
+function titleOf(data: ApiPipelineEvent['data']): string {
+  return data.issueIdentifier || data.title || data.taskId || '';
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
 }
 
 export interface ApiPipelineEvent {
@@ -38,6 +105,15 @@ export interface ApiPipelineEvent {
     model?: string;
     title?: string;
     issueIdentifier?: string;
+    repository?: string;
+    projectPath?: string;
+    durationMs?: number;
+    decision?: string;
+    summary?: string;
+    feedback?: string;
+    error?: string;
+    filesChangedCount?: number;
+    issuesCount?: number;
   };
 }
 
@@ -46,24 +122,36 @@ const STAGE_ICON: Record<string, string> = { start: '◐', complete: '●', fail
 /** Most-recent pipeline stage events as task rows (newest first). */
 export function pipelineToTable(stages: ApiPipelineEvent[], limit = 15): Table {
   const info = new Map<string, string>(); // taskId → identifier/title
-  const events: Array<{ taskId: string; stage: string; status: string; model?: string }> = [];
+  const events: Array<ApiPipelineEvent['data'] & { taskId: string; stage: string; status: string }> = [];
   for (const ev of stages) {
     if (ev.type === 'task:started' && ev.data.taskId) {
       info.set(ev.data.taskId, ev.data.issueIdentifier || ev.data.title || ev.data.taskId);
     } else if (ev.type === 'pipeline:stage' && ev.data.taskId && ev.data.stage) {
-      events.push({ taskId: ev.data.taskId, stage: ev.data.stage, status: ev.data.status ?? '', model: ev.data.model });
+      events.push({ ...ev.data, taskId: ev.data.taskId, stage: ev.data.stage, status: ev.data.status ?? '' });
     }
   }
   const recent = events.slice(-limit).reverse();
   return {
-    columns: ['TASK', 'STAGE', 'MODEL', 'STATUS'],
+    columns: ['TASK', 'PROJECT', 'STAGE', 'MODEL', 'STATE', 'AGE', 'DETAIL'],
     rows: recent.map((e) => [
-      (info.get(e.taskId) ?? e.taskId).slice(0, 14),
+      truncate(info.get(e.taskId) ?? titleOf(e), 16),
+      e.repository ?? compactPath(e.projectPath ?? ''),
       e.stage,
-      e.model ? e.model.split('-').slice(-2).join('-') : '',
-      `${STAGE_ICON[e.status] ?? '○'} ${e.status}`,
+      shortModel(e.model),
+      `${STAGE_ICON[e.status] ?? '○'} ${e.status}${e.decision ? `/${e.decision}` : ''}`,
+      elapsed(e.durationMs),
+      stageDetail(e),
     ]),
   };
+}
+
+function stageDetail(e: ApiPipelineEvent['data']): string {
+  if (e.error) return truncate(e.error, 24);
+  if (e.summary) return truncate(e.summary, 24);
+  if (e.feedback) return truncate(e.feedback, 24);
+  if (e.filesChangedCount != null) return `${e.filesChangedCount} files`;
+  if (e.issuesCount != null) return `${e.issuesCount} issues`;
+  return '';
 }
 
 export interface ApiStuckIssue {
@@ -72,6 +160,10 @@ export interface ApiStuckIssue {
   reason: string;
   priority: number | string;
   project?: { name: string };
+  state?: string;
+  labels?: string[];
+  comments?: Array<{ body: string; createdAt: string }>;
+  stuckDays?: number;
 }
 
 const PRIO = (p: number | string) => {
@@ -88,12 +180,24 @@ export function stuckToTable(stuck: ApiStuckIssue[], failed: ApiStuckIssue[]): T
     i.identifier,
     i.title.length > 40 ? `${i.title.slice(0, 39)}…` : i.title,
     PRIO(i.priority),
+    i.project?.name ?? '',
     i.reason.length > 30 ? `${i.reason.slice(0, 29)}…` : i.reason,
+    issueContext(i),
   ];
   return {
-    columns: ['KIND', 'ID', 'TITLE', 'PRIO', 'REASON'],
+    columns: ['KIND', 'ID', 'TITLE', 'PRIO', 'PROJECT', 'REASON', 'CONTEXT'],
     rows: [...stuck.map(row('stuck')), ...failed.map(row('failed'))],
   };
+}
+
+function issueContext(i: ApiStuckIssue): string {
+  const latestComment = [...(i.comments ?? [])]
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
+  if (latestComment?.body) return truncate(latestComment.body.replace(/\s+/g, ' ').trim(), 24);
+  if (typeof i.stuckDays === 'number') return `${i.stuckDays}d stale`;
+  const labels = (i.labels ?? []).filter(l => ['retry', 'failed', 'blocked', 'needs-help', 'swarm:stuck'].includes(l));
+  if (labels.length > 0) return truncate(labels.join(','), 24);
+  return i.state ?? '';
 }
 
 export interface ApiIssue {

--- a/src/tui/panels/MonitorPanel.tsx
+++ b/src/tui/panels/MonitorPanel.tsx
@@ -11,12 +11,13 @@ export interface MonitorPanelProps {
   port?: number;
   fetcher: (port: number) => Promise<Table>;
   empty?: string;
+  terminalWidth?: number;
 }
 
-export function MonitorPanel({ port, fetcher, empty }: MonitorPanelProps) {
+export function MonitorPanel({ port, fetcher, empty, terminalWidth }: MonitorPanelProps) {
   const { table, error, loading } = useMonitor(port, fetcher);
   if (!port) return <Text dimColor>○ daemon port unknown</Text>;
   if (error) return <Text color={theme.err}>{`load failed: ${error}`}</Text>;
   if (!table) return <Text dimColor>{loading ? 'loading…' : '(no data)'}</Text>;
-  return <DataTable columns={table.columns} rows={table.rows} empty={empty} />;
+  return <DataTable columns={table.columns} rows={table.rows} empty={empty} terminalWidth={terminalWidth} />;
 }


### PR DESCRIPTION
## Summary
- Enrich TUI Projects/Tasks/Stuck monitor rows with project git/worktree, Linear project, pending activity, stage detail, and stuck context from existing API producer fields.
- Add terminal-width-aware DataTable truncation and pass App terminal columns through MonitorPanel.
- Extend /api/projects with backward-compatible linearProject metadata.

## Verification
- npm test -- src/tui/monitorRows.test.ts src/tui/dataTable.test.tsx
- npm run typecheck
- npm run lint
- npm test
- npm run build
- git diff --check
- openswarm review --path .: APPROVE