### PR TITLE
feat(review): --max --fix loops fix→re-review until findings clear (INT-2443)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -305,12 +305,13 @@ program
   .option('--no-linear', 'For --max: skip creating the default Linear master audit issue')
   .option('--fallback <adapter>', 'For --max: retry usage-limited areas on this adapter (default: claude for codex)')
   .option('--no-fallback', 'For --max: disable the automatic usage-limit fallback')
-  .option('--fix', 'For --max: apply the reviewer fixes to each flagged area (working tree only, no commit)')
+  .option('--fix', 'For --max: apply the reviewer fixes to each flagged area, then re-review — looping up to --fix-rounds (working tree only, no commit)')
+  .option('--fix-rounds <n>', 'For --max --fix: max fix → re-review rounds before giving up (default 3)', parsePositiveIntegerOption)
   .option('--no-learn', 'For --max: do not record the audit findings into the repo knowledge memory')
   .action(async (opts: {
     path?: string; issues?: string | boolean; issuesPerArea?: string | boolean; file?: string | boolean; adapter?: string; debug?: boolean;
     max?: boolean; concurrency?: number; maxFilesPerArea?: number; yes?: boolean; dryRun?: boolean;
-    out?: string; linear?: boolean; fallback?: string | boolean; fix?: boolean; learn?: boolean;
+    out?: string; linear?: boolean; fallback?: string | boolean; fix?: boolean; fixRounds?: number; learn?: boolean;
   }) => {
     try {
       if (opts.max) {
@@ -331,6 +332,7 @@ program
           fallbackAdapter: typeof opts.fallback === 'string' ? opts.fallback : undefined,
           noFallback: opts.fallback === false,
           fix: opts.fix,
+          fixRounds: opts.fixRounds,
           learn: opts.learn,
         });
         if (result && result.decision === 'reject') process.exitCode = 1;

--- a/src/cli/reviewAudit.test.ts
+++ b/src/cli/reviewAudit.test.ts
@@ -9,9 +9,11 @@ import {
   formatAuditSummary,
   runMaxReview,
   runAreaFixes,
+  runFixVerifyLoop,
   fixTargets,
   buildFixTaskDescription,
   mergeFallback,
+  mergeReReview,
   type AuditArea,
   type AuditAreaResult,
   type AuditProgress,
@@ -429,5 +431,112 @@ describe('fixTargets + runAreaFixes (INT-2249)', () => {
     const c = fixes.find((f) => f.label === 'src/c');
     expect(c?.applied).toBe(false);
     expect(c?.error).toContain('worker died');
+  });
+});
+
+describe('runFixVerifyLoop (INT-2443)', () => {
+  const area = (label: string): AuditArea => ({ label, dir: label, files: [`${label}/f.ts`] });
+  // src/a already approves; src/b is flagged and needs fixing.
+  const initial = (): AuditRun => ({
+    results: [
+      { area: area('src/a'), review: { decision: 'approve', feedback: '' } },
+      { area: area('src/b'), review: { decision: 'revise', feedback: '', issues: ['bug'] } },
+    ],
+    summary: aggregateAuditResults([]),
+  });
+
+  it('mergeReReview overlays fresh verdicts, flipping reject→approve', () => {
+    const base: AuditRun = {
+      results: [
+        { area: area('src/a'), review: { decision: 'approve', feedback: '' } },
+        { area: area('src/b'), review: { decision: 'reject', feedback: '' } },
+      ],
+      summary: aggregateAuditResults([]),
+    };
+    const reReview: AuditRun = {
+      results: [{ area: area('src/b'), review: { decision: 'approve', feedback: '' } }],
+      summary: aggregateAuditResults([]),
+    };
+    const merged = mergeReReview(base, reReview);
+    expect(merged.results.find((r) => r.area.label === 'src/b')?.review?.decision).toBe('approve');
+    expect(merged.summary.decision).toBe('approve'); // both areas now approve
+  });
+
+  it('loops fix → re-review and converges once the re-review approves', async () => {
+    let reviews = 0;
+    const fixed: string[] = [];
+    const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 2, maxRounds: 3 }, {
+      fix: async (a) => { fixed.push(a.label); return { success: true, filesChanged: a.files }; },
+      // round 1 re-review still revises, round 2 approves
+      review: async () => ({ decision: ++reviews >= 2 ? 'approve' : 'revise', feedback: '' }),
+    });
+    expect(result.rounds).toHaveLength(2);
+    expect(result.resolved).toBe(true);
+    expect(result.stopReason).toBe('all-approved');
+    expect(result.filesChanged).toEqual(['src/b/f.ts']); // only the flagged area, deduped
+    expect(fixed).toEqual(['src/b', 'src/b']);            // fixed twice, never touched src/a
+  });
+
+  it('stops at the round budget and reports the still-flagged area', async () => {
+    const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1, maxRounds: 2 }, {
+      fix: async (a) => ({ success: true, filesChanged: a.files }),
+      review: async () => ({ decision: 'reject', feedback: '' }), // never clears
+    });
+    expect(result.rounds).toHaveLength(2);
+    expect(result.stopReason).toBe('max-rounds');
+    expect(result.resolved).toBe(false);
+    expect(fixTargets(result.finalRun).map((t) => t.area.label)).toEqual(['src/b']);
+  });
+
+  it('bails out with no-progress when a round edits nothing, and never re-reviews', async () => {
+    let reviewed = 0;
+    const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1, maxRounds: 3 }, {
+      fix: async () => ({ success: true, filesChanged: [] }), // worker touched nothing
+      review: async () => { reviewed++; return { decision: 'approve', feedback: '' }; },
+    });
+    expect(result.rounds).toHaveLength(1);
+    expect(result.stopReason).toBe('no-progress');
+    expect(result.resolved).toBe(false);
+    expect(reviewed).toBe(0); // re-review skipped — no edits to verify
+  });
+
+  it('stops when a re-review hits a usage limit, and stays unresolved', async () => {
+    const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1, maxRounds: 3 }, {
+      fix: async (a) => ({ success: true, filesChanged: a.files }),
+      review: async () => { throw new RateLimitError(1770000000, 'usage limit'); },
+    });
+    expect(result.stopReason).toBe('rate-limit');
+    // The errored (rate-limited) area is NOT resolved — fixTargets would miss it
+    // because it lost its review, but resolved counts it as not-approved.
+    expect(result.resolved).toBe(false);
+  });
+
+  it('a rate-limited/errored re-review preserves the original findings (does not erase follow-ups)', async () => {
+    // src/b carries an actionable follow-up; the fix edits it but the re-review
+    // rate-limits before it can re-verdict. The prior findings must survive into
+    // the final summary — otherwise the report and Linear filing lose them.
+    const flagged = (): AuditRun => ({
+      results: [
+        {
+          area: area('src/b'),
+          review: {
+            decision: 'revise',
+            feedback: '',
+            issues: ['bug in f'],
+            recommendedActions: [{ type: 'fix', title: 'patch the bug', location: 'src/b/f.ts:1' }],
+          },
+        },
+      ],
+      summary: aggregateAuditResults([]),
+    });
+    const result = await runFixVerifyLoop(flagged(), '/repo', { concurrency: 1, maxRounds: 3 }, {
+      fix: async (a) => ({ success: true, filesChanged: a.files }),
+      review: async () => { throw new RateLimitError(1770000000, 'usage limit'); },
+    });
+    const b = result.finalRun.results.find((r) => r.area.label === 'src/b');
+    expect(b?.review?.decision).toBe('revise');          // original verdict kept, not turned into an error row
+    expect(b?.review?.issues).toEqual(['bug in f']);
+    // The actionable follow-up still reaches the aggregated summary for report/Linear filing.
+    expect(result.finalRun.summary.recommendedActions.map((a) => a.title)).toContain('patch the bug');
   });
 });

