### PR TITLE
fix(adapter): surface provider-override≠config + codex MCP-auth diagnostic (INT-2408)

### DIFF
--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -10,6 +10,7 @@ import { parseCliStreamChunk } from '../agents/cliStreamParser.js';
 import { registerProcess } from './processRegistry.js';
 import { buildWorkerEnv } from './envPath.js';
 import { detectRateLimit } from './rateLimitError.js';
+import { codexMcpAuthHint } from './errorClassification.js';
 
 /**
  * Spawn a CLI process using the given adapter and options.
@@ -106,6 +107,15 @@ export async function spawnCli(
           console.error(`[${adapter.name}] stderr: ${stderrSnippet || '(empty)'}`);
           console.error(`[${adapter.name}] stdout (first 300): ${stdoutSnippet || '(empty)'}`);
           console.error(`[${adapter.name}] Duration: ${durationMs}ms, CWD: ${options.cwd}`);
+
+          // Non-blocking diagnostic: an OAuth-protected `url=` MCP server in
+          // ~/.codex/config.toml makes codex quit with an opaque rmcp AuthRequired
+          // error. Surface the real cause here instead of leaving it to be
+          // investigated by hand. Additive only — does not affect control flow. (INT-2408)
+          const mcpAuthHint = codexMcpAuthHint(`${stderr}\n${stdout}`);
+          if (mcpAuthHint) {
+            console.warn(`[${adapter.name}] ${mcpAuthHint}`);
+          }
 
           const rateLimitErr = detectRateLimit(stdout, stderr);
           if (rateLimitErr) {

--- a/src/adapters/errorClassification.test.ts
+++ b/src/adapters/errorClassification.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isInfraError } from './errorClassification.js';
+import { isInfraError, codexMcpAuthHint } from './errorClassification.js';
 
 describe('isInfraError (INT-2010)', () => {
   it('flags CLI non-zero exit as infra (the production STUCK driver)', () => {
@@ -28,5 +28,38 @@ describe('isInfraError (INT-2010)', () => {
     expect(isInfraError(undefined)).toBe(false);
     expect(isInfraError(null)).toBe(false);
     expect(isInfraError('')).toBe(false);
+  });
+});
+
+describe('codexMcpAuthHint (INT-2408)', () => {
+  it('returns a hint for the real codex rmcp AuthRequired transport failure', () => {
+    const err = new Error(
+      'codex CLI failed with code 1: rmcp::transport::worker: worker quit with fatal: ' +
+        'Transport channel closed, when AuthRequired',
+    );
+    const hint = codexMcpAuthHint(err);
+    expect(hint).toContain('~/.codex/config.toml');
+    expect(hint).toContain('401');
+    expect(hint).toContain("url=");
+  });
+
+  it('matches the bare "Transport channel closed ... AuthRequired" stderr text too', () => {
+    expect(codexMcpAuthHint('Transport channel closed, when AuthRequired')).not.toBeNull();
+  });
+
+  it('requires BOTH an AuthRequired signal and an rmcp/transport marker', () => {
+    // rmcp marker but no AuthRequired -> not our case
+    expect(codexMcpAuthHint('rmcp::transport::worker: worker quit with fatal: EOF')).toBeNull();
+    // AuthRequired but no rmcp/transport marker -> not our case
+    expect(codexMcpAuthHint('AuthRequired: token expired')).toBeNull();
+    // generic 401 with neither marker
+    expect(codexMcpAuthHint('Request failed: 401 Unauthorized')).toBeNull();
+  });
+
+  it('returns null for unrelated and empty inputs', () => {
+    expect(codexMcpAuthHint(new Error('TypeError: cannot read property foo of undefined'))).toBeNull();
+    expect(codexMcpAuthHint(undefined)).toBeNull();
+    expect(codexMcpAuthHint(null)).toBeNull();
+    expect(codexMcpAuthHint('')).toBeNull();
   });
 });

--- a/src/adapters/errorClassification.ts
+++ b/src/adapters/errorClassification.ts
@@ -53,3 +53,25 @@ export function isInfraError(error: unknown): boolean {
   if (!msg) return false;
   return INFRA_ERROR_PATTERNS.some((p) => msg.includes(p));
 }
+
+/**
+ * Diagnostic hint for the opaque failure where codex CLI dies because an MCP server
+ * declared in ~/.codex/config.toml is OAuth-protected. A direct `url=` MCP server that
+ * returns 401 makes codex's rmcp transport quit with a fatal line like:
+ *   rmcp::transport::worker: worker quit with fatal: Transport channel closed, when AuthRequired
+ * That message names neither the config file nor the real cause, so the failure looks
+ * like a generic `codex CLI failed with code 1`. This returns a one-line pointer at the
+ * actual fix; returns null for unrelated errors. Pure and additive — it does NOT change
+ * error classification (isInfraError still owns that) or any control flow. (INT-2408)
+ */
+export function codexMcpAuthHint(error: unknown): string | null {
+  const msg = (error instanceof Error ? error.message : String(error ?? '')).toLowerCase();
+  if (!msg) return null;
+  const authRequired = msg.includes('authrequired');
+  const rmcpTransport = msg.includes('rmcp') || msg.includes('transport channel closed');
+  if (!authRequired || !rmcpTransport) return null;
+  return (
+    "codex CLI: an MCP server in ~/.codex/config.toml returned 401 (OAuth). " +
+    "Replace a direct 'url=' server with an mcp-remote (stdio) entry, or remove it."
+  );
+}

