### PR TITLE
fix(worker/fix): snapshot only the pre-work tree + 15-min fix timeout (INT-2447)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -357,8 +357,9 @@ program
   .option('--concurrency <n>', 'Max fix workers in flight (default 4)', (v) => parseInt(v, 10))
   .option('--rounds <n>', 'Max check → fix → re-check rounds (default 3)', (v) => parseInt(v, 10))
   .option('--adapter <name>', 'Adapter override for the fix workers')
+  .option('--timeout <ms>', 'Per-area fix worker timeout in ms (default 900000 = 15 min)', parsePositiveIntegerOption)
   .option('--no-learn', 'Do not record a successful fix into the repo knowledge memory')
-  .action(async (opts: { path?: string; checks?: string[]; concurrency?: number; rounds?: number; adapter?: string; learn?: boolean }) => {
+  .action(async (opts: { path?: string; checks?: string[]; concurrency?: number; rounds?: number; adapter?: string; timeout?: number; learn?: boolean }) => {
     try {
       const { runFixCommand } = await import('./cli/fixCommand.js');
       const report = await runFixCommand({
@@ -367,6 +368,7 @@ program
         concurrency: opts.concurrency,
         rounds: opts.rounds,
         adapter: opts.adapter as import('./adapters/types.js').AdapterName | undefined,
+        timeoutMs: opts.timeout,
         learn: opts.learn,
       });
       if (!report.green) process.exitCode = 1;

--- a/src/cli/fixCommand.test.ts
+++ b/src/cli/fixCommand.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   resolveChecks,
   resolveProjectChecks,
@@ -11,6 +11,12 @@ import {
   type FixArea,
   type ProjectProbe,
 } from './fixCommand.js';
+
+// defaultRunFixWorker dynamically imports runWorker; mock it so the default fix
+// path is exercised without spawning a real agent. Only the timeout test drives
+// this path (every other test injects runFixWorker). (INT-2447)
+const runWorkerMock = vi.hoisted(() => vi.fn());
+vi.mock('../agents/worker.js', () => ({ runWorker: runWorkerMock }));
 
 describe('resolveChecks (INT-2267)', () => {
   const scripts = { lint: 'oxlint src/', typecheck: 'tsc --noEmit', build: 'tsc', test: 'vitest run', dev: 'x' };
@@ -217,6 +223,32 @@ describe('runFixCommand loop (INT-2267)', () => {
   it('reports no-checks when nothing resolves', async () => {
     const report = await runFixCommand({}, { log: () => {}, checks: [] });
     expect(report.reason).toBe('no-checks');
+  });
+
+  describe('fix worker timeout (INT-2447)', () => {
+    // No injected runFixWorker → the default path runs → defaultRunFixWorker →
+    // the mocked runWorker, whose options we inspect.
+    const base = {
+      log: () => {},
+      exists: () => true,
+      checks,
+      recordOutcome: async () => {},
+      runCheck: async () => ({ passed: false, output: 'src/a/x.ts:1 fail' }),
+    };
+    beforeEach(() => {
+      runWorkerMock.mockReset().mockResolvedValue({ success: true, filesChanged: [] });
+    });
+
+    it('defaults the fix worker timeout to 15 minutes, not the 5-min adapter default', async () => {
+      await runFixCommand({ rounds: 2 }, base);
+      expect(runWorkerMock).toHaveBeenCalled();
+      expect(runWorkerMock.mock.calls[0][0].timeoutMs).toBe(900_000);
+    });
+
+    it('honors an explicit --timeout override', async () => {
+      await runFixCommand({ rounds: 2, timeoutMs: 123_456 }, base);
+      expect(runWorkerMock.mock.calls[0][0].timeoutMs).toBe(123_456);
+    });
   });
 
   it('emits start/done/error to the live board during the fan-out (INT-2446)', async () => {

--- a/src/cli/fixCommand.ts
+++ b/src/cli/fixCommand.ts
@@ -392,7 +392,12 @@ export async function runFixCommand(opts: FixOptions = {}, deps: FixDeps = {}): 
   const log = deps.log ?? ((l: string) => console.log(l));
   const exists = deps.exists ?? ((p, base) => existsSync(join(base, p)));
   const runCheck = deps.runCheck ?? defaultRunCheck;
-  const runFixWorker = deps.runFixWorker ?? ((area, checks, onLog) => defaultRunFixWorker(area, checks, cwd, opts, onLog));
+  // 15 min per area by default: codex on a real area routinely exceeds the 5-min
+  // adapter default and gets SIGKILLed ("codex timeout after 300000ms"). Mirrors
+  // review --max --fix. `--timeout` overrides. (INT-2447)
+  const workerTimeoutMs = opts.timeoutMs ?? 900_000;
+  const runFixWorker =
+    deps.runFixWorker ?? ((area, checks, onLog) => defaultRunFixWorker(area, checks, cwd, { ...opts, timeoutMs: workerTimeoutMs }, onLog));
   // TTY-guard the import so scripted/piped runs (and tests) never load Ink. (INT-2446)
   const renderBoard =
     deps.renderBoard ??

--- a/src/support/gitTracker.test.ts
+++ b/src/support/gitTracker.test.ts
@@ -32,6 +32,32 @@ describe('gitTracker', () => {
     await expect(getChangedFilesSinceSnapshot(repo, snapshot)).resolves.toContain('new-file.txt');
   });
 
+  it('excludes pre-existing dirty files, reporting only changes after the snapshot (INT-2447)', async () => {
+    // Repo is ALREADY dirty before the snapshot: an untracked file + a modified
+    // tracked file. Previously the HEAD-only snapshot blamed the worker for both.
+    writeFileSync(join(repo, 'preexisting-untracked.txt'), 'junk\n');
+    writeFileSync(join(repo, 'tracked.txt'), 'tracked\ndirty-before\n');
+    const snapshot = await takeSnapshot(repo);
+
+    // Now the "worker" makes ITS edit.
+    writeFileSync(join(repo, 'worker-edit.txt'), 'fix\n');
+
+    const changed = await getChangedFilesSinceSnapshot(repo, snapshot);
+    expect(changed).toContain('worker-edit.txt');              // the worker's edit is reported
+    expect(changed).not.toContain('preexisting-untracked.txt'); // pre-existing dirt is NOT attributed
+    expect(changed).not.toContain('tracked.txt');              // pre-existing modification is NOT attributed
+  });
+
+  it('reports a worker edit to an already-dirty tracked file (no false negative) (INT-2447)', async () => {
+    // A file dirty before the snapshot that the worker ALSO edits must still be
+    // reported — the snapshot captures content, so a further change is detected.
+    writeFileSync(join(repo, 'tracked.txt'), 'tracked\ndirty-before\n');
+    const snapshot = await takeSnapshot(repo);
+    writeFileSync(join(repo, 'tracked.txt'), 'tracked\ndirty-before\nworker-added\n');
+
+    await expect(getChangedFilesSinceSnapshot(repo, snapshot)).resolves.toContain('tracked.txt');
+  });
+
   it('includes untracked files in current change detection', async () => {
     writeFileSync(join(repo, 'new-current.txt'), 'new\n');
 

--- a/src/support/gitTracker.ts
+++ b/src/support/gitTracker.ts
@@ -4,6 +4,9 @@
 // ============================================
 
 import { spawn } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 /**
  * Extract changed file list via git diff
@@ -38,13 +41,38 @@ export async function getChangedFiles(
 }
 
 /**
- * Save pre-work snapshot (stash or commit hash)
+ * Capture the CURRENT worktree state (tracked + untracked-non-ignored) as a git
+ * tree object, without touching the real index or worktree. A throwaway index
+ * (via GIT_INDEX_FILE) lets `git add -A` stage everything there, then `write-tree`
+ * turns it into a tree SHA we can diff against later.
+ *
+ * This is what makes change detection correct on an already-dirty repo: the
+ * pre-existing dirty files live in the snapshot tree, so only edits made AFTER
+ * the snapshot show up as changes. (Before this, the "snapshot" was just HEAD, so
+ * every worker was blamed for the repo's entire pre-existing dirty tree.)
+ */
+async function writeWorktreeTree(projectPath: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'osw-idx-'));
+  const indexFile = join(dir, 'index');
+  try {
+    const env: NodeJS.ProcessEnv = { GIT_INDEX_FILE: indexFile };
+    // Fresh temp index → `add -A` stages the full current worktree (new/modified,
+    // honoring .gitignore); write-tree records it. Works even in an empty repo.
+    await runGitCommand(projectPath, ['add', '-A'], env);
+    return (await runGitCommand(projectPath, ['write-tree'], env)).trim();
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+/**
+ * Save a pre-work snapshot of the worktree as a git tree SHA (opaque token —
+ * pass it back to getChangedFilesSinceSnapshot). Captures the dirty state so
+ * pre-existing changes are NOT later attributed to the worker. (INT-2447)
  */
 export async function takeSnapshot(projectPath: string): Promise<string> {
   try {
-    // Return current HEAD commit hash
-    const output = await runGitCommand(projectPath, ['rev-parse', 'HEAD']);
-    return output.trim();
+    return await writeWorktreeTree(projectPath);
   } catch (error) {
     console.error('[GitTracker] takeSnapshot error:', error);
     return '';
@@ -52,39 +80,22 @@ export async function takeSnapshot(projectPath: string): Promise<string> {
 }
 
 /**
- * Get files changed since snapshot
+ * Files changed since the snapshot: build the current worktree tree the same way
+ * and diff it against the snapshot tree. Reports ONLY what changed after the
+ * snapshot (added/modified/deleted, untracked included) — pre-existing dirty
+ * files identical in both trees don't appear. (INT-2447)
  */
 export async function getChangedFilesSinceSnapshot(
   projectPath: string,
-  snapshotHash: string
+  snapshotTree: string
 ): Promise<string[]> {
-  if (!snapshotHash) return [];
+  if (!snapshotTree) return [];
 
   try {
-    // Committed changes
-    const committedOutput = await runGitCommand(projectPath, [
-      'diff', '--name-only', snapshotHash, 'HEAD'
-    ]);
-
-    // Uncommitted changes (staged + unstaged)
-    const uncommittedOutput = await runGitCommand(projectPath, [
-      'diff', '--name-only'
-    ]);
-    const stagedOutput = await runGitCommand(projectPath, [
-      'diff', '--name-only', '--cached'
-    ]);
-    const untrackedOutput = await runGitCommand(projectPath, [
-      'ls-files', '--others', '--exclude-standard'
-    ]);
-
-    const files = new Set<string>();
-
-    committedOutput.split('\n').filter(Boolean).forEach(f => files.add(f));
-    uncommittedOutput.split('\n').filter(Boolean).forEach(f => files.add(f));
-    stagedOutput.split('\n').filter(Boolean).forEach(f => files.add(f));
-    untrackedOutput.split('\n').filter(Boolean).forEach(f => files.add(f));
-
-    return Array.from(files);
+    const currentTree = await writeWorktreeTree(projectPath);
+    if (currentTree === snapshotTree) return [];
+    const diff = await runGitCommand(projectPath, ['diff', '--name-only', snapshotTree, currentTree]);
+    return diff.split('\n').filter(Boolean);
   } catch (error) {
     console.error('[GitTracker] getChangedFilesSinceSnapshot error:', error);
     return [];
@@ -211,9 +222,9 @@ export async function getWorkingDiffDetail(projectPath: string): Promise<FileDif
 /**
  * Git command execution utility
  */
-function runGitCommand(cwd: string, args: string[]): Promise<string> {
+function runGitCommand(cwd: string, args: string[], env?: NodeJS.ProcessEnv): Promise<string> {
   return new Promise((resolve, reject) => {
-    const proc = spawn('git', args, { cwd });
+    const proc = spawn('git', args, { cwd, env: env ? { ...process.env, ...env } : process.env });
 
     let stdout = '';
     let stderr = '';


### PR DESCRIPTION
## Context

Found running `openswarm fix` on a large, dirty monorepo: every worker logged `Git detected 7428 changed file(s)` and many hit `codex timeout after 300000ms`. Two independent defects.

## 1. Snapshot attributes the whole dirty tree to every worker (correctness)

`gitTracker.takeSnapshot()` recorded **only HEAD** (`git rev-parse HEAD`), so `getChangedFilesSinceSnapshot()` computed `diff HEAD..HEAD` (empty) + the entire current unstaged/staged/untracked set = **the repo's whole pre-existing dirty tree**, blamed on every worker regardless of what it edited. This pollutes `filesChanged` and the "promote to success" signal for **all** workers (daemon pipeline, `review --max --fix`, `fix`).

**Fix:** capture the current worktree as a git **tree object** via a throwaway `GIT_INDEX_FILE` + `git add -A` + `write-tree` (no real index/worktree mutation). Detection builds the current tree the same way and diffs `snapshotTree..currentTree`, so only changes made **after** the snapshot are reported. Untracked included, gitignored excluded, and a worker edit to an already-dirty file is still detected (content-based, no false negative).

## 2. `openswarm fix` workers had no timeout override

Fix workers ran under the **5-min adapter default** (`base.ts` hard SIGKILL) because the `fix` command never passed `timeoutMs` — unlike `review --max --fix` (900_000). On real areas codex routinely exceeds 5 min → killed.

**Fix:** default the fix worker timeout to **900_000 (15 min)** and add a `--timeout <ms>` flag validated by `parsePositiveIntegerOption` (rejects NaN/≤0, which would otherwise pass through and *disable* the timeout entirely).

## Verification

- New tests: snapshot excludes pre-existing dirt + still catches a worker edit to an already-dirty tracked file; fix worker defaults to 900k and honors `--timeout`.
- Runtime smoke (compiled): on a dirty scratch repo, `getChangedFilesSinceSnapshot` returns only the worker's edit; `--timeout abc` is rejected.
- `npm run ci` clean; full `vitest` green (1549, +4); `openswarm review` self-gate → APPROVE.

## Out of scope (noted)

`deriveFixAreas` still fans into vendored/`trash`/`archive` dirs (the 43-area blowup) — deliberately left for a separate change per scoping.

INT-2447