--- a/src/cli/reviewAudit.ts
+++ b/src/cli/reviewAudit.ts
@@ -619,3 +619,151 @@ export async function runAreaFixes(
     return { label, applied: s.value.success, filesChanged: s.value.filesChanged };
   });
 }
+
+// ── Fix → verify loop (--fix-rounds) ─────────────────────────────────────────
+
+/** What one fix → re-review round did. */
+export interface FixVerifyRound {
+  round: number;
+  /** Areas flagged (non-approve) at the start of the round. */
+  flagged: number;
+  /** Areas the fix workers actually edited. */
+  edited: number;
+  filesChanged: string[];
+  /** Edited areas that flipped to approve after the re-review. */
+  resolved: number;
+  /** Areas still flagged across the whole run after the re-review. */
+  remaining: number;
+}
+
+/** Why the loop stopped. */
+export type FixVerifyStop = 'all-approved' | 'max-rounds' | 'no-progress' | 'rate-limit';
+
+export interface FixVerifyResult {
+  rounds: FixVerifyRound[];
+  /** The run carrying the latest per-area verdicts. */
+  finalRun: AuditRun;
+  /** True when no area is flagged at the end. */
+  resolved: boolean;
+  stopReason: FixVerifyStop;
+  /** Union of every file touched across all rounds. */
+  filesChanged: string[];
+}
+
+export interface RunFixVerifyLoopOptions {
+  concurrency: number;
+  adapter?: AdapterName;
+  /** Per-area fix-worker timeout (caller sets the long default). */
+  fixTimeoutMs?: number;
+  /** Hard cap on fix → re-review rounds (default 3). */
+  maxRounds?: number;
+  signal?: AbortSignal;
+}
+
+export interface RunFixVerifyLoopDeps {
+  review?: RunMaxReviewDeps['review'];
+  fix?: RunAreaFixesDeps['fix'];
+  /** Start of each round: (round, flaggedCount). */
+  onRoundStart?: (round: number, flagged: number) => void;
+  /** Fix-phase progress. */
+  onFixProgress?: (e: FixProgress) => void;
+  /** Re-review-phase progress. */
+  onReviewProgress?: (e: AuditProgress) => void;
+  /** End of each round: its record. */
+  onRoundEnd?: (r: FixVerifyRound) => void;
+}
+
+/**
+ * Overlay fresh re-review verdicts onto a base run: any area the re-review
+ * actually re-verdicted takes the new result, the rest keep theirs. (mergeFallback
+ * only fills *errored* base areas, so it can't downgrade an already-reviewed area
+ * from reject→approve — this can.)
+ *
+ * Only areas with a real verdict (`r.review`) overlay. A fresh result that errored
+ * (subagent crash / rate limit) carries no verdict — keep the prior findings, so a
+ * failed re-review can't silently erase a still-unresolved area's issues and
+ * follow-ups (which then vanish from the report and Linear filing). (INT-2443)
+ */
+export function mergeReReview(base: AuditRun, reReview: AuditRun): AuditRun {
+  const fresh = new Map(reReview.results.filter((r) => r.review).map((r) => [r.area.label, r]));
+  const results = base.results.map((r) => fresh.get(r.area.label) ?? r);
+  return { summary: aggregateAuditResults(results), results, rateLimit: reReview.rateLimit ?? base.rateLimit };
+}
+
+/**
+ * Iterate fix → re-review until every area approves or the round budget runs
+ * out. Each round applies the reviewer's fixes to the currently-flagged areas,
+ * then re-reviews ONLY the areas actually edited (an untouched flagged area
+ * keeps its prior verdict — re-reviewing it would waste a subagent). Stops early
+ * when a round edits nothing (workers can't progress) or a re-review hits a
+ * usage limit, so it never spins. Edits accumulate in the working tree — no
+ * commit — so the user reviews the diff before committing. (INT-2443)
+ */
+export async function runFixVerifyLoop(
+  initial: AuditRun,
+  cwd: string,
+  opts: RunFixVerifyLoopOptions,
+  deps: RunFixVerifyLoopDeps = {},
+): Promise<FixVerifyResult> {
+  const maxRounds = opts.maxRounds && opts.maxRounds > 0 ? opts.maxRounds : 3;
+  const reviewOpts: RunMaxReviewOptions = { concurrency: opts.concurrency, adapter: opts.adapter, signal: opts.signal };
+  const fixOpts: RunAreaFixesOptions = { concurrency: opts.concurrency, adapter: opts.adapter, timeoutMs: opts.fixTimeoutMs, signal: opts.signal };
+  const reviewDeps: RunMaxReviewDeps = { review: deps.review, onProgress: deps.onReviewProgress };
+  const fixDeps: RunAreaFixesDeps = { fix: deps.fix, onProgress: deps.onFixProgress };
+
+  let run = initial;
+  const rounds: FixVerifyRound[] = [];
+  const allFiles = new Set<string>();
+  let stopReason: FixVerifyStop = 'all-approved';
+  // "Unresolved" = not approved, which includes errored areas (a re-review that
+  // crashed is NOT resolved) — unlike fixTargets, which only counts non-approve
+  // areas that still carry review findings worth another fix pass.
+  const unresolved = (r: AuditRun): number => r.results.filter((x) => x.review?.decision !== 'approve').length;
+
+  for (let round = 1; round <= maxRounds; round++) {
+    const targets = fixTargets(run);
+    if (!targets.length) {
+      // Nothing left to fix. Clean if every area approves; otherwise the leftover
+      // is an errored/unfixable area, not a success.
+      stopReason = unresolved(run) === 0 ? 'all-approved' : 'no-progress';
+      break;
+    }
+    deps.onRoundStart?.(round, targets.length);
+
+    const fixes = await runAreaFixes(run, cwd, fixOpts, fixDeps);
+    const edited = fixes.filter((f) => f.applied && f.filesChanged.length);
+    for (const f of edited) for (const p of f.filesChanged) allFiles.add(p);
+
+    if (!edited.length) {
+      const rec: FixVerifyRound = { round, flagged: targets.length, edited: 0, filesChanged: [], resolved: 0, remaining: unresolved(run) };
+      rounds.push(rec);
+      deps.onRoundEnd?.(rec);
+      stopReason = 'no-progress';
+      break;
+    }
+
+    // Re-review only the edited areas; merge their fresh verdicts back in.
+    const editedLabels = new Set(edited.map((f) => f.label));
+    const editedAreas = targets.filter((t) => editedLabels.has(t.area.label)).map((t) => t.area);
+    const reReview = await runMaxReview(editedAreas, cwd, reviewOpts, reviewDeps);
+    run = mergeReReview(run, reReview);
+
+    const remaining = unresolved(run);
+    const rec: FixVerifyRound = {
+      round,
+      flagged: targets.length,
+      edited: edited.length,
+      filesChanged: edited.flatMap((f) => f.filesChanged),
+      resolved: reReview.results.filter((r) => r.review?.decision === 'approve').length,
+      remaining,
+    };
+    rounds.push(rec);
+    deps.onRoundEnd?.(rec);
+
+    if (reReview.rateLimit) { stopReason = 'rate-limit'; break; }
+    if (!remaining) { stopReason = 'all-approved'; break; }
+    if (round === maxRounds) { stopReason = 'max-rounds'; break; }
+  }
+
+  return { rounds, finalRun: run, resolved: unresolved(run) === 0, stopReason, filesChanged: [...allFiles] };
+}