--- a/src/core/providerOverride.test.ts
+++ b/src/core/providerOverride.test.ts
@@ -60,4 +60,17 @@ describe('providerOverride', () => {
     const { readProviderOverride } = await import('./providerOverride.js');
     expect(readProviderOverride()).toBeUndefined();
   });
+
+  it('formats a loud mismatch warning naming both providers and the override file (INT-2408)', async () => {
+    const { formatProviderOverrideMismatchWarning } = await import('./providerOverride.js');
+    const msg = formatProviderOverrideMismatchWarning('codex', 'codex-responses');
+
+    // Both values must appear so the divergence is obvious.
+    expect(msg).toContain('"codex"');
+    expect(msg).toContain('"codex-responses"');
+    // Points at the actual file to delete, and reads as a warning.
+    expect(msg).toContain('provider-override.json');
+    expect(msg).toContain('overriding config.yaml');
+    expect(msg).toContain('⚠️');
+  });
 });

--- a/src/core/providerOverride.ts
+++ b/src/core/providerOverride.ts
@@ -27,6 +27,24 @@ export function readProviderOverride(): AdapterName | undefined {
   }
 }
 
+/**
+ * Build the loud startup warning shown when provider-override.json disagrees with
+ * config.yaml's `adapter`. The override still wins (that is the documented toggle
+ * behaviour) — this only makes the otherwise-silent divergence visible so an operator
+ * does not waste time wondering why the daemon runs a different provider than
+ * config.yaml declares (e.g. a stale `codex` pin masking `codex-responses`). Pure —
+ * safe to unit-test. (INT-2408)
+ */
+export function formatProviderOverrideMismatchWarning(
+  override: AdapterName,
+  configAdapter: AdapterName,
+): string {
+  return (
+    `⚠️ [Service] provider-override.json forces "${override}" — overriding config.yaml ` +
+    `adapter "${configAdapter}". Delete ${OVERRIDE_PATH} to use the config value.`
+  );
+}
+
 /** Record the user's provider choice so it survives a restart. Best-effort — never blocks the toggle. */
 export function writeProviderOverride(provider: AdapterName): void {
   try {

--- a/src/core/service.test.ts
+++ b/src/core/service.test.ts
@@ -73,6 +73,7 @@ vi.mock('../adapters/index.js', () => ({
 
 vi.mock('./providerOverride.js', () => ({
   readProviderOverride: vi.fn(),
+  formatProviderOverrideMismatchWarning: vi.fn(() => 'provider-override mismatch (test)'),
 }));
 
 vi.mock('../automation/prProcessor.js', () => {

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -24,7 +24,7 @@ import { initRateLimiters, destroyRateLimiters } from '../support/rateLimiter.js
 import { compactMemoryTable, shouldCompact, cleanupBackupFiles } from '../memory/compaction.js';
 import { Cron } from 'croner';
 import { setDefaultAdapter } from '../adapters/index.js';
-import { readProviderOverride } from './providerOverride.js';
+import { readProviderOverride, formatProviderOverrideMismatchWarning } from './providerOverride.js';
 import { enrichTaskFromState, hydrateTaskStateFromComments, updateTaskLinearState } from '../taskState/store.js';
 
 let state: ServiceState = {
@@ -244,7 +244,10 @@ export async function startService(config: SwarmConfig): Promise<void> {
     if (providerOverride && providerOverride !== (config.adapter ?? 'codex')) {
       setDefaultAdapter(providerOverride);
       runnerInstance.switchProvider(providerOverride);
-      console.log(`[Service] Restored persisted provider: ${providerOverride}`);
+      // The override silently wins over config.yaml — make that divergence loud so the
+      // operator isn't left wondering why the daemon runs a different provider than
+      // config.yaml declares. Behaviour is unchanged; only visibility. (INT-2408)
+      console.warn(formatProviderOverrideMismatchWarning(providerOverride, config.adapter ?? 'codex'));
     }
     const modelInfo = config.autonomous.models
       ? `, Worker: ${config.autonomous.models.worker || 'default'}, Reviewer: ${config.autonomous.models.reviewer || 'default'}`


### PR DESCRIPTION
## Root cause (confirmed)

The intermittent `codex CLI failed with code 1: … rmcp::transport::worker: … AuthRequired` is **not** an OpenSwarm bug — it's a hidden config mismatch:

- `config.yaml` says `adapter: codex-responses` (PKCE, no CLI), but `~/.config/openswarm/provider-override.json` = `{"provider":"codex"}`.
- `service.ts` reads that override on boot and, when it differs from config, **silently** `setDefaultAdapter/switchProvider('codex')` → the daemon actually runs **codex CLI**, not PKCE.
- codex CLI then connects to the MCP servers in `~/.codex/config.toml`; `[mcp_servers.superthread]` is a direct `url=` server that's OAuth-protected (**verified HTTP 401**), so codex's rmcp transport quits fatal → `codex exec` exit 1. (`[mcp_servers.linear]` is already worked around via mcp-remote/stdio.)
- OpenSwarm already classifies this as `isInfraError`, so the pipeline doesn't misfire STUCK — hence "non-blocking".

**Reverting the override is an environment decision** (repo owner): delete `~/.config/openswarm/provider-override.json` + restart the daemon → config's codex-responses (PKCE) is used, codex CLI is never invoked, and the MCP-401 problem disappears. This PR is the **repo-side hardening** so the trap is visible and self-diagnosing next time.

## Changes

- **`formatProviderOverrideMismatchWarning` + `service.ts`**: when `provider-override.json` disagrees with `config.yaml`, warn loudly (both provider values + the exact file path to delete) instead of a quiet info log. **Behavior unchanged** — the override still applies; only visibility.
- **`codexMcpAuthHint` + `base.ts`**: when a codex CLI error contains `AuthRequired` **and** `rmcp`/`Transport channel closed`, log a one-line hint pointing at the OAuth MCP server (swap `url=` for mcp-remote/stdio). Pure + additive — does not change error classification or control flow.

## Tests

- `providerOverride.test.ts`: mismatch-warning formatter (names both providers + file path).
- `errorClassification.test.ts`: `codexMcpAuthHint` returns the hint only when **both** markers present; rmcp-only / AuthRequired-only / generic 401 / empty → null.
- `service.test.ts` mock updated for the new export.
- Full suite **1518 green**, lint+typecheck+build clean.

Refs INT-2408. (The environment fix — reverting the provider override — is tracked in the issue for the repo owner to apply.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)