### PR TITLE
fix(pipeline): show actual model in TUI/dashboard when role model is omitted (INT-2393)

### DIFF
--- a/src/agents/pairPipeline.test.ts
+++ b/src/agents/pairPipeline.test.ts
@@ -7,6 +7,7 @@ import { RateLimitError } from '../adapters/rateLimitError.js';
 const runWorker = vi.fn();
 const runReviewer = vi.fn();
 const broadcastEvent = vi.fn();
+const getDefaultModel = vi.fn();
 
 vi.mock('./worker.js', () => ({
   runWorker,
@@ -34,6 +35,11 @@ vi.mock('../core/eventHub.js', () => ({
   broadcastEvent,
 }));
 
+vi.mock('../adapters/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../adapters/index.js')>('../adapters/index.js');
+  return { ...actual, getAdapter: () => ({ getDefaultModel }) };
+});
+
 describe('PairPipeline model selection', () => {
   beforeEach(() => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
@@ -52,6 +58,7 @@ describe('PairPipeline model selection', () => {
       decision: 'approve',
       feedback: 'approved',
     });
+    getDefaultModel.mockResolvedValue('codex-live-model');
   });
 
   afterEach(() => {
@@ -153,5 +160,62 @@ describe('PairPipeline model selection', () => {
         rateLimitResetsAt: 1770000000000,
       }),
     }));
+  });
+
+  // INT-2393: when role model is omitted, the pipeline:stage events must carry
+  // the adapter's real default model so the TUI/dashboard can display it.
+  function stageModels(): (string | undefined)[] {
+    return broadcastEvent.mock.calls
+      .map(c => c[0])
+      .filter(e => e.type === 'pipeline:stage')
+      .map(e => e.data.model);
+  }
+
+  it('resolves the adapter default model when role model is omitted, and caches it', async () => {
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker', 'reviewer'],
+      maxIterations: 1,
+      roles: {
+        worker: { enabled: true, timeoutMs: 0 },   // no model → adapter default
+        reviewer: { enabled: true, timeoutMs: 0 },
+      },
+    });
+
+    await pipeline.run(task(), process.cwd());
+
+    const models = stageModels();
+    expect(models.length).toBeGreaterThan(0);
+    expect(models.every(m => m === 'codex-live-model')).toBe(true);
+    // worker + reviewer share the '<default>' adapter key → resolved once.
+    expect(getDefaultModel).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefers an explicit role model over the adapter default (no getDefaultModel call)', async () => {
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker'],
+      maxIterations: 1,
+      roles: { worker: { enabled: true, model: 'explicit-worker', timeoutMs: 0 } },
+    });
+
+    await pipeline.run(task(), process.cwd());
+
+    expect(stageModels().every(m => m === 'explicit-worker')).toBe(true);
+    expect(getDefaultModel).not.toHaveBeenCalled();
+  });
+
+  it('degrades to an undefined model when getDefaultModel fails', async () => {
+    getDefaultModel.mockRejectedValue(new Error('no auth'));
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker'],
+      maxIterations: 1,
+      roles: { worker: { enabled: true, timeoutMs: 0 } },
+    });
+
+    await pipeline.run(task(), process.cwd());
+
+    expect(stageModels().every(m => m === undefined)).toBe(true);
   });
 });

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -39,6 +39,7 @@ import * as skillDocumenterAgent from './skillDocumenter.js';
 import { StuckDetector, createStuckDetector } from '../support/stuckDetector.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
 import { isInfraError } from '../adapters/errorClassification.js';
+import { resolveAdapterDefaultModel } from './stageModelResolver.js';
 
 // Types
 