--- a/src/cli/reviewMaxCommand.tsx
+++ b/src/cli/reviewMaxCommand.tsx
@@ -17,13 +17,14 @@ import {
   listSourceFiles,
   balanceAreasToConcurrency,
   runMaxReview,
-  runAreaFixes,
+  runFixVerifyLoop,
   fixTargets,
   formatAuditSummary,
   formatAuditReport,
   mergeFallback,
   type AuditArea,
-  type FixAreaResult,
+  type FixVerifyRound,
+  type FixVerifyStop,
   type AuditRun,
   type AuditSummary,
 } from './reviewAudit.js';
@@ -60,6 +61,8 @@ export interface ReviewMaxOptions {
   noFallback?: boolean;
   /** Apply the reviewer's fixes to each non-approve area (working tree only). (INT-2249) */
   fix?: boolean;
+  /** For --fix: max fix → re-review rounds before giving up (default 3). (INT-2443) */
+  fixRounds?: number;
   /** Record the audit findings into repo knowledge (default true; --no-learn opts out). (INT-2268) */
   learn?: boolean;
 }
@@ -231,7 +234,69 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
     console.warn(`  Retry after ${when}${resolveFallbackAdapter(opts) ? ' (fallback adapter also exhausted)' : ', or set `--fallback <adapter>`'}.`);
   }
 
