### PR TITLE
feat(cli): auto-update from npm on launch — install + re-exec (INT-2394)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ import { runCli } from './runners/cliRunner.js';
 import { loadConfig, validateConfig, generateSampleConfig } from './core/config.js';
 import { loadEnvFile } from './core/envFile.js';
 import { initTelemetry, track } from './telemetry/telemetry.js';
-import { maybeNotifyUpdate } from './support/updateNotifier.js';
+import { maybeAutoUpdate } from './support/updateNotifier.js';
 
 // Load .env so CLI commands (e.g. `auth login --provider linear` reading
 // LINEAR_OAUTH_CLIENT_ID) see the same env the daemon does. Idempotent; never
@@ -717,7 +717,9 @@ program.action(launchChatTui);
 
 // Parse & Execute
 
-// Surface an "update available" notice (cached, TTY-only, never blocking on the
-// network for more than a moment) before dispatching the command. (INT-2270)
-await maybeNotifyUpdate(VERSION);
+// Auto-update from npm before dispatching: if a newer version is published,
+// `npm i -g` it and re-exec on the new binary (default ON; opt out with
+// OPENSWARM_NO_AUTO_UPDATE → passive notice). Cached 24h, skips CI/non-TTY/meta,
+// never blocks the CLI. (INT-2394, extends INT-2270)
+await maybeAutoUpdate(VERSION);
 program.parse();

