### PR TITLE
feat(worktree): share repo deps/data into worktrees + raise worker bash timeout (INT-2415)

### DIFF
--- a/src/agents/pairPipeline.test.ts
+++ b/src/agents/pairPipeline.test.ts
@@ -9,9 +9,12 @@ const runReviewer = vi.fn();
 const broadcastEvent = vi.fn();
 const getDefaultModel = vi.fn();
 
-vi.mock('./worker.js', () => ({
-  runWorker,
-}));
+// Override runWorker only; keep the real pure helpers (e.g. resolveWorkerBashTimeoutMs
+// the worker stage now calls to set bashTimeoutMs — INT-2415).
+vi.mock('./worker.js', async () => {
+  const actual = await vi.importActual<typeof import('./worker.js')>('./worker.js');
+  return { ...actual, runWorker };
+});
 
 vi.mock('./reviewer.js', async () => {
   const actual = await vi.importActual<typeof import('./reviewer.js')>('./reviewer.js');
@@ -103,6 +106,8 @@ describe('PairPipeline model selection', () => {
     expect(result.success).toBe(true);
     expect(runWorker).toHaveBeenCalledWith(expect.objectContaining<Partial<WorkerOptions>>({
       model: 'profile-worker',
+      // No effort/repo override on this profile → 5min default reaches the worker. (INT-2415)
+      bashTimeoutMs: 300_000,
     }));
     expect(runReviewer).toHaveBeenCalledWith(expect.objectContaining<Partial<ReviewerOptions>>({
       model: 'profile-reviewer',

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -615,6 +615,7 @@ export class PairPipeline extends EventEmitter {
             maxTurns: this.config.roles?.worker?.maxTurns,
             adapterName: this.config.roles?.worker?.adapter,
             reasoningEffort: this.getEffortForTask(context.task),
+            bashTimeoutMs: await workerAgent.resolveWorkerBashTimeout(context.projectPath, this.getEffortForTask(context.task)), // INT-2415
             // No-edit guard (re-applied from stranded feat/v0.7.0 commit 2eea3bc):
             // reasoning workers frequently end with analysis only and never call
             // edit_file. Without this the guard defaults to 0 (disabled) — measured:

--- a/src/agents/worker.test.ts
+++ b/src/agents/worker.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { WorkerResult } from './agentPair.js';
-import { formatWorkReport, formatWorkerGitChangeStatus, type WorkerOptions } from './worker.js';
+import { formatWorkReport, formatWorkerGitChangeStatus, resolveWorkerBashTimeoutMs, WORKER_BASH_TIMEOUT_DEFAULT_MS, type WorkerOptions } from './worker.js';
 
 describe('worker', () => {
   beforeEach(() => {
@@ -27,6 +27,29 @@ describe('worker', () => {
 
     it('formats the no-change status', () => {
       expect(formatWorkerGitChangeStatus([])).toBe('[Worker] No file changes detected by Git or LLM');
+    });
+  });
+
+  describe('resolveWorkerBashTimeoutMs (INT-2415)', () => {
+    it('maps jobProfile effort to a timeout, ignoring any repo override', () => {
+      expect(resolveWorkerBashTimeoutMs({ effort: 'low' })).toBe(120_000);
+      expect(resolveWorkerBashTimeoutMs({ effort: 'medium' })).toBe(300_000);
+      expect(resolveWorkerBashTimeoutMs({ effort: 'high' })).toBe(900_000);
+      // Effort takes precedence over a repo override.
+      expect(resolveWorkerBashTimeoutMs({ effort: 'high', repoOverrideMs: 5_000 })).toBe(900_000);
+    });
+
+    it('falls back to the repo override when no effort is set', () => {
+      expect(resolveWorkerBashTimeoutMs({ repoOverrideMs: 600_000 })).toBe(600_000);
+    });
+
+    it('falls back to the 5min default when neither effort nor a valid override is present', () => {
+      expect(resolveWorkerBashTimeoutMs({})).toBe(WORKER_BASH_TIMEOUT_DEFAULT_MS);
+      expect(WORKER_BASH_TIMEOUT_DEFAULT_MS).toBe(300_000);
+      // Non-positive / NaN overrides are ignored.
+      expect(resolveWorkerBashTimeoutMs({ repoOverrideMs: 0 })).toBe(WORKER_BASH_TIMEOUT_DEFAULT_MS);
+      expect(resolveWorkerBashTimeoutMs({ repoOverrideMs: -1 })).toBe(WORKER_BASH_TIMEOUT_DEFAULT_MS);
+      expect(resolveWorkerBashTimeoutMs({ repoOverrideMs: Number.NaN })).toBe(WORKER_BASH_TIMEOUT_DEFAULT_MS);
     });
   });
 

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -14,6 +14,7 @@ import { expandPath } from '../core/config.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
 import { isInfraError } from '../adapters/errorClassification.js';
 import { resolveEditFormat, SEARCH_REPLACE_PROMPT, WHOLE_FILE_PROMPT, type EditFormat } from '../support/editParser.js';
+import { loadSandboxBashTimeoutMs } from '../support/repoMetadata.js';
 
 // Types
 
@@ -55,6 +56,57 @@ export interface WorkerOptions {
    * Set explicitly to pin a format (e.g. roll back a regressing model to 'json').
    */
   editFormat?: EditFormat;
+}
+
+// Bash timeout policy (INT-2415)
+
+/**
+ * Default worker bash timeout (5min). The tools.ts DEFAULT_BASH_TIMEOUT_MS (30s)
+ * is the floor for non-worker callers, but the autonomous worker runs real
+ * verification (pytest / playwright / backtests / retraining) that needs minutes,
+ * not seconds — a 30s cap made every such command time out, so reviewers demanded
+ * "live/E2E verification" the worker could never physically complete.
+ */
+export const WORKER_BASH_TIMEOUT_DEFAULT_MS = 300_000;
+
+/** jobProfile effort → bash timeout. Heavier tasks get longer verification budgets. */
+const EFFORT_BASH_TIMEOUT_MS: Record<'low' | 'medium' | 'high', number> = {
+  low: 120_000, // 2min
+  medium: 300_000, // 5min
+  high: 900_000, // 15min
+};
+
+/**
+ * Resolve the worker's bash tool timeout (ms). Pure + total.
+ *
+ * Precedence (INT-2415):
+ *   1. matched jobProfile `effort` (low/medium/high) — task-shaped budget
+ *   2. repo override — openswarm.json `sandbox.bashTimeoutMs`
+ *   3. a 5min default (WORKER_BASH_TIMEOUT_DEFAULT_MS)
+ *
+ * A non-positive/NaN repo override is ignored (falls through to the default).
+ */
+export function resolveWorkerBashTimeoutMs(input: {
+  effort?: 'low' | 'medium' | 'high';
+  repoOverrideMs?: number;
+}): number {
+  if (input.effort) return EFFORT_BASH_TIMEOUT_MS[input.effort];
+  if (typeof input.repoOverrideMs === 'number' && input.repoOverrideMs > 0) {
+    return input.repoOverrideMs;
+  }
+  return WORKER_BASH_TIMEOUT_DEFAULT_MS;
+}
+
+/**
+ * Async convenience over resolveWorkerBashTimeoutMs: reads the repo override
+ * (openswarm.json `sandbox.bashTimeoutMs`) from `projectPath` itself, so callers
+ * pass only the matched jobProfile effort. Best-effort I/O. (INT-2415)
+ */
+export async function resolveWorkerBashTimeout(
+  projectPath: string,
+  effort?: 'low' | 'medium' | 'high',
+): Promise<number> {
+  return resolveWorkerBashTimeoutMs({ effort, repoOverrideMs: await loadSandboxBashTimeoutMs(projectPath) });
 }
 
 // Prompts

--- a/src/support/repoMetadata.ts
+++ b/src/support/repoMetadata.ts
@@ -35,6 +35,23 @@ const RepoMetadataSchema = z.object({
    * the escape hatch for any language/toolchain. (INT-2303)
    */
   checks: z.record(z.string(), z.string()).optional(),
+  /**
+   * Sandbox / worktree execution knobs (INT-2415). Autonomous workers run in a
+   * fresh git worktree checked out from origin/main — it has no installed deps
+   * (node_modules/.venv) and none of the repo's gitignored real data (e.g.
+   * db/*.db), so a worker physically cannot run pytest/playwright/real-data
+   * verification. These knobs let a repo (a) opt gitignored paths into the
+   * worktree (symlinked from the original repo, which is the installed sandbox)
+   * and (b) raise the worker bash timeout for slow E2E/backtests/retraining.
+   */
+  sandbox: z
+    .object({
+      /** Gitignored dep/data paths to symlink from the original repo into the worktree. */
+      sharedPaths: z.array(z.string()).optional(),
+      /** Worker bash tool timeout in ms — E2E/backtests need minutes, not 30s. */
+      bashTimeoutMs: z.number().int().positive().optional(),
+    })
+    .optional(),
   /** Free-form notes the swarm should keep in mind. */
   notes: z.string().optional(),
 });
@@ -101,6 +118,20 @@ export async function saveRepoMetadata(repoPath: string, meta: RepoMetadata): Pr
   const filePath = join(repoPath, REPO_METADATA_FILENAME);
   await writeFile(filePath, `${JSON.stringify(validated, null, 2)}\n`, 'utf-8');
   return filePath;
+}
+
+/**
+ * Read `openswarm.json` `sandbox.bashTimeoutMs` from `repoPath`. Best-effort —
+ * a missing/malformed file yields `undefined` (the caller then falls back to an
+ * effort-derived or default timeout). Never throws. (INT-2415)
+ */
+export async function loadSandboxBashTimeoutMs(repoPath: string): Promise<number | undefined> {
+  try {
+    const meta = await loadRepoMetadata(repoPath);
+    return meta?.sandbox?.bashTimeoutMs;
+  } catch {
+    return undefined;
+  }
 }
 
 export class RepoMetadataError extends Error {

--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -1,8 +1,9 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { existsSync, lstatSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { createWorktree, removeWorktree, computeFileOverlaps, formatOverlapReport, type WorktreeInfo } from './worktreeManager.js';
+import { createWorktree, removeWorktree, resolveSharedPaths, computeFileOverlaps, formatOverlapReport, type WorktreeInfo } from './worktreeManager.js';
 
 describe('worktreeManager path safety', () => {
   let root: string;
@@ -52,6 +53,106 @@ describe('worktreeManager path safety', () => {
 
     await removeWorktree(info);
     expect(existsSync(managedPath)).toBe(false);
+  });
+});
+
+describe('resolveSharedPaths (INT-2415)', () => {
+  let root: string;
+  let repo: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `openswarm-shared-paths-${process.pid}-${Date.now()}`);
+    repo = join(root, 'repo');
+    mkdirSync(repo, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('auto-detects node_modules/.venv/venv that exist at the repo root', () => {
+    mkdirSync(join(repo, 'node_modules'), { recursive: true });
+    mkdirSync(join(repo, '.venv'), { recursive: true });
+    // venv is absent → excluded; only existing candidates are returned.
+    expect(resolveSharedPaths(repo, null).sort()).toEqual(['.venv', 'node_modules']);
+  });
+
+  it('returns [] when no auto-detect candidates exist', () => {
+    expect(resolveSharedPaths(repo)).toEqual([]);
+  });
+
+  it('uses sandbox.sharedPaths verbatim (existing only) and overrides auto-detect', () => {
+    mkdirSync(join(repo, 'db'), { recursive: true });
+    writeFileSync(join(repo, 'db', 'prod.db'), 'x');
+    mkdirSync(join(repo, 'node_modules'), { recursive: true }); // present but NOT in config
+    const result = resolveSharedPaths(repo, { sandbox: { sharedPaths: ['db', 'missing-dir'] } });
+    // Only existing configured paths; node_modules is dropped because config takes over.
+    expect(result).toEqual(['db']);
+  });
+
+  it('falls back to auto-detect when sharedPaths is an empty array', () => {
+    mkdirSync(join(repo, 'venv'), { recursive: true });
+    expect(resolveSharedPaths(repo, { sandbox: { sharedPaths: [] } })).toEqual(['venv']);
+  });
+
+  it('drops absolute and parent-escaping entries', () => {
+    expect(resolveSharedPaths(repo, { sandbox: { sharedPaths: ['/etc', '../secrets', ''] } })).toEqual([]);
+  });
+});
+
+describe('createWorktree shared-path symlinks (INT-2415)', () => {
+  let root: string;
+  let repo: string;
+
+  const git = (cwd: string, ...args: string[]) =>
+    execFileSync('git', ['-C', cwd, ...args], { stdio: 'pipe' });
+
+  beforeEach(() => {
+    root = join(tmpdir(), `openswarm-worktree-link-${process.pid}-${Date.now()}`);
+    repo = join(root, 'repo');
+    mkdirSync(repo, { recursive: true });
+  });
+
+  afterEach(() => {
+    // Best-effort worktree teardown before removing the tree.
+    try { git(repo, 'worktree', 'remove', '--force', join(repo, 'worktree', 'INT-1')); } catch { /* ignore */ }
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('symlinks the repo node_modules into the worktree without clobbering tracked dirs', async () => {
+    const originBare = join(root, 'origin.git');
+    execFileSync('git', ['init', '--bare', '-b', 'main', originBare], { stdio: 'pipe' });
+    execFileSync('git', ['init', '-b', 'main', repo], { stdio: 'pipe' });
+    git(repo, 'config', 'user.email', 'test@example.com');
+    git(repo, 'config', 'user.name', 'Test');
+    git(repo, 'config', 'commit.gpgsign', 'false');
+
+    // A tracked source dir (checked out into the worktree from origin/main).
+    mkdirSync(join(repo, 'src'), { recursive: true });
+    writeFileSync(join(repo, 'src', 'index.ts'), 'export const x = 1;\n');
+    writeFileSync(join(repo, '.gitignore'), 'node_modules/\n');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-m', 'init');
+    git(repo, 'remote', 'add', 'origin', originBare);
+    git(repo, 'push', 'origin', 'main');
+
+    // Gitignored dep present only in the original working tree (untracked).
+    mkdirSync(join(repo, 'node_modules', 'leftpad'), { recursive: true });
+    writeFileSync(join(repo, 'node_modules', 'leftpad', 'index.js'), 'module.exports = 1;\n');
+
+    const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-test');
+
+    // node_modules is a symlink pointing at the original repo's node_modules.
+    const wtNodeModules = join(info.worktreePath, 'node_modules');
+    expect(lstatSync(wtNodeModules).isSymbolicLink()).toBe(true);
+    expect(realpathSync(wtNodeModules)).toBe(realpathSync(join(repo, 'node_modules')));
+    // The shared dep is reachable through the link.
+    expect(existsSync(join(wtNodeModules, 'leftpad', 'index.js'))).toBe(true);
+
+    // The tracked dir is a real checked-out dir, never replaced by a symlink.
+    const wtSrc = join(info.worktreePath, 'src');
+    expect(existsSync(join(wtSrc, 'index.ts'))).toBe(true);
+    expect(lstatSync(wtSrc).isSymbolicLink()).toBe(false);
   });
 });
 

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -5,10 +5,11 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { existsSync, rmSync } from 'node:fs';
-import { isAbsolute, join, relative, resolve } from 'node:path';
+import { existsSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { registerOwnedPR } from '../automation/prOwnership.js';
 import { runConventionalCommitGuard } from '../agents/pipelineGuards.js';
+import { loadRepoMetadata } from './repoMetadata.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -85,6 +86,80 @@ function assertManagedWorktreePath(repoPath: string, worktreePath: string): stri
   return path;
 }
 
+// Shared deps/data linking (INT-2415)
+//
+// A worktree is created fresh from origin/main, so it has NO node_modules / .venv
+// and none of the repo's gitignored real data (db/*.db etc.) — a worker there
+// physically cannot run npm/pytest/playwright or real-data verification. We keep
+// the worktree isolating CODE, but SHARE the original repo's gitignored deps/data
+// into it via symlink. The original repo is itself the installed sandbox, and
+// deps/DBs are read-mostly, so parallel workers sharing them is safe.
+
+/** Always-gitignored dependency dirs safe to auto-link without a config. */
+const AUTO_SHARED_CANDIDATES = ['node_modules', '.venv', 'venv'];
+
+interface SandboxConfig {
+  sandbox?: { sharedPaths?: string[] } | null;
+}
+
+/**
+ * Pure decision: which repo-relative paths should be symlinked into a worktree.
+ *
+ * - If openswarm.json declares `sandbox.sharedPaths`, trust that list verbatim
+ *   (the repo owner opted in — no gitignore check).
+ * - Otherwise auto-detect only the always-gitignored dependency dirs
+ *   (node_modules/.venv/venv); never a tracked dir.
+ *
+ * Returns only candidates that actually EXIST at `<repoPath>/<P>` (read-only
+ * check). Absolute or parent-escaping (`..`) entries are dropped for safety.
+ * The symlink creation itself is the caller's side effect. (INT-2415)
+ */
+export function resolveSharedPaths(repoPath: string, openswarmJson?: SandboxConfig | null): string[] {
+  const configured = openswarmJson?.sandbox?.sharedPaths;
+  const candidates = configured && configured.length > 0 ? configured : AUTO_SHARED_CANDIDATES;
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of candidates) {
+    const p = (raw ?? '').trim();
+    if (!p) continue;
+    if (isAbsolute(p) || p.split(/[\\/]/).includes('..')) continue; // never escape the repo
+    if (seen.has(p)) continue;
+    seen.add(p);
+    if (existsSync(join(repoPath, p))) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Symlink the original repo's shared gitignored deps/data into a fresh worktree.
+ * Best-effort and idempotent: skips paths already present in the worktree (never
+ * clobbers a checked-out tracked dir) and swallows per-link failures (a failed
+ * symlink degrades to today's no-deps behavior, never breaks worktree creation).
+ */
+async function linkSharedPaths(repoPath: string, worktreePath: string): Promise<void> {
+  let meta: SandboxConfig | null = null;
+  try {
+    meta = await loadRepoMetadata(repoPath);
+  } catch (err) {
+    // Malformed openswarm.json must not break worktree creation. (INT-2415)
+    console.warn(`[Worktree] openswarm.json unreadable; skipping sharedPaths config:`, err);
+  }
+
+  for (const rel of resolveSharedPaths(repoPath, meta)) {
+    const target = join(repoPath, rel); // absolute source so the link survives any cwd
+    const linkPath = join(worktreePath, rel);
+    try {
+      if (existsSync(linkPath)) continue; // tracked dir already checked out — do not clobber
+      mkdirSync(dirname(linkPath), { recursive: true }); // support nested sharedPaths (e.g. db/x.db)
+      symlinkSync(target, linkPath);
+      console.log(`[Worktree] Linked shared path: ${rel} -> ${target}`);
+    } catch (err) {
+      console.warn(`[Worktree] Failed to link shared path ${rel}:`, err);
+    }
+  }
+}
+
 // Worktree Lifecycle
 
 /** Create git worktree + checkout branch */
@@ -122,6 +197,10 @@ export async function createWorktree(
   // Create fresh worktree from origin/main
   await git(repoPath, 'worktree', 'add', '-b', branchName, worktreePath, 'origin/main');
   console.log(`[Worktree] Created: ${worktreePath} (branch: ${branchName})`);
+
+  // Share the original repo's gitignored deps/data into the fresh worktree so the
+  // worker can actually install / run tests / verify against real data. (INT-2415)
+  await linkSharedPaths(repoPath, worktreePath);
 
   return { worktreePath, branchName, originalPath: repoPath, issueId };
 }


### PR DESCRIPTION
## Root cause

Workers run in git worktrees created **fresh from origin/main** (`worktreeManager.ts`), so the worktree has **no `node_modules`/`.venv`**, **no pip deps**, and **none of the repo's gitignored real data** (`db/*.db`). On top of that the worker `bash` tool caps at **30s** (`tools.ts DEFAULT_BASH_TIMEOUT_MS`). So a worker **physically cannot** run `pytest`/`playwright`/real-data verification or any multi-minute E2E/backtest.

Reviewers (rightly) demand that verification — which the worker can't execute — so tasks loop REVISE until they fail. pipeline-history: **88/100 failed, and they're DoD-unmet rejections, not infra errors** (reviewerFeedback: "live before/after 검증 없음", "실제 분봉 데이터에 연결 안 됨", "Playwright E2E 미실행"). **The bottleneck was the harness not giving the worker the tools to verify — not model ability.**

## Fix (no docker, no separate clone, no shared global venv)

Keep the worktree isolating **code**, but **share the original repo's read-mostly deps/data via symlink** — the original repo is itself the "installed sandbox".

- **`resolveSharedPaths` / `linkSharedPaths`** (`worktreeManager.ts`): right after `git worktree add`, symlink `node_modules`/`.venv`/`venv` (auto-detected) or `openswarm.json` `sandbox.sharedPaths` into the worktree with **absolute targets**. Idempotent + safe: skips a path already present (never clobbers a checked-out tracked dir), drops absolute/`..` entries, per-link `try/catch` degrades to today's no-deps behavior (never breaks worktree creation).
- **`repoMetadata`**: `openswarm.json` gains optional `sandbox: { sharedPaths?, bashTimeoutMs? }` (zod-validated, best-effort read).
- **Worker bash timeout**: the upstream gap was `pairPipeline → runWorker` never setting `bashTimeoutMs` (so it fell through to 30s). Now set at that call site — **effort-based** (low 120s / medium 300s / high 900s), else `openswarm.json` override, else **300s** default. `tools.ts` 30s stays the floor for non-worker callers.

## Tests

`resolveSharedPaths` (config vs auto-detect vs missing, absolute/`..` dropped), effort→timeout mapping (+ precedence/override/default), and a `createWorktree` integration test (real tmp repo: links `node_modules`, leaves tracked `src/` a real dir). Full suite **1522 green**, lint+typecheck+build clean.

## Note

Zero-config already covers Node/Python (auto-links node_modules/.venv). A repo with real-data needs (e.g. STONKS `db/`) adds `"sandbox": { "sharedPaths": ["db"] }` to its `openswarm.json`.

Closes INT-2415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)