-  // (3) Persist a markdown report so the result isn't lost to the scrollback. (INT-2022)
+  // (3.5) --fix: iterate fix → re-review until every flagged area approves or the
+  //       round budget (--fix-rounds, default 3) runs out. Each round fixes the
+  //       currently-flagged areas, then re-reviews only the ones actually edited
+  //       for a fresh verdict. Edits accumulate in the working tree — no commit —
+  //       so the user reviews the diff first. (INT-2249 / INT-2443)
+  if (opts.fix) {
+    const targets = fixTargets(run);
+    if (!targets.length) {
+      console.log('\n--fix: nothing to apply (every area approved).');
+    } else {
+      const maxRounds = positiveIntegerOption(opts.fixRounds, 3, '--fix-rounds');
+      console.log(
+        `\n${status.running('Fix → verify loop')} up to ${c.yellow(String(maxRounds))} round(s), ` +
+          `${c.yellow(String(targets.length))} area(s) flagged, ${concurrency} concurrent worker(s).`,
+      );
+      const loop = await runFixVerifyLoop(
+        run,
+        cwd,
+        // 15 min per area: the adapter default (5 min) SIGKILLs fix workers on
+        // issue-heavy areas mid-edit.
+        { concurrency, adapter: opts.adapter as AdapterName | undefined, fixTimeoutMs: 900_000, maxRounds },
+        {
+          onRoundStart: (round, flagged) =>
+            console.log(`\n${c.bold(`Round ${round}/${maxRounds}`)} — fixing ${flagged} area(s)...`),
+          onFixProgress: (e) => {
+            if (e.type === 'done') console.log(`  ${status.ok(`${e.label} — ${e.filesChanged} file(s) changed`)}`);
+            else if (e.type === 'error') console.log(`  ${status.err(`${e.label} — ${e.error}`)}`);
+          },
+          onReviewProgress: (e) => {
+            if (e.type === 'done') console.log(`  ${status.info(`re-review ${e.label} — ${e.decision}`)}`);
+            else if (e.type === 'error') console.log(`  ${status.err(`re-review ${e.label} — failed`)}`);
+          },
+          onRoundEnd: (r: FixVerifyRound) =>
+            console.log(
+              `  ${c.dim(`Round ${r.round}: ${r.edited} area(s) edited, ${r.resolved} resolved, ${r.remaining} still flagged.`)}`,
+            ),
+        },
+      );
+      // The loop's re-review carries the fresh verdicts — report/persist on those,
+      // not the stale first-pass run.
+      run = loop.finalRun;
+      const stopLabel: Record<FixVerifyStop, string> = {
+        'all-approved': 'all findings cleared',
+        'max-rounds': 'round budget spent',
+        'no-progress': 'workers made no edits',
+        'rate-limit': 'usage limit hit',
+      };
+      // Count "not approved" (includes errored/rate-limited areas), matching
+      // loop.resolved — fixTargets would undercount an errored area.
+      const still = run.results.filter((r) => r.review?.decision !== 'approve').length;
+      const headline = loop.resolved
+        ? status.ok(`--fix: resolved every flagged area in ${loop.rounds.length} round(s)`)
+        : status.warn(
+            `--fix: ${still} area(s) still flagged after ${loop.rounds.length} round(s) (${stopLabel[loop.stopReason]})`,
+          );
+      console.log(`\n${headline} · ${c.yellow(`${loop.filesChanged.length} file(s) touched`)}`);
+      console.log(c.dim('Changes are in the working tree — review the diff before committing.'));
+    }
+  }
+
+  // (3.6) Persist a markdown report so the result isn't lost to the scrollback.
+  //       Built here (after --fix) so it reflects the verified post-fix verdicts —
+  //       and so the Linear master issue below embeds the same final state. (INT-2022 / INT-2443)
   const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
   const report = formatAuditReport(run.summary, basename(cwd) || cwd, ts);
   const outPath = opts.out ?? join(cwd, '.openswarm', 'audit', `audit-${ts}.md`);
