### PR TITLE
Add adaptive worker fan-out

### DIFF
--- a/benchmarks/codexSparkRealWork.ts
+++ b/benchmarks/codexSparkRealWork.ts
@@ -1,0 +1,431 @@
+#!/usr/bin/env tsx
+// ============================================
+// OpenSwarm - Codex Spark Real-Work Benchmark
+// ============================================
+//
+// Runs codex-responses models against isolated copies of this repository with
+// real OpenSwarm regressions injected. The grader is the focused test suite, not
+// a string heuristic, so this measures whether the worker can read, patch, and
+// verify real harness code.
+//
+// Usage:
+//   npx tsx benchmarks/codexSparkRealWork.ts --condition spark-low --condition spark-medium
+//   npx tsx benchmarks/codexSparkRealWork.ts --task spark-sse --repeat 2 --keep
+
+import { cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { execFile } from 'node:child_process';
+import { dirname, join, relative } from 'node:path';
+import { tmpdir } from 'node:os';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { runWorker } from '../src/agents/worker.js';
+import { initLocale } from '../src/locale/index.js';
+import { loadEnvFile } from '../src/core/envFile.js';
+import type { WorkerResult } from '../src/agents/agentPair.js';
+
+const exec = promisify(execFile);
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const RESULTS_DIR = join(ROOT, 'benchmarks', 'results');
+
+interface BenchTask {
+  id: string;
+  title: string;
+  description: string;
+  inject: (repoDir: string) => Promise<void>;
+  verify: (repoDir: string) => Promise<{ passed: boolean; reason: string; commands: string[] }>;
+}
+
+interface Condition {
+  id: string;
+  model: string;
+  reasoningEffort?: 'low' | 'medium' | 'high';
+  nudgeMaxOnNoEdit: number;
+  maxTurns: number;
+}
+
+interface RunResult {
+  conditionId: string;
+  model: string;
+  reasoningEffort?: 'low' | 'medium' | 'high';
+  nudgeMaxOnNoEdit: number;
+  taskId: string;
+  rep: number;
+  passed: boolean;
+  reason: string;
+  workerSuccess: boolean;
+  workerSummary: string;
+  filesChanged: string[];
+  toolCalls: number;
+  editCalls: number;
+  apiCalls: number;
+  totalTokens: number;
+  cachedTokens: number;
+  durationMs: number;
+  verifyCommands: string[];
+  tmpDir?: string;
+}
+
+const CONDITIONS: Condition[] = [
+  {
+    id: 'spark-low',
+    model: 'gpt-5.3-codex-spark',
+    reasoningEffort: 'low',
+    nudgeMaxOnNoEdit: 3,
+    maxTurns: 18,
+  },
+  {
+    id: 'spark-medium',
+    model: 'gpt-5.3-codex-spark',
+    reasoningEffort: 'medium',
+    nudgeMaxOnNoEdit: 3,
+    maxTurns: 18,
+  },
+  {
+    id: 'mini-low',
+    model: 'gpt-5.4-mini',
+    reasoningEffort: 'low',
+    nudgeMaxOnNoEdit: 3,
+    maxTurns: 18,
+  },
+  {
+    id: 'top-low',
+    model: 'gpt-5.5',
+    reasoningEffort: 'low',
+    nudgeMaxOnNoEdit: 3,
+    maxTurns: 18,
+  },
+];
+
+const TASKS: BenchTask[] = [
+  {
+    id: 'fallback-persistence',
+    title: 'Fix Codex Responses unsupported-model fallback persistence',
+    description:
+      'The focused codexResponses test suite is failing because unsupported-model fallback only changes the current request body. ' +
+      'Fix the CodexResponsesAdapter so the effective fallback model persists across later tool-loop API turns. ' +
+      'Read src/adapters/codexResponses.ts and src/adapters/codexResponses.test.ts, make the minimal code change, then run ' +
+      '`npm test -- src/adapters/codexResponses.test.ts` and `npm run typecheck`.',
+    inject: async (repoDir) => {
+      const p = join(repoDir, 'src', 'adapters', 'codexResponses.ts');
+      const text = await readFile(p, 'utf8');
+      const broken = text.replace(/\n\s+effectiveModel = alt;\n\s+body\.model = alt;/, '\n              body.model = alt;');
+      if (broken === text) throw new Error('fallback-persistence injection failed');
+      await writeFile(p, broken, 'utf8');
+    },
+    verify: (repoDir) => verifyFocused(repoDir),
+  },
+  {
+    id: 'spark-sse',
+    title: 'Restore Spark Responses function-call SSE support',
+    description:
+      'The focused codexResponses tests are failing because Spark-shaped Responses function-call events are no longer reduced correctly. ' +
+      'Restore support for function-call details arriving via response.output_item.done and argument done events. ' +
+      'Read src/adapters/codexResponses.ts and src/adapters/codexResponses.test.ts, make the minimal fix, then run ' +
+      '`npm test -- src/adapters/codexResponses.test.ts` and `npm run typecheck`.',
+    inject: async (repoDir) => {
+      const p = join(repoDir, 'src', 'adapters', 'codexResponses.ts');
+      const text = await readFile(p, 'utf8');
+      const broken = text
+        .replace("      case 'response.output_item.added':\n      case 'response.output_item.done':", "      case 'response.output_item.added':")
+        .replace('        const c = ev.item_id ? calls.get(ev.item_id) : getOnlyCall();\n        if (c && typeof ev.arguments === \'string\') c.args = ev.arguments;', '        const c = ev.item_id ? calls.get(ev.item_id) : undefined;\n        if (c && typeof ev.arguments === \'string\') c.args = ev.arguments;');
+      if (broken === text) throw new Error('spark-sse injection failed');
+      await writeFile(p, broken, 'utf8');
+    },
+    verify: (repoDir) => verifyFocused(repoDir),
+  },
+  {
+    id: 'tool-strict-false',
+    title: 'Restore strict:false on Codex Responses tools',
+    description:
+      'The focused codexResponses tests and typecheck are failing because the Responses tool transform no longer marks OpenSwarm tools as strict:false. ' +
+      'Restore the flat Responses tool shape expected by the tests while keeping the permissive OpenSwarm schemas. ' +
+      'Read src/adapters/codexResponses.ts and src/adapters/codexResponses.test.ts, make the minimal fix, then run ' +
+      '`npm test -- src/adapters/codexResponses.test.ts` and `npm run typecheck`.',
+    inject: async (repoDir) => {
+      const p = join(repoDir, 'src', 'adapters', 'codexResponses.ts');
+      const text = await readFile(p, 'utf8');
+      const broken = text.replace(/\n\s+\/\/ OpenSwarm tools use permissive JSON schemas\.[\s\S]*?\n\s+strict: false,/, '');
+      if (broken === text) throw new Error('tool-strict-false injection failed');
+      await writeFile(p, broken, 'utf8');
+    },
+    verify: (repoDir) => verifyFocused(repoDir),
+  },
+];
+
+function parseArgs(argv: string[]) {
+  const conditionIds: string[] = [];
+  const taskIds: string[] = [];
+  let repeat = 1;
+  let timeoutMs = 240_000;
+  let keep = false;
+  let out = '';
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--condition') conditionIds.push(argv[++i]);
+    else if (arg === '--task') taskIds.push(argv[++i]);
+    else if (arg === '--repeat') repeat = Number(argv[++i]);
+    else if (arg === '--timeout-ms') timeoutMs = Number(argv[++i]);
+    else if (arg === '--keep') keep = true;
+    else if (arg === '--out') out = argv[++i];
+    else if (arg === '--help' || arg === '-h') {
+      printUsage();
+      process.exit(0);
+    }
+  }
+
+  const conditions = conditionIds.length
+    ? conditionIds.map((id) => {
+        const found = CONDITIONS.find((c) => c.id === id);
+        if (!found) throw new Error(`unknown condition: ${id}`);
+        return found;
+      })
+    : CONDITIONS.filter((c) => ['spark-low', 'spark-medium', 'mini-low'].includes(c.id));
+
+  const tasks = taskIds.length
+    ? taskIds.map((id) => {
+        const found = TASKS.find((t) => t.id === id);
+        if (!found) throw new Error(`unknown task: ${id}`);
+        return found;
+      })
+    : TASKS;
+
+  return { conditions, tasks, repeat, timeoutMs, keep, out };
+}
+
+function printUsage(): void {
+  console.log([
+    'Usage: npx tsx benchmarks/codexSparkRealWork.ts [options]',
+    '',
+    'Options:',
+    '  --condition <id>   Repeatable. spark-low, spark-medium, mini-low, top-low',
+    '  --task <id>        Repeatable. fallback-persistence, spark-sse, tool-strict-false',
+    '  --repeat <n>       Repetitions per condition/task (default 1)',
+    '  --timeout-ms <n>   Worker timeout per run (default 240000)',
+    '  --keep             Keep temp repos for inspection',
+    '  --out <file>       Write JSON result path',
+  ].join('\n'));
+}
+
+async function verifyFocused(repoDir: string): Promise<{ passed: boolean; reason: string; commands: string[] }> {
+  const commands = ['npm test -- src/adapters/codexResponses.test.ts', 'npm run typecheck'];
+  const test = await runCommand(repoDir, 'npm', ['test', '--', 'src/adapters/codexResponses.test.ts'], 120_000);
+  if (!test.ok) return { passed: false, reason: `focused test failed: ${test.output.slice(0, 240)}`, commands };
+
+  const typecheck = await runCommand(repoDir, 'npm', ['run', 'typecheck'], 120_000);
+  if (!typecheck.ok) return { passed: false, reason: `typecheck failed: ${typecheck.output.slice(0, 240)}`, commands };
+
+  return { passed: true, reason: 'focused test + typecheck passed', commands };
+}
+
+async function runCommand(
+  cwd: string,
+  command: string,
+  args: string[],
+  timeoutMs: number,
+): Promise<{ ok: boolean; output: string }> {
+  try {
+    const out = await exec(command, args, {
+      cwd,
+      timeout: timeoutMs,
+      encoding: 'utf8',
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return { ok: true, output: `${out.stdout}${out.stderr}` };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; message?: string };
+    return { ok: false, output: `${e.stdout ?? ''}${e.stderr ?? ''}${e.message ?? ''}` };
+  }
+}
+
+async function setupRepo(task: BenchTask): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'osw-spark-real-'));
+
+  for (const name of ['package.json', 'package-lock.json', 'tsconfig.json', 'vitest.config.ts', 'vitest.setup.ts']) {
+    await cp(join(ROOT, name), join(dir, name));
+  }
+  await cp(join(ROOT, 'src'), join(dir, 'src'), { recursive: true });
+
+  const rootNodeModules = join(ROOT, 'node_modules');
+  if (existsSync(rootNodeModules)) {
+    await symlink(rootNodeModules, join(dir, 'node_modules'), 'dir');
+  }
+
+  await task.inject(dir);
+  await exec('git', ['init', '-q'], { cwd: dir });
+  await exec('git', ['config', 'user.email', 'bench@local'], { cwd: dir });
+  await exec('git', ['config', 'user.name', 'bench'], { cwd: dir });
+  await exec('git', ['add', '-A'], { cwd: dir });
+  await exec('git', ['commit', '-qm', `bench fixture ${task.id}`], { cwd: dir });
+
+  return dir;
+}
+
+async function runOne(
+  condition: Condition,
+  task: BenchTask,
+  rep: number,
+  timeoutMs: number,
+  keep: boolean,
+): Promise<RunResult> {
+  const dir = await setupRepo(task);
+  const logs: string[] = [];
+  const started = Date.now();
+  let worker: WorkerResult | undefined;
+  let workerError = '';
+
+  try {
+    worker = await runWorker({
+      taskTitle: task.title,
+      taskDescription: task.description,
+      projectPath: dir,
+      adapterName: 'codex-responses',
+      model: condition.model,
+      reasoningEffort: condition.reasoningEffort,
+      timeoutMs,
+      maxTurns: condition.maxTurns,
+      nudgeMaxOnNoEdit: condition.nudgeMaxOnNoEdit,
+      webTools: false,
+      memoryTools: false,
+      suppressStatusLogs: true,
+      onLog: (line) => logs.push(line),
+    });
+  } catch (err) {
+    workerError = err instanceof Error ? err.message : String(err);
+    logs.push(`FATAL: ${workerError}`);
+  }
+
+  const verify = await task.verify(dir);
+  const durationMs = Date.now() - started;
+  const filesChanged = await changedFiles(dir);
+
+  const result: RunResult = {
+    conditionId: condition.id,
+    model: condition.model,
+    reasoningEffort: condition.reasoningEffort,
+    nudgeMaxOnNoEdit: condition.nudgeMaxOnNoEdit,
+    taskId: task.id,
+    rep,
+    passed: verify.passed,
+    reason: verify.passed ? verify.reason : `${verify.reason}${workerError ? `; worker error: ${workerError}` : ''}`,
+    workerSuccess: Boolean(worker?.success),
+    workerSummary: worker?.summary ?? workerError,
+    filesChanged,
+    toolCalls: logs.filter((line) => line.includes('🔧')).length,
+    editCalls: logs.filter((line) => line.includes('🔧') && /edit_file|write_file|apply_patch/.test(line)).length,
+    apiCalls: logs.filter((line) => line.includes('API call #')).length,
+    totalTokens: parseLastTokenMetric(logs, /(\d+) tokens/),
+    cachedTokens: parseLastTokenMetric(logs, /\((\d+) cached/),
+    durationMs,
+    verifyCommands: verify.commands,
+    tmpDir: keep ? dir : undefined,
+  };
+
+  if (!keep) await rm(dir, { recursive: true, force: true });
+  return result;
+}
+
+async function changedFiles(repoDir: string): Promise<string[]> {
+  const out = await runCommand(repoDir, 'git', ['diff', '--name-only', 'HEAD'], 30_000);
+  return out.output.split('\n').map((line) => line.trim()).filter(Boolean);
+}
+
+function parseLastTokenMetric(logs: string[], pattern: RegExp): number {
+  for (const line of [...logs].reverse()) {
+    const match = line.match(pattern);
+    if (match) return Number(match[1]);
+  }
+  return 0;
+}
+
+function summarize(results: RunResult[]): string {
+  const byCondition = new Map<string, RunResult[]>();
+  for (const result of results) {
+    const items = byCondition.get(result.conditionId) ?? [];
+    items.push(result);
+    byCondition.set(result.conditionId, items);
+  }
+
+  const lines: string[] = [];
+  lines.push('\n========== CODEX SPARK REAL-WORK BENCH ==========');
+  lines.push('condition           pass   avg api  avg tools  avg edits  avg tok  avg cached  avg sec');
+  for (const [condition, rows] of byCondition) {
+    const pass = rows.filter((r) => r.passed).length;
+    const avg = (f: (r: RunResult) => number) => rows.reduce((sum, row) => sum + f(row), 0) / rows.length;
+    lines.push(
+      `${condition.padEnd(18)} ` +
+      `${`${pass}/${rows.length}`.padStart(5)} ` +
+      `${avg((r) => r.apiCalls).toFixed(1).padStart(7)} ` +
+      `${avg((r) => r.toolCalls).toFixed(1).padStart(10)} ` +
+      `${avg((r) => r.editCalls).toFixed(1).padStart(9)} ` +
+      `${Math.round(avg((r) => r.totalTokens)).toString().padStart(8)} ` +
+      `${Math.round(avg((r) => r.cachedTokens)).toString().padStart(11)} ` +
+      `${(avg((r) => r.durationMs) / 1000).toFixed(1).padStart(7)}`,
+    );
+  }
+
+  lines.push('\nRuns:');
+  for (const result of results) {
+    const mark = result.passed ? '✅' : '❌';
+    lines.push(
+      `${mark} ${result.conditionId.padEnd(13)} ${result.taskId.padEnd(22)} rep${result.rep} ` +
+      `${result.apiCalls}api ${result.toolCalls}tools ${result.editCalls}edits ` +
+      `${result.totalTokens}tok ${(result.durationMs / 1000).toFixed(1)}s - ${result.reason}`,
+    );
+  }
+  return lines.join('\n');
+}
+
+async function main(): Promise<void> {
+  loadEnvFile();
+  initLocale('en');
+
+  const { conditions, tasks, repeat, timeoutMs, keep, out } = parseArgs(process.argv.slice(2));
+  console.log(`[spark-bench] conditions=${conditions.map((c) => c.id).join(',')} tasks=${tasks.map((t) => t.id).join(',')} repeat=${repeat}`);
+  console.log(`[spark-bench] total runs=${conditions.length * tasks.length * repeat}`);
+
+  const results: RunResult[] = [];
+  for (const condition of conditions) {
+    for (const task of tasks) {
+      for (let rep = 1; rep <= repeat; rep += 1) {
+        const result = await runOne(condition, task, rep, timeoutMs, keep);
+        results.push(result);
+        const mark = result.passed ? '✅' : '❌';
+        console.log(
+          `${mark} ${condition.id} ${task.id} rep${rep}: ` +
+          `${result.apiCalls}api ${result.toolCalls}tools ${result.editCalls}edits ` +
+          `${result.totalTokens}tok ${(result.durationMs / 1000).toFixed(1)}s - ${result.reason}`,
+        );
+      }
+    }
+  }
+
+  const report = summarize(results);
+  console.log(report);
+
+  await mkdir(RESULTS_DIR, { recursive: true });
+  const stamp = new Date().toISOString().replaceAll(':', '-').replace(/\.\d+Z$/, 'Z');
+  const outPath = out ? join(ROOT, out) : join(RESULTS_DIR, `codexSparkRealWork-${stamp}.json`);
+  await mkdir(dirname(outPath), { recursive: true });
+  const payload = {
+    createdAt: new Date().toISOString(),
+    repo: '.',
+    conditions,
+    tasks: tasks.map((task) => ({ id: task.id, title: task.title })),
+    results,
+    report,
+  };
+  await writeFile(outPath, JSON.stringify(payload, null, 2), 'utf8');
+  await writeFile(join(RESULTS_DIR, 'codexSparkRealWork-latest.json'), JSON.stringify(payload, null, 2), 'utf8');
+  console.log(`\n[spark-bench] raw results -> ${relative(ROOT, outPath)}`);
+  console.log(`[spark-bench] latest -> ${relative(ROOT, join(RESULTS_DIR, 'codexSparkRealWork-latest.json'))}`);
+
+  if (results.some((r) => !r.passed)) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error('FATAL:', err instanceof Error ? err.stack || err.message : String(err));
+  process.exit(1);
+});

