### PR TITLE
feat(fix): live Ink board for the openswarm fix worker fan-out (INT-2446)

### DIFF
--- a/src/cli/fixBoard.tsx
+++ b/src/cli/fixBoard.tsx
@@ -1,0 +1,39 @@
+// ============================================
+// OpenSwarm - `openswarm fix` live worker board (INT-2446)
+// ============================================
+//
+// Effectful Ink boundary for the fix-worker fan-out: renders the shared
+// AuditBoard (mode="fix") to stderr so runFixCommand's orchestration stays
+// ink-free and unit-testable. TTY-only — returns null when stderr isn't a TTY
+// so scripted/piped runs keep the plain per-area line output. Same board the
+// review --max fix pass uses, so the two commands look identical. (INT-2006 / INT-2260)
+
+import { render } from 'ink';
+import { EventEmitter } from 'node:events';
+import { AuditBoard } from '../tui/components/AuditBoard.js';
+import type { AuditArea, FixProgress } from './reviewAudit.js';
+
+export interface FixBoardHandle {
+  /** Feed one fan-out event to the live board. */
+  emit: (e: FixProgress) => void;
+  /** Tear the board down (call before printing anything else to stderr). */
+  unmount: () => void;
+}
+
+/**
+ * Mount the live fix board over `areas`. Returns null when stderr is not a TTY
+ * (scripted/piped runs), so the caller falls back to plain line logging. Rendered
+ * to stderr so stdout stays clean for anything piped. (INT-2446)
+ */
+export function renderFixBoard(areas: AuditArea[], concurrency: number): FixBoardHandle | null {
+  if (!(process.stderr as NodeJS.WriteStream).isTTY) return null;
+  const events = new EventEmitter();
+  events.setMaxListeners(0);
+  const board = render(<AuditBoard areas={areas} concurrency={concurrency} events={events} mode="fix" />, {
+    stdout: process.stderr as unknown as NodeJS.WriteStream,
+  });
+  return {
+    emit: (e) => events.emit('progress', e),
+    unmount: () => board.unmount(),
+  };
+}

--- a/src/cli/fixCommand.test.ts
+++ b/src/cli/fixCommand.test.ts
@@ -219,6 +219,27 @@ describe('runFixCommand loop (INT-2267)', () => {
     expect(report.reason).toBe('no-checks');
   });
 