@@ -241,60 +306,6 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
     console.log(`\nReport saved: ${outPath}`);
   } catch (e) {
     console.warn(`Could not save report: ${e instanceof Error ? e.message : String(e)}`);
-  }
-
-  // (3.5) --fix: apply the reviewer's findings for every non-approve area,
-  //       fanned out with the same concurrency. Edits land in the working tree —
-  //       no commit, no re-review — so the user reviews the diff first. (INT-2249)
-  if (opts.fix) {
-    const targets = fixTargets(run);
-    if (!targets.length) {
-      console.log('\n--fix: nothing to apply (every area approved).');
-    } else {
-      console.log(`\nApplying fixes across ${targets.length} area(s) with ${concurrency} concurrent worker(s)...`);
-      const fixEvents = new EventEmitter();
-      fixEvents.setMaxListeners(0);
-      const showFixBoard = Boolean((process.stderr as NodeJS.WriteStream).isTTY);
-      const fixBoard = showFixBoard
-        ? render(
-            <AuditBoard
-              areas={targets.map((t) => t.area)}
-              concurrency={concurrency}
-              events={fixEvents}
-              mode="fix"
-            />,
-            { stdout: process.stderr as unknown as NodeJS.WriteStream },
-          )
-        : undefined;
-      let fixes: FixAreaResult[];
-      try {
-        fixes = await runAreaFixes(
-          run,
-          cwd,
-          // 15 min per area: without an explicit timeoutMs the adapter default (5 min)
-          // SIGKILLed fix workers on issue-heavy areas mid-edit.
-          { concurrency, adapter: opts.adapter as AdapterName | undefined, timeoutMs: 900_000 },
-          {
-            onProgress: (e) => {
-              if (showFixBoard) fixEvents.emit('progress', e);
-              else if (e.type === 'done') console.log(`  ${status.ok(`${e.label} — ${e.filesChanged} file(s) changed`)}`);
-              else if (e.type === 'error') console.log(`  ${status.err(`${e.label} — ${e.error}`)}`);
-            },
-          },
-        );
-      } finally {
-        fixBoard?.unmount();
-      }
-      const edited = fixes.filter((f) => f.applied && f.filesChanged.length);
-      const failed = fixes.filter((f) => !f.applied);
-      const touched = [...new Set(edited.flatMap((f) => f.filesChanged))];
-      console.log(
-        `\n${status.ok(`--fix: ${edited.length}/${targets.length} area(s) edited`)}` +
-          ` ${c.yellow(`${touched.length} file(s) touched`)}` +
-          `${failed.length ? ` ${status.err(`${failed.length} failed`)}` : ''}`,
-      );
-      console.log(c.dim('Changes are in the working tree — review the diff before committing.'));
-    }
   }
 
   // (4) Linear: PM synthesis is the DEFAULT — a master parent + ≤10 cohesive


