### PR TITLE
fix(pipeline): propagate infra/rate-limit errors from runStage (INT-2424)

### DIFF
--- a/src/agents/pairPipeline.test.ts
+++ b/src/agents/pairPipeline.test.ts
@@ -155,7 +155,7 @@ describe('PairPipeline model selection', () => {
       },
     });
 
-    await pipeline.run(task(), process.cwd());
+    const result = await pipeline.run(task(), process.cwd());
 
     expect(broadcastEvent).toHaveBeenCalledWith(expect.objectContaining({
       type: 'pipeline:stage',
@@ -165,6 +165,59 @@ describe('PairPipeline model selection', () => {
         rateLimitResetsAt: 1770000000000,
       }),
     }));
+    // A 429 must be classified 'rate_limited' at the pipeline level, not a
+    // plain 'failed' — the runner keeps rate-limited attempts out of the
+    // STUCK failure count (INT-1906).
+    expect(result.finalStatus).toBe('rate_limited');
+    // The rethrow that carries the classification to run() must not drop the
+    // failed stage from the reported result (INT-2424) — formatters render
+    // "No stages" otherwise, even though the worker stage genuinely ran.
+    expect(result.stages).toHaveLength(1);
+    expect(result.stages[0]).toMatchObject({ stage: 'worker', success: false });
+  });
+
+  // INT-2424: runStage()'s catch used to swallow a CLI/infra failure into an
+  // ordinary StageResult and just retry, so a codex usage-limit or non-zero
+  // exit never reached run()'s isInfraError() classification — it silently
+  // counted toward the STUCK failure budget like a genuine bad edit.
+  it('classifies a worker CLI/infra failure as infra_error, not a plain failure', async () => {
+    runWorker.mockRejectedValueOnce(new Error('codex CLI failed with code 1: Reading prompt from stdin...'));
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker'],
+      maxIterations: 1,
+      roles: {
+        worker: { enabled: true, model: 'fallback-worker', timeoutMs: 0 },
+      },
+    });
+
+    const result = await pipeline.run(task(), process.cwd());
+
+    expect(result.finalStatus).toBe('infra_error');
+    expect(result.success).toBe(false);
+    // Same result-contract guarantee as the rate-limit case above (INT-2424).
+    expect(result.stages).toHaveLength(1);
+    expect(result.stages[0]).toMatchObject({ stage: 'worker', success: false });
+  });
+
+  // isInfraError() also classifies a raw (non-Error) rejection — rethrowClassified
+  // must not throw a TypeError trying to attach stageResult to a primitive. (INT-2424)
+  it('classifies a raw string infra rejection as infra_error, not a plain failure', async () => {
+    runWorker.mockRejectedValueOnce('getaddrinfo ENOTFOUND api.openai.com');
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker'],
+      maxIterations: 1,
+      roles: {
+        worker: { enabled: true, model: 'fallback-worker', timeoutMs: 0 },
+      },
+    });
+
+    const result = await pipeline.run(task(), process.cwd());
+
+    expect(result.finalStatus).toBe('infra_error');
+    expect(result.stages).toHaveLength(1);
+    expect(result.stages[0]).toMatchObject({ stage: 'worker', success: false });
   });
 
   // INT-2393: when role model is omitted, the pipeline:stage events must carry

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -40,6 +40,9 @@ import { StuckDetector, createStuckDetector } from '../support/stuckDetector.js'
 import { RateLimitError } from '../adapters/rateLimitError.js';
 import { isInfraError } from '../adapters/errorClassification.js';
 import { resolveAdapterDefaultModel } from './stageModelResolver.js';
+import { isClassifiedStageError, rethrowClassified, extractClassifiedStageResult, PipelineCancelledError } from './stageErrorClassification.js';
+
+export { PipelineCancelledError };
 
 // Types
 
@@ -205,14 +208,6 @@ export type PipelineEventType =
   | 'halt';
 
 // Pair Pipeline
-
-/** Thrown when the pipeline is cancelled mid-run (project disable / manual stop). */
-export class PipelineCancelledError extends Error {
-  constructor() {
-    super('Pipeline cancelled');
-    this.name = 'PipelineCancelledError';
-  }
-}
 
 export class PairPipeline extends EventEmitter {
   private config: PipelineConfig;
@@ -381,6 +376,8 @@ export class PairPipeline extends EventEmitter {
       // spawn, timeout) is not a task failure — surface it distinctly so the
       // runner does a backoff retry instead of counting it toward STUCK. (INT-2010)
       const infra = !cancelled && !rateLimited && isInfraError(error);
+      const classifiedStage = extractClassifiedStageResult(error); // INT-2424
+      if (classifiedStage) stages.push(classifiedStage);
       if (cancelled) {
         console.log(`[${context.taskPrefix}] Pipeline cancelled`);
       } else if (rateLimited) {
@@ -848,6 +845,7 @@ export class PairPipeline extends EventEmitter {
         rateLimitResetsAt: error instanceof RateLimitError && error.resetsAt ? error.resetsAt * 1000 : undefined,
         error: error instanceof Error ? error.message : String(error),
       } });
+      if (isClassifiedStageError(error)) rethrowClassified(error, stageResult); // INT-2424
       return stageResult;
     }
   }