--- a/src/support/updateNotifier.test.ts
+++ b/src/support/updateNotifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { isNewer, shouldSkip, maybeNotifyUpdate } from './updateNotifier.js';
+import { isNewer, shouldSkip, maybeNotifyUpdate, maybeAutoUpdate } from './updateNotifier.js';
 
 describe('isNewer (INT-2270)', () => {
   it('compares semver numerically', () => {
@@ -94,5 +94,88 @@ describe('maybeNotifyUpdate (INT-2270)', () => {
     await maybeNotifyUpdate('0.12.0', { ...base, isTTY: false, fetchLatest, write });
     expect(fetchLatest).not.toHaveBeenCalled();
     expect(write).not.toHaveBeenCalled();
+  });
+});
+
+describe('maybeAutoUpdate (INT-2394)', () => {
+  const base = { argv: ['n', 'c', 'start'], env: {} as NodeJS.ProcessEnv, isTTY: true };
+
+  it('installs and re-execs when a newer version exists', async () => {
+    const install = vi.fn(() => true);
+    const reexec = vi.fn();
+    const write = vi.fn();
+    await maybeAutoUpdate('0.12.0', {
+      ...base,
+      readCache: () => ({ latest: '0.13.0', checkedAt: 1000 }),
+      now: () => 1001,
+      write, install, reexec,
+    });
+    expect(install).toHaveBeenCalledWith('@intrect/openswarm');
+    expect(reexec).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing when already on the latest', async () => {
+    const install = vi.fn(() => true);
+    const reexec = vi.fn();
+    await maybeAutoUpdate('0.13.0', {
+      ...base,
+      readCache: () => ({ latest: '0.13.0', checkedAt: 1000 }),
+      now: () => 1001,
+      install, reexec,
+    });
+    expect(install).not.toHaveBeenCalled();
+    expect(reexec).not.toHaveBeenCalled();
+  });
+
+  it('does NOT re-exec when install fails (stays on current)', async () => {
+    const install = vi.fn(() => false);
+    const reexec = vi.fn();
+    const write = vi.fn();
+    await maybeAutoUpdate('0.12.0', {
+      ...base,
+      readCache: () => ({ latest: '0.13.0', checkedAt: 1000 }),
+      now: () => 1001,
+      write, install, reexec,
+    });
+    expect(install).toHaveBeenCalledOnce();
+    expect(reexec).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a passive notice when opted out', async () => {
+    const install = vi.fn(() => true);
+    const reexec = vi.fn();
+    const write = vi.fn();
+    await maybeAutoUpdate('0.12.0', {
+      ...base,
+      env: { OPENSWARM_NO_AUTO_UPDATE: '1' } as NodeJS.ProcessEnv,
+      readCache: () => ({ latest: '0.13.0', checkedAt: 1000 }),
+      now: () => 1001,
+      write, install, reexec,
+    });
+    expect(install).not.toHaveBeenCalled();
+    expect(reexec).not.toHaveBeenCalled();
+    expect(write).toHaveBeenCalledOnce(); // the passive notice
+  });
+
+  it('no-ops once re-executed (OPENSWARM_UPDATED loop guard)', async () => {
+    const install = vi.fn(() => true);
+    const reexec = vi.fn();
+    const fetchLatest = vi.fn();
+    await maybeAutoUpdate('0.12.0', {
+      ...base,
+      env: { OPENSWARM_UPDATED: '1' } as NodeJS.ProcessEnv,
+      fetchLatest, install, reexec,
+    });
+    expect(fetchLatest).not.toHaveBeenCalled();
+    expect(install).not.toHaveBeenCalled();
+    expect(reexec).not.toHaveBeenCalled();
+  });
+
+  it('skips install in CI / non-TTY', async () => {
+    const install = vi.fn(() => true);
+    const reexec = vi.fn();
+    await maybeAutoUpdate('0.12.0', { ...base, isTTY: false, install, reexec });
+    expect(install).not.toHaveBeenCalled();
+    expect(reexec).not.toHaveBeenCalled();
   });
 });

--- a/src/support/updateNotifier.ts
+++ b/src/support/updateNotifier.ts
@@ -9,6 +9,7 @@
 // break the CLI. The network/fs/clock are injectable for tests.
 
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { c } from './colors.js';
@@ -131,5 +132,81 @@ export async function maybeNotifyUpdate(current: string, deps: NotifierDeps = {}
     if (latest && isNewer(latest, current)) out(formatUpdateNotice(current, latest));
   } catch {
     // A notifier must never break the CLI.
+  }
+}
+
+/** `npm install -g <pkg>@latest`. Returns true on success. (INT-2394) */
+function defaultInstall(pkg: string): boolean {
+  try {
+    execFileSync('npm', ['install', '-g', `${pkg}@latest`], { stdio: 'inherit', timeout: 180_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Re-run the current command with the freshly-installed binary. Marks the child
+ * with OPENSWARM_UPDATED=1 so it won't try to update again (loop guard), waits
+ * for it, and exits with its code. Does not return on success. (INT-2394)
+ */
+function defaultReexec(): void {
+  const child = spawnSync(process.execPath, process.argv.slice(1), {
+    stdio: 'inherit',
+    env: { ...process.env, OPENSWARM_UPDATED: '1' },
+  });
+  process.exit(child.status ?? 0);
+}
+
+export interface AutoUpdateDeps extends NotifierDeps {
+  install?: (pkg: string) => boolean;
+  reexec?: () => void;
+}
+
+/**
+ * Auto-update: if a newer version is on npm, `npm i -g` it and re-exec the
+ * current command on the new binary. Default ON; falls back to a passive notice
+ * when opted out (OPENSWARM_NO_AUTO_UPDATE). Skips CI/non-TTY/meta invocations
+ * (never installs unattended) and no-ops once re-executed (OPENSWARM_UPDATED).
+ * Uses the same 24h cache as the notice. Never throws. (INT-2394)
+ */
+export async function maybeAutoUpdate(current: string, deps: AutoUpdateDeps = {}): Promise<void> {
+  try {
+    const argv = deps.argv ?? process.argv;
+    const env = deps.env ?? process.env;
+    const isTTY = deps.isTTY ?? !!process.stdout.isTTY;
+
+    if (env.OPENSWARM_UPDATED) return;                       // already the re-exec'd child
+    if (env.OPENSWARM_NO_AUTO_UPDATE) return maybeNotifyUpdate(current, deps); // opted out → notice only
+    if (shouldSkip(argv, env, isTTY)) return;                // CI / non-TTY / --version etc.
+
+    const now = deps.now ?? (() => Date.now());
+    const read = deps.readCache ?? readCache;
+    const write = deps.writeCache ?? writeCache;
+    const fetchFn = deps.fetchLatest ?? fetchLatest;
+    const out = deps.write ?? ((s: string) => process.stderr.write(s));
+    const install = deps.install ?? defaultInstall;
+    const reexec = deps.reexec ?? defaultReexec;
+
+    const cache = read();
+    let latest = cache?.latest ?? null;
+    const fresh = cache != null && now() - cache.checkedAt < DAY_MS;
+    if (!fresh) {
+      const fetched = await fetchFn();
+      write({ latest: fetched ?? latest ?? current, checkedAt: now() });
+      if (fetched) latest = fetched;
+    }
+
+    if (!latest || !isNewer(latest, current)) return;
+
+    out(`\n  ${c.dim('Updating')} ${c.dim(current)} ${c.dim('→')} ${c.green(latest)}…\n`);
+    if (!install(PKG)) {
+      out(`  ${c.dim(`Auto-update failed; continuing on ${current}. Run npm i -g ${PKG} manually.`)}\n`);
+      return;
+    }
+    out(`  ${c.green('Updated')} ${c.dim('→')} ${c.green(latest)}. ${c.dim('Restarting…')}\n`);
+    reexec(); // replaces/exits the process on success
+  } catch {
+    // Auto-update must never break the CLI.
   }
 }


### PR DESCRIPTION
## What

`openswarm` now auto-updates itself: on launch, if a newer version is published to npm, it runs `npm i -g @intrect/openswarm@latest` and **re-execs the current command on the new binary** — so a restart automatically picks up the latest (no manual `npm i`).

## Behavior (as requested)

- **Default ON**, every invocation. Cached 24h (reuses INT-2270's `update-check.json`), so it only hits the network once a day.
- **Re-exec**: after install, the same argv runs again with `OPENSWARM_UPDATED=1` set — the child skips the update check (loop guard) and runs the real command.
- **Opt out**: `OPENSWARM_NO_AUTO_UPDATE=1` → falls back to the passive "update available" notice.
- **Never unattended**: skips CI / non-TTY / meta commands (`--version`, `--help`) — no surprise global installs in scripts.
- **Safe failure**: if `npm i -g` fails (perms/network), it prints a note and continues on the current version. Never throws.

## Implementation

- `maybeAutoUpdate()` in `updateNotifier.ts`, reusing `fetchLatest` / `isNewer` / `shouldSkip` / cache. `install` and `reexec` are injected deps (default: `execFileSync npm i -g` / `spawnSync` re-exec) so the whole flow is unit-testable without touching the real environment.
- `cli.ts` calls `maybeAutoUpdate(VERSION)` where it previously called `maybeNotifyUpdate`.

## Tests

install+reexec on newer / same-version no-op / install-failure → no re-exec / opt-out → notice / `OPENSWARM_UPDATED` loop guard / CI-skip. Full suite green (1500).

Closes INT-2394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)