--- a/benchmarks/results/codexSparkRealWork-2026-07-04T13-27-55Z.json
+++ b/benchmarks/results/codexSparkRealWork-2026-07-04T13-27-55Z.json
@@ -1,0 +1,269 @@
+{
+  "createdAt": "2026-07-04T13:27:55.071Z",
+  "repo": ".",
+  "conditions": [
+    {
+      "id": "spark-low",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "maxTurns": 18
+    },
+    {
+      "id": "spark-medium",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "medium",
+      "nudgeMaxOnNoEdit": 3,
+      "maxTurns": 18
+    },
+    {
+      "id": "mini-low",
+      "model": "gpt-5.4-mini",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "maxTurns": 18
+    }
+  ],
+  "tasks": [
+    {
+      "id": "fallback-persistence",
+      "title": "Fix Codex Responses unsupported-model fallback persistence"
+    },
+    {
+      "id": "spark-sse",
+      "title": "Restore Spark Responses function-call SSE support"
+    },
+    {
+      "id": "tool-strict-false",
+      "title": "Restore strict:false on Codex Responses tools"
+    }
+  ],
+  "results": [
+    {
+      "conditionId": "spark-low",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "fallback-persistence",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "Done. I made the minimal fix and verified it.",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 16,
+      "editCalls": 1,
+      "apiCalls": 14,
+      "totalTokens": 83295,
+      "cachedTokens": 28672,
+      "durationMs": 42614,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "spark-low",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "spark-sse",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "Implemented and verified the fix for function-call reduction in `reduceResponsesEvents`.",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 19,
+      "editCalls": 2,
+      "apiCalls": 19,
+      "totalTokens": 128058,
+      "cachedTokens": 40832,
+      "durationMs": 44346,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "spark-low",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "tool-strict-false",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "Files modified:",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 11,
+      "editCalls": 1,
+      "apiCalls": 11,
+      "totalTokens": 51059,
+      "cachedTokens": 17792,
+      "durationMs": 34498,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "spark-medium",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "medium",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "fallback-persistence",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "Modified files:",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 16,
+      "editCalls": 3,
+      "apiCalls": 17,
+      "totalTokens": 84776,
+      "cachedTokens": 32256,
+      "durationMs": 38667,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "spark-medium",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "medium",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "spark-sse",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "- `src/adapters/codexResponses.ts`",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 17,
+      "editCalls": 2,
+      "apiCalls": 17,
+      "totalTokens": 121153,
+      "cachedTokens": 33664,
+      "durationMs": 36167,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "spark-medium",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "medium",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "tool-strict-false",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "- `src/adapters/codexResponses.ts` (added `strict: false` in `toolsToResponsesTools` output object)",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 12,
+      "editCalls": 1,
+      "apiCalls": 13,
+      "totalTokens": 61708,
+      "cachedTokens": 20864,
+      "durationMs": 39164,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "mini-low",
+      "model": "gpt-5.4-mini",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "fallback-persistence",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "Modified files:",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 12,
+      "editCalls": 1,
+      "apiCalls": 8,
+      "totalTokens": 42868,
+      "cachedTokens": 11264,
+      "durationMs": 33720,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "mini-low",
+      "model": "gpt-5.4-mini",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "spark-sse",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "Modified files:",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 13,
+      "editCalls": 1,
+      "apiCalls": 7,
+      "totalTokens": 43347,
+      "cachedTokens": 4608,
+      "durationMs": 35228,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "mini-low",
+      "model": "gpt-5.4-mini",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "tool-strict-false",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "Modified files:",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 10,
+      "editCalls": 1,
+      "apiCalls": 6,
+      "totalTokens": 26794,
+      "cachedTokens": 3584,
+      "durationMs": 42101,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    }
+  ],
+  "report": "\n========== CODEX SPARK REAL-WORK BENCH ==========\ncondition           pass   avg api  avg tools  avg edits  avg tok  avg cached  avg sec\nspark-low            3/3    14.7       15.3       1.3    87471       29099    40.5\nspark-medium         3/3    15.7       15.0       2.0    89212       28928    38.0\nmini-low             3/3     7.0       11.7       1.0    37670        6485    37.0\n\nRuns:\n✅ spark-low     fallback-persistence   rep1 14api 16tools 1edits 83295tok 42.6s - focused test + typecheck passed\n✅ spark-low     spark-sse              rep1 19api 19tools 2edits 128058tok 44.3s - focused test + typecheck passed\n✅ spark-low     tool-strict-false      rep1 11api 11tools 1edits 51059tok 34.5s - focused test + typecheck passed\n✅ spark-medium  fallback-persistence   rep1 17api 16tools 3edits 84776tok 38.7s - focused test + typecheck passed\n✅ spark-medium  spark-sse              rep1 17api 17tools 2edits 121153tok 36.2s - focused test + typecheck passed\n✅ spark-medium  tool-strict-false      rep1 13api 12tools 1edits 61708tok 39.2s - focused test + typecheck passed\n✅ mini-low      fallback-persistence   rep1 8api 12tools 1edits 42868tok 33.7s - focused test + typecheck passed\n✅ mini-low      spark-sse              rep1 7api 13tools 1edits 43347tok 35.2s - focused test + typecheck passed\n✅ mini-low      tool-strict-false      rep1 6api 10tools 1edits 26794tok 42.1s - focused test + typecheck passed"
+}

--- a/benchmarks/results/codexSparkRealWork-latest.json
+++ b/benchmarks/results/codexSparkRealWork-latest.json
@@ -1,0 +1,269 @@
+{
+  "createdAt": "2026-07-04T13:27:55.071Z",
+  "repo": ".",
+  "conditions": [
+    {
+      "id": "spark-low",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "maxTurns": 18
+    },
+    {
+      "id": "spark-medium",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "medium",
+      "nudgeMaxOnNoEdit": 3,
+      "maxTurns": 18
+    },
+    {
+      "id": "mini-low",
+      "model": "gpt-5.4-mini",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "maxTurns": 18
+    }
+  ],
+  "tasks": [
+    {
+      "id": "fallback-persistence",
+      "title": "Fix Codex Responses unsupported-model fallback persistence"
+    },
+    {
+      "id": "spark-sse",
+      "title": "Restore Spark Responses function-call SSE support"
+    },
+    {
+      "id": "tool-strict-false",
+      "title": "Restore strict:false on Codex Responses tools"
+    }
+  ],
+  "results": [
+    {
+      "conditionId": "spark-low",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "fallback-persistence",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "Done. I made the minimal fix and verified it.",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 16,
+      "editCalls": 1,
+      "apiCalls": 14,
+      "totalTokens": 83295,
+      "cachedTokens": 28672,
+      "durationMs": 42614,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "spark-low",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "spark-sse",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "Implemented and verified the fix for function-call reduction in `reduceResponsesEvents`.",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 19,
+      "editCalls": 2,
+      "apiCalls": 19,
+      "totalTokens": 128058,
+      "cachedTokens": 40832,
+      "durationMs": 44346,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "spark-low",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "tool-strict-false",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "Files modified:",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 11,
+      "editCalls": 1,
+      "apiCalls": 11,
+      "totalTokens": 51059,
+      "cachedTokens": 17792,
+      "durationMs": 34498,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "spark-medium",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "medium",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "fallback-persistence",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "Modified files:",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 16,
+      "editCalls": 3,
+      "apiCalls": 17,
+      "totalTokens": 84776,
+      "cachedTokens": 32256,
+      "durationMs": 38667,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "spark-medium",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "medium",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "spark-sse",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "- `src/adapters/codexResponses.ts`",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 17,
+      "editCalls": 2,
+      "apiCalls": 17,
+      "totalTokens": 121153,
+      "cachedTokens": 33664,
+      "durationMs": 36167,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "spark-medium",
+      "model": "gpt-5.3-codex-spark",
+      "reasoningEffort": "medium",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "tool-strict-false",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "- `src/adapters/codexResponses.ts` (added `strict: false` in `toolsToResponsesTools` output object)",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 12,
+      "editCalls": 1,
+      "apiCalls": 13,
+      "totalTokens": 61708,
+      "cachedTokens": 20864,
+      "durationMs": 39164,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "mini-low",
+      "model": "gpt-5.4-mini",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "fallback-persistence",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "Modified files:",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 12,
+      "editCalls": 1,
+      "apiCalls": 8,
+      "totalTokens": 42868,
+      "cachedTokens": 11264,
+      "durationMs": 33720,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "mini-low",
+      "model": "gpt-5.4-mini",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "spark-sse",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "Modified files:",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 13,
+      "editCalls": 1,
+      "apiCalls": 7,
+      "totalTokens": 43347,
+      "cachedTokens": 4608,
+      "durationMs": 35228,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    },
+    {
+      "conditionId": "mini-low",
+      "model": "gpt-5.4-mini",
+      "reasoningEffort": "low",
+      "nudgeMaxOnNoEdit": 3,
+      "taskId": "tool-strict-false",
+      "rep": 1,
+      "passed": true,
+      "reason": "focused test + typecheck passed",
+      "workerSuccess": true,
+      "workerSummary": "Modified files:",
+      "filesChanged": [
+        "src/adapters/codexResponses.ts"
+      ],
+      "toolCalls": 10,
+      "editCalls": 1,
+      "apiCalls": 6,
+      "totalTokens": 26794,
+      "cachedTokens": 3584,
+      "durationMs": 42101,
+      "verifyCommands": [
+        "npm test -- src/adapters/codexResponses.test.ts",
+        "npm run typecheck"
+      ]
+    }
+  ],
+  "report": "\n========== CODEX SPARK REAL-WORK BENCH ==========\ncondition           pass   avg api  avg tools  avg edits  avg tok  avg cached  avg sec\nspark-low            3/3    14.7       15.3       1.3    87471       29099    40.5\nspark-medium         3/3    15.7       15.0       2.0    89212       28928    38.0\nmini-low             3/3     7.0       11.7       1.0    37670        6485    37.0\n\nRuns:\n✅ spark-low     fallback-persistence   rep1 14api 16tools 1edits 83295tok 42.6s - focused test + typecheck passed\n✅ spark-low     spark-sse              rep1 19api 19tools 2edits 128058tok 44.3s - focused test + typecheck passed\n✅ spark-low     tool-strict-false      rep1 11api 11tools 1edits 51059tok 34.5s - focused test + typecheck passed\n✅ spark-medium  fallback-persistence   rep1 17api 16tools 3edits 84776tok 38.7s - focused test + typecheck passed\n✅ spark-medium  spark-sse              rep1 17api 17tools 2edits 121153tok 36.2s - focused test + typecheck passed\n✅ spark-medium  tool-strict-false      rep1 13api 12tools 1edits 61708tok 39.2s - focused test + typecheck passed\n✅ mini-low      fallback-persistence   rep1 8api 12tools 1edits 42868tok 33.7s - focused test + typecheck passed\n✅ mini-low      spark-sse              rep1 7api 13tools 1edits 43347tok 35.2s - focused test + typecheck passed\n✅ mini-low      tool-strict-false      rep1 6api 10tools 1edits 26794tok 42.1s - focused test + typecheck passed"
+}