+  it('emits start/done/error to the live board during the fan-out (INT-2446)', async () => {
+    const events: Array<{ type: string; label: string }> = [];
+    const board = { emit: (e: { type: string; label: string }) => events.push({ type: e.type, label: e.label }), unmount: () => {} };
+    await runFixCommand(
+      { rounds: 2, concurrency: 2 },
+      {
+        ...silent,
+        // two files in two dirs → two areas; one worker succeeds, one throws
+        runCheck: async () => ({ passed: false, output: 'src/a/x.ts:1 fail\nsrc/b/y.ts:2 fail' }),
+        runFixWorker: async (area) => {
+          if (area.label === 'src/b') throw new Error('worker died');
+          return { success: true, filesChanged: ['src/a/x.ts'] };
+        },
+        renderBoard: () => board,
+      },
+    );
+    expect(events.filter((e) => e.type === 'start').map((e) => e.label).sort()).toEqual(['src/a', 'src/b']);
+    expect(events.filter((e) => e.type === 'done').map((e) => e.label)).toEqual(['src/a']);
+    expect(events.filter((e) => e.type === 'error').map((e) => e.label)).toEqual(['src/b']);
+  });
+
   it('records the outcome into repo knowledge on green after edits (INT-2268)', async () => {
     let pass = false;
     const recordOutcome = vi.fn(async () => {});

--- a/src/cli/fixCommand.ts
+++ b/src/cli/fixCommand.ts
@@ -16,11 +16,12 @@
 import { execFile } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { balanceAreasToConcurrency } from './reviewAudit.js';
+import { balanceAreasToConcurrency, type AuditArea } from './reviewAudit.js';
 import { runPool } from '../support/concurrencyPool.js';
 import { startProgressHeartbeat } from './reviewProgress.js';
 import { status, c } from '../support/colors.js';
 import type { AdapterName } from '../adapters/types.js';
+import type { FixBoardHandle } from './fixBoard.js';
 
 /** A resolvable objective check (`npm run lint`, `cargo test`, `pytest`, …). */
 export interface Check {
@@ -309,6 +310,12 @@ export interface FixDeps {
   exists?: (relPath: string, cwd: string) => boolean;
   /** Record a green fix into repo knowledge. Default writes via recordTaskOutcome; tests pass a noop. */
   recordOutcome?: (info: { taskTitle: string; filesChanged: string[]; summary: string }) => Promise<void>;
+  /**
+   * Mount the live fix board over the round's areas → handle, or null to fall back
+   * to plain line output. Default lazily renders the Ink board on a TTY only; tests
+   * (non-TTY) get null and keep the injectable-log path. (INT-2446)
+   */
+  renderBoard?: (areas: AuditArea[], concurrency: number) => Promise<FixBoardHandle | null> | FixBoardHandle | null;
   log?: (line: string) => void;
 }
 
@@ -386,6 +393,14 @@ export async function runFixCommand(opts: FixOptions = {}, deps: FixDeps = {}): 
   const exists = deps.exists ?? ((p, base) => existsSync(join(base, p)));
   const runCheck = deps.runCheck ?? defaultRunCheck;
   const runFixWorker = deps.runFixWorker ?? ((area, checks, onLog) => defaultRunFixWorker(area, checks, cwd, opts, onLog));
+  // TTY-guard the import so scripted/piped runs (and tests) never load Ink. (INT-2446)
+  const renderBoard =
+    deps.renderBoard ??
+    (async (areas: AuditArea[], conc: number): Promise<FixBoardHandle | null> => {
+      if (!(process.stderr as NodeJS.WriteStream).isTTY) return null;
+      const { renderFixBoard } = await import('./fixBoard.js');
+      return renderFixBoard(areas, conc);
+    });
   const checks = deps.checks ?? resolveProjectChecks(probeProject(cwd), opts.checks);
   const recordOutcome =
     deps.recordOutcome ??
@@ -441,16 +456,43 @@ export async function runFixCommand(opts: FixOptions = {}, deps: FixDeps = {}): 
 
     const areas = deriveFixAreas(failing, concurrency, opts.maxFilesPerArea);
     log(`\nFixing ${failing.length} failing check(s) across ${areas.length} area(s)...`);
-    const settled = await runPool(areas, concurrency, async (area) => {
-      const r = await runFixWorker(area, checks, () => {});
-      log(r.filesChanged.length ? `  ${status.ok(`${area.label} — ${r.filesChanged.length} file(s)`)}` : `  ${status.warn(`${area.label} — no edit`)}`);
-      return r;
-    });
+    // Live board on a TTY; null (scripted/piped) falls back to per-area line logs.
+    // Board writes to stderr, so we suppress the stdout line logs while it's up to
+    // avoid clobbering it. (INT-2446)
+    const board = await renderBoard(areas, concurrency);
+    const total = areas.length;
+    let done = 0;
+    const settled = await runPool(
+      areas,
+      concurrency,
+      async (area) => {
+        board?.emit({ type: 'start', label: area.label, done, total });
+        return runFixWorker(area, checks, (line) => board?.emit({ type: 'log', label: area.label, line }));
+      },
+      (s) => {
+        done++;
+        const area = areas[s.index];
+        if (s.error) {
+          const message = s.error instanceof Error ? s.error.message : String(s.error);
+          if (board) board.emit({ type: 'error', label: area?.label ?? `area:${s.index}`, error: message, done, total });
+          else log(`  ${status.err(`${area?.label ?? `area:${s.index}`} — worker error: ${message}`)}`);
+        } else {
+          const n = s.value?.filesChanged.length ?? 0;
+          if (board) board.emit({ type: 'done', label: area.label, filesChanged: n, done, total });
+          else log(n ? `  ${status.ok(`${area.label} — ${n} file(s)`)}` : `  ${status.warn(`${area.label} — no edit`)}`);
+        }
+      },
+    );
+    board?.unmount();
     const workerErrors = settled.filter((s) => s.error !== undefined);
-    for (const s of workerErrors) {
-      const area = areas[s.index];
-      const message = s.error instanceof Error ? s.error.message : String(s.error);
-      log(`  ${status.err(`${area?.label ?? `area:${s.index}`} — worker error: ${message}`)}`);
+    // The board only renders running rows, so an errored area's message never
+    // showed — surface the details now that the board is torn down. (INT-2446)
+    if (board) {
+      for (const s of workerErrors) {
+        const area = areas[s.index];
+        const message = s.error instanceof Error ? s.error.message : String(s.error);
+        log(`  ${status.err(`${area?.label ?? `area:${s.index}`} — worker error: ${message}`)}`);
+      }
     }
     const filesChanged = [...new Set(settled.flatMap((s) => s.value?.filesChanged ?? []))];
     rounds.push({ round, outcomes, filesChanged });


### PR DESCRIPTION
## What

\`openswarm fix\` already had colored output (\`status\`/\`c\`) and a check-phase spinner (\`startProgressHeartbeat\`), but the **worker fan-out — the slow part — showed nothing** until each area finished: during the multi-minute \`runPool\` worker runs there was no live indicator, just a line per area on completion.

This mounts the same \`AuditBoard\` (mode=\`fix\`) that \`review --max\` uses, so fix workers now get per-area live rows (spinner + last tool line) and a running edited/files tally.

## Changes

- **new \`src/cli/fixBoard.tsx\`** — TTY-only Ink boundary: \`renderFixBoard(areas, concurrency) → {emit, unmount} | null\`. Renders to **stderr** (stdout stays clean), returns **null off-TTY** so \`runFixCommand\` stays ink-free and unit-testable.
- **\`fixCommand.ts\` fan-out** emits \`start\`/\`log\`/\`done\`/\`error\` via \`runPool\`'s worker + \`onSettle\`. Non-TTY keeps the plain per-area line output. Errored areas' messages print **after** the board unmounts (the board only renders running rows, so an error row would otherwise be lost).
- **\`FixDeps.renderBoard\`** injectable; the import is TTY-guarded so scripted runs and tests never load Ink.

## Why not just a heartbeat

Chose the shared \`AuditBoard\` over a single-line heartbeat so \`fix\` and \`review --max\` look identical — one component, one status/glyph source (INT-2260), no drift.

## Verification

- \`npm run ci\` (lint + typecheck + build) clean; full \`vitest\` green (1545, +1 board-wiring test)
- runtime smoke: non-TTY → \`renderFixBoard\` returns null (line fallback); forced-TTY → board mounts, takes start/log/done/error, unmounts cleanly
- \`openswarm review\` self-gate → APPROVE (no issues)

INT-2446