### PR TITLE
fix(tui): de-flicker the Pipeline/Logs tab by coalescing SSE bursts (INT-2407)

### DIFF
--- a/src/tui/components/StageTimeline.tsx
+++ b/src/tui/components/StageTimeline.tsx
@@ -2,6 +2,7 @@
 // Presentational: takes already-reduced stage entries (parity with the
 // dashboard's renderStages).
 import { Box, Text } from 'ink';
+import { memo } from 'react';
 import { STATUS } from '../theme.js';
 import type { StatusKind } from '../../support/glyphs.js';
 import type { StageEntry } from '../pipelineEvents.js';
@@ -14,7 +15,9 @@ export interface StageTimelineProps {
   max?: number;
 }
 
-export function StageTimeline({ stages, max = 12 }: StageTimelineProps) {
+// Memoized so a log-only pipeline update (unchanged `stages` identity) skips
+// re-rendering the timeline, cutting per-commit work during SSE bursts. (INT-2407)
+export const StageTimeline = memo(function StageTimeline({ stages, max = 12 }: StageTimelineProps) {
   const shown = max > 0 ? stages.slice(-max) : [];
   return (
     <Box flexDirection="column">
@@ -36,4 +39,4 @@ export function StageTimeline({ stages, max = 12 }: StageTimelineProps) {
       )}
     </Box>
   );
-}
+});

--- a/src/tui/components/SubagentTree.tsx
+++ b/src/tui/components/SubagentTree.tsx
@@ -1,7 +1,7 @@
 // SubagentTree — concurrent tasks as a per-worktree agent tree (S7).
 // Presentational: takes nodes built by buildSubagentTree.
 import { Box, Text } from 'ink';
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { STATUS } from '../theme.js';
 import type { StatusKind } from '../../support/glyphs.js';
 import type { RepositoryNode, TaskStatus } from '../subagentTree.js';
@@ -52,7 +52,10 @@ function worktreeLabel(task: RepositoryNode['worktrees'][number]): string {
   return sanitizeTerminalLabel(`${id}${branch}${stage}${duration ? ` ${duration}` : ''}${decision}${title}`, NODE_LABEL_MAX_CHARS);
 }
 
-export function SubagentTree({ repositories, max = 6, maxRoles = 5 }: SubagentTreeProps) {
+// Memoized so log-only pipeline updates (stable `repositories` identity from the
+// panel's useMemo) skip re-rendering the tree — only stage changes rebuild it,
+// which also keeps the spinner interval from re-subscribing each render. (INT-2407)
+export const SubagentTree = memo(function SubagentTree({ repositories, max = 6, maxRoles = 5 }: SubagentTreeProps) {
   const worktreeLimit = clampLimit(max);
   const roleLimit = clampLimit(maxRoles);
   const [tick, setTick] = useState(0);
@@ -87,4 +90,4 @@ export function SubagentTree({ repositories, max = 6, maxRoles = 5 }: SubagentTr
       )}
     </Box>
   );
-}
+});