--- a/benchmarks/results/workerFanoutGate-2026-07-04T13-59-01Z.json
+++ b/benchmarks/results/workerFanoutGate-2026-07-04T13-59-01Z.json
@@ -1,0 +1,420 @@
+{
+  "createdAt": "2026-07-04T13:59:01.145Z",
+  "cases": [
+    {
+      "id": "small-doc",
+      "expected": "single",
+      "title": "Update README wording"
+    },
+    {
+      "id": "small-leaf-bug",
+      "expected": "single",
+      "title": "Fix typo in locale formatter"
+    },
+    {
+      "id": "broad-ui",
+      "expected": "single",
+      "title": "Polish dashboard empty states"
+    },
+    {
+      "id": "pipeline-core",
+      "expected": "fanout",
+      "title": "Add adaptive fan-out gate to PairPipeline"
+    },
+    {
+      "id": "worktree-core",
+      "expected": "fanout",
+      "title": "Harden worktree cleanup and PR publishing"
+    },
+    {
+      "id": "insufficient-draft-large",
+      "expected": "fanout",
+      "title": "Implement provider routing fallback"
+    },
+    {
+      "id": "review-retry",
+      "expected": "fanout",
+      "title": "Revise reviewer-requested worker fix"
+    },
+    {
+      "id": "objective-retry",
+      "expected": "fanout",
+      "title": "Fix test failure from previous worker attempt"
+    },
+    {
+      "id": "high-effort-small",
+      "expected": "single",
+      "title": "Check a tricky but tiny config parser edge case"
+    },
+    {
+      "id": "urgent-nontrivial",
+      "expected": "fanout",
+      "title": "Urgently fix scheduler stuck loop"
+    }
+  ],
+  "byThreshold": [
+    {
+      "threshold": 1,
+      "pass": 8,
+      "total": 10,
+      "fanoutCount": 8,
+      "rows": [
+        {
+          "id": "small-doc",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 0,
+          "threshold": 1,
+          "signals": []
+        },
+        {
+          "id": "small-leaf-bug",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 0,
+          "threshold": 1,
+          "signals": []
+        },
+        {
+          "id": "broad-ui",
+          "expected": "single",
+          "actual": "fanout",
+          "passed": false,
+          "score": 1,
+          "threshold": 1,
+          "signals": [
+            "broad-file-scope"
+          ]
+        },
+        {
+          "id": "pipeline-core",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 2,
+          "threshold": 1,
+          "signals": [
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "worktree-core",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 2,
+          "threshold": 1,
+          "signals": [
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "insufficient-draft-large",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 1,
+          "signals": [
+            "insufficient-draft",
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "review-retry",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 1,
+          "signals": [
+            "review-retry",
+            "core-orchestration-scope"
+          ]
+        },
+        {
+          "id": "objective-retry",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 1,
+          "signals": [
+            "objective-retry",
+            "core-orchestration-scope"
+          ]
+        },
+        {
+          "id": "high-effort-small",
+          "expected": "single",
+          "actual": "fanout",
+          "passed": false,
+          "score": 1,
+          "threshold": 1,
+          "signals": [
+            "high-effort-profile"
+          ]
+        },
+        {
+          "id": "urgent-nontrivial",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 2,
+          "threshold": 1,
+          "signals": [
+            "core-orchestration-scope",
+            "urgent-nontrivial"
+          ]
+        }
+      ]
+    },
+    {
+      "threshold": 2,
+      "pass": 10,
+      "total": 10,
+      "fanoutCount": 6,
+      "rows": [
+        {
+          "id": "small-doc",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 0,
+          "threshold": 2,
+          "signals": []
+        },
+        {
+          "id": "small-leaf-bug",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 0,
+          "threshold": 2,
+          "signals": []
+        },
+        {
+          "id": "broad-ui",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 1,
+          "threshold": 2,
+          "signals": [
+            "broad-file-scope"
+          ]
+        },
+        {
+          "id": "pipeline-core",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 2,
+          "threshold": 2,
+          "signals": [
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "worktree-core",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 2,
+          "threshold": 2,
+          "signals": [
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "insufficient-draft-large",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 2,
+          "signals": [
+            "insufficient-draft",
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "review-retry",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 2,
+          "signals": [
+            "review-retry",
+            "core-orchestration-scope"
+          ]
+        },
+        {
+          "id": "objective-retry",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 2,
+          "signals": [
+            "objective-retry",
+            "core-orchestration-scope"
+          ]
+        },
+        {
+          "id": "high-effort-small",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 1,
+          "threshold": 2,
+          "signals": [
+            "high-effort-profile"
+          ]
+        },
+        {
+          "id": "urgent-nontrivial",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 2,
+          "threshold": 2,
+          "signals": [
+            "core-orchestration-scope",
+            "urgent-nontrivial"
+          ]
+        }
+      ]
+    },
+    {
+      "threshold": 3,
+      "pass": 7,
+      "total": 10,
+      "fanoutCount": 3,
+      "rows": [
+        {
+          "id": "small-doc",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 0,
+          "threshold": 3,
+          "signals": []
+        },
+        {
+          "id": "small-leaf-bug",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 0,
+          "threshold": 3,
+          "signals": []
+        },
+        {
+          "id": "broad-ui",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 1,
+          "threshold": 3,
+          "signals": [
+            "broad-file-scope"
+          ]
+        },
+        {
+          "id": "pipeline-core",
+          "expected": "fanout",
+          "actual": "single",
+          "passed": false,
+          "score": 2,
+          "threshold": 3,
+          "signals": [
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "worktree-core",
+          "expected": "fanout",
+          "actual": "single",
+          "passed": false,
+          "score": 2,
+          "threshold": 3,
+          "signals": [
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "insufficient-draft-large",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 3,
+          "signals": [
+            "insufficient-draft",
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "review-retry",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 3,
+          "signals": [
+            "review-retry",
+            "core-orchestration-scope"
+          ]
+        },
+        {
+          "id": "objective-retry",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 3,
+          "signals": [
+            "objective-retry",
+            "core-orchestration-scope"
+          ]
+        },
+        {
+          "id": "high-effort-small",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 1,
+          "threshold": 3,
+          "signals": [
+            "high-effort-profile"
+          ]
+        },
+        {
+          "id": "urgent-nontrivial",
+          "expected": "fanout",
+          "actual": "single",
+          "passed": false,
+          "score": 2,
+          "threshold": 3,
+          "signals": [
+            "core-orchestration-scope",
+            "urgent-nontrivial"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/benchmarks/results/workerFanoutGate-2026-07-04T14-32-40Z.json
+++ b/benchmarks/results/workerFanoutGate-2026-07-04T14-32-40Z.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-04T13:59:01.145Z",
+  "createdAt": "2026-07-04T14:32:40.620Z",
   "cases": [
     {
       "id": "small-doc",

--- a/benchmarks/results/workerFanoutGate-latest.json
+++ b/benchmarks/results/workerFanoutGate-latest.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-04T13:59:01.145Z",
+  "createdAt": "2026-07-04T14:32:40.620Z",
   "cases": [
     {
       "id": "small-doc",

--- a/benchmarks/results/workerFanoutGate-latest.json
+++ b/benchmarks/results/workerFanoutGate-latest.json
@@ -1,0 +1,420 @@
+{
+  "createdAt": "2026-07-04T13:59:01.145Z",
+  "cases": [
+    {
+      "id": "small-doc",
+      "expected": "single",
+      "title": "Update README wording"
+    },
+    {
+      "id": "small-leaf-bug",
+      "expected": "single",
+      "title": "Fix typo in locale formatter"
+    },
+    {
+      "id": "broad-ui",
+      "expected": "single",
+      "title": "Polish dashboard empty states"
+    },
+    {
+      "id": "pipeline-core",
+      "expected": "fanout",
+      "title": "Add adaptive fan-out gate to PairPipeline"
+    },
+    {
+      "id": "worktree-core",
+      "expected": "fanout",
+      "title": "Harden worktree cleanup and PR publishing"
+    },
+    {
+      "id": "insufficient-draft-large",
+      "expected": "fanout",
+      "title": "Implement provider routing fallback"
+    },
+    {
+      "id": "review-retry",
+      "expected": "fanout",
+      "title": "Revise reviewer-requested worker fix"
+    },
+    {
+      "id": "objective-retry",
+      "expected": "fanout",
+      "title": "Fix test failure from previous worker attempt"
+    },
+    {
+      "id": "high-effort-small",
+      "expected": "single",
+      "title": "Check a tricky but tiny config parser edge case"
+    },
+    {
+      "id": "urgent-nontrivial",
+      "expected": "fanout",
+      "title": "Urgently fix scheduler stuck loop"
+    }
+  ],
+  "byThreshold": [
+    {
+      "threshold": 1,
+      "pass": 8,
+      "total": 10,
+      "fanoutCount": 8,
+      "rows": [
+        {
+          "id": "small-doc",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 0,
+          "threshold": 1,
+          "signals": []
+        },
+        {
+          "id": "small-leaf-bug",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 0,
+          "threshold": 1,
+          "signals": []
+        },
+        {
+          "id": "broad-ui",
+          "expected": "single",
+          "actual": "fanout",
+          "passed": false,
+          "score": 1,
+          "threshold": 1,
+          "signals": [
+            "broad-file-scope"
+          ]
+        },
+        {
+          "id": "pipeline-core",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 2,
+          "threshold": 1,
+          "signals": [
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "worktree-core",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 2,
+          "threshold": 1,
+          "signals": [
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "insufficient-draft-large",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 1,
+          "signals": [
+            "insufficient-draft",
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "review-retry",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 1,
+          "signals": [
+            "review-retry",
+            "core-orchestration-scope"
+          ]
+        },
+        {
+          "id": "objective-retry",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 1,
+          "signals": [
+            "objective-retry",
+            "core-orchestration-scope"
+          ]
+        },
+        {
+          "id": "high-effort-small",
+          "expected": "single",
+          "actual": "fanout",
+          "passed": false,
+          "score": 1,
+          "threshold": 1,
+          "signals": [
+            "high-effort-profile"
+          ]
+        },
+        {
+          "id": "urgent-nontrivial",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 2,
+          "threshold": 1,
+          "signals": [
+            "core-orchestration-scope",
+            "urgent-nontrivial"
+          ]
+        }
+      ]
+    },
+    {
+      "threshold": 2,
+      "pass": 10,
+      "total": 10,
+      "fanoutCount": 6,
+      "rows": [
+        {
+          "id": "small-doc",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 0,
+          "threshold": 2,
+          "signals": []
+        },
+        {
+          "id": "small-leaf-bug",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 0,
+          "threshold": 2,
+          "signals": []
+        },
+        {
+          "id": "broad-ui",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 1,
+          "threshold": 2,
+          "signals": [
+            "broad-file-scope"
+          ]
+        },
+        {
+          "id": "pipeline-core",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 2,
+          "threshold": 2,
+          "signals": [
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "worktree-core",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 2,
+          "threshold": 2,
+          "signals": [
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "insufficient-draft-large",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 2,
+          "signals": [
+            "insufficient-draft",
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "review-retry",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 2,
+          "signals": [
+            "review-retry",
+            "core-orchestration-scope"
+          ]
+        },
+        {
+          "id": "objective-retry",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 2,
+          "signals": [
+            "objective-retry",
+            "core-orchestration-scope"
+          ]
+        },
+        {
+          "id": "high-effort-small",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 1,
+          "threshold": 2,
+          "signals": [
+            "high-effort-profile"
+          ]
+        },
+        {
+          "id": "urgent-nontrivial",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 2,
+          "threshold": 2,
+          "signals": [
+            "core-orchestration-scope",
+            "urgent-nontrivial"
+          ]
+        }
+      ]
+    },
+    {
+      "threshold": 3,
+      "pass": 7,
+      "total": 10,
+      "fanoutCount": 3,
+      "rows": [
+        {
+          "id": "small-doc",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 0,
+          "threshold": 3,
+          "signals": []
+        },
+        {
+          "id": "small-leaf-bug",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 0,
+          "threshold": 3,
+          "signals": []
+        },
+        {
+          "id": "broad-ui",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 1,
+          "threshold": 3,
+          "signals": [
+            "broad-file-scope"
+          ]
+        },
+        {
+          "id": "pipeline-core",
+          "expected": "fanout",
+          "actual": "single",
+          "passed": false,
+          "score": 2,
+          "threshold": 3,
+          "signals": [
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "worktree-core",
+          "expected": "fanout",
+          "actual": "single",
+          "passed": false,
+          "score": 2,
+          "threshold": 3,
+          "signals": [
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "insufficient-draft-large",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 3,
+          "signals": [
+            "insufficient-draft",
+            "core-orchestration-scope",
+            "large-estimate"
+          ]
+        },
+        {
+          "id": "review-retry",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 3,
+          "signals": [
+            "review-retry",
+            "core-orchestration-scope"
+          ]
+        },
+        {
+          "id": "objective-retry",
+          "expected": "fanout",
+          "actual": "fanout",
+          "passed": true,
+          "score": 3,
+          "threshold": 3,
+          "signals": [
+            "objective-retry",
+            "core-orchestration-scope"
+          ]
+        },
+        {
+          "id": "high-effort-small",
+          "expected": "single",
+          "actual": "single",
+          "passed": true,
+          "score": 1,
+          "threshold": 3,
+          "signals": [
+            "high-effort-profile"
+          ]
+        },
+        {
+          "id": "urgent-nontrivial",
+          "expected": "fanout",
+          "actual": "single",
+          "passed": false,
+          "score": 2,
+          "threshold": 3,
+          "signals": [
+            "core-orchestration-scope",
+            "urgent-nontrivial"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/benchmarks/workerFanoutGate.ts
+++ b/benchmarks/workerFanoutGate.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env tsx
+// ============================================
+// OpenSwarm - Worker Fan-out Gate Benchmark
+// ============================================
+//
+// Deterministic calibration set for the adaptive worker fan-out gate. This does
+// not call models; it answers: "which representative tasks would fan-out execute
+// for at a given threshold?"
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { evaluateWorkerFanoutGate } from '../src/agents/workerFanoutGate.js';
+import type { TaskItem } from '../src/orchestration/decisionEngine.js';
+import type { PipelineConfig } from '../src/agents/pairPipeline.js';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const RESULTS_DIR = join(ROOT, 'benchmarks', 'results');
+
+interface GateCase {
+  id: string;
+  expected: 'single' | 'fanout';
+  task: TaskItem;
+  draftAnalysis?: PipelineConfig['draftAnalysis'];
+  iteration?: number;
+  feedbackSource?: 'objective' | 'review';
+  effort?: 'low' | 'medium' | 'high';
+}
+
+function task(id: string, title: string, overrides: Partial<TaskItem> = {}): TaskItem {
+  return {
+    id,
+    source: 'local',
+    title,
+    priority: 3,
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+const CASES: GateCase[] = [
+  {
+    id: 'small-doc',
+    expected: 'single',
+    task: task('small-doc', 'Update README wording', { estimatedMinutes: 5, fileScope: ['README.md'] }),
+  },
+  {
+    id: 'small-leaf-bug',
+    expected: 'single',
+    task: task('small-leaf-bug', 'Fix typo in locale formatter', { estimatedMinutes: 10, fileScope: ['src/locale/en.ts'] }),
+  },
+  {
+    id: 'broad-ui',
+    expected: 'single',
+    task: task('broad-ui', 'Polish dashboard empty states', {
+      estimatedMinutes: 20,
+      fileScope: ['src/support/dashboardHtml.ts', 'src/support/web.ts', 'src/locale/en.ts', 'src/locale/ko.ts'],
+    }),
+  },
+  {
+    id: 'pipeline-core',
+    expected: 'fanout',
+    task: task('pipeline-core', 'Add adaptive fan-out gate to PairPipeline', {
+      estimatedMinutes: 45,
+      fileScope: ['src/agents/pairPipeline.ts', 'src/agents/worker.ts'],
+    }),
+  },
+  {
+    id: 'worktree-core',
+    expected: 'fanout',
+    task: task('worktree-core', 'Harden worktree cleanup and PR publishing', {
+      estimatedMinutes: 35,
+      fileScope: ['src/support/worktreeManager.ts'],
+    }),
+  },
+  {
+    id: 'insufficient-draft-large',
+    expected: 'fanout',
+    task: task('insufficient-draft-large', 'Implement provider routing fallback', {
+      estimatedMinutes: 30,
+      fileScope: ['src/adapters/codexResponses.ts', 'src/adapters/gpt.ts'],
+    }),
+    draftAnalysis: {
+      taskType: 'feature',
+      intentSummary: 'Provider routing fallback',
+      relevantFiles: ['src/adapters/codexResponses.ts', 'src/adapters/gpt.ts'],
+      suggestedApproach: 'Investigate adapter fallbacks.',
+      completionCriteria: ['Fallback is verified.'],
+      sufficient: false,
+    },
+  },
+  {
+    id: 'review-retry',
+    expected: 'fanout',
+    task: task('review-retry', 'Revise reviewer-requested worker fix', { estimatedMinutes: 15 }),
+    iteration: 2,
+    feedbackSource: 'review',
+  },
+  {
+    id: 'objective-retry',
+    expected: 'fanout',
+    task: task('objective-retry', 'Fix test failure from previous worker attempt', { estimatedMinutes: 15 }),
+    iteration: 2,
+    feedbackSource: 'objective',
+  },
+  {
+    id: 'high-effort-small',
+    expected: 'single',
+    task: task('high-effort-small', 'Check a tricky but tiny config parser edge case', {
+      estimatedMinutes: 10,
+      fileScope: ['src/core/config.ts'],
+    }),
+    effort: 'high',
+  },
+  {
+    id: 'urgent-nontrivial',
+    expected: 'fanout',
+    task: task('urgent-nontrivial', 'Urgently fix scheduler stuck loop', {
+      priority: 1,
+      estimatedMinutes: 20,
+      fileScope: ['src/automation/autonomousRunner.ts', 'src/support/stuckDetector.ts'],
+    }),
+  },
+];
+
+function run(threshold: number) {
+  return CASES.map((item) => {
+    const decision = evaluateWorkerFanoutGate({
+      task: item.task,
+      draftAnalysis: item.draftAnalysis,
+      iteration: item.iteration ?? 1,
+      feedbackSource: item.feedbackSource,
+      effort: item.effort,
+      config: { minScore: threshold },
+    });
+    const actual = decision.shouldFanOut ? 'fanout' : 'single';
+    return {
+      id: item.id,
+      expected: item.expected,
+      actual,
+      passed: actual === item.expected,
+      score: decision.score,
+      threshold: decision.threshold,
+      signals: decision.signals.map((signal) => signal.code),
+    };
+  });
+}
+
+async function main(): Promise<void> {
+  const thresholds = [1, 2, 3];
+  const byThreshold = thresholds.map((threshold) => {
+    const rows = run(threshold);
+    return {
+      threshold,
+      pass: rows.filter((row) => row.passed).length,
+      total: rows.length,
+      fanoutCount: rows.filter((row) => row.actual === 'fanout').length,
+      rows,
+    };
+  });
+
+  for (const result of byThreshold) {
+    console.log(`threshold=${result.threshold} pass=${result.pass}/${result.total} fanout=${result.fanoutCount}/${result.total}`);
+  }
+
+  await mkdir(RESULTS_DIR, { recursive: true });
+  const stamp = new Date().toISOString().replaceAll(':', '-').replace(/\.\d+Z$/, 'Z');
+  const payload = {
+    createdAt: new Date().toISOString(),
+    cases: CASES.map((item) => ({ id: item.id, expected: item.expected, title: item.task.title })),
+    byThreshold,
+  };
+  const out = join(RESULTS_DIR, `workerFanoutGate-${stamp}.json`);
+  await writeFile(out, JSON.stringify(payload, null, 2), 'utf8');
+  await writeFile(join(RESULTS_DIR, 'workerFanoutGate-latest.json'), JSON.stringify(payload, null, 2), 'utf8');
+  console.log(`results -> ${relative(ROOT, out)}`);
+  console.log(`latest -> ${relative(ROOT, join(RESULTS_DIR, 'workerFanoutGate-latest.json'))}`);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack || err.message : String(err));
+  process.exit(1);
+});

--- a/src/adapters/agenticLoop.test.ts
+++ b/src/adapters/agenticLoop.test.ts
@@ -220,6 +220,29 @@ describe('runAgenticLoop timeout contract', () => {
   });
 });
 
+describe('runAgenticLoop tool exposure options', () => {
+  it('hides search_memory when memoryTools=false without disabling file tools', async () => {
+    let toolNames: string[] = [];
+
+    await runAgenticLoop({
+      prompt: 'x',
+      cwd: process.cwd(),
+      model: 'test',
+      webTools: false,
+      memoryTools: false,
+      maxTurns: 1,
+      callApi: async (_messages, tools) => {
+        toolNames = tools.map((tool) => tool.function.name);
+        return finalResp('done');
+      },
+    });
+
+    expect(toolNames).toContain('read_file');
+    expect(toolNames).toContain('bash');
+    expect(toolNames).not.toContain('search_memory');
+  });
+});
+
 describe('runAgenticLoop read cache vs compaction (INT-1929)', () => {
   let tmp: string;
   beforeEach(async () => { tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'aloop-')); });

--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -122,6 +122,8 @@ export interface AgenticLoopOptions {
   bashTimeoutMs?: number;
   /** Expose web_fetch + web_search tools (default true). Disabled e.g. for SWE-bench integrity. */
   webTools?: boolean;
+  /** Expose search_memory (default true). Disabled for isolated/temp repo benchmarks. */
+  memoryTools?: boolean;
   /** Read-only mode: hide mutation/shell tools and refuse response-text edits. */
   readOnly?: boolean;
   /** Expose the apply_patch (V4A) tool — codex adapters only (codex models are
@@ -187,6 +189,7 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
     protectedFiles,
     bashTimeoutMs,
     webTools = true,
+    memoryTools = true,
     readOnly = false,
     applyPatch = false,
     mcpTools,
@@ -218,9 +221,12 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
   const baseTools = editFormat === 'json'
     ? TOOL_DEFINITIONS
     : TOOL_DEFINITIONS.filter(t => t.function.name !== 'edit_file');
+  const memoryFilteredTools = memoryTools
+    ? baseTools
+    : baseTools.filter((t) => t.function.name !== 'search_memory');
   const visibleBaseTools = readOnly
-    ? baseTools.filter((t) => !['write_file', 'edit_file', 'bash'].includes(t.function.name))
-    : baseTools;
+    ? memoryFilteredTools.filter((t) => !['write_file', 'edit_file', 'bash'].includes(t.function.name))
+    : memoryFilteredTools;
   const tools = enableTools
     ? [
         ...visibleBaseTools,

--- a/src/adapters/claude.test.ts
+++ b/src/adapters/claude.test.ts
@@ -13,4 +13,17 @@ describe('ClaudeCliAdapter.buildCommand', () => {
     expect(command).toContain('--mcp-config');
     expect(command).toMatch(/--mcp-config \S+mcp\.json/);
   });
+
+  it('omits the memory MCP config when memoryTools=false', () => {
+    const { command } = new ClaudeCliAdapter().buildCommand({
+      prompt: '/tmp/prompt.txt',
+      cwd: '/tmp/project',
+      model: 'claude-sonnet-4',
+      memoryTools: false,
+    });
+
+    expect(command).toContain('claude -p');
+    expect(command).toContain('--permission-mode bypassPermissions');
+    expect(command).not.toContain('--mcp-config');
+  });
 });

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -48,9 +48,12 @@ export class ClaudeCliAdapter implements CliAdapter {
     const promptFile = options.prompt;
     const modelFlag = options.model ? ` --model ${options.model}` : '';
     const maxTurnsFlag = options.maxTurns ? ` --max-turns ${options.maxTurns}` : '';
-    // Register OpenSwarm's memory MCP server; bypassPermissions auto-allows its tool.
-    const mcpConfig = writeClaudeMcpConfig();
-    const cmd = `echo "" | claude -p "$(cat ${promptFile})" --output-format stream-json --verbose --permission-mode bypassPermissions --mcp-config ${mcpConfig}${modelFlag}${maxTurnsFlag}`;
+    // Register OpenSwarm's memory MCP server unless the caller needs an isolated run.
+    // bypassPermissions auto-allows its tool when present.
+    const mcpConfigFlag = options.memoryTools === false
+      ? ''
+      : ` --mcp-config ${writeClaudeMcpConfig()}`;
+    const cmd = `echo "" | claude -p "$(cat ${promptFile})" --output-format stream-json --verbose --permission-mode bypassPermissions${mcpConfigFlag}${modelFlag}${maxTurnsFlag}`;
     return { command: cmd, args: [] };
   }
 

--- a/src/adapters/codex.test.ts
+++ b/src/adapters/codex.test.ts
@@ -23,6 +23,19 @@ describe('CodexCliAdapter', () => {
     expect(command).toContain("-c 'mcp_servers.openswarm_memory.args=[");
   });
 
+  it('omits the memory MCP flags when memoryTools=false', () => {
+    const { command } = adapter.buildCommand({
+      prompt: '/tmp/prompt.txt',
+      cwd: '/tmp/project',
+      model: 'gpt-5-codex',
+      memoryTools: false,
+    });
+
+    expect(command).toContain('codex exec');
+    expect(command).not.toContain('openswarm_memory');
+    expect(command).not.toContain("mcp_servers.openswarm_memory");
+  });
+
   it('substitutes a claude model with the codex default and warns', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -75,8 +75,9 @@ export class CodexCliAdapter implements CliAdapter {
     // `--full-auto` was deprecated in codex 0.137 (warns, still runs). Its documented
     // replacement is `--sandbox workspace-write`: same low-friction policy (writes
     // confined to the workspace, no approval prompts in non-interactive `exec`). (INT-1699)
-    // Register OpenSwarm's memory MCP server so codex can call `search_memory`.
-    const cmd = `cat ${shellEscape(promptFile)} | codex exec --json --sandbox workspace-write --skip-git-repo-check${modelFlag} ${codexMcpConfigFlags()}`;
+    // Register OpenSwarm's memory MCP server unless the caller needs an isolated run.
+    const memoryFlags = options.memoryTools === false ? '' : ` ${codexMcpConfigFlags()}`;
+    const cmd = `cat ${shellEscape(promptFile)} | codex exec --json --sandbox workspace-write --skip-git-repo-check${modelFlag}${memoryFlags}`;
     return { command: cmd, args: [] };
   }
 

--- a/src/adapters/codexResponses.test.ts
+++ b/src/adapters/codexResponses.test.ts
@@ -1,16 +1,76 @@
-import { describe, it, expect } from 'vitest';
-import { chatToResponsesInput, toolsToResponsesTools, reduceResponsesEvents, resolveReasoningEffort, substituteSpark } from './codexResponses.js';
-import type { ChatMessage } from './agenticLoop.js';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  CodexResponsesAdapter,
+  chatToResponsesInput,
+  toolsToResponsesTools,
+  reduceResponsesEvents,
+  resolveReasoningEffort,
+  selectDefaultCodexResponseModel,
+} from './codexResponses.js';
+import { runAgenticLoop, type ChatMessage } from './agenticLoop.js';
 import type { ToolDefinition } from './tools.js';
 
-describe('substituteSpark', () => {
-  it('replaces gpt-5.3-codex-spark with the safe cheap model', () => {
-    expect(substituteSpark('gpt-5.3-codex-spark')).toBe('gpt-5.4-mini');
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('selectDefaultCodexResponseModel', () => {
+  it('prefers the stable default when the live catalog includes it', () => {
+    expect(selectDefaultCodexResponseModel(['gpt-5.3-codex-spark', 'gpt-5.4-mini', 'gpt-5.5'])).toBe('gpt-5.5');
   });
-  it('leaves every other model untouched', () => {
-    for (const m of ['gpt-5.4-mini', 'gpt-5.4', 'gpt-5.5', 'gpt-5-codex']) {
-      expect(substituteSpark(m)).toBe(m);
-    }
+
+  it('does not pick Spark implicitly when another model is available', () => {
+    expect(selectDefaultCodexResponseModel(['gpt-5.3-codex-spark', 'gpt-5.4-mini'])).toBe('gpt-5.4-mini');
+  });
+
+  it('does not choose Spark implicitly even if it is the only discovered model', () => {
+    expect(selectDefaultCodexResponseModel(['gpt-5.3-codex-spark'])).toBe('gpt-5.5');
+  });
+});
+
+describe('unsupported-model fallback', () => {
+  it('persists the fallback model across subsequent tool-loop API turns', async () => {
+    const requestedModels: string[] = [];
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const target = String(url);
+      if (target.includes('/backend-api/codex/models')) {
+        return new Response(JSON.stringify({ models: [{ slug: 'gpt-5.5', priority: 1 }] }), { status: 200 });
+      }
+
+      const body = JSON.parse(String(init?.body ?? '{}')) as { model?: string };
+      requestedModels.push(String(body.model));
+      if (body.model === 'unsupported-model') {
+        return new Response('model is not supported for this account', { status: 400 });
+      }
+
+      return new Response(
+        [
+          'data: {"type":"response.output_text.delta","delta":"ok"}',
+          'data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}',
+          'data: [DONE]',
+          '',
+        ].join('\n'),
+        { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    type CreateApiCaller = (
+      initialToken: string,
+      accountId: string,
+      store: unknown,
+      model: string,
+    ) => (messages: ChatMessage[], tools: ToolDefinition[]) => Promise<unknown>;
+    const adapter = new CodexResponsesAdapter() as unknown as { createApiCaller: CreateApiCaller };
+    const callApi = adapter.createApiCaller('token', 'account', {}, 'unsupported-model');
+
+    await callApi([{ role: 'user', content: 'first' }], []);
+    await callApi([{ role: 'user', content: 'second' }], []);
+
+    expect(requestedModels).toEqual(['unsupported-model', 'gpt-5.5', 'gpt-5.5']);
   });
 });
 
@@ -62,7 +122,7 @@ describe('toolsToResponsesTools', () => {
       { type: 'function', function: { name: 'bash', description: 'run', parameters: { type: 'object' } } },
     ];
     expect(toolsToResponsesTools(tools)).toEqual([
-      { type: 'function', name: 'bash', description: 'run', parameters: { type: 'object' } },
+      { type: 'function', name: 'bash', description: 'run', parameters: { type: 'object' }, strict: false },
     ]);
   });
 });
@@ -109,6 +169,113 @@ describe('reduceResponsesEvents', () => {
     ]);
     expect(res.choices[0].message.tool_calls![0].function.arguments).toBe('{"cmd":"ls"}');
   });
+
+  it('accepts final function-call details from response.output_item.done', () => {
+    const res = reduceResponsesEvents([
+      { type: 'response.output_item.added', item: { type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'emit_marker', arguments: '' } },
+      { type: 'response.output_item.done', item: { type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'emit_marker', arguments: '{"marker":"SPARK_TOOL_OK"}' } },
+    ]);
+    expect(res.choices[0].message.tool_calls![0]).toEqual({
+      id: 'call_1',
+      type: 'function',
+      function: { name: 'emit_marker', arguments: '{"marker":"SPARK_TOOL_OK"}' },
+    });
+  });
+
+  it('maps Spark-style argument done events even when item_id is omitted for a single call', () => {
+    const res = reduceResponsesEvents([
+      { type: 'response.output_item.added', item: { type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'emit_marker' } },
+      { type: 'response.function_call_arguments.done', arguments: '{"marker":"SPARK_TOOL_OK"}' },
+    ]);
+    expect(res.choices[0].message.tool_calls![0].function.arguments).toBe('{"marker":"SPARK_TOOL_OK"}');
+  });
+
+  it('reduces the live-observed Spark function-call event sequence', () => {
+    const res = reduceResponsesEvents([
+      { type: 'response.created' },
+      { type: 'response.in_progress' },
+      { type: 'response.output_item.added', item: { type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'emit_marker', arguments: '' } },
+      { type: 'response.output_item.done', item: { type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'emit_marker', arguments: '{"marker":"SPARK_TOOL_OK"}' } },
+      { type: 'response.function_call_arguments.done', item_id: 'fc_1', arguments: '{"marker":"SPARK_TOOL_OK"}' },
+      { type: 'response.completed', response: { usage: { input_tokens: 42, output_tokens: 7 } } },
+    ]);
+
+    expect(res.choices[0]).toEqual({
+      finish_reason: 'tool_calls',
+      message: {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'emit_marker', arguments: '{"marker":"SPARK_TOOL_OK"}' },
+          },
+        ],
+      },
+    });
+    expect(res.usage).toEqual({ prompt_tokens: 42, completion_tokens: 7, total_tokens: 49, cached_tokens: 0 });
+  });
+});
+
+describe('Spark-shaped Responses events through the OpenSwarm loop', () => {
+  it('executes an apply_patch tool call and feeds the result into the next turn', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'openswarm-spark-loop-'));
+    const filePath = join(cwd, 'note.txt');
+    writeFileSync(filePath, 'status=ALPHA', 'utf8');
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: note.txt',
+      '@@',
+      '-status=ALPHA',
+      '+status=SPARK_TOOL_OK',
+      '*** End Patch',
+    ].join('\n');
+    let apiCalls = 0;
+
+    try {
+      const result = await runAgenticLoop({
+        cwd,
+        model: 'gpt-5.3-codex-spark',
+        prompt: 'Change note.txt to SPARK_TOOL_OK.',
+        webTools: false,
+        applyPatch: true,
+        maxTurns: 4,
+        callApi: async (messages, tools) => {
+          apiCalls++;
+          if (apiCalls === 1) {
+            expect(tools.some((t) => t.function.name === 'apply_patch')).toBe(true);
+            return reduceResponsesEvents([
+              { type: 'response.output_item.added', item: { type: 'function_call', id: 'fc_patch', call_id: 'call_patch', name: 'apply_patch', arguments: '' } },
+              {
+                type: 'response.output_item.done',
+                item: {
+                  type: 'function_call',
+                  id: 'fc_patch',
+                  call_id: 'call_patch',
+                  name: 'apply_patch',
+                  arguments: JSON.stringify({ input: patch }),
+                },
+              },
+              { type: 'response.function_call_arguments.done', item_id: 'fc_patch', arguments: JSON.stringify({ input: patch }) },
+            ]);
+          }
+
+          expect(messages.some((m) => m.role === 'tool' && m.content.includes('Patched: note.txt'))).toBe(true);
+          return {
+            choices: [{ message: { role: 'assistant', content: 'status=SPARK_TOOL_OK' }, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          };
+        },
+      });
+
+      expect(result.toolCallCount).toBe(1);
+      expect(result.text).toBe('status=SPARK_TOOL_OK');
+      expect(readFileSync(filePath, 'utf8')).toBe('status=SPARK_TOOL_OK');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('resolveReasoningEffort — jobProfile effort wiring', () => {
@@ -127,3 +294,42 @@ describe('resolveReasoningEffort — jobProfile effort wiring', () => {
     expect(resolveReasoningEffort(undefined, undefined)).toBe('medium');
   });
 })
+
+const liveSparkIt = process.env.OPEN_SWARM_LIVE_CODEX_SPARK ? it : it.skip;
+
+describe('codex-responses live Spark smoke', () => {
+  // Opt-in because this hits the ChatGPT OAuth backend. Manual evidence captured
+  // while adding explicit Spark support: this test passed with Spark calling
+  // read_file → apply_patch → read_file and changing note.txt to SPARK_TOOL_OK.
+  liveSparkIt('uses PKCE auth and Spark to edit through the OpenSwarm tool loop', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'openswarm-spark-edit-'));
+    const filePath = join(cwd, 'note.txt');
+    writeFileSync(filePath, 'status=ALPHA\n', 'utf8');
+    const logs: string[] = [];
+
+    try {
+      const result = await new CodexResponsesAdapter().run({
+        cwd,
+        model: 'gpt-5.3-codex-spark',
+        prompt:
+          'Use tools to edit note.txt. Change the exact text "status=ALPHA" to "status=SPARK_TOOL_OK". ' +
+          'After editing, verify by reading the file and answer with the final file content only.',
+        systemPrompt:
+          'You are an edit-tool smoke test. You must inspect and modify the file using tools; do not answer without editing.',
+        enableTools: true,
+        webTools: false,
+        maxTurns: 8,
+        nudgeMaxOnNoEdit: 2,
+        timeoutMs: 180000,
+        onLog: (line) => logs.push(line),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(logs.some((line) => /edit_file|apply_patch|write_file/.test(line))).toBe(true);
+      expect(readFileSync(filePath, 'utf8').trim()).toBe('status=SPARK_TOOL_OK');
+      expect(result.stdout).toContain('SPARK_TOOL_OK');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 180000);
+});

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -24,17 +24,7 @@ import { getCodexModelIds } from './codexModels.js';
 const CODEX_RESPONSES_URL = 'https://chatgpt.com/backend-api/codex/responses';
 const DEFAULT_MODEL = 'gpt-5.5';
 const PROFILE_KEY = 'openai-gpt:default';
-
-// gpt-5.3-codex-spark read-paralyzes in our agentic worker harness — 0 edits at 458k
-// tokens across edit_file AND apply_patch AND nudge AND guidance (verified 2026-06-25),
-// while every other codex model from gpt-5.4-mini up edits fine. It must NEVER run as a
-// worker here, whether picked by default or requested explicitly — substitute the
-// cheapest capable model.
 const SPARK_MODEL = 'gpt-5.3-codex-spark';
-const SAFE_CHEAP_MODEL = 'gpt-5.4-mini';
-export function substituteSpark(model: string): string {
-  return model === SPARK_MODEL ? SAFE_CHEAP_MODEL : model;
-}
 
 // ---- Responses API wire types (the subset we send/receive) ----
 
@@ -43,6 +33,7 @@ interface ResponsesTool {
   name: string;
   description?: string;
   parameters: Record<string, unknown>;
+  strict: false;
 }
 
 type ResponsesInputItem =
@@ -60,6 +51,14 @@ export function resolveReasoningEffort(
   disableReasoning?: boolean,
 ): 'low' | 'medium' | 'high' {
   return reasoningEffort ?? (disableReasoning ? 'low' : 'medium');
+}
+
+export function selectDefaultCodexResponseModel(modelIds: string[]): string {
+  return (
+    modelIds.find((m) => m === DEFAULT_MODEL) ??
+    modelIds.find((m) => m !== SPARK_MODEL) ??
+    DEFAULT_MODEL
+  );
 }
 
 /** The agenticLoop callApi return shape (structurally equals its ChatCompletionResponse). */
@@ -112,6 +111,9 @@ export function toolsToResponsesTools(tools: ToolDefinition[]): ResponsesTool[] 
     name: t.function.name,
     description: t.function.description,
     parameters: t.function.parameters,
+    // OpenSwarm tools use permissive JSON schemas. Keep Responses in best-effort
+    // mode instead of asking it to normalize these into strict Structured Outputs.
+    strict: false,
   }));
 }
 
@@ -137,6 +139,7 @@ export function reduceResponsesEvents(events: SseEvent[]): ChatLikeResponse {
   // round-trips back as `function_call_output.call_id` on the next turn.
   const calls = new Map<string, { callId: string; name: string; args: string }>();
   let usage: ChatLikeResponse['usage'];
+  const getOnlyCall = () => calls.size === 1 ? calls.values().next().value : undefined;
 
   for (const ev of events) {
     switch (ev.type) {
@@ -144,21 +147,26 @@ export function reduceResponsesEvents(events: SseEvent[]): ChatLikeResponse {
         if (ev.delta) text += ev.delta;
         break;
       case 'response.output_item.added':
+      case 'response.output_item.done':
         if (ev.item?.type === 'function_call' && ev.item.id) {
+          const existing = calls.get(ev.item.id);
+          const itemArgs = ev.item.arguments;
           calls.set(ev.item.id, {
-            callId: ev.item.call_id || ev.item.id,
-            name: ev.item.name ?? '',
-            args: ev.item.arguments ?? '',
+            callId: ev.item.call_id || existing?.callId || ev.item.id,
+            name: ev.item.name ?? existing?.name ?? '',
+            args: typeof itemArgs === 'string' && (itemArgs || !existing?.args)
+              ? itemArgs
+              : existing?.args ?? '',
           });
         }
         break;
       case 'response.function_call_arguments.delta': {
-        const c = ev.item_id ? calls.get(ev.item_id) : undefined;
+        const c = ev.item_id ? calls.get(ev.item_id) : getOnlyCall();
         if (c && ev.delta) c.args += ev.delta;
         break;
       }
       case 'response.function_call_arguments.done': {
-        const c = ev.item_id ? calls.get(ev.item_id) : undefined;
+        const c = ev.item_id ? calls.get(ev.item_id) : getOnlyCall();
         if (c && typeof ev.arguments === 'string') c.args = ev.arguments;
         break;
       }
@@ -295,13 +303,6 @@ export class CodexResponsesAdapter implements CliAdapter {
 
   /** Default = top model from the Codex OAuth catalog (live/local), else constant. */
   async getDefaultModel(): Promise<string> {
-    // gpt-5.3-codex-spark read-paralyzes in our agentic worker harness — 0 edits at
-    // 458k tokens (verified 2026-06-25), while every other codex model from
-    // gpt-5.4-mini up edits fine (mini: 182k, 2 apply_patch). It's the live list's
-    // first entry, so a no-model fallthrough (e.g. a task with no estimate that
-    // matches no jobProfile) would silently pick the one broken model. Exclude it and
-    // prefer the cheapest capable model. Roles/profiles that pass an explicit model
-    // are unaffected.
     // Resolve the LIVE catalog with the account's OAuth token (INT-1872): the
     // curated offline list is account-stale (e.g. gpt-5-codex 400s
     // "model is not supported … with a ChatGPT account"). With a token,
@@ -312,8 +313,8 @@ export class CodexResponsesAdapter implements CliAdapter {
     } catch {
       // no/expired auth → getCodexModelIds falls back to the offline curated list
     }
-    const ids = (await getCodexModelIds(token)).filter((m) => m !== SPARK_MODEL);
-    return ids.find((m) => m === SAFE_CHEAP_MODEL) ?? ids[0] ?? DEFAULT_MODEL;
+    const ids = await getCodexModelIds(token);
+    return selectDefaultCodexResponseModel(ids);
   }
 
   async run(options: CliRunOptions): Promise<CliRunResult> {
@@ -339,11 +340,12 @@ export class CodexResponsesAdapter implements CliAdapter {
       };
     }
 
-    const requestedModel = options.model ?? await this.getDefaultModel();
-    const model = substituteSpark(requestedModel);
-    if (model !== requestedModel) {
-      options.onLog?.(`[codex-responses] ${requestedModel} read-paralyzes in the agentic harness — using ${model} instead.`);
-    }
+    // Honor explicit model requests. In particular, gpt-5.3-codex-spark must
+    // exercise the same PKCE/tool loop as every other Codex Responses model.
+    // Counter-evidence for the old read-paralysis guard is codified in
+    // codexResponses.test.ts: a non-live Spark-shaped SSE loop executes
+    // apply_patch, and the opt-in live smoke verifies PKCE + Spark edit tools.
+    const model = options.model ?? await this.getDefaultModel();
     // Stream the model's reasoning summary to the live log as 💭 thoughts.
     const onReasoning = options.onLog ? (line: string) => options.onLog!(`💭 ${line}`) : undefined;
     // Stable prompt_cache_key so every turn of THIS run routes to the same cache
@@ -369,6 +371,7 @@ export class CodexResponsesAdapter implements CliAdapter {
       protectedFiles: options.protectedFiles,
       bashTimeoutMs: options.bashTimeoutMs,
       webTools: options.webTools,
+      memoryTools: options.memoryTools,
       mcpTools: options.mcpTools,
       readOnly: options.readOnly,
       // codex models are RLHF-trained on the V4A apply_patch format — expose it as
@@ -414,11 +417,12 @@ export class CodexResponsesAdapter implements CliAdapter {
     let token = initialToken;
     let retried = false;
     let modelRetried = false;
+    let effectiveModel = model;
 
     return async (messages: ChatMessage[], tools: ToolDefinition[]): Promise<ChatLikeResponse> => {
       const { instructions, input } = chatToResponsesInput(messages);
       const body: Record<string, unknown> = {
-        model,
+        model: effectiveModel,
         input,
         store: false,
         stream: true,
@@ -468,9 +472,13 @@ export class CodexResponsesAdapter implements CliAdapter {
           // model availability varies, so adapt instead of failing the task.
           if (res.status === 400 && /not supported/i.test(errText) && !modelRetried) {
             modelRetried = true;
-            const alt = (await getCodexModelIds(token)).find((m) => m !== SPARK_MODEL && m !== body.model);
+            const candidates = (await getCodexModelIds(token)).filter((m) => m !== body.model);
+            const alt =
+              candidates.find((m) => m === DEFAULT_MODEL) ??
+              candidates.find((m) => m !== SPARK_MODEL);
             if (alt) {
               onReasoning?.(`model ${String(body.model)} not supported on this account — retrying with ${alt}`);
+              effectiveModel = alt;
               body.model = alt;
               return doCall(token);
             }

--- a/src/adapters/gpt.ts
+++ b/src/adapters/gpt.ts
@@ -95,6 +95,7 @@ export class GptCliAdapter implements CliAdapter {
       protectedFiles: options.protectedFiles,
       bashTimeoutMs: options.bashTimeoutMs,
       webTools: options.webTools,
+      memoryTools: options.memoryTools,
       readOnly: options.readOnly,
       mcpTools,
       signal: options.signal,

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -173,6 +173,7 @@ export class LocalModelAdapter implements CliAdapter {
       protectedFiles: options.protectedFiles,
       bashTimeoutMs: options.bashTimeoutMs,
       webTools: options.webTools,
+      memoryTools: options.memoryTools,
       readOnly: options.readOnly,
       mcpTools,
       signal: options.signal,

--- a/src/adapters/openrouter.ts
+++ b/src/adapters/openrouter.ts
@@ -114,6 +114,7 @@ export class OpenRouterCliAdapter implements CliAdapter {
       protectedFiles: options.protectedFiles,
       bashTimeoutMs: options.bashTimeoutMs,
       webTools: options.webTools,
+      memoryTools: options.memoryTools,
       readOnly: options.readOnly,
       mcpTools,
       signal: options.signal,

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -69,6 +69,8 @@ export interface CliRunOptions {
   bashTimeoutMs?: number;
   /** Expose web_fetch + web_search tools (default true). Set false for SWE-bench integrity. */
   webTools?: boolean;
+  /** Expose repository memory search (default true). Set false for isolated/temp repo benchmarks. */
+  memoryTools?: boolean;
   /** Enforce read-only tool exposure/execution where the adapter supports OpenSwarm's tool layer. */
   readOnly?: boolean;
   /**

--- a/src/agents/pairPipeline.test.ts
+++ b/src/agents/pairPipeline.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import type { WorkerOptions } from './worker.js';
 import type { ReviewerOptions } from './reviewer.js';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
@@ -80,6 +85,14 @@ describe('PairPipeline model selection', () => {
       estimatedMinutes: 60,
       ...overrides,
     };
+  }
+
+  function initRepo(dir: string): void {
+    execFileSync('git', ['init', '-q'], { cwd: dir });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+    execFileSync('git', ['add', '-A'], { cwd: dir });
+    execFileSync('git', ['commit', '-qm', 'init'], { cwd: dir });
   }
 
   it('passes matched jobProfile models to worker and reviewer calls', async () => {
@@ -275,5 +288,331 @@ describe('PairPipeline model selection', () => {
     await pipeline.run(task(), process.cwd());
 
     expect(stageModels().every(m => m === undefined)).toBe(true);
+  });
+
+  it('scores core orchestration work as a fan-out candidate without running extra workers', async () => {
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const { evaluateWorkerFanoutGate } = await import('./workerFanoutGate.js');
+    const draftAnalysis = {
+      taskType: 'feature',
+      intentSummary: 'Add an adaptive fan-out gate to the worker pipeline.',
+      relevantFiles: ['src/agents/pairPipeline.ts', 'src/support/worktreeManager.ts'],
+      suggestedApproach: 'Evaluate risk signals before the worker stage and report the decision.',
+      completionCriteria: ['A fan-out gate decision is emitted before the worker starts.'],
+      sufficient: true,
+    };
+
+    const decision = evaluateWorkerFanoutGate({
+      task: task({
+        title: 'Add adaptive fan-out gate to PairPipeline',
+        estimatedMinutes: 45,
+      }),
+      draftAnalysis,
+      iteration: 1,
+      config: { minScore: 2 },
+    });
+
+    expect(decision.shouldFanOut).toBe(true);
+    expect(decision.signals.map((s) => s.code)).toContain('core-orchestration-scope');
+
+    const pipeline = new PairPipeline({
+      stages: ['worker'],
+      maxIterations: 1,
+      roles: {
+        worker: {
+          enabled: true,
+          model: 'mini-worker',
+          timeoutMs: 0,
+          fanout: { mode: 'report', minScore: 2 },
+        },
+      },
+      draftAnalysis,
+    });
+
+    const result = await pipeline.run(task({
+      title: 'Add adaptive fan-out gate to PairPipeline',
+      estimatedMinutes: 45,
+    }), process.cwd());
+
+    expect(result.success).toBe(true);
+    expect(runWorker).toHaveBeenCalledTimes(1);
+    const fanoutEvent = broadcastEvent.mock.calls
+      .map(c => c[0])
+      .find(e => e.type === 'pipeline:fanout');
+    expect(fanoutEvent).toEqual(expect.objectContaining({
+      type: 'pipeline:fanout',
+      data: expect.objectContaining({
+        shouldFanOut: true,
+        score: expect.any(Number),
+        threshold: 2,
+      }),
+    }));
+  });
+
+  it('executes adaptive fan-out in sandboxes and promotes only the winning diff', async () => {
+    const repo = await mkdtemp(path.join(tmpdir(), 'osw-pipeline-fanout-'));
+    try {
+      await writeFile(path.join(repo, 'README.md'), 'base\n', 'utf8');
+      initRepo(repo);
+
+      runWorker.mockImplementation(async (opts: WorkerOptions) => {
+        const isSpark = opts.model === 'gpt-5.3-codex-spark';
+        const file = isSpark ? 'spark.txt' : 'primary.txt';
+        await writeFile(path.join(opts.projectPath, file), isSpark ? 'spark\n' : 'primary\n', 'utf8');
+        return {
+          success: true,
+          summary: isSpark ? 'spark patch' : 'primary patch',
+          filesChanged: [file],
+          commands: [],
+          output: '',
+          confidencePercent: isSpark ? 95 : 70,
+        };
+      });
+
+      const { PairPipeline } = await import('./pairPipeline.js');
+      const pipeline = new PairPipeline({
+        stages: ['worker'],
+        maxIterations: 1,
+        roles: {
+          worker: {
+            enabled: true,
+            adapter: 'codex-responses',
+            model: 'gpt-5.4-mini',
+            timeoutMs: 0,
+            fanout: { mode: 'execute', minScore: 1, concurrency: 2 },
+          },
+        },
+      });
+
+      const result = await pipeline.run(task({
+        title: 'Touch PairPipeline worker fan-out',
+        estimatedMinutes: 45,
+      }), repo);
+      expect(result.success).toBe(true);
+      expect(runWorker).toHaveBeenCalledTimes(2);
+      expect(await readFile(path.join(repo, 'spark.txt'), 'utf8')).toBe('spark\n');
+      expect(existsSync(path.join(repo, 'primary.txt'))).toBe(false);
+      expect(result.workerResult?.summary).toContain('[fanout:spark-diversity]');
+      expect(result.workerResult?.filesChanged).toEqual(['spark.txt']);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('excludes fan-out candidates whose sandbox diff fails a blocking guard', async () => {
+    const repo = await mkdtemp(path.join(tmpdir(), 'osw-pipeline-fanout-guards-'));
+    try {
+      await writeFile(path.join(repo, 'README.md'), 'base\n', 'utf8');
+      initRepo(repo);
+
+      runWorker.mockImplementation(async (opts: WorkerOptions) => {
+        const isSpark = opts.model === 'gpt-5.3-codex-spark';
+        if (isSpark) {
+          await writeFile(path.join(opts.projectPath, 'package.json'), '{"name":"spoofed-dep"}\n', 'utf8');
+          return {
+            success: true,
+            summary: 'spark patch',
+            filesChanged: ['package.json'],
+            commands: [],
+            output: 'Cannot find module left-pad',
+            confidencePercent: 99,
+          };
+        }
+
+        await writeFile(path.join(opts.projectPath, 'primary.txt'), 'primary\n', 'utf8');
+        return {
+          success: true,
+          summary: 'primary patch',
+          filesChanged: ['primary.txt'],
+          commands: [],
+          output: '',
+          confidencePercent: 90,
+        };
+      });
+
+      const { PairPipeline } = await import('./pairPipeline.js');
+      const pipeline = new PairPipeline({
+        stages: ['worker'],
+        maxIterations: 1,
+        guards: { dependencyAntiPatternCheck: true },
+        roles: {
+          worker: {
+            enabled: true,
+            adapter: 'codex-responses',
+            model: 'gpt-5.4-mini',
+            timeoutMs: 0,
+            fanout: { mode: 'execute', minScore: 1, concurrency: 2 },
+          },
+        },
+      });
+
+      const result = await pipeline.run(task({
+        title: 'Touch PairPipeline worker fan-out',
+        estimatedMinutes: 45,
+      }), repo);
+      expect(result.success).toBe(true);
+      expect(runWorker).toHaveBeenCalledTimes(2);
+      expect(await readFile(path.join(repo, 'primary.txt'), 'utf8')).toBe('primary\n');
+      expect(existsSync(path.join(repo, 'package.json'))).toBe(false);
+      expect(result.workerResult?.summary).toContain('[fanout:primary]');
+      expect(result.workerResult?.filesChanged).toEqual(['primary.txt']);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('copies shared dependency paths into fan-out sandboxes by default', async () => {
+    const repo = await mkdtemp(path.join(tmpdir(), 'osw-pipeline-fanout-deps-'));
+    try {
+      await writeFile(path.join(repo, '.gitignore'), 'node_modules/\n', 'utf8');
+      await writeFile(path.join(repo, 'README.md'), 'base\n', 'utf8');
+      await mkdir(path.join(repo, 'node_modules', '.bin'), { recursive: true });
+      const localCheck = path.join(repo, 'node_modules', '.bin', 'local-check');
+      await writeFile(localCheck, '#!/usr/bin/env node\nconsole.log("ok")\n', 'utf8');
+      await chmod(localCheck, 0o755);
+      initRepo(repo);
+
+      runWorker.mockImplementation(async (opts: WorkerOptions) => {
+        execFileSync(path.join(opts.projectPath, 'node_modules', '.bin', 'local-check'), [], {
+          cwd: opts.projectPath,
+        });
+        const isSpark = opts.model === 'gpt-5.3-codex-spark';
+        const file = isSpark ? 'spark.txt' : 'primary.txt';
+        await writeFile(path.join(opts.projectPath, file), isSpark ? 'spark\n' : 'primary\n', 'utf8');
+        return {
+          success: true,
+          summary: isSpark ? 'spark patch' : 'primary patch',
+          filesChanged: [file],
+          commands: ['node_modules/.bin/local-check'],
+          output: 'ok',
+          confidencePercent: isSpark ? 95 : 70,
+        };
+      });
+
+      const { PairPipeline } = await import('./pairPipeline.js');
+      const pipeline = new PairPipeline({
+        stages: ['worker'],
+        maxIterations: 1,
+        roles: {
+          worker: {
+            enabled: true,
+            adapter: 'codex-responses',
+            model: 'gpt-5.4-mini',
+            timeoutMs: 0,
+            fanout: { mode: 'execute', minScore: 1, concurrency: 2 },
+          },
+        },
+      });
+
+      const result = await pipeline.run(task({
+        title: 'Touch PairPipeline worker fan-out',
+        estimatedMinutes: 45,
+      }), repo);
+
+      expect(result.success).toBe(true);
+      expect(runWorker).toHaveBeenCalledTimes(2);
+      expect(result.workerResult?.summary).toContain('[fanout:spark-diversity]');
+      expect(await readFile(path.join(repo, 'spark.txt'), 'utf8')).toBe('spark\n');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('does not let losing fan-out candidates mutate original shared paths by default', async () => {
+    const repo = await mkdtemp(path.join(tmpdir(), 'osw-pipeline-fanout-shared-'));
+    try {
+      await writeFile(path.join(repo, '.gitignore'), 'node_modules/\n', 'utf8');
+      await writeFile(path.join(repo, 'README.md'), 'base\n', 'utf8');
+      await mkdir(path.join(repo, 'node_modules'), { recursive: true });
+      await writeFile(path.join(repo, 'node_modules', 'original.txt'), 'original\n', 'utf8');
+      initRepo(repo);
+
+      runWorker.mockImplementation(async (opts: WorkerOptions) => {
+        const isSpark = opts.model === 'gpt-5.3-codex-spark';
+        if (!isSpark) {
+          await mkdir(path.join(opts.projectPath, 'node_modules'), { recursive: true });
+          await writeFile(path.join(opts.projectPath, 'node_modules', 'loser-leak.txt'), 'leak\n', 'utf8');
+          await writeFile(path.join(opts.projectPath, 'primary.txt'), 'primary\n', 'utf8');
+        } else {
+          await writeFile(path.join(opts.projectPath, 'spark.txt'), 'spark\n', 'utf8');
+        }
+        return {
+          success: true,
+          summary: isSpark ? 'spark patch' : 'primary patch',
+          filesChanged: [isSpark ? 'spark.txt' : 'primary.txt'],
+          commands: [],
+          output: '',
+          confidencePercent: isSpark ? 95 : 70,
+        };
+      });
+
+      const { PairPipeline } = await import('./pairPipeline.js');
+      const pipeline = new PairPipeline({
+        stages: ['worker'],
+        maxIterations: 1,
+        roles: {
+          worker: {
+            enabled: true,
+            adapter: 'codex-responses',
+            model: 'gpt-5.4-mini',
+            timeoutMs: 0,
+            fanout: { mode: 'execute', minScore: 1, concurrency: 2 },
+          },
+        },
+      });
+
+      const result = await pipeline.run(task({
+        title: 'Touch PairPipeline worker fan-out',
+        estimatedMinutes: 45,
+      }), repo);
+
+      expect(result.success).toBe(true);
+      expect(await readFile(path.join(repo, 'spark.txt'), 'utf8')).toBe('spark\n');
+      expect(existsSync(path.join(repo, 'node_modules', 'loser-leak.txt'))).toBe(false);
+      expect(await readFile(path.join(repo, 'node_modules', 'original.txt'), 'utf8')).toBe('original\n');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the adaptive fan-out gate disabled when configured off', async () => {
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker'],
+      maxIterations: 1,
+      roles: {
+        worker: {
+          enabled: true,
+          model: 'mini-worker',
+          timeoutMs: 0,
+          fanout: { enabled: false },
+        },
+      },
+      draftAnalysis: {
+        taskType: 'feature',
+        intentSummary: 'Add a risky change to the worker pipeline.',
+        relevantFiles: ['src/agents/pairPipeline.ts'],
+        suggestedApproach: 'Change the pipeline loop.',
+        completionCriteria: ['Pipeline still runs.'],
+        sufficient: true,
+      },
+    });
+
+    await pipeline.run(task({
+      title: 'Add adaptive fan-out gate to PairPipeline',
+      estimatedMinutes: 45,
+    }), process.cwd());
+
+    const fanoutEvent = broadcastEvent.mock.calls
+      .map(c => c[0])
+      .find(e => e.type === 'pipeline:fanout');
+    expect(fanoutEvent).toEqual(expect.objectContaining({
+      type: 'pipeline:fanout',
+      data: expect.objectContaining({
+        enabled: false,
+        shouldFanOut: false,
+        score: 0,
+      }),
+    }));
   });
 });

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -31,6 +31,9 @@ import { getRegistryStore } from '../registry/sqliteStore.js';
 import { recallRepoKnowledge } from '../memory/repoKnowledge.js';
 import type { WorkerContext } from '../locale/types.js';
 import * as workerAgent from './worker.js';
+import type { WorkerOptions } from './worker.js';
+import { buildTaskPrefix } from './pipelineTaskPrefix.js';
+import { emitWorkerFanoutGateDecision, evaluateWorkerFanoutGate, runWorkerWithOptionalFanout, type WorkerFanoutGateDecision } from './workerFanoutGate.js';
 import * as reviewerAgent from './reviewer.js';
 import * as testerAgent from './tester.js';
 import * as documenterAgent from './documenter.js';
@@ -97,14 +100,9 @@ export interface PipelineConfig {
   };
 }
 
-export interface PipelineRunMetadata {
-  repository?: string;
-  projectPath?: string;
-  worktree?: string;
-  branch?: string;
-  issueIdentifier?: string;
-  title?: string;
-}
+export { buildTaskPrefix } from './pipelineTaskPrefix.js';
+
+export interface PipelineRunMetadata { repository?: string; projectPath?: string; worktree?: string; branch?: string; issueIdentifier?: string; title?: string; }
 
 export interface StageResult {
   stage: PipelineStage;
@@ -171,41 +169,13 @@ export interface PipelineContext {
    * fresh-context retry.
    */
   feedbackSource?: 'objective' | 'review';
-}
-
-/**
- * Build a consistent task prefix for logging across all pipeline stages.
- * Format: "ProjectName | INT-XXX | worktree/abc123" or "ProjectName | INT-XXX"
- */
-export function buildTaskPrefix(task: TaskItem, projectPath: string): string {
-  const parts: string[] = [];
-  const projectName = task.linearProject?.name || projectPath.split('/').pop() || 'unknown';
-  parts.push(projectName);
-  if (task.issueIdentifier) {
-    parts.push(task.issueIdentifier);
-  } else if (task.issueId) {
-    parts.push(task.issueId.slice(0, 8));
-  }
-  // Detect worktree path
-  const worktreeMatch = projectPath.match(/worktree\/([a-f0-9-]+)/);
-  if (worktreeMatch) {
-    parts.push(`worktree/${worktreeMatch[1].slice(0, 8)}`);
-  }
-  return parts.join(' | ');
+  /** Last adaptive fan-out gate decision for the worker stage. */
+  workerFanoutDecision?: WorkerFanoutGateDecision;
 }
 
 // Pipeline Events
 
-export type PipelineEventType =
-  | 'stage:start'
-  | 'stage:complete'
-  | 'stage:fail'
-  | 'iteration:start'
-  | 'iteration:complete'
-  | 'iteration:fail'
-  | 'pipeline:complete'
-  | 'pipeline:fail'
-  | 'halt';
+export type PipelineEventType = 'stage:start' | 'stage:complete' | 'stage:fail' | 'iteration:start' | 'iteration:complete' | 'iteration:fail' | 'pipeline:complete' | 'pipeline:fail' | 'fanout:gate' | 'halt';
 
 // Pair Pipeline
 
@@ -598,7 +568,7 @@ export class PairPipeline extends EventEmitter {
           const combinedFeedback =
             [reflectionPart, reviewPart].filter(Boolean).join('\n\n') || undefined;
 
-          result = await workerAgent.runWorker({
+          const workerOptions: WorkerOptions = {
             taskTitle: context.task.title,
             taskDescription: context.task.description || '',
             projectPath: context.projectPath,
@@ -625,6 +595,16 @@ export class PairPipeline extends EventEmitter {
             processContext: { taskId: context.task.id, stage: 'worker' },
             workerContext,
             signal: this.abortSignal,
+          };
+
+          result = await runWorkerWithOptionalFanout({
+            projectPath: context.projectPath,
+            workerOptions,
+            fanoutDecision: context.workerFanoutDecision,
+            fanoutConfig: this.config.roles?.worker?.fanout,
+            guards: this.config.guards,
+            onLog,
+            runWorker: workerAgent.runWorker,
           });
           agentPair.saveWorkerResult(context.session.id, result as WorkerResult);
           context.workerResult = result as WorkerResult;
@@ -997,6 +977,22 @@ export class PairPipeline extends EventEmitter {
           toModel: escalateModel,
         } });
       }
+
+      const fanoutDecision = evaluateWorkerFanoutGate({
+        task: context.task,
+        draftAnalysis: this.config.draftAnalysis,
+        iteration: context.currentIteration,
+        feedbackSource: context.feedbackSource,
+        effort: this.getEffortForTask(context.task),
+        config: this.config.roles?.worker?.fanout,
+      });
+      context.workerFanoutDecision = fanoutDecision;
+      emitWorkerFanoutGateDecision({
+        context,
+        decision: fanoutDecision,
+        verbose: this.config.verbose,
+        emit: (event, payload) => this.emit(event, payload),
+      });
 
       agentPair.updateSessionStatus(context.session.id, 'working');
       const workerResult = await this.runStage('worker', context, workerOverrides);

--- a/src/agents/pipelineTaskPrefix.ts
+++ b/src/agents/pipelineTaskPrefix.ts
@@ -1,0 +1,15 @@
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+
+export function buildTaskPrefix(task: TaskItem, projectPath: string): string {
+  const parts: string[] = [];
+  const projectName = task.linearProject?.name || projectPath.split('/').pop() || 'unknown';
+  parts.push(projectName);
+  if (task.issueIdentifier) {
+    parts.push(task.issueIdentifier);
+  } else if (task.issueId) {
+    parts.push(task.issueId.slice(0, 8));
+  }
+  const worktreeMatch = projectPath.match(/worktree\/([a-f0-9-]+)/);
+  if (worktreeMatch) parts.push(`worktree/${worktreeMatch[1].slice(0, 8)}`);
+  return parts.join(' | ');
+}

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -45,6 +45,8 @@ export interface WorkerOptions {
   bashTimeoutMs?: number;
   /** Expose web_fetch + web_search tools (default true). Set false for SWE-bench integrity. */
   webTools?: boolean;
+  /** Expose repository memory search (default true). Set false for isolated/temp repo benchmarks. */
+  memoryTools?: boolean;
   /** MCP tools to expose to the agentic loop (server__tool). When unset the adapter
    * self-sources from the registry (INT-1951); set to pin a specific set. (INT-1950) */
   mcpTools?: ToolDefinition[];
@@ -239,6 +241,7 @@ export async function runWorker(options: WorkerOptions): Promise<WorkerResult> {
       protectedFiles: options.protectedFiles,
       bashTimeoutMs: options.bashTimeoutMs,
       webTools: options.webTools,
+      memoryTools: options.memoryTools,
       mcpTools: options.mcpTools,
       signal: options.signal,
     });

--- a/src/agents/workerFanout.ts
+++ b/src/agents/workerFanout.ts
@@ -87,7 +87,7 @@ async function cloneSandbox(
   sharedPathMode: 'copy' | 'link' | 'off',
 ): Promise<string> {
   const sandbox = join(root, id);
-  await git(projectPath, ['clone', '--quiet', '--no-hardlinks', projectPath, sandbox]);
+  await git(projectPath, ['clone', '--quiet', '--no-hardlinks', '--', projectPath, sandbox]);
   if (sharedPathMode === 'link') await linkSharedPaths(projectPath, sandbox);
   if (sharedPathMode === 'copy') await copySharedPaths(projectPath, sandbox);
   return sandbox;

--- a/src/agents/workerFanout.ts
+++ b/src/agents/workerFanout.ts
@@ -1,0 +1,312 @@
+// ============================================
+// OpenSwarm - Adaptive worker fan-out
+// ============================================
+//
+// Runs candidate workers in isolated temporary git clones and promotes only the
+// selected winner's diff back into the real project path.
+
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { cp, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import type { WorkerFanoutCandidateConfig, PipelineGuardsConfig } from '../core/types.js';
+import { runPool } from '../support/concurrencyPool.js';
+import { loadRepoMetadata } from '../support/repoMetadata.js';
+import { resolveSharedPaths } from '../support/worktreeManager.js';
+import type { WorkerResult } from './agentPair.js';
+import { runWorker, type WorkerOptions } from './worker.js';
+import { runGuards, type GuardsRunResult } from './pipelineGuards.js';
+
+const exec = promisify(execFile);
+
+export interface WorkerFanoutCandidateRun {
+  id: string;
+  projectPath: string;
+  result: WorkerResult;
+  filesChanged: string[];
+  guards?: GuardsRunResult;
+  durationMs: number;
+  score: number;
+  eligible: boolean;
+  error?: string;
+}
+
+export interface WorkerFanoutRunResult {
+  winner?: WorkerFanoutCandidateRun;
+  candidates: WorkerFanoutCandidateRun[];
+  fallbackReason?: string;
+}
+
+export interface RunWorkerFanoutOptions {
+  projectPath: string;
+  baseWorkerOptions: WorkerOptions;
+  candidates: WorkerFanoutCandidateConfig[];
+  concurrency: number;
+  keepSandboxes?: boolean;
+  /**
+   * Shared deps/data handling:
+   * - undefined: copy shared paths into each sandbox (verification works, no loser write leak)
+   * - true: symlink shared paths (faster, but writes hit the original shared path)
+   * - false: do not provide shared paths
+   */
+  linkSharedPaths?: boolean;
+  guards?: Partial<PipelineGuardsConfig>;
+  onLog?: (line: string) => void;
+}
+
+function safeCandidateId(id: string, index: number): string {
+  const safe = id.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-|-$/g, '').slice(0, 48);
+  return safe || `candidate-${index + 1}`;
+}
+
+async function git(cwd: string, args: string[], input?: string): Promise<string> {
+  const { stdout } = await exec('git', args, {
+    cwd,
+    encoding: 'utf8',
+    input,
+    maxBuffer: 20 * 1024 * 1024,
+  } as Parameters<typeof exec>[2] & { input?: string });
+  return String(stdout);
+}
+
+async function isGitWorktreeClean(projectPath: string): Promise<boolean> {
+  try {
+    const status = await git(projectPath, ['status', '--porcelain']);
+    return status.trim().length === 0;
+  } catch {
+    return false;
+  }
+}
+
+async function cloneSandbox(
+  projectPath: string,
+  root: string,
+  id: string,
+  sharedPathMode: 'copy' | 'link' | 'off',
+): Promise<string> {
+  const sandbox = join(root, id);
+  await git(projectPath, ['clone', '--quiet', '--no-hardlinks', projectPath, sandbox]);
+  if (sharedPathMode === 'link') await linkSharedPaths(projectPath, sandbox);
+  if (sharedPathMode === 'copy') await copySharedPaths(projectPath, sandbox);
+  return sandbox;
+}
+
+async function linkSharedPaths(projectPath: string, sandboxPath: string): Promise<void> {
+  let metadata = null;
+  try {
+    metadata = await loadRepoMetadata(projectPath);
+  } catch {
+    metadata = null;
+  }
+
+  for (const rel of resolveSharedPaths(projectPath, metadata)) {
+    const target = resolve(projectPath, rel);
+    const linkPath = resolve(sandboxPath, rel);
+    if (existsSync(linkPath)) continue;
+    await mkdir(dirname(linkPath), { recursive: true });
+    await symlink(target, linkPath);
+  }
+}
+
+async function copySharedPaths(projectPath: string, sandboxPath: string): Promise<void> {
+  let metadata = null;
+  try {
+    metadata = await loadRepoMetadata(projectPath);
+  } catch {
+    metadata = null;
+  }
+
+  for (const rel of resolveSharedPaths(projectPath, metadata)) {
+    const source = resolve(projectPath, rel);
+    const target = resolve(sandboxPath, rel);
+    if (existsSync(target)) continue;
+    await mkdir(dirname(target), { recursive: true });
+    await cp(source, target, {
+      recursive: true,
+      force: false,
+      errorOnExist: false,
+      verbatimSymlinks: true,
+    });
+  }
+}
+
+function sharedPathModeFor(linkSharedPaths: boolean | undefined): 'copy' | 'link' | 'off' {
+  if (linkSharedPaths === true) return 'link';
+  if (linkSharedPaths === false) return 'off';
+  return 'copy';
+}
+
+async function changedFiles(projectPath: string): Promise<string[]> {
+  const out = await git(projectPath, ['status', '--porcelain']).catch(() => '');
+  return out
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => {
+      const file = line.slice(3);
+      return file.includes(' -> ') ? file.split(' -> ').pop() ?? file : file;
+    })
+    .filter(Boolean);
+}
+
+async function diffBinary(projectPath: string): Promise<string> {
+  await git(projectPath, ['add', '-A']);
+  return git(projectPath, ['diff', '--cached', '--binary', 'HEAD']);
+}
+
+async function applyDiff(projectPath: string, patchRoot: string, diff: string): Promise<void> {
+  const patchPath = join(patchRoot, 'winner.patch');
+  await writeFile(patchPath, diff, 'utf8');
+  await git(projectPath, ['apply', '--3way', '--whitespace=nowarn', patchPath]);
+}
+
+function scoreCandidate(input: {
+  result: WorkerResult;
+  filesChanged: string[];
+  guards?: GuardsRunResult;
+  durationMs: number;
+  error?: string;
+}): { score: number; eligible: boolean } {
+  const blockingIssues = input.guards?.results.filter((r) => !r.passed && r.blocking).flatMap((r) => r.issues) ?? [];
+  const hasDiff = input.filesChanged.length > 0;
+  const guardsPass = blockingIssues.length === 0;
+  const eligible = input.result.success && hasDiff && guardsPass && !input.error;
+
+  let score = 0;
+  if (input.result.success) score += 100;
+  if (hasDiff) score += 25;
+  if (guardsPass) score += 25;
+  if (typeof input.result.confidencePercent === 'number') score += Math.max(0, Math.min(100, input.result.confidencePercent)) / 10;
+  score -= Math.min(input.filesChanged.length, 20);
+  score -= Math.min(Math.round(input.durationMs / 30_000), 20);
+  if (input.error) score -= 100;
+  if (blockingIssues.length > 0) score -= 50 + blockingIssues.length * 5;
+
+  return { score, eligible };
+}
+
+async function runCandidate(
+  options: RunWorkerFanoutOptions,
+  candidate: WorkerFanoutCandidateConfig,
+  index: number,
+  root: string,
+): Promise<WorkerFanoutCandidateRun> {
+  const id = safeCandidateId(candidate.id, index);
+  const started = Date.now();
+  let sandbox = '';
+
+  try {
+    sandbox = await cloneSandbox(options.projectPath, root, id, sharedPathModeFor(options.linkSharedPaths));
+    const result = await runWorker({
+      ...options.baseWorkerOptions,
+      projectPath: sandbox,
+      model: candidate.model ?? options.baseWorkerOptions.model,
+      adapterName: candidate.adapter ?? options.baseWorkerOptions.adapterName,
+      reasoningEffort: candidate.reasoningEffort ?? options.baseWorkerOptions.reasoningEffort,
+      maxTurns: candidate.maxTurns ?? options.baseWorkerOptions.maxTurns,
+      nudgeMaxOnNoEdit: candidate.nudgeMaxOnNoEdit ?? options.baseWorkerOptions.nudgeMaxOnNoEdit,
+      webTools: candidate.webTools ?? options.baseWorkerOptions.webTools,
+      memoryTools: candidate.memoryTools ?? options.baseWorkerOptions.memoryTools,
+      processContext: options.baseWorkerOptions.processContext
+        ? { ...options.baseWorkerOptions.processContext, stage: `worker:${id}` }
+        : undefined,
+      onLog: (line) => options.onLog?.(`[${id}] ${line}`),
+    });
+    const files = await changedFiles(sandbox);
+    const guards = options.guards && files.length > 0
+      ? await runGuards({ ...result, filesChanged: files }, sandbox, options.guards)
+      : undefined;
+    const scored = scoreCandidate({ result, filesChanged: files, guards, durationMs: Date.now() - started });
+    return {
+      id,
+      projectPath: sandbox,
+      result,
+      filesChanged: files,
+      guards,
+      durationMs: Date.now() - started,
+      score: scored.score,
+      eligible: scored.eligible,
+    };
+  } catch (err) {
+    const result: WorkerResult = {
+      success: false,
+      summary: `Fan-out candidate ${id} failed`,
+      filesChanged: [],
+      commands: [],
+      output: '',
+      error: err instanceof Error ? err.message : String(err),
+    };
+    const scored = scoreCandidate({ result, filesChanged: [], durationMs: Date.now() - started, error: result.error });
+    return {
+      id,
+      projectPath: sandbox,
+      result,
+      filesChanged: [],
+      durationMs: Date.now() - started,
+      score: scored.score,
+      eligible: false,
+      error: result.error,
+    };
+  }
+}
+
+export async function runWorkerFanout(options: RunWorkerFanoutOptions): Promise<WorkerFanoutRunResult> {
+  if (options.candidates.length < 2) {
+    return { candidates: [], fallbackReason: 'fan-out needs at least two candidates' };
+  }
+
+  if (!(await isGitWorktreeClean(options.projectPath))) {
+    return { candidates: [], fallbackReason: 'project worktree has pre-existing changes' };
+  }
+
+  const root = await mkdtemp(join(tmpdir(), 'openswarm-worker-fanout-'));
+  try {
+    options.onLog?.(`[fanout] launching ${options.candidates.length} candidate worker(s)`);
+    const settled = await runPool(
+      options.candidates,
+      options.concurrency,
+      (candidate, index) => runCandidate(options, candidate, index, root),
+      (item) => {
+        if (item.value) {
+          options.onLog?.(`[fanout] ${item.value.id}: score=${item.value.score.toFixed(1)} eligible=${item.value.eligible} files=${item.value.filesChanged.length}`);
+        } else if (item.error) {
+          options.onLog?.(`[fanout] candidate ${item.index + 1} failed: ${item.error instanceof Error ? item.error.message : String(item.error)}`);
+        }
+      },
+    );
+
+    const candidates = settled
+      .map((item) => item.value)
+      .filter((item): item is WorkerFanoutCandidateRun => Boolean(item));
+    const winner = candidates
+      .filter((candidate) => candidate.eligible)
+      .sort((a, b) => b.score - a.score)[0];
+
+    if (!winner) {
+      return { candidates, fallbackReason: 'no eligible fan-out candidate produced a guarded diff' };
+    }
+
+    const diff = await diffBinary(winner.projectPath);
+    if (!diff.trim()) {
+      return { candidates, fallbackReason: 'selected fan-out candidate had no diff to promote' };
+    }
+
+    await applyDiff(options.projectPath, root, diff);
+    const promotedFiles = await changedFiles(options.projectPath);
+    winner.result = {
+      ...winner.result,
+      summary: `[fanout:${winner.id}] ${winner.result.summary}`,
+      filesChanged: promotedFiles,
+    };
+    options.onLog?.(`[fanout] promoted ${winner.id}: ${promotedFiles.length} file(s)`);
+    return { winner, candidates };
+  } finally {
+    if (!options.keepSandboxes) {
+      await rm(root, { recursive: true, force: true });
+    } else {
+      options.onLog?.(`[fanout] kept sandboxes at ${root}`);
+    }
+  }
+}

--- a/src/agents/workerFanoutGate.ts
+++ b/src/agents/workerFanoutGate.ts
@@ -1,0 +1,199 @@
+// ============================================
+// OpenSwarm - Adaptive worker fan-out gate
+// ============================================
+
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import type { PipelineGuardsConfig, RoleConfig, WorkerFanoutCandidateConfig } from '../core/types.js';
+import { broadcastEvent } from '../core/eventHub.js';
+import type { WorkerResult } from './agentPair.js';
+import type { WorkerOptions } from './worker.js';
+import { runWorkerFanout } from './workerFanout.js';
+
+export interface WorkerFanoutGateSignal {
+  code: string;
+  weight: number;
+  reason: string;
+}
+
+export interface WorkerFanoutGateDecision {
+  enabled: boolean;
+  shouldFanOut: boolean;
+  score: number;
+  threshold: number;
+  signals: WorkerFanoutGateSignal[];
+}
+
+export interface FanoutDraftAnalysis {
+  relevantFiles: string[];
+  sufficient?: boolean;
+}
+
+const DEFAULT_FANOUT_GATE_MIN_SCORE = 2;
+const CORE_ORCHESTRATION_PATTERN =
+  /\b(pairpipeline|pipeline|autonomousrunner|runnerexecution|worktree|scheduler|adapter|agenticloop|worker|reviewer|tester|auth|mcp|codexresponses|eventhub)\b/i;
+
+function textMatchesCoreOrchestration(text: string): boolean {
+  return CORE_ORCHESTRATION_PATTERN.test(text.replace(/[^A-Za-z0-9_/.-]+/g, ' '));
+}
+
+export function evaluateWorkerFanoutGate(input: {
+  task: TaskItem;
+  draftAnalysis?: FanoutDraftAnalysis;
+  iteration: number;
+  feedbackSource?: 'objective' | 'review';
+  effort?: 'low' | 'medium' | 'high';
+  config?: RoleConfig['fanout'];
+}): WorkerFanoutGateDecision {
+  const enabled = input.config?.enabled ?? true;
+  const threshold = input.config?.minScore ?? DEFAULT_FANOUT_GATE_MIN_SCORE;
+  if (!enabled) {
+    return { enabled: false, shouldFanOut: false, score: 0, threshold, signals: [] };
+  }
+
+  const signals: WorkerFanoutGateSignal[] = [];
+  const add = (code: string, weight: number, reason: string) => {
+    signals.push({ code, weight, reason });
+  };
+
+  if (input.iteration > 1 && input.feedbackSource === 'objective') {
+    add('objective-retry', 2, 'objective guard/test feedback from a previous iteration');
+  }
+  if (input.iteration > 1 && input.feedbackSource === 'review') {
+    add('review-retry', 2, 'reviewer or confidence feedback requested a revision');
+  }
+  if (input.draftAnalysis?.sufficient === false) {
+    add('insufficient-draft', 1, 'draft analysis was insufficient');
+  }
+
+  const relevantFiles = input.draftAnalysis?.relevantFiles ?? input.task.fileScope ?? [];
+  if (relevantFiles.length >= 4) {
+    add('broad-file-scope', 1, `broad file scope (${relevantFiles.length} files)`);
+  }
+
+  const scopeText = [
+    input.task.title,
+    input.task.description ?? '',
+    relevantFiles.join(' '),
+  ].join(' ');
+  if (textMatchesCoreOrchestration(scopeText)) {
+    add('core-orchestration-scope', 1, 'core orchestration or agent pipeline surface');
+  }
+
+  if ((input.task.estimatedMinutes ?? 0) >= 30) {
+    add('large-estimate', 1, `estimated ${input.task.estimatedMinutes} minutes`);
+  }
+  if (input.task.priority === 1 && (input.task.estimatedMinutes ?? 0) >= 15) {
+    add('urgent-nontrivial', 1, 'urgent non-trivial task');
+  }
+  if (input.effort === 'high') {
+    add('high-effort-profile', 1, 'matched high-effort job profile');
+  }
+
+  const score = signals.reduce((sum, signal) => sum + signal.weight, 0);
+  return {
+    enabled,
+    shouldFanOut: score >= threshold,
+    score,
+    threshold,
+    signals,
+  };
+}
+
+function buildWorkerFanoutCandidates(
+  base: WorkerOptions,
+  configured?: WorkerFanoutCandidateConfig[],
+): WorkerFanoutCandidateConfig[] {
+  if (configured && configured.length > 0) return configured;
+
+  const primary: WorkerFanoutCandidateConfig = {
+    id: 'primary',
+    adapter: base.adapterName,
+    model: base.model,
+    reasoningEffort: base.reasoningEffort,
+    maxTurns: base.maxTurns,
+    nudgeMaxOnNoEdit: base.nudgeMaxOnNoEdit,
+    webTools: base.webTools,
+    memoryTools: base.memoryTools,
+  };
+  const spark: WorkerFanoutCandidateConfig = {
+    id: 'spark-diversity',
+    adapter: 'codex-responses',
+    model: 'gpt-5.3-codex-spark',
+    reasoningEffort: 'low',
+    maxTurns: Math.min(base.maxTurns ?? 12, 12),
+    nudgeMaxOnNoEdit: base.nudgeMaxOnNoEdit,
+    webTools: false,
+    memoryTools: false,
+  };
+
+  const seen = new Set<string>();
+  return [primary, spark].filter((candidate) => {
+    const key = `${candidate.adapter ?? ''}:${candidate.model ?? ''}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function emitWorkerFanoutGateDecision(input: {
+  context: { task: TaskItem; currentIteration: number; taskPrefix: string };
+  decision: WorkerFanoutGateDecision;
+  verbose?: boolean;
+  emit: (event: 'fanout:gate' | 'log', payload: unknown) => void;
+}): void {
+  const { context, decision } = input;
+  const reasons = decision.signals.map((signal) => signal.reason);
+  input.emit('fanout:gate', { context, decision });
+  broadcastEvent({
+    type: 'pipeline:fanout',
+    data: {
+      taskId: context.task.id,
+      iteration: context.currentIteration,
+      enabled: decision.enabled,
+      shouldFanOut: decision.shouldFanOut,
+      score: decision.score,
+      threshold: decision.threshold,
+      reasons,
+    },
+  });
+
+  if (!decision.enabled) return;
+  if (!decision.shouldFanOut && !input.verbose) return;
+
+  const verdict = decision.shouldFanOut ? 'recommend fan-out' : 'single worker';
+  const detail = reasons.length > 0 ? `: ${reasons.join('; ')}` : '';
+  const line = `[FanoutGate] ${verdict} (${decision.score}/${decision.threshold})${detail}`;
+  console.log(`[${context.taskPrefix}] ${line}`);
+  input.emit('log', { line });
+  broadcastEvent({ type: 'log', data: { taskId: context.task.id, stage: 'worker', line: `[${context.taskPrefix}] ${line}` } });
+}
+
+export async function runWorkerWithOptionalFanout(input: {
+  projectPath: string;
+  workerOptions: WorkerOptions;
+  fanoutDecision?: WorkerFanoutGateDecision;
+  fanoutConfig?: RoleConfig['fanout'];
+  guards?: Partial<PipelineGuardsConfig>;
+  onLog: (line: string) => void;
+  runWorker: (options: WorkerOptions) => Promise<WorkerResult>;
+}): Promise<WorkerResult> {
+  const { fanoutDecision, fanoutConfig, workerOptions } = input;
+  if (fanoutDecision?.shouldFanOut && fanoutConfig?.mode === 'execute') {
+    const candidates = buildWorkerFanoutCandidates(workerOptions, fanoutConfig.candidates);
+    const fanoutResult = await runWorkerFanout({
+      projectPath: input.projectPath,
+      baseWorkerOptions: workerOptions,
+      candidates,
+      concurrency: fanoutConfig.concurrency ?? Math.min(candidates.length, 3),
+      keepSandboxes: fanoutConfig.keepSandboxes,
+      linkSharedPaths: fanoutConfig.linkSharedPaths,
+      guards: input.guards,
+      onLog: input.onLog,
+    });
+
+    if (fanoutResult.winner) return fanoutResult.winner.result;
+    input.onLog(`[fanout] fallback to single worker: ${fanoutResult.fallbackReason ?? 'no winner'}`);
+  }
+
+  return input.runWorker(workerOptions);
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -123,6 +123,25 @@ const RoleConfigSchema = z.object({
   escalateAfterIteration: z.number().min(1).optional(),
   /** Max agentic turns per CLI invocation */
   maxTurns: z.number().min(1).optional(),
+  /** Adaptive worker fan-out gate and candidate execution. */
+  fanout: z.object({
+    enabled: z.boolean().optional(),
+    mode: z.enum(['report', 'execute']).optional(),
+    minScore: z.number().min(1).max(10).optional(),
+    concurrency: z.number().int().min(1).max(3).optional(),
+    keepSandboxes: z.boolean().optional(),
+    linkSharedPaths: z.boolean().optional(),
+    candidates: z.array(z.object({
+      id: z.string().min(1),
+      adapter: AdapterNameSchema.optional(),
+      model: z.string().optional(),
+      reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+      maxTurns: z.number().min(1).optional(),
+      nudgeMaxOnNoEdit: z.number().min(0).optional(),
+      webTools: z.boolean().optional(),
+      memoryTools: z.boolean().optional(),
+    })).optional(),
+  }).optional(),
 });
 
 /** Default roles configuration schema */

--- a/src/core/eventHub.test.ts
+++ b/src/core/eventHub.test.ts
@@ -340,9 +340,23 @@ describe('eventHub', () => {
         },
       });
 
+      broadcastEvent({
+        type: 'pipeline:fanout',
+        data: {
+          taskId: 'task-1',
+          iteration: 1,
+          enabled: true,
+          shouldFanOut: true,
+          score: 3,
+          threshold: 2,
+          reasons: ['core-orchestration-scope'],
+        },
+      });
+
       const buffer = getStageBuffer();
       expect(buffer.length).toBeGreaterThan(0);
       expect(buffer.some(e => e.type === 'pipeline:stage')).toBe(true);
+      expect(buffer.some(e => e.type === 'pipeline:fanout')).toBe(true);
     });
 
     it('should store chat events in chatBuffer', () => {
@@ -495,6 +509,21 @@ describe('eventHub', () => {
             iteration: 3,
             fromModel: 'model-1',
             toModel: 'model-2',
+          },
+        },
+      ],
+      [
+        'pipeline:fanout',
+        {
+          type: 'pipeline:fanout',
+          data: {
+            taskId: 'task-1',
+            iteration: 1,
+            enabled: true,
+            shouldFanOut: true,
+            score: 3,
+            threshold: 2,
+            reasons: ['core-orchestration-scope'],
           },
         },
       ],

--- a/src/core/eventHub.ts
+++ b/src/core/eventHub.ts
@@ -69,6 +69,15 @@ export type HubEvent =
     } }
   | { type: 'pipeline:iteration'; data: { taskId: string; iteration: number } }
   | { type: 'pipeline:escalation'; data: { taskId: string; iteration: number; fromModel?: string; toModel: string } }
+  | { type: 'pipeline:fanout'; data: {
+      taskId: string;
+      iteration: number;
+      enabled: boolean;
+      shouldFanOut: boolean;
+      score: number;
+      threshold: number;
+      reasons: string[];
+    } }
   | { type: 'log'; data: { taskId: string; stage: string; line: string } }
   | { type: 'project:toggled'; data: { projectPath: string; enabled: boolean } }
   | { type: 'task:cost'; data: { taskId: string; cost: CostInfo } }
@@ -154,6 +163,7 @@ export function broadcastEvent(event: HubEvent): void {
     case 'pipeline:stage':
     case 'pipeline:iteration':
     case 'pipeline:escalation':
+    case 'pipeline:fanout':
     case 'task:queued':
     case 'task:started':
     case 'task:completed':

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -282,11 +282,32 @@ export type ModelConfig = {
 /**
  * Per-role configuration
  */
+export type AgentAdapterName = 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter' | 'claude';
+
+export type WorkerFanoutCandidateConfig = {
+  /** Stable display/id for logs and scoring. */
+  id: string;
+  /** Candidate adapter override. Omit to inherit the worker role adapter. */
+  adapter?: AgentAdapterName;
+  /** Candidate model override. Omit to inherit the resolved worker model. */
+  model?: string;
+  /** Candidate reasoning effort override. */
+  reasoningEffort?: 'low' | 'medium' | 'high';
+  /** Candidate max agentic turns override. */
+  maxTurns?: number;
+  /** Candidate no-edit guard override. */
+  nudgeMaxOnNoEdit?: number;
+  /** Candidate web tool exposure override. */
+  webTools?: boolean;
+  /** Candidate memory tool exposure override. */
+  memoryTools?: boolean;
+};
+
 export type RoleConfig = {
   /** Whether role is enabled */
   enabled: boolean;
   /** CLI adapter name */
-  adapter?: 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter' | 'claude';
+  adapter?: AgentAdapterName;
   /** Model ID. Omit → resolved dynamically from the role's adapter (getDefaultModel). */
   model?: string;
   /** Timeout (ms), 0 = unlimited */
@@ -297,6 +318,25 @@ export type RoleConfig = {
   escalateAfterIteration?: number;
   /** Max agentic turns per CLI invocation */
   maxTurns?: number;
+  /**
+   * Adaptive worker fan-out gate and optional candidate execution.
+   */
+  fanout?: {
+    /** Enable gate evaluation (default true when omitted). */
+    enabled?: boolean;
+    /** Report only or execute candidate workers (default report). */
+    mode?: 'report' | 'execute';
+    /** Minimum signal score required to recommend fan-out (default 2). */
+    minScore?: number;
+    /** Max candidate workers in flight (default candidates length, capped at 3). */
+    concurrency?: number;
+    /** Keep temporary candidate repos for debugging. */
+    keepSandboxes?: boolean;
+    /** Shared paths default to sandbox-local copies; true symlinks them, false disables them. */
+    linkSharedPaths?: boolean;
+    /** Candidate lanes. Omit for primary + Spark diversity defaults. */
+    candidates?: WorkerFanoutCandidateConfig[];
+  };
 };
 
 /**

--- a/src/memory/memoryCore.ts
+++ b/src/memory/memoryCore.ts
@@ -860,7 +860,10 @@ export async function searchMemorySafe(
       predicates.push(`repo IN (${[repo, 'system', 'cognitive'].map(sqlString).join(', ')})`);
     }
     if (!includeExpired) {
-      predicates.push(`(expiresAt IS NULL OR expiresAt >= ${now} OR expiresAt >= ${PERMANENT_EXPIRY})`);
+      // Lance/DataFusion normalizes unquoted identifiers to lowercase. This
+      // column is camelCase in the Arrow schema, so quote it or vector search
+      // fails with "No field named expiresat".
+      predicates.push(`("expiresAt" IS NULL OR "expiresAt" >= ${now} OR "expiresAt" >= ${PERMANENT_EXPIRY})`);
     }
     if (minTrust > 0) {
       predicates.push(`(confidence >= ${minTrust} OR (confidence IS NULL AND trust >= ${minTrust}))`);

--- a/src/support/dashboardHtml.ts
+++ b/src/support/dashboardHtml.ts
@@ -859,6 +859,18 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
           break;
         }
         case "pipeline:stage": addStageRow(ev.data); break;
+        case "pipeline:fanout":
+          addStageRow({
+            taskId: ev.data.taskId,
+            stage: "fanout",
+            status: "complete",
+            summary: ev.data.enabled
+              ? ((ev.data.shouldFanOut ? "fan-out recommended" : "single-worker path") + " (score " + ev.data.score + "/" + ev.data.threshold + ")")
+              : "fan-out disabled",
+            issues: ev.data.reasons || [],
+            issuesCount: (ev.data.reasons || []).length,
+          });
+          break;
         case "pipeline:iteration":
           addStageRow({ taskId: ev.data.taskId, stage: "iter #" + ev.data.iteration, status: "start" });
           break;

--- a/src/tui/pipelineEvents.test.ts
+++ b/src/tui/pipelineEvents.test.ts
@@ -15,6 +15,19 @@ const processExit = (over: Record<string, unknown> = {}): HubEvent => ({
   type: 'process:exit',
   data: { pid: 1, taskId: 't1', stage: 'worker', exitCode: 0, signal: null, durationMs: 1000, ...over },
 }) as HubEvent;
+const fanout = (over: Record<string, unknown> = {}): HubEvent => ({
+  type: 'pipeline:fanout',
+  data: {
+    taskId: 't1',
+    iteration: 1,
+    enabled: true,
+    shouldFanOut: true,
+    score: 3,
+    threshold: 2,
+    reasons: ['core-orchestration-scope'],
+    ...over,
+  },
+}) as HubEvent;
 
 describe('reducePipelineEvent (EPIC INT-1813 S5)', () => {
   it('appends pipeline:stage entries with their fields', () => {
@@ -57,6 +70,18 @@ describe('reducePipelineEvent (EPIC INT-1813 S5)', () => {
 
     s = reducePipelineEvent(s, log('reasoning about next patch'));
     expect(s.stages[0]).toMatchObject({ activity: 'thinking' });
+  });
+
+  it('records fan-out gate decisions as compact stage entries', () => {
+    const s = reducePipelineEvent(initialPipelineState, fanout());
+
+    expect(s.stages[0]).toMatchObject({
+      taskId: 't1',
+      stage: 'fanout',
+      status: 'complete',
+      activity: 'fan-out',
+      summary: 'fan-out recommended (score 3/2): core-orchestration-scope',
+    });
   });
 
   it('clears process waiting activity only for the matching task and stage', () => {

--- a/src/tui/pipelineEvents.ts
+++ b/src/tui/pipelineEvents.ts
@@ -59,6 +59,20 @@ export function reducePipelineEvent(state: PipelineState, ev: HubEvent): Pipelin
     };
     return { ...state, stages: [...state.stages, entry].slice(-MAX_STAGES) };
   }
+  if (ev.type === 'pipeline:fanout') {
+    const d = ev.data;
+    const summary = d.enabled
+      ? `${d.shouldFanOut ? 'fan-out recommended' : 'single-worker path'} (score ${d.score}/${d.threshold})`
+      : 'fan-out disabled';
+    const entry: StageEntry = {
+      taskId: d.taskId,
+      stage: 'fanout',
+      status: 'complete',
+      summary: d.reasons.length > 0 ? `${summary}: ${d.reasons.join(', ')}` : summary,
+      activity: d.shouldFanOut ? 'fan-out' : 'single-worker',
+    };
+    return { ...state, stages: [...state.stages, entry].slice(-MAX_STAGES) };
+  }
   if (ev.type === 'log') {
     const activity = classifyActivity(ev.data.line);
     return {


### PR DESCRIPTION
## Summary
- Add an adaptive worker fan-out gate that reports by default and only executes candidate workers when `roles.worker.fanout.mode: execute` is configured.
- Add isolated fan-out execution with primary + Spark diversity defaults, guard-aware scoring, winner-only diff promotion, shared-path copy defaults, and dashboard/TUI `pipeline:fanout` visibility.
- Keep Spark opt-in/explicit for `codex-responses`, add benchmark evidence, and wire `memoryTools: false` consistently across native and external CLI adapters.

## Verification
- OpenSwarm review: approve. Verified staged diff, call-site wiring, config/event contracts, targeted tests, lint, typecheck, build, and full test with writable temp HOME.
- `npm test -- src/agents/pairPipeline.test.ts src/core/eventHub.test.ts src/tui/pipelineEvents.test.ts src/adapters/codex.test.ts src/adapters/claude.test.ts src/adapters/agenticLoop.test.ts src/core/config.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npx oxlint benchmarks/codexSparkRealWork.ts benchmarks/workerFanoutGate.ts`
- `HOME=$(mktemp -d /tmp/openswarm-test-home-XXXXXX) npm test`
- `npm run build`
- `npx tsx benchmarks/workerFanoutGate.ts` -> threshold 2 pass 10/10, fanout 6/10

## Benchmark Evidence
- `benchmarks/results/codexSparkRealWork-latest.json`: Spark/mini real-work benchmark, 9/9 passing.
- `benchmarks/results/workerFanoutGate-latest.json`: deterministic gate calibration, threshold 2 selected.