--- a/src/agents/stageErrorClassification.ts
+++ b/src/agents/stageErrorClassification.ts
@@ -1,0 +1,45 @@
+// ============================================
+// OpenSwarm - Stage error classification helpers (INT-2424)
+// ============================================
+//
+// runStage() must rethrow rate-limit/infra errors so run()'s top-level catch
+// can classify them as 'rate_limited'/'infra_error' (INT-1906, INT-2010)
+// instead of counting them toward the STUCK failure budget like a genuine
+// bad edit. These helpers carry the StageResult runStage() already built
+// onto the rethrown error, so run() can restore it into PipelineResult.stages
+// instead of silently dropping the failed stage.
+
+import type { StageResult } from './pairPipeline.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
+import { isInfraError } from '../adapters/errorClassification.js';
+
+type ClassifiedStageError = Error & { stageResult?: StageResult };
+
+/** Thrown when the pipeline is cancelled mid-run (project disable / manual stop). */
+export class PipelineCancelledError extends Error {
+  constructor() {
+    super('Pipeline cancelled');
+    this.name = 'PipelineCancelledError';
+  }
+}
+
+export function isClassifiedStageError(error: unknown): boolean {
+  return error instanceof RateLimitError || isInfraError(error);
+}
+
+/**
+ * Attaches `stageResult` to `error` and rethrows it. `isInfraError()` also
+ * classifies raw primitives (e.g. a rejected string) — assigning a property
+ * onto one throws under ESM strict mode, so non-Error values are wrapped
+ * first (preserving `.message`, which is all isInfraError()/RateLimitError
+ * downstream care about).
+ */
+export function rethrowClassified(error: unknown, stageResult: StageResult): never {
+  const err = error instanceof Error ? error : new Error(String(error));
+  (err as ClassifiedStageError).stageResult = stageResult;
+  throw err;
+}
+
+export function extractClassifiedStageResult(error: unknown): StageResult | undefined {
+  return (error as ClassifiedStageError)?.stageResult;
+}


### PR DESCRIPTION
## Summary
- `runStage()`'s catch swallowed every error into an ordinary `StageResult` and returned normally, so `worker.ts`'s `isInfraError()` throw (INT-2010) and `RateLimitError` (INT-1906) never reached `run()`'s top-level catch, where the actual `'infra_error'`/`'rate_limited'` classification lives. A codex usage-limit or CLI crash silently retried as a plain worker failure and counted toward the STUCK budget exactly like a genuine bad edit.
- Confirmed via daemon logs: STO-1448/1446/1260/1286 all hit codex's usage limit (`CLI failed with code 1`) across all 3 attempts and were marked STUCK with a generic "no output" message instead of getting a backoff retry.
- `runStage()` now rethrows classified errors after emitting the usual `stage:fail` event, carrying the already-built `StageResult` on the error so `run()`'s catch can restore it into `PipelineResult.stages` (a plain rethrow would have dropped the failed stage from the reported result — caught by `openswarm review`).
- Non-Error rejections (`isInfraError()` also classifies raw strings, e.g. `ENOTFOUND`) are wrapped before attaching `stageResult`, since assigning a property to a primitive throws under ESM strict mode (also caught by `openswarm review`).
- Extracted the classification helpers + `PipelineCancelledError` into `stageErrorClassification.ts` to stay under the 1500-line file-size gate.

## Test plan
- [x] `npx vitest run src/agents/pairPipeline.test.ts` — 8/8 passing (3 new/extended regression tests: rate_limited, infra_error via Error, infra_error via raw string — each asserts `finalStatus` and that `result.stages` still contains the failed stage)
- [x] `npx vitest run` — full suite 136 files / 1538 tests passing
- [x] `npx tsc --noEmit` — clean
- [x] `openswarm review` — APPROVE (after two rounds of revise/fix for the stages-drop and raw-string-TypeError findings)

Linear: INT-2424

🤖 Generated with [Claude Code](https://claude.com/claude-code)