--- a/src/tui/eventCoalescer.test.ts
+++ b/src/tui/eventCoalescer.test.ts
@@ -1,0 +1,82 @@
+// Purpose: coalescer batches bursts into one flush per window (INT-2407).
+import { describe, it, expect, vi } from 'vitest';
+import { createCoalescer } from './eventCoalescer.js';
+
+describe('createCoalescer (INT-2407)', () => {
+  it('coalesces a burst of pushes into a single flush, preserving order', () => {
+    vi.useFakeTimers();
+    try {
+      const batches: number[][] = [];
+      const c = createCoalescer<number>({ delayMs: 90, onFlush: (items) => batches.push(items) });
+      c.push(1);
+      c.push(2);
+      c.push(3);
+      // Nothing flushes until the window elapses.
+      expect(batches).toEqual([]);
+      expect(c.pending()).toBe(3);
+      vi.advanceTimersByTime(90);
+      expect(batches).toEqual([[1, 2, 3]]);
+      expect(c.pending()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('starts a fresh window after a flush (one flush per window)', () => {
+    vi.useFakeTimers();
+    try {
+      const batches: number[][] = [];
+      const c = createCoalescer<number>({ delayMs: 50, onFlush: (items) => batches.push(items) });
+      c.push(1);
+      vi.advanceTimersByTime(50);
+      c.push(2);
+      c.push(3);
+      vi.advanceTimersByTime(50);
+      expect(batches).toEqual([[1], [2, 3]]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('flushes synchronously when delayMs <= 0', () => {
+    const batches: number[][] = [];
+    const c = createCoalescer<number>({ delayMs: 0, onFlush: (items) => batches.push(items) });
+    c.push(1);
+    c.push(2);
+    expect(batches).toEqual([[1], [2]]);
+  });
+
+  it('flush() drains buffered items immediately and clears the pending timer', () => {
+    const cleared: unknown[] = [];
+    const batches: number[][] = [];
+    const c = createCoalescer<number>({
+      delayMs: 90,
+      onFlush: (items) => batches.push(items),
+      setTimer: () => 42 as unknown as ReturnType<typeof setTimeout>,
+      clearTimer: (h) => cleared.push(h),
+    });
+    c.push(1);
+    c.push(2);
+    c.flush();
+    expect(batches).toEqual([[1, 2]]);
+    expect(cleared).toEqual([42]);
+    // No-op when nothing is buffered.
+    c.flush();
+    expect(batches).toEqual([[1, 2]]);
+  });
+
+  it('cancel() drops buffered items without flushing', () => {
+    vi.useFakeTimers();
+    try {
+      const batches: number[][] = [];
+      const c = createCoalescer<number>({ delayMs: 90, onFlush: (items) => batches.push(items) });
+      c.push(1);
+      c.cancel();
+      expect(c.pending()).toBe(0);
+      vi.advanceTimersByTime(200);
+      expect(batches).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/tui/eventCoalescer.ts
+++ b/src/tui/eventCoalescer.ts
@@ -1,0 +1,80 @@
+// ============================================
+// OpenSwarm - Event coalescer (INT-2407)
+// Buffers a burst of items and flushes them as one batch at most once per
+// `delayMs`, so rapid SSE events cause a single re-render instead of N. In the
+// alternate-screen buffer every React commit repaints the whole frame, so N
+// per-event commits = N visible erase/redraws = flicker. Pure (timer injectable)
+// — unit-tested without React/ink.
+// ============================================
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+export interface Coalescer<T> {
+  /** Buffer an item; schedules a trailing flush if none is pending. */
+  push(item: T): void;
+  /** Immediately flush any buffered items (no-op when empty). */
+  flush(): void;
+  /** Drop buffered items and cancel a pending flush. */
+  cancel(): void;
+  /** Buffered-but-not-yet-flushed count (introspection/tests). */
+  pending(): number;
+}
+
+export interface CoalescerOptions<T> {
+  /** Receives the batch (in push order) on each flush. Never called with []. */
+  onFlush: (items: T[]) => void;
+  /** Max time an item waits before flushing. `<= 0` flushes synchronously on push. */
+  delayMs: number;
+  /** Injectable timer (defaults to global setTimeout) — swapped in tests. */
+  setTimer?: (cb: () => void, ms: number) => TimerHandle;
+  /** Injectable clear (defaults to global clearTimeout). */
+  clearTimer?: (handle: TimerHandle) => void;
+}
+
+/**
+ * Create a trailing-edge coalescer: the first `push` schedules a flush in
+ * `delayMs`; further pushes within that window accumulate without rescheduling,
+ * so throughput is bounded to one flush per `delayMs` and latency to `delayMs`.
+ */
+export function createCoalescer<T>(options: CoalescerOptions<T>): Coalescer<T> {
+  const setTimer = options.setTimer ?? ((cb, ms) => setTimeout(cb, ms));
+  const clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle));
+  let buffer: T[] = [];
+  let timer: TimerHandle | null = null;
+
+  const emit = () => {
+    timer = null;
+    if (buffer.length === 0) return;
+    const batch = buffer;
+    buffer = [];
+    options.onFlush(batch);
+  };
+
+  return {
+    push(item) {
+      buffer.push(item);
+      if (options.delayMs <= 0) {
+        emit();
+        return;
+      }
+      if (timer === null) timer = setTimer(emit, options.delayMs);
+    },
+    flush() {
+      if (timer !== null) {
+        clearTimer(timer);
+        timer = null;
+      }
+      emit();
+    },
+    cancel() {
+      if (timer !== null) {
+        clearTimer(timer);
+        timer = null;
+      }
+      buffer = [];
+    },
+    pending() {
+      return buffer.length;
+    },
+  };
+}

--- a/src/tui/hooks/usePipelineEvents.ts
+++ b/src/tui/hooks/usePipelineEvents.ts
@@ -6,21 +6,40 @@
 // ============================================
 
 import { useEffect, useReducer, useState } from 'react';
+import type { HubEvent } from '../../core/eventHub.js';
 import { connectEventStream } from '../sse.js';
-import { reducePipelineEvent, initialPipelineState, type PipelineState } from '../pipelineEvents.js';
+import { createCoalescer } from '../eventCoalescer.js';
+import {
+  reducePipelineEvent,
+  reducePipelineEvents,
+  initialPipelineState,
+  type PipelineState,
+} from '../pipelineEvents.js';
 
 export interface PipelineEventsResult extends PipelineState {
   connected: boolean;
 }
 
-type PipelineAction = Parameters<typeof reducePipelineEvent>[1] | { type: 'reset' };
+// Coalesce SSE bursts into at most one repaint per window. In the alternate
+// screen every commit repaints the whole frame, so dispatching per event made
+// the Pipeline tab flicker on every log/stage event. (INT-2407)
+const DEFAULT_FLUSH_MS = 90;
+
+type PipelineAction =
+  | Parameters<typeof reducePipelineEvent>[1]
+  | { type: 'reset' }
+  | { type: 'batch'; events: HubEvent[] };
 
 function pipelineReducer(state: PipelineState, action: PipelineAction): PipelineState {
   if (action.type === 'reset') return initialPipelineState;
+  if (action.type === 'batch') return reducePipelineEvents(state, action.events);
   return reducePipelineEvent(state, action);
 }
 
-export function usePipelineEvents(port: number | undefined): PipelineEventsResult {
+export function usePipelineEvents(
+  port: number | undefined,
+  flushMs: number = DEFAULT_FLUSH_MS,
+): PipelineEventsResult {
   const [state, dispatch] = useReducer(pipelineReducer, initialPipelineState);
   const [connected, setConnected] = useState(false);
 
@@ -28,12 +47,19 @@ export function usePipelineEvents(port: number | undefined): PipelineEventsResul
     dispatch({ type: 'reset' });
     setConnected(false);
     if (!port) return;
-    const handle = connectEventStream({ port, onEvent: dispatch, onStatus: setConnected });
+    // Buffer events and flush a single batched dispatch per window; connection
+    // status stays immediate (not coalesced) so the live indicator is snappy.
+    const coalescer = createCoalescer<HubEvent>({
+      delayMs: flushMs,
+      onFlush: (events) => dispatch({ type: 'batch', events }),
+    });
+    const handle = connectEventStream({ port, onEvent: (e) => coalescer.push(e), onStatus: setConnected });
     return () => {
       setConnected(false);
+      coalescer.cancel();
       handle.close();
     };
-  }, [port]);
+  }, [port, flushMs]);
 
   return { ...state, connected };
 }

--- a/src/tui/panels/PipelinePanel.tsx
+++ b/src/tui/panels/PipelinePanel.tsx
@@ -2,6 +2,7 @@
 // Subscribes to the daemon SSE stream and shows the stage timeline + live log,
 // the CLI counterpart of the web dashboard's PIPELINE tab.
 import { Box, Text } from 'ink';
+import { useMemo } from 'react';
 import { StageTimeline } from '../components/StageTimeline.js';
 import { SubagentTree } from '../components/SubagentTree.js';
 import { LiveLog } from '../components/LiveLog.js';
@@ -16,6 +17,10 @@ export interface PipelinePanelProps {
 
 export function PipelinePanel({ port }: PipelinePanelProps) {
   const { stages, logs, connected } = usePipelineEvents(port);
+  // Stabilize the tree identity so it only rebuilds when stages actually change
+  // (log-only updates keep the same `stages` reference). Prevents SubagentTree's
+  // spinner effect from re-subscribing every render + lets React.memo skip it. (INT-2407)
+  const repositories = useMemo(() => buildSubagentTree(stages), [stages]);
   const live = !!port && connected;
   const label = !port
     ? ' daemon port unknown'
@@ -28,7 +33,7 @@ export function PipelinePanel({ port }: PipelinePanelProps) {
         <Text color={live ? theme.ok : theme.dim}>{live ? '●' : '○'}</Text>
         <Text dimColor>{label}</Text>
       </Text>
-      <SubagentTree repositories={buildSubagentTree(stages)} />
+      <SubagentTree repositories={repositories} />
       <Box marginTop={1}>
         <StageTimeline stages={stages} />
       </Box>

--- a/src/tui/pipelineEvents.test.ts
+++ b/src/tui/pipelineEvents.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { classifyActivity, reducePipelineEvent, initialPipelineState, MAX_STAGES, MAX_LOGS } from './pipelineEvents.js';
+import { classifyActivity, reducePipelineEvent, reducePipelineEvents, initialPipelineState, MAX_STAGES, MAX_LOGS } from './pipelineEvents.js';
 import type { HubEvent } from '../core/eventHub.js';
 
 const stage = (over: Record<string, unknown> = {}): HubEvent => ({
@@ -101,5 +101,23 @@ describe('reducePipelineEvent (EPIC INT-1813 S5)', () => {
     for (let i = 0; i < MAX_LOGS + 10; i++) t = reducePipelineEvent(t, log(`l${i}`));
     expect(t.logs).toHaveLength(MAX_LOGS);
     expect(t.logs[t.logs.length - 1]).toBe(`[worker] l${MAX_LOGS + 9}`);
+  });
+});
+
+describe('reducePipelineEvents batch fold (INT-2407)', () => {
+  it('folds a batch into the same state as applying events one by one', () => {
+    const events: HubEvent[] = [
+      stage({ status: 'start' }),
+      log('🔧 read_file src/app.ts'),
+      stage({ status: 'complete', model: 'gpt', durationMs: 3000 }),
+      log('done'),
+    ];
+    const sequential = events.reduce(reducePipelineEvent, initialPipelineState);
+    const batched = reducePipelineEvents(initialPipelineState, events);
+    expect(batched).toEqual(sequential);
+  });
+
+  it('returns the same state reference for an empty batch', () => {
+    expect(reducePipelineEvents(initialPipelineState, [])).toBe(initialPipelineState);
   });
 });

--- a/src/tui/pipelineEvents.ts
+++ b/src/tui/pipelineEvents.ts
@@ -87,6 +87,14 @@ export function reducePipelineEvent(state: PipelineState, ev: HubEvent): Pipelin
   return state;
 }
 
+/**
+ * Fold a batch of events into state in a single step so a coalesced burst of
+ * SSE events produces one new state (one commit → one repaint). (INT-2407)
+ */
+export function reducePipelineEvents(state: PipelineState, events: HubEvent[]): PipelineState {
+  return events.reduce(reducePipelineEvent, state);
+}
+
 export function classifyActivity(line: string): string | undefined {
   const text = line.trim();
   const lower = text.toLowerCase();


### PR DESCRIPTION
## Problem

The TUI `2:Pipeline` tab flickers on every `pipeline:stage` / `log` SSE event. In the alternate-screen buffer each React commit erases+redraws the whole frame, so an event burst = N full-frame repaints = visible flicker.

## Root cause

- `usePipelineEvents` dispatched **per event** (no throttle); `sse.ts` delivers several events per frame → many commits/sec.
- Ink 7.1.0 throttles renders to `maxFps=30`, but each commit is still a full-frame redraw, so throttling alone doesn't stop it during a stream.
- Secondary churn: `PipelinePanel` called `buildSubagentTree(stages)` inline every render → new array each time → `SubagentTree`'s `useEffect([repositories])` tore down + recreated its 120ms spinner interval on every commit.

## Fix

- **`eventCoalescer.ts`** (new): trailing-edge coalescer — buffers a burst and flushes **one batch per ~90ms window**. Pure, timer-injectable, unit-tested; no event loss.
- **`usePipelineEvents`**: feed SSE through the coalescer → one `batch` dispatch per window. Connection status stays immediate (not coalesced). Also de-flickers the `3:Logs` tab (shared hook).
- **`pipelineEvents`**: `reducePipelineEvents(state, events[])` batch fold — a batch collapses into one new state (empty batch returns the same reference).
- **`PipelinePanel`**: `useMemo(buildSubagentTree, [stages])` — log-only updates keep `stages` identity, so the tree is stable and the spinner effect stops re-subscribing.
- **`StageTimeline` / `SubagentTree`**: `React.memo` to skip re-render on stable props.

## Behavior

Preserved — the tab still updates live as events stream; only the burst repaint cadence is capped (~90ms, below the existing 120ms spinner, so imperceptible). The live connection indicator stays instant.

## Tests

`eventCoalescer.test.ts` (burst→1 flush, order, fresh window, sync `delayMs<=0`, flush/cancel) + `pipelineEvents.test.ts` (batch fold == sequential apply, empty-batch same-ref). Full suite **1520 green**, lint+typecheck+build clean.

Closes INT-2407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)