### PR DESCRIPTION
## What

Turns \`openswarm review --max --fix\` from a **single-pass** apply into a **bounded fix→verify loop**, per user request ("수정 권고받은 모든 문제가 다 패스할 때까지 반복해서 돌려라").

Each round:
1. applies the reviewer's fixes to the currently-flagged areas, then
2. re-reviews **only the areas actually edited** for a fresh verdict, and
3. merges those verdicts back.

The loop stops on the first of: **all areas approve**, a round that **edits nothing** (workers can't progress), a **re-review usage limit**, or the **`--fix-rounds` cap** (default 3). Edits accumulate in the working tree — no commit, no auto-push — so the user reviews the diff.

## Why bounded (not unlimited)

Unlimited repeat doesn't guarantee convergence and risks burning the whole codex/claude usage budget on an oscillating fix. The verify loop gives the "keep going until it passes" behavior while capping cost and detecting no-progress.

## Changes

- \`runFixVerifyLoop\` + \`mergeReReview\` in \`src/cli/reviewAudit.ts\` (injectable review/fix deps for tests)
- \`mergeReReview\` only overlays areas that got a real verdict — a re-review that errors/rate-limits keeps the prior findings, so a failed re-verify can't silently erase still-unresolved issues/follow-ups
- report generation moved **after** the loop so the saved markdown report + Linear master issue reflect the verified post-fix state (not stale pre-fix findings)
- \`--fix-rounds <n>\` flag wired through \`src/cli.ts\`
- 6 unit tests: convergence, max-rounds, no-progress, rate-limit stop, findings-preservation on rate-limited re-review, mergeReReview overlay

## Verification

- \`npm run ci\` (lint + typecheck + build) clean
- full \`vitest\` suite green (1544 tests, +6 new)
- 3 rounds of \`openswarm review\` self-gate: 2× REVISE (report ordering, then mergeReReview findings-erasure) both addressed → 3rd APPROVE

INT-2443