@@ -219,6 +220,8 @@ export class PairPipeline extends EventEmitter {
   private jobProfiles: JobProfile[];
   /** Set per run() — aborts the pipeline + in-flight adapter call on cancel/disable. */
   private abortSignal?: AbortSignal;
+  /** Cache of adapter default models (heavy: OAuth + live catalog) keyed by adapter name. (INT-2393) */
+  private defaultModelCache = new Map<string, Promise<string | undefined>>();
 
   /** Throw if this run has been cancelled. Called at iteration/stage boundaries. */
   private throwIfAborted(): void {
@@ -259,6 +262,7 @@ export class PairPipeline extends EventEmitter {
     const profile = this.getProfileForTask(task);
     return profile?.roles?.[stage] || this.config.roles?.[stage]?.model;
   }
+
 
   /** Reasoning effort from the matched jobProfile (heavy tasks reason harder). */
   private getEffortForTask(task: TaskItem): 'low' | 'medium' | 'high' | undefined {
@@ -538,7 +542,11 @@ export class PairPipeline extends EventEmitter {
     overrides?: { model?: string }
   ): Promise<StageResult> {
     const startTime = Date.now();
-    const stageModel = overrides?.model ?? this.getModelForRole(stage, context.task);
+    // Display model: explicit override → configured (jobProfile/role) → adapter
+    // default (so the TUI/dashboard aren't blank when config omits it). (INT-2393)
+    const stageModel = overrides?.model
+      ?? this.getModelForRole(stage, context.task)
+      ?? await resolveAdapterDefaultModel(this.config.roles?.[stage]?.adapter, this.defaultModelCache);
     const prefix = context.taskPrefix;
     const metadata = this.stageMetadata(context);
     console.log(`[${prefix}] Stage starting: ${stage}`);
@@ -806,7 +814,7 @@ export class PairPipeline extends EventEmitter {
       broadcastEvent({ type: 'pipeline:stage', data: {
         taskId: context.task.id, stage, status: 'complete',
         ...metadata,
-        model: costInfo?.model,
+        model: costInfo?.model ?? stageModel,
         inputTokens: costInfo?.inputTokens,
         outputTokens: costInfo?.outputTokens,
         costUsd: costInfo?.costUsd,
@@ -834,6 +842,7 @@ export class PairPipeline extends EventEmitter {
       broadcastEvent({ type: 'pipeline:stage', data: {
         taskId: context.task.id, stage, status: 'fail',
         ...metadata,
+        model: stageModel,
         durationMs: stageResult.duration,
         rateLimitResetsAt: error instanceof RateLimitError && error.resetsAt ? error.resetsAt * 1000 : undefined,
         error: error instanceof Error ? error.message : String(error),

--- a/src/agents/stageModelResolver.test.ts
+++ b/src/agents/stageModelResolver.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getDefaultModel = vi.fn();
+
+vi.mock('../adapters/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../adapters/index.js')>('../adapters/index.js');
+  return { ...actual, getAdapter: () => ({ getDefaultModel }) };
+});
+
+import { resolveAdapterDefaultModel } from './stageModelResolver.js';
+
+describe('resolveAdapterDefaultModel', () => {
+  beforeEach(() => {
+    getDefaultModel.mockReset();
+  });
+
+  it('resolves the adapter default model', async () => {
+    getDefaultModel.mockResolvedValue('gpt-5.4-mini');
+    const cache = new Map<string, Promise<string | undefined>>();
+    await expect(resolveAdapterDefaultModel('codex-responses', cache)).resolves.toBe('gpt-5.4-mini');
+  });
+
+  it('caches per adapter — getDefaultModel runs once across repeated calls', async () => {
+    getDefaultModel.mockResolvedValue('gpt-5.4-mini');
+    const cache = new Map<string, Promise<string | undefined>>();
+    await resolveAdapterDefaultModel('codex', cache);
+    await resolveAdapterDefaultModel('codex', cache);
+    expect(getDefaultModel).toHaveBeenCalledTimes(1);
+  });
+
+  it('keys an undefined adapter name under <default>', async () => {
+    getDefaultModel.mockResolvedValue('m');
+    const cache = new Map<string, Promise<string | undefined>>();
+    await resolveAdapterDefaultModel(undefined, cache);
+    await resolveAdapterDefaultModel(undefined, cache);
+    expect(getDefaultModel).toHaveBeenCalledTimes(1);
+    expect(cache.has('<default>')).toBe(true);
+  });
+
+  it('degrades to undefined when getDefaultModel throws', async () => {
+    getDefaultModel.mockRejectedValue(new Error('no auth'));
+    const cache = new Map<string, Promise<string | undefined>>();
+    await expect(resolveAdapterDefaultModel('codex', cache)).resolves.toBeUndefined();
+  });
+});

--- a/src/agents/stageModelResolver.ts
+++ b/src/agents/stageModelResolver.ts
@@ -1,0 +1,26 @@
+// ============================================
+// OpenSwarm - Stage model resolution (INT-2393)
+// ============================================
+
+import { getAdapter } from '../adapters/index.js';
+
+/**
+ * Resolve (and cache) an adapter's default model. `getDefaultModel` is heavy
+ * (OAuth + live catalog), so results are cached per adapter name; failures
+ * degrade to undefined. Used to fill the display model when a role omits it and
+ * relies on the adapter default, so the TUI/dashboard aren't left blank.
+ */
+export function resolveAdapterDefaultModel(
+  adapterName: string | undefined,
+  cache: Map<string, Promise<string | undefined>>,
+): Promise<string | undefined> {
+  const cacheKey = adapterName ?? '<default>';
+  let pending = cache.get(cacheKey);
+  if (!pending) {
+    pending = Promise.resolve()
+      .then(() => getAdapter(adapterName).getDefaultModel())
+      .catch(() => undefined);
+    cache.set(cacheKey, pending);
+  }
+  return pending;
+}

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -51,6 +51,7 @@ import { STUCK_LABEL } from '../linear/index.js';
 import { refreshGraph, toProjectSlug } from '../knowledge/index.js';
 import { checkAllMonitors, getActiveMonitors } from './longRunningMonitor.js';
 import { detectFileConflicts } from '../orchestration/conflictDetector.js';
+import { resolveAdapterDefaultModel } from '../agents/stageModelResolver.js';
 import type { AutonomousConfig, RunnerState } from './runnerTypes.js';
 import type { AdapterName } from '../adapters/types.js';
 import {
@@ -81,6 +82,8 @@ export class AutonomousRunner {
   private config: AutonomousConfig;
   private engine: DecisionEngine;
   private scheduler: TaskScheduler;
+  /** Adapter default-model cache for the dashboard PAIR bar (INT-2393). */
+  private defaultModelCache = new Map<string, Promise<string | undefined>>();
   private cronJob: Cron | null = null;
   private state: RunnerState = {
     isRunning: false,
@@ -1467,20 +1470,26 @@ export class AutonomousRunner {
     }
   }
 
-  getAdapterSummary() {
+  async getAdapterSummary() {
     const defaultAdapter = this.config.defaultAdapter ?? 'codex';
     const defaultRoles = this.config.defaultRoles;
+    const workerAdapter = defaultRoles?.worker?.adapter ?? defaultAdapter;
+    const reviewerAdapter = defaultRoles?.reviewer?.adapter ?? defaultAdapter;
 
     return {
       defaultAdapter,
       worker: {
-        adapter: defaultRoles?.worker?.adapter ?? defaultAdapter,
-        model: defaultRoles?.worker?.model ?? this.config.workerModel,
+        adapter: workerAdapter,
+        // Resolve the adapter's real default when config omits the model, so the
+        // dashboard's PAIR bar shows what's running instead of "-". (INT-2393)
+        model: defaultRoles?.worker?.model ?? this.config.workerModel
+          ?? await resolveAdapterDefaultModel(workerAdapter, this.defaultModelCache),
         enabled: defaultRoles?.worker?.enabled !== false,
       },
       reviewer: {
-        adapter: defaultRoles?.reviewer?.adapter ?? defaultAdapter,
-        model: defaultRoles?.reviewer?.model ?? this.config.reviewerModel,
+        adapter: reviewerAdapter,
+        model: defaultRoles?.reviewer?.model ?? this.config.reviewerModel
+          ?? await resolveAdapterDefaultModel(reviewerAdapter, this.defaultModelCache),
         enabled: defaultRoles?.reviewer?.enabled !== false,
       },
       tester: defaultRoles?.tester ? {

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -478,7 +478,7 @@ export async function startWebServer(port: number = 3847): Promise<void> {
       } else if (url === '/api/stats') {
         const stats = runnerRef?.getStats();
         const state = runnerRef?.getState();
-        const adapters = runnerRef?.getAdapterSummary();
+        const adapters = await runnerRef?.getAdapterSummary();
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
           runningTasks: stats?.schedulerStats?.running ?? 0,
@@ -845,8 +845,9 @@ export async function startWebServer(port: number = 3847): Promise<void> {
           ? '## Relevant Past Discussions\n' + memories.map(m => `- ${m.content.replace(/^Q: |^A: /g, '')}`).join('\n')
           : '';
 
-        const provider = runnerRef?.getAdapterSummary().defaultAdapter ?? 'codex';
-        const model = runnerRef?.getAdapterSummary().worker?.model ?? getDefaultChatModel(provider);
+        const adapterSummary = await runnerRef?.getAdapterSummary();
+        const provider = adapterSummary?.defaultAdapter ?? 'codex';
+        const model = adapterSummary?.worker?.model ?? getDefaultChatModel(provider);
 
         const contextPrompt = [
           'You are OpenSwarm, an autonomous code development supervisor.',


### PR DESCRIPTION
## What

TUI pipeline/monitor and the web dashboard weren't showing the worker/reviewer **model name**. The display UI already exists (`SubagentTree.tsx:80`, `StageTimeline.tsx:27`, `monitorRows.shortModel`, dashboard `shortModel`) — the `pipeline:stage` `model` field was simply empty.

## Root cause

`config.yaml` sets `adapter: codex-responses` but omits `defaultRoles.*.model`, relying on the adapter default. `getModelForRole` only returned `profile?.roles?.[stage] || config.roles?.[stage]?.model`, so any task not matching a jobProfile (quick/heavy) resolved to `undefined` → blank model. The actual run resolves the model via the adapter's `getDefaultModel()`, but that value never reached the UI.

## Fix

- **`resolveAdapterDefaultModel()`** (new `stageModelResolver.ts`): resolves + **caches** the adapter's real default model. `getDefaultModel` is heavy (OAuth + live catalog), so it's cached per adapter; failures degrade to `undefined` (prior behavior).
- `runStage` display model = `override → configured (jobProfile/role) → adapter default`. All **start/complete/fail** `pipeline:stage` events now carry it (complete previously depended on `usage.model`; fail carried none).
- Extracted the resolver to keep `pairPipeline.ts` under the 1500-line pre-commit gate.

## Verified

Live: `codex-responses → gpt-5.4-mini`, `codex → gpt-5.5`, `claude → sonnet`.
Tests: resolve+cache (1 `getDefaultModel` call shared by worker+reviewer), explicit-model precedence, graceful failure. Full suite green.

Closes INT-2393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)