### PR TITLE
Add adaptive worker fan-out and validation caps

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -47,6 +47,9 @@ autonomous:
   schedule: "*/15 * * * *"  # Every 15 minutes
   maxAttempts: 3
   maxConcurrentTasks: 4  # Number of concurrent tasks
+  worktreeMode: true  # Required for same-project parallel tasks
+  allowSameProjectConcurrent: true
+  maxConcurrentPerProject: 2  # Optional cap for same-project worktree parallelism
 
   allowedProjects:
     - ~/dev/your-project

--- a/src/agents/pairPipeline.test.ts
+++ b/src/agents/pairPipeline.test.ts
@@ -315,6 +315,36 @@ describe('PairPipeline model selection', () => {
     }));
   });
 
+  it('defers to the reviewer instead of hard-failing when validation evidence stays missing', async () => {
+    // A worker whose git changes were promoted to success with commands=[]
+    // (no JSON block) must not be killed after a couple of retries — the gate is
+    // a nudge, so once self-repair stagnates the reviewer gets the final say.
+    runWorker.mockResolvedValue({
+      success: true,
+      summary: 'changed code, never self-reported commands',
+      filesChanged: ['src/example.ts'],
+      commands: [],
+      output: '',
+      confidencePercent: 95,
+    });
+
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker', 'reviewer'],
+      maxIterations: 4,
+      roles: {
+        worker: { enabled: true, model: 'worker', timeoutMs: 0 },
+        reviewer: { enabled: true, model: 'reviewer', timeoutMs: 0 },
+      },
+    });
+
+    const result = await pipeline.run(task(), process.cwd());
+
+    // Reviewer approves → task succeeds despite never getting validation evidence.
+    expect(result.success).toBe(true);
+    expect(runReviewer).toHaveBeenCalledTimes(1);
+  });
+
   it('does not treat inspection-only commands as validation evidence', async () => {
     runWorker
       .mockResolvedValueOnce({

--- a/src/agents/pairPipeline.test.ts
+++ b/src/agents/pairPipeline.test.ts
@@ -58,7 +58,7 @@ describe('PairPipeline model selection', () => {
       success: true,
       summary: 'done',
       filesChanged: ['src/example.ts'],
-      commands: [],
+      commands: ['npm test -- src/example.test.ts'],
       output: '',
       confidencePercent: 100,
     });
@@ -274,6 +274,190 @@ describe('PairPipeline model selection', () => {
 
     expect(stageModels().every(m => m === 'explicit-worker')).toBe(true);
     expect(getDefaultModel).not.toHaveBeenCalled();
+  });
+
+  it('retries code-changing workers before review when validation commands are missing', async () => {
+    runWorker
+      .mockResolvedValueOnce({
+        success: true,
+        summary: 'changed code without checking it',
+        filesChanged: ['src/example.ts'],
+        commands: [],
+        output: '',
+        confidencePercent: 95,
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        summary: 'changed code and ran a focused test',
+        filesChanged: ['src/example.ts'],
+        commands: ['npm test -- src/example.test.ts'],
+        output: 'PASS src/example.test.ts',
+        confidencePercent: 95,
+      });
+
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker', 'reviewer'],
+      maxIterations: 2,
+      roles: {
+        worker: { enabled: true, model: 'worker', timeoutMs: 0 },
+        reviewer: { enabled: true, model: 'reviewer', timeoutMs: 0 },
+      },
+    });
+
+    const result = await pipeline.run(task(), process.cwd());
+
+    expect(result.success).toBe(true);
+    expect(runWorker).toHaveBeenCalledTimes(2);
+    expect(runReviewer).toHaveBeenCalledTimes(1);
+    expect(runWorker.mock.calls[1][0]).toEqual(expect.objectContaining({
+      previousFeedback: expect.stringContaining('validation evidence missing'),
+    }));
+  });
+
+  it('does not treat inspection-only commands as validation evidence', async () => {
+    runWorker
+      .mockResolvedValueOnce({
+        success: true,
+        summary: 'changed code after searching',
+        filesChanged: ['src/example.ts'],
+        commands: ['rg "npm test" package.json', 'git grep "cargo test"'],
+        output: '',
+        confidencePercent: 95,
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        summary: 'changed code and ran a script smoke check',
+        filesChanged: ['src/example.ts'],
+        commands: ['python scripts/smoke_example.py --dry-run'],
+        output: 'ok',
+        confidencePercent: 95,
+      });
+
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker', 'reviewer'],
+      maxIterations: 2,
+      roles: {
+        worker: { enabled: true, model: 'worker', timeoutMs: 0 },
+        reviewer: { enabled: true, model: 'reviewer', timeoutMs: 0 },
+      },
+    });
+
+    const result = await pipeline.run(task(), process.cwd());
+
+    expect(result.success).toBe(true);
+    expect(runWorker).toHaveBeenCalledTimes(2);
+    expect(runReviewer).toHaveBeenCalledTimes(1);
+    expect(runWorker.mock.calls[1][0]).toEqual(expect.objectContaining({
+      previousFeedback: expect.stringContaining('non-validation commands'),
+    }));
+  });
+
+  it('requires validation for build and dependency manifests without extensions', async () => {
+    runWorker
+      .mockResolvedValueOnce({
+        success: true,
+        summary: 'changed runtime manifests without checking them',
+        filesChanged: ['Dockerfile', 'Makefile', 'requirements.txt', 'go.mod', 'Cargo.lock'],
+        commands: [],
+        output: '',
+        confidencePercent: 95,
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        summary: 'changed manifests and ran a smoke build',
+        filesChanged: ['Dockerfile', 'Makefile', 'requirements.txt', 'go.mod', 'Cargo.lock'],
+        commands: ['npm run ci'],
+        output: 'ok',
+        confidencePercent: 95,
+      });
+
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker', 'reviewer'],
+      maxIterations: 2,
+      roles: {
+        worker: { enabled: true, model: 'worker', timeoutMs: 0 },
+        reviewer: { enabled: true, model: 'reviewer', timeoutMs: 0 },
+      },
+    });
+
+    const result = await pipeline.run(task(), process.cwd());
+
+    expect(result.success).toBe(true);
+    expect(runWorker).toHaveBeenCalledTimes(2);
+    expect(runReviewer).toHaveBeenCalledTimes(1);
+    expect(runWorker.mock.calls[1][0]).toEqual(expect.objectContaining({
+      previousFeedback: expect.stringContaining('requirements.txt'),
+    }));
+  });
+
+  it('still requires validation when tester is enabled but would skip manifest-only changes', async () => {
+    runWorker
+      .mockResolvedValueOnce({
+        success: true,
+        summary: 'changed package metadata without checking it',
+        filesChanged: ['package.json'],
+        commands: [],
+        output: '',
+        confidencePercent: 95,
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        summary: 'changed package metadata and ran ci',
+        filesChanged: ['package.json'],
+        commands: ['npm run ci'],
+        output: 'ok',
+        confidencePercent: 95,
+      });
+
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker', 'tester', 'reviewer'],
+      maxIterations: 2,
+      roles: {
+        worker: { enabled: true, model: 'worker', timeoutMs: 0 },
+        tester: { enabled: true, model: 'tester', timeoutMs: 0 },
+        reviewer: { enabled: true, model: 'reviewer', timeoutMs: 0 },
+      },
+    });
+
+    const result = await pipeline.run(task(), process.cwd());
+
+    expect(result.success).toBe(true);
+    expect(runWorker).toHaveBeenCalledTimes(2);
+    expect(runReviewer).toHaveBeenCalledTimes(1);
+    expect(runWorker.mock.calls[1][0]).toEqual(expect.objectContaining({
+      previousFeedback: expect.stringContaining('validation evidence missing'),
+    }));
+  });
+
+  it('allows docs-only workers to reach review without validation commands', async () => {
+    runWorker.mockResolvedValueOnce({
+      success: true,
+      summary: 'updated docs',
+      filesChanged: ['docs/usage.md'],
+      commands: [],
+      output: '',
+      confidencePercent: 95,
+    });
+
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker', 'reviewer'],
+      maxIterations: 1,
+      roles: {
+        worker: { enabled: true, model: 'worker', timeoutMs: 0 },
+        reviewer: { enabled: true, model: 'reviewer', timeoutMs: 0 },
+      },
+    });
+
+    const result = await pipeline.run(task({ title: 'Update docs' }), process.cwd());
+
+    expect(result.success).toBe(true);
+    expect(runWorker).toHaveBeenCalledTimes(1);
+    expect(runReviewer).toHaveBeenCalledTimes(1);
   });
 
   it('degrades to an undefined model when getDefaultModel fails', async () => {

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -5,20 +5,19 @@
 
 import { EventEmitter } from 'node:events';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
-import type { WorkerResult, ReviewResult, PairSession } from './agentPair.js';
+import type { WorkerResult, ReviewResult } from './agentPair.js';
 import type { TesterResult } from './tester.js';
 import type { DocumenterResult } from './documenter.js';
 import type { AuditorResult } from './auditor.js';
 import type { SkillDocumenterResult } from './skillDocumenter.js';
-import type { PipelineStage, RoleConfig, PipelineGuardsConfig, JobProfile } from '../core/types.js';
+import type { PipelineStage, PipelineGuardsConfig, JobProfile } from '../core/types.js';
 import { type CostInfo, aggregateCosts, formatCost } from '../support/costTracker.js';
 
 import { broadcastEvent } from '../core/eventHub.js';
 import { CONFIDENCE_THRESHOLDS } from './agentPair.js';
 import * as agentPair from './agentPair.js';
-import { runGuards, type GuardsRunResult } from './pipelineGuards.js';
+import { runGuards } from './pipelineGuards.js';
 import {
-  type ReflectionState,
   type ReflectionSource,
   createReflectionState,
   recordReflection,
@@ -33,7 +32,14 @@ import type { WorkerContext } from '../locale/types.js';
 import * as workerAgent from './worker.js';
 import type { WorkerOptions } from './worker.js';
 import { buildTaskPrefix } from './pipelineTaskPrefix.js';
-import { emitWorkerFanoutGateDecision, evaluateWorkerFanoutGate, runWorkerWithOptionalFanout, type WorkerFanoutGateDecision } from './workerFanoutGate.js';
+import { emitWorkerFanoutGateDecision, evaluateWorkerFanoutGate, runWorkerWithOptionalFanout } from './workerFanoutGate.js';
+import type {
+  PipelineConfig,
+  PipelineContext,
+  PipelineResult,
+  PipelineRunMetadata,
+  StageResult,
+} from './pairPipelineTypes.js';
 import * as reviewerAgent from './reviewer.js';
 import * as testerAgent from './tester.js';
 import * as documenterAgent from './documenter.js';
@@ -44,138 +50,23 @@ import { RateLimitError } from '../adapters/rateLimitError.js';
 import { isInfraError } from '../adapters/errorClassification.js';
 import { resolveAdapterDefaultModel } from './stageModelResolver.js';
 import { isClassifiedStageError, rethrowClassified, extractClassifiedStageResult, PipelineCancelledError } from './stageErrorClassification.js';
+import {
+  isTesterCodeFile,
+  missingWorkerValidationIssues,
+  testerWouldRunForWorkerResult,
+} from './workerValidationEvidence.js';
 
 export { PipelineCancelledError };
-
-// Types
-
-export interface PipelineConfig {
-  /** List of active stages (executed in order) */
-  stages: PipelineStage[];
-  /** Whether to continue on test failure */
-  continueOnTestFail?: boolean;
-  /** Skip Documenter if no changes */
-  skipDocumenterIfNoChange?: boolean;
-  /** Max total iterations (one cycle = Worker → Reviewer → Tester) */
-  maxIterations?: number;
-  /**
-   * Max objective self-repair attempts (lint/bs/test failures) before the loop
-   * gives up on bad edits. Independent of maxIterations so an operator can cap
-   * token burn on reflection without shrinking the reviewer-revise budget.
-   * Default: DEFAULT_MAX_REFLECTIONS (3).
-   */
-  maxReflections?: number;
-  /** Per-role configuration */
-  roles?: {
-    worker?: RoleConfig;
-    reviewer?: RoleConfig;
-    tester?: RoleConfig;
-    documenter?: RoleConfig;
-    auditor?: RoleConfig;
-    'skill-documenter'?: RoleConfig;
-  };
-  /** Pipeline guards configuration */
-  guards?: Partial<PipelineGuardsConfig>;
-  /** Optional job profiles for model selection */
-  jobProfiles?: JobProfile[];
-  /** Runtime metadata used by observers such as the TUI pipeline tree. */
-  runMetadata?: PipelineRunMetadata;
-  /** Skip tester if no code files (.ts/.js/.py etc.) changed (default: true) */
-  skipTesterIfNoCodeChange?: boolean;
-  /** Skip auditor if fewer than N files changed (default: 3) */
-  skipAuditorUnderFileCount?: number;
-  /** Enable verbose logging (detailed stage info, agent decisions, timing) */
-  verbose?: boolean;
-  /** Draft Analyzer 사전 분석 결과 (Haiku) — Worker/Planner에 주입 */
-  draftAnalysis?: {
-    taskType: string;
-    intentSummary: string;
-    relevantFiles: string[];
-    suggestedApproach: string;
-    projectStats?: string;
-    completionCriteria?: string[];
-    sufficient?: boolean;
-    impactAnalysis?: import('../knowledge/types.js').ImpactAnalysis;
-    registrySnapshot?: Array<{ filePath: string; summary: string; highlights: string[] }>;
-  };
-}
+export type {
+  PipelineConfig,
+  PipelineContext,
+  PipelineEventType,
+  PipelineResult,
+  PipelineRunMetadata,
+  StageResult,
+} from './pairPipelineTypes.js';
 
 export { buildTaskPrefix } from './pipelineTaskPrefix.js';
-
-export interface PipelineRunMetadata { repository?: string; projectPath?: string; worktree?: string; branch?: string; issueIdentifier?: string; title?: string; }
-
-export interface StageResult {
-  stage: PipelineStage;
-  success: boolean;
-  result: WorkerResult | ReviewResult | TesterResult | DocumenterResult | AuditorResult | SkillDocumenterResult | { success: false; error: string };
-  duration: number;
-  /** Stage start time (epoch ms) */
-  startedAt: number;
-  /** Stage completion time (epoch ms) */
-  completedAt: number;
-}
-
-export interface PipelineResult {
-  success: boolean;
-  sessionId: string;
-  stages: StageResult[];
-  finalStatus: 'approved' | 'rejected' | 'failed' | 'cancelled' | 'decomposed' | 'rate_limited' | 'infra_error';
-  /** Unix timestamp (ms) when the rate-limit quota resets — set when finalStatus is 'rate_limited'. */
-  rateLimitResetsAt?: number;
-  totalDuration: number;
-  /** Total number of completed iterations */
-  iterations: number;
-  workerResult?: WorkerResult;
-  reviewResult?: ReviewResult;
-  testerResult?: TesterResult;
-  documenterResult?: DocumenterResult;
-  auditorResult?: AuditorResult;
-  skillDocumenterResult?: SkillDocumenterResult;
-  /** Task context (for reporting) */
-  taskContext?: {
-    issueIdentifier?: string;
-    projectName?: string;
-    projectPath?: string;
-    taskTitle?: string;
-  };
-  /** PR URL (auto-created PR in worktree mode) */
-  prUrl?: string;
-  /** Total cost across all stages */
-  totalCost?: CostInfo;
-}
-
-export interface PipelineContext {
-  task: TaskItem;
-  projectPath: string;
-  session: PairSession;
-  config: PipelineConfig;
-  /** Current iteration number (1-based) */
-  currentIteration: number;
-  /** Formatted task prefix for consistent logging (e.g., "OpenSwarm | INT-1171 | worktree/abc123") */
-  taskPrefix: string;
-  workerResult?: WorkerResult;
-  reviewResult?: ReviewResult;
-  testerResult?: TesterResult;
-  documenterResult?: DocumenterResult;
-  auditorResult?: AuditorResult;
-  skillDocumenterResult?: SkillDocumenterResult;
-  guardsResult?: GuardsRunResult;
-  /** Accumulated objective (lint/bs/test) errors for self-repair reflection */
-  reflection: ReflectionState;
-  /**
-   * Source of the latest revise feedback. 'objective' failures (lint/bs/test)
-   * flow through the reflection trail and are preserved across fresh-context
-   * resets; 'review' feedback (reviewer/halt) is subjective and dropped on a
-   * fresh-context retry.
-   */
-  feedbackSource?: 'objective' | 'review';
-  /** Last adaptive fan-out gate decision for the worker stage. */
-  workerFanoutDecision?: WorkerFanoutGateDecision;
-}
-
-// Pipeline Events
-
-export type PipelineEventType = 'stage:start' | 'stage:complete' | 'stage:fail' | 'iteration:start' | 'iteration:complete' | 'iteration:fail' | 'pipeline:complete' | 'pipeline:fail' | 'fanout:gate' | 'halt';
 
 // Pair Pipeline
 
@@ -1074,6 +965,47 @@ export class PairPipeline extends EventEmitter {
         }
       }
 
+      // A code-changing worker that reports no commands is usually a low-accuracy
+      // partial implementation: the reviewer then spends a full pass rediscovering
+      // that nothing was built, tested, or smoke-checked. When there is no tester
+      // stage to provide objective evidence, bounce it back immediately with a
+      // ground-truth validation reflection.
+      if (hasReviewer && context.workerResult && !testerWouldRunForWorkerResult(
+        context.workerResult,
+        hasTester,
+        this.config.skipTesterIfNoCodeChange ?? true
+      )) {
+        const validationIssues = missingWorkerValidationIssues(context.workerResult);
+        if (validationIssues.length > 0) {
+          console.log(`[${context.taskPrefix}] Missing worker validation evidence: ${validationIssues.join('; ')}`);
+          const { progressed } = recordReflection(context.reflection, {
+            iteration: context.currentIteration,
+            source: 'validation',
+            errors: validationIssues,
+          });
+
+          context.reviewResult = {
+            decision: 'revise',
+            feedback: `Worker validation evidence missing: ${validationIssues.join('; ')}`,
+            issues: validationIssues,
+            suggestions: ['Run a relevant validation command before asking for review'],
+          };
+          context.feedbackSource = 'objective';
+          agentPair.trackFailure(context.session.id);
+          this.emit('iteration:fail', {
+            iteration: context.currentIteration,
+            stage: 'worker',
+            context,
+          });
+          agentPair.updateSessionStatus(context.session.id, 'revising');
+
+          if (this.shouldAbortSelfRepair(context, progressed, 'validation')) {
+            return { success: false };
+          }
+          continue;
+        }
+      }
+
       // ========== HALT CHECK (confidence too low) ==========
       if (context.workerResult) {
         const confidence = agentPair.calculateConfidence(context.workerResult);
@@ -1117,9 +1049,8 @@ export class PairPipeline extends EventEmitter {
       if (hasTester) {
         // Skip tester if no code files changed (configurable, default true)
         const skipIfNoCode = this.config.skipTesterIfNoCodeChange ?? true;
-        const codeExtensions = /\.(ts|tsx|js|jsx|py|rs|go|java|rb|c|cpp|h|hpp)$/;
         const changedFiles = context.workerResult?.filesChanged || [];
-        const hasCodeChange = changedFiles.some(f => codeExtensions.test(f));
+        const hasCodeChange = changedFiles.some(isTesterCodeFile);
         if (skipIfNoCode && !hasCodeChange) {
           console.log(`[${context.taskPrefix}] Skipping tester: no code files changed (${changedFiles.length} files: ${changedFiles.join(', ') || 'none'})`);
         } else {

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -977,32 +977,43 @@ export class PairPipeline extends EventEmitter {
       )) {
         const validationIssues = missingWorkerValidationIssues(context.workerResult);
         if (validationIssues.length > 0) {
-          console.log(`[${context.taskPrefix}] Missing worker validation evidence: ${validationIssues.join('; ')}`);
           const { progressed } = recordReflection(context.reflection, {
             iteration: context.currentIteration,
             source: 'validation',
             errors: validationIssues,
           });
 
-          context.reviewResult = {
-            decision: 'revise',
-            feedback: `Worker validation evidence missing: ${validationIssues.join('; ')}`,
-            issues: validationIssues,
-            suggestions: ['Run a relevant validation command before asking for review'],
-          };
-          context.feedbackSource = 'objective';
-          agentPair.trackFailure(context.session.id);
-          this.emit('iteration:fail', {
-            iteration: context.currentIteration,
-            stage: 'worker',
-            context,
-          });
-          agentPair.updateSessionStatus(context.session.id, 'revising');
-
-          if (this.shouldAbortSelfRepair(context, progressed, 'validation')) {
-            return { success: false };
+          // Missing validation evidence is a nudge, not a verdict: the worker may
+          // simply be unable to self-report its commands (e.g. git-detected
+          // changes with no JSON block — worker.ts promotes those to success with
+          // commands=[]). Bounce it back to re-run with validation while that can
+          // still make progress; once it stagnates or the reflection budget is
+          // spent, DEFER to the reviewer (pre-gate behavior) rather than
+          // hard-failing the whole task. This is a pure predicate — do NOT reuse
+          // shouldAbortSelfRepair here: it marks the session 'failed' as a side
+          // effect (see ~L795), which would sink an otherwise-approvable task.
+          const reflectionBudget = this.config.maxReflections ?? DEFAULT_MAX_REFLECTIONS;
+          const canRetryForValidation = progressed && !shouldStopReflecting(context.reflection, reflectionBudget);
+          if (canRetryForValidation) {
+            console.log(`[${context.taskPrefix}] Missing worker validation evidence: ${validationIssues.join('; ')}`);
+            context.reviewResult = {
+              decision: 'revise',
+              feedback: `Worker validation evidence missing: ${validationIssues.join('; ')}`,
+              issues: validationIssues,
+              suggestions: ['Run a relevant validation command before asking for review'],
+            };
+            context.feedbackSource = 'objective';
+            agentPair.trackFailure(context.session.id);
+            this.emit('iteration:fail', {
+              iteration: context.currentIteration,
+              stage: 'worker',
+              context,
+            });
+            agentPair.updateSessionStatus(context.session.id, 'revising');
+            continue;
           }
-          continue;
+          console.log(`[${context.taskPrefix}] Validation evidence still missing after retries — deferring to reviewer`);
+          this.emit('log', { line: '⚠️ Validation evidence missing; deferring to reviewer' });
         }
       }
 

--- a/src/agents/pairPipelineTypes.ts
+++ b/src/agents/pairPipelineTypes.ts
@@ -1,0 +1,107 @@
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import type { PipelineStage, RoleConfig, PipelineGuardsConfig, JobProfile } from '../core/types.js';
+import type { CostInfo } from '../support/costTracker.js';
+import type { WorkerResult, ReviewResult, PairSession } from './agentPair.js';
+import type { TesterResult } from './tester.js';
+import type { DocumenterResult } from './documenter.js';
+import type { AuditorResult } from './auditor.js';
+import type { SkillDocumenterResult } from './skillDocumenter.js';
+import type { GuardsRunResult } from './pipelineGuards.js';
+import type { ReflectionState } from './reflection.js';
+import type { WorkerFanoutGateDecision } from './workerFanoutGate.js';
+
+export interface PipelineRunMetadata {
+  repository?: string;
+  projectPath?: string;
+  worktree?: string;
+  branch?: string;
+  issueIdentifier?: string;
+  title?: string;
+}
+
+export interface PipelineConfig {
+  stages: PipelineStage[];
+  continueOnTestFail?: boolean;
+  skipDocumenterIfNoChange?: boolean;
+  maxIterations?: number;
+  maxReflections?: number;
+  roles?: {
+    worker?: RoleConfig;
+    reviewer?: RoleConfig;
+    tester?: RoleConfig;
+    documenter?: RoleConfig;
+    auditor?: RoleConfig;
+    'skill-documenter'?: RoleConfig;
+  };
+  guards?: Partial<PipelineGuardsConfig>;
+  jobProfiles?: JobProfile[];
+  runMetadata?: PipelineRunMetadata;
+  skipTesterIfNoCodeChange?: boolean;
+  skipAuditorUnderFileCount?: number;
+  verbose?: boolean;
+  draftAnalysis?: {
+    taskType: string;
+    intentSummary: string;
+    relevantFiles: string[];
+    suggestedApproach: string;
+    projectStats?: string;
+    completionCriteria?: string[];
+    sufficient?: boolean;
+    impactAnalysis?: import('../knowledge/types.js').ImpactAnalysis;
+    registrySnapshot?: Array<{ filePath: string; summary: string; highlights: string[] }>;
+  };
+}
+
+export interface StageResult {
+  stage: PipelineStage;
+  success: boolean;
+  result: WorkerResult | ReviewResult | TesterResult | DocumenterResult | AuditorResult | SkillDocumenterResult | { success: false; error: string };
+  duration: number;
+  startedAt: number;
+  completedAt: number;
+}
+
+export interface PipelineResult {
+  success: boolean;
+  sessionId: string;
+  stages: StageResult[];
+  finalStatus: 'approved' | 'rejected' | 'failed' | 'cancelled' | 'decomposed' | 'rate_limited' | 'infra_error';
+  rateLimitResetsAt?: number;
+  totalDuration: number;
+  iterations: number;
+  workerResult?: WorkerResult;
+  reviewResult?: ReviewResult;
+  testerResult?: TesterResult;
+  documenterResult?: DocumenterResult;
+  auditorResult?: AuditorResult;
+  skillDocumenterResult?: SkillDocumenterResult;
+  taskContext?: {
+    issueIdentifier?: string;
+    projectName?: string;
+    projectPath?: string;
+    taskTitle?: string;
+  };
+  prUrl?: string;
+  totalCost?: CostInfo;
+}
+
+export interface PipelineContext {
+  task: TaskItem;
+  projectPath: string;
+  session: PairSession;
+  config: PipelineConfig;
+  currentIteration: number;
+  taskPrefix: string;
+  workerResult?: WorkerResult;
+  reviewResult?: ReviewResult;
+  testerResult?: TesterResult;
+  documenterResult?: DocumenterResult;
+  auditorResult?: AuditorResult;
+  skillDocumenterResult?: SkillDocumenterResult;
+  guardsResult?: GuardsRunResult;
+  reflection: ReflectionState;
+  feedbackSource?: 'objective' | 'review';
+  workerFanoutDecision?: WorkerFanoutGateDecision;
+}
+
+export type PipelineEventType = 'stage:start' | 'stage:complete' | 'stage:fail' | 'iteration:start' | 'iteration:complete' | 'iteration:fail' | 'pipeline:complete' | 'pipeline:fail' | 'fanout:gate' | 'halt';

--- a/src/agents/reflection.test.ts
+++ b/src/agents/reflection.test.ts
@@ -24,10 +24,11 @@ describe('reflection', () => {
   });
 
   describe('isObjective', () => {
-    it('treats lint/bs/test as objective', () => {
+    it('treats lint/bs/test/validation as objective', () => {
       expect(isObjective('lint')).toBe(true);
       expect(isObjective('bs')).toBe(true);
       expect(isObjective('test')).toBe(true);
+      expect(isObjective('validation')).toBe(true);
     });
 
     it('treats review as subjective', () => {
@@ -44,6 +45,8 @@ describe('reflection', () => {
       expect(s.reflectionCount).toBe(1); // review does not count
       recordReflection(s, { iteration: 3, source: 'test', errors: ['t1'] });
       expect(s.reflectionCount).toBe(2);
+      recordReflection(s, { iteration: 4, source: 'validation', errors: ['missing command'] });
+      expect(s.reflectionCount).toBe(3);
     });
 
     it('reports progress on the first objective failure', () => {

--- a/src/agents/reflection.ts
+++ b/src/agents/reflection.ts
@@ -30,7 +30,7 @@
  * Subjective sources (review) are opinion and are handled by the existing
  * reviewer-feedback channel, not this trail.
  */
-export type ReflectionSource = 'lint' | 'bs' | 'test' | 'review';
+export type ReflectionSource = 'lint' | 'bs' | 'test' | 'validation' | 'review';
 
 export interface ReflectionEntry {
   /** 1-based pipeline iteration this failure was observed in */
@@ -58,7 +58,7 @@ export const MAX_TRAIL_ENTRIES = 3;
 /** Cap error lines per entry so a chatty compiler cannot blow up the prompt. */
 const MAX_ERRORS_PER_ENTRY = 5;
 
-const OBJECTIVE_SOURCES: readonly ReflectionSource[] = ['lint', 'bs', 'test'];
+const OBJECTIVE_SOURCES: readonly ReflectionSource[] = ['lint', 'bs', 'test', 'validation'];
 
 // State
 
@@ -164,6 +164,8 @@ function labelForSource(source: ReflectionSource): string {
       return 'code-smell guard failed';
     case 'test':
       return 'tests failed';
+    case 'validation':
+      return 'validation evidence missing';
     case 'review':
       return 'reviewer feedback';
   }

--- a/src/agents/workerFanout.test.ts
+++ b/src/agents/workerFanout.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { WorkerOptions } from './worker.js';
+
+const runWorker = vi.fn();
+vi.mock('./worker.js', async () => {
+  const actual = await vi.importActual<typeof import('./worker.js')>('./worker.js');
+  return { ...actual, runWorker };
+});
+
+function initRepo(dir: string): void {
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+  execFileSync('git', ['add', '-A'], { cwd: dir });
+  execFileSync('git', ['commit', '-qm', 'init'], { cwd: dir });
+}
+
+const baseWorkerOptions = {
+  projectPath: '',
+  adapterName: 'codex-responses',
+  model: 'gpt-5.4-mini',
+  timeoutMs: 0,
+} as unknown as WorkerOptions;
+
+describe('runWorkerFanout on a dirty worktree', () => {
+  it('seeds pre-existing uncommitted changes and promotes only the incremental winner diff', async () => {
+    const repo = await mkdtemp(path.join(tmpdir(), 'osw-fanout-dirty-'));
+    try {
+      await writeFile(path.join(repo, 'README.md'), 'base\n', 'utf8');
+      initRepo(repo);
+
+      // Make the project worktree DIRTY (a self-repair retry still holding the
+      // previous iteration's edits): a tracked modification + an untracked file.
+      await writeFile(path.join(repo, 'README.md'), 'base\npreexisting-edit\n', 'utf8');
+      await writeFile(path.join(repo, 'preexisting.txt'), 'from a prior iteration\n', 'utf8');
+
+      // Each candidate adds its own new file on top of the seeded dirty base.
+      runWorker.mockImplementation(async (opts: WorkerOptions) => {
+        const isSpark = opts.model === 'gpt-5.3-codex-spark';
+        const file = isSpark ? 'spark.txt' : 'primary.txt';
+        await writeFile(path.join(opts.projectPath, file), isSpark ? 'spark\n' : 'primary\n', 'utf8');
+        return {
+          success: true,
+          summary: isSpark ? 'spark patch' : 'primary patch',
+          filesChanged: [file],
+          commands: [],
+          output: '',
+          confidencePercent: isSpark ? 95 : 70,
+        };
+      });
+
+      const { runWorkerFanout } = await import('./workerFanout.js');
+      const result = await runWorkerFanout({
+        projectPath: repo,
+        baseWorkerOptions: { ...baseWorkerOptions, projectPath: repo },
+        candidates: [
+          { id: 'primary', adapter: 'codex-responses', model: 'gpt-5.4-mini' },
+          { id: 'spark-diversity', adapter: 'codex-responses', model: 'gpt-5.3-codex-spark' },
+        ],
+        concurrency: 2,
+      });
+
+      // Fan-out ran (not bailed on the dirty tree) and picked the higher-confidence spark.
+      expect(result.fallbackReason).toBeUndefined();
+      expect(result.winner?.id).toBe('spark-diversity');
+      expect(runWorker).toHaveBeenCalledTimes(2);
+
+      // The pre-existing dirty state survives, AND the winner's incremental diff
+      // is layered on top of it — the loser's file is not promoted.
+      expect(await readFile(path.join(repo, 'README.md'), 'utf8')).toBe('base\npreexisting-edit\n');
+      expect(existsSync(path.join(repo, 'preexisting.txt'))).toBe(true);
+      expect(await readFile(path.join(repo, 'spark.txt'), 'utf8')).toBe('spark\n');
+      expect(existsSync(path.join(repo, 'primary.txt'))).toBe(false);
+      // filesChanged reflects the promoted worktree (accumulated dirty base +
+      // the winner's increment) so downstream review sees the full change set —
+      // it includes spark.txt but never the losing candidate's primary.txt.
+      expect(result.winner?.result.filesChanged).toEqual(
+        expect.arrayContaining(['spark.txt', 'README.md', 'preexisting.txt']),
+      );
+      expect(result.winner?.result.filesChanged).not.toContain('primary.txt');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/workerFanout.ts
+++ b/src/agents/workerFanout.ts
@@ -61,22 +61,30 @@ function safeCandidateId(id: string, index: number): string {
   return safe || `candidate-${index + 1}`;
 }
 
-async function git(cwd: string, args: string[], input?: string): Promise<string> {
+async function git(cwd: string, args: string[], opts?: { env?: NodeJS.ProcessEnv }): Promise<string> {
   const { stdout } = await exec('git', args, {
     cwd,
     encoding: 'utf8',
-    input,
+    env: opts?.env,
     maxBuffer: 20 * 1024 * 1024,
-  } as Parameters<typeof exec>[2] & { input?: string });
+  } as Parameters<typeof exec>[2]);
   return String(stdout);
 }
 
-async function isGitWorktreeClean(projectPath: string): Promise<boolean> {
+// Capture ALL uncommitted work in the project (tracked edits, deletions, and
+// untracked new files) as a binary patch vs HEAD, WITHOUT mutating the project's
+// real index or worktree — everything is staged into a throwaway temporary index
+// selected via GIT_INDEX_FILE. Returns '' when the worktree is clean. This lets
+// fan-out run on a dirty tree (e.g. a self-repair retry that still holds the
+// previous iteration's edits) by seeding that state into each sandbox.
+async function captureBaselinePatch(projectPath: string): Promise<string> {
+  const idxDir = await mkdtemp(join(tmpdir(), 'openswarm-fanout-idx-'));
+  const env = { ...process.env, GIT_INDEX_FILE: join(idxDir, 'index') };
   try {
-    const status = await git(projectPath, ['status', '--porcelain']);
-    return status.trim().length === 0;
-  } catch {
-    return false;
+    await git(projectPath, ['add', '-A'], { env });
+    return await git(projectPath, ['diff', '--cached', '--binary', 'HEAD'], { env });
+  } finally {
+    await rm(idxDir, { recursive: true, force: true });
   }
 }
 
@@ -187,11 +195,30 @@ function scoreCandidate(input: {
   return { score, eligible };
 }
 
+// Seed the project's pre-existing uncommitted state into a freshly-cloned
+// sandbox and commit it, so the candidate continues from the dirty base and the
+// winner's promoted diff is the incremental delta (not base+delta, which would
+// double-apply onto the already-dirty project).
+async function seedBaseline(sandbox: string, root: string, id: string, baseline: string): Promise<void> {
+  if (!baseline.trim()) return;
+  const patchPath = join(root, `${id}-base.patch`);
+  await writeFile(patchPath, baseline, 'utf8');
+  await git(sandbox, ['apply', '--whitespace=nowarn', patchPath]);
+  await rm(patchPath, { force: true });
+  await git(sandbox, ['add', '-A']);
+  await git(sandbox, [
+    '-c', 'user.email=fanout@openswarm.local',
+    '-c', 'user.name=OpenSwarm Fanout',
+    'commit', '--quiet', '--no-verify', '-m', 'fanout: seed pre-existing worktree state',
+  ]);
+}
+
 async function runCandidate(
   options: RunWorkerFanoutOptions,
   candidate: WorkerFanoutCandidateConfig,
   index: number,
   root: string,
+  baseline: string,
 ): Promise<WorkerFanoutCandidateRun> {
   const id = safeCandidateId(candidate.id, index);
   const started = Date.now();
@@ -199,6 +226,7 @@ async function runCandidate(
 
   try {
     sandbox = await cloneSandbox(options.projectPath, root, id, sharedPathModeFor(options.linkSharedPaths));
+    await seedBaseline(sandbox, root, id, baseline);
     const result = await runWorker({
       ...options.baseWorkerOptions,
       projectPath: sandbox,
@@ -257,17 +285,19 @@ export async function runWorkerFanout(options: RunWorkerFanoutOptions): Promise<
     return { candidates: [], fallbackReason: 'fan-out needs at least two candidates' };
   }
 
-  if (!(await isGitWorktreeClean(options.projectPath))) {
-    return { candidates: [], fallbackReason: 'project worktree has pre-existing changes' };
-  }
+  // A dirty worktree is expected on self-repair retries (the gate scores fan-out
+  // mainly on retry signals). Rather than bail, snapshot the uncommitted state
+  // and seed it into each sandbox so candidates continue from it and only the
+  // incremental winner diff is promoted back. Falls back to '' (clean) on error.
+  const baseline = await captureBaselinePatch(options.projectPath).catch(() => '');
 
   const root = await mkdtemp(join(tmpdir(), 'openswarm-worker-fanout-'));
   try {
-    options.onLog?.(`[fanout] launching ${options.candidates.length} candidate worker(s)`);
+    options.onLog?.(`[fanout] launching ${options.candidates.length} candidate worker(s)${baseline.trim() ? ' (seeded from dirty worktree)' : ''}`);
     const settled = await runPool(
       options.candidates,
       options.concurrency,
-      (candidate, index) => runCandidate(options, candidate, index, root),
+      (candidate, index) => runCandidate(options, candidate, index, root, baseline),
       (item) => {
         if (item.value) {
           options.onLog?.(`[fanout] ${item.value.id}: score=${item.value.score.toFixed(1)} eligible=${item.value.eligible} files=${item.value.filesChanged.length}`);

--- a/src/agents/workerFanoutGate.ts
+++ b/src/agents/workerFanoutGate.ts
@@ -180,6 +180,10 @@ export async function runWorkerWithOptionalFanout(input: {
   const { fanoutDecision, fanoutConfig, workerOptions } = input;
   if (fanoutDecision?.shouldFanOut && fanoutConfig?.mode === 'execute') {
     const candidates = buildWorkerFanoutCandidates(workerOptions, fanoutConfig.candidates);
+    // Surface execution to stdout too: onLog only reaches broadcastEvent, so
+    // without this the daemon log shows the gate's "recommend fan-out" line but
+    // no evidence fan-out actually ran (the exact symptom that hid this path).
+    console.log(`[fanout] executing ${candidates.length} candidate(s) — gate score ${fanoutDecision.score}/${fanoutDecision.threshold}`);
     const fanoutResult = await runWorkerFanout({
       projectPath: input.projectPath,
       baseWorkerOptions: workerOptions,
@@ -191,7 +195,11 @@ export async function runWorkerWithOptionalFanout(input: {
       onLog: input.onLog,
     });
 
-    if (fanoutResult.winner) return fanoutResult.winner.result;
+    if (fanoutResult.winner) {
+      console.log(`[fanout] promoted winner ${fanoutResult.winner.id} (${fanoutResult.winner.filesChanged.length} file(s))`);
+      return fanoutResult.winner.result;
+    }
+    console.log(`[fanout] fallback to single worker: ${fanoutResult.fallbackReason ?? 'no winner'}`);
     input.onLog(`[fanout] fallback to single worker: ${fanoutResult.fallbackReason ?? 'no winner'}`);
   }
 

--- a/src/agents/workerValidationEvidence.test.ts
+++ b/src/agents/workerValidationEvidence.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import type { WorkerResult } from './agentPair.js';
+import { missingWorkerValidationIssues } from './workerValidationEvidence.js';
+
+function worker(partial: Partial<WorkerResult>): WorkerResult {
+  return {
+    success: true,
+    summary: 'test',
+    filesChanged: [],
+    commands: [],
+    output: '',
+    ...partial,
+  } as WorkerResult;
+}
+
+describe('missingWorkerValidationIssues', () => {
+  it('accepts a validation command chained after a leading inspection verb', () => {
+    // Regression: `git diff && npm test` was rejected because the inspection
+    // short-circuit fired before the validation check.
+    expect(missingWorkerValidationIssues(worker({
+      filesChanged: ['src/example.ts'],
+      commands: ['git diff && npm test'],
+    }))).toEqual([]);
+
+    expect(missingWorkerValidationIssues(worker({
+      filesChanged: ['src/example.ts'],
+      commands: ['git status; npm run build'],
+    }))).toEqual([]);
+  });
+
+  it('still rejects an inspection command that only mentions a test string', () => {
+    // `rg "npm test"` searches for the string, it does not run it.
+    expect(missingWorkerValidationIssues(worker({
+      filesChanged: ['src/example.ts'],
+      commands: ['rg "npm test" package.json'],
+    })).length).toBeGreaterThan(0);
+  });
+
+  it('flags .mts/.cts source edited without a validation command', () => {
+    expect(missingWorkerValidationIssues(worker({
+      filesChanged: ['src/config.mts'],
+      commands: [],
+    })).length).toBeGreaterThan(0);
+    expect(missingWorkerValidationIssues(worker({
+      filesChanged: ['src/loader.cts'],
+      commands: [],
+    })).length).toBeGreaterThan(0);
+  });
+
+  it('does not require validation for data-only trees (locale/fixtures/snapshots)', () => {
+    expect(missingWorkerValidationIssues(worker({
+      filesChanged: ['src/locales/en.json', 'test/fixtures/data.json', 'src/__snapshots__/a.snap'],
+      commands: [],
+    }))).toEqual([]);
+  });
+
+  it('still gates real source modules that live under a data/mock/fixture dir', () => {
+    // The data-dir exemption must not bypass code — a .ts under __mocks__/fixtures
+    // is a source change that needs a validation command.
+    expect(missingWorkerValidationIssues(worker({
+      filesChanged: ['src/__mocks__/api.ts'],
+      commands: [],
+    })).length).toBeGreaterThan(0);
+    expect(missingWorkerValidationIssues(worker({
+      filesChanged: ['test/fixtures/helper.ts'],
+      commands: [],
+    })).length).toBeGreaterThan(0);
+  });
+
+  it('treats a source module named readme.ts as code, not docs', () => {
+    // README.md is docs; readme.ts is a real module and must hit the gate.
+    expect(missingWorkerValidationIssues(worker({
+      filesChanged: ['src/readme.ts'],
+      commands: [],
+    })).length).toBeGreaterThan(0);
+    expect(missingWorkerValidationIssues(worker({
+      filesChanged: ['README.md', 'CHANGELOG.md'],
+      commands: [],
+    }))).toEqual([]);
+  });
+});

--- a/src/agents/workerValidationEvidence.ts
+++ b/src/agents/workerValidationEvidence.ts
@@ -1,0 +1,54 @@
+import type { WorkerResult } from './agentPair.js';
+
+const VALIDATION_RELEVANT_FILE_RE = /\.(ts|tsx|js|jsx|mjs|cjs|py|rs|go|java|rb|c|cc|cpp|h|hpp|swift|kt|kts|scala|cs|php|sh|bash|zsh|sql|toml|ya?ml|json)$/i;
+const VALIDATION_RELEVANT_BASENAME_RE = /(^|\/)(Dockerfile(?:\.[^/]+)?|Containerfile(?:\.[^/]+)?|Makefile|GNUmakefile|go\.mod|go\.sum|Cargo\.toml|Cargo\.lock|package(?:-lock)?\.json|pnpm-lock\.ya?ml|yarn\.lock|bun\.lockb?|requirements(?:-[^/]+)?\.txt|pyproject\.toml|poetry\.lock|Pipfile(?:\.lock)?|Gemfile(?:\.lock)?|pom\.xml|build\.gradle(?:\.kts)?|settings\.gradle(?:\.kts)?|flake\.nix|shell\.nix|docker-compose\.ya?ml|compose\.ya?ml)$/i;
+const DOC_ONLY_FILE_RE = /(^|\/)(README|CHANGELOG|LICENSE|NOTICE)(\.[^./]+)?$|(^|\/)docs?\/|\.((md|mdx|txt|rst|adoc))$/i;
+const VALIDATION_COMMAND_RE = /\b(npm\s+(?:test|run\s+(?:test|build|lint|typecheck|check|ci|verify|validate|smoke))|pnpm\s+(?:test|run\s+(?:test|build|lint|typecheck|check|ci|verify|validate|smoke))|yarn\s+(?:test|run\s+(?:test|build|lint|typecheck|check|ci|verify|validate|smoke))|bun\s+(?:test|run\s+(?:test|build|lint|typecheck|check|ci|verify|validate|smoke))|vitest|jest|mocha|pytest|ruff|mypy|pyright|tsc|eslint|oxlint|cargo\s+(?:check|test|clippy|build)|go\s+(?:test|vet|build)|swift\s+test|gradle\s+(?:test|build|check)|mvn\s+(?:test|verify)|make\b|cmake\b|py_compile|compileall|clippy|fmt\s+--check)\b/i;
+const INSPECTION_ONLY_COMMAND_RE = /^\s*(?:cd\b.*?(?:&&|;)\s*)?(?:rg|grep|sed|cat|ls|find|pwd|git\s+(?:status|diff|show|log|grep)|jq|head|tail|wc|tree|du|file|which)\b/i;
+const SCRIPT_SMOKE_COMMAND_RE = /^\s*(?:cd\b.*?(?:&&|;)\s*)?(?:python3?|node|tsx|ts-node|uv\s+run|npx|bunx|bash|sh)\b.*\b(?:scripts?\/|tests?\/|\.py|\.js|\.ts|\.sh|--help|--dry-run|smoke|verify|validate|check|test|build|compile)\b/i;
+const TESTER_CODE_FILE_RE = /\.(ts|tsx|js|jsx|py|rs|go|java|rb|c|cpp|h|hpp)$/;
+
+function validationRelevantFiles(files: string[]): string[] {
+  return files.filter(file => {
+    if (/(^|\/)docs?\//i.test(file)) return false;
+    if (VALIDATION_RELEVANT_BASENAME_RE.test(file)) return true;
+    return VALIDATION_RELEVANT_FILE_RE.test(file) && !DOC_ONLY_FILE_RE.test(file);
+  });
+}
+
+function commandLooksLikeValidation(command: string): boolean {
+  if (INSPECTION_ONLY_COMMAND_RE.test(command)) return false;
+  if (VALIDATION_COMMAND_RE.test(command)) return true;
+  return SCRIPT_SMOKE_COMMAND_RE.test(command);
+}
+
+export function missingWorkerValidationIssues(result: WorkerResult): string[] {
+  const changed = validationRelevantFiles(result.filesChanged ?? []);
+  if (changed.length === 0) return [];
+  const commands = result.commands ?? [];
+  if (commands.some(commandLooksLikeValidation)) return [];
+
+  const sample = changed.slice(0, 6).join(', ');
+  const suffix = changed.length > 6 ? `, +${changed.length - 6} more` : '';
+  const commandIssue = commands.length === 0
+    ? 'Worker changed code/config files but reported zero validation commands.'
+    : `Worker changed code/config files but only reported non-validation commands: ${commands.slice(0, 3).join('; ')}`;
+  return [
+    commandIssue,
+    `Run at least one relevant smoke/build/test/static check before review, or run the closest available check and report its failure. Files needing validation: ${sample}${suffix}`,
+  ];
+}
+
+export function testerWouldRunForWorkerResult(
+  result: WorkerResult,
+  hasTester: boolean,
+  skipIfNoCode: boolean
+): boolean {
+  if (!hasTester) return false;
+  if (!skipIfNoCode) return true;
+  return (result.filesChanged ?? []).some(file => TESTER_CODE_FILE_RE.test(file));
+}
+
+export function isTesterCodeFile(file: string): boolean {
+  return TESTER_CODE_FILE_RE.test(file);
+}

--- a/src/agents/workerValidationEvidence.ts
+++ b/src/agents/workerValidationEvidence.ts
@@ -1,25 +1,49 @@
 import type { WorkerResult } from './agentPair.js';
 
-const VALIDATION_RELEVANT_FILE_RE = /\.(ts|tsx|js|jsx|mjs|cjs|py|rs|go|java|rb|c|cc|cpp|h|hpp|swift|kt|kts|scala|cs|php|sh|bash|zsh|sql|toml|ya?ml|json)$/i;
+const VALIDATION_RELEVANT_FILE_RE = /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rs|go|java|rb|c|cc|cpp|h|hpp|swift|kt|kts|scala|cs|php|sh|bash|zsh|sql|toml|ya?ml|json)$/i;
 const VALIDATION_RELEVANT_BASENAME_RE = /(^|\/)(Dockerfile(?:\.[^/]+)?|Containerfile(?:\.[^/]+)?|Makefile|GNUmakefile|go\.mod|go\.sum|Cargo\.toml|Cargo\.lock|package(?:-lock)?\.json|pnpm-lock\.ya?ml|yarn\.lock|bun\.lockb?|requirements(?:-[^/]+)?\.txt|pyproject\.toml|poetry\.lock|Pipfile(?:\.lock)?|Gemfile(?:\.lock)?|pom\.xml|build\.gradle(?:\.kts)?|settings\.gradle(?:\.kts)?|flake\.nix|shell\.nix|docker-compose\.ya?ml|compose\.ya?ml)$/i;
-const DOC_ONLY_FILE_RE = /(^|\/)(README|CHANGELOG|LICENSE|NOTICE)(\.[^./]+)?$|(^|\/)docs?\/|\.((md|mdx|txt|rst|adoc))$/i;
+// Only treat README/CHANGELOG/LICENSE/NOTICE as doc-only when they carry a doc
+// extension (or none). A real source module named e.g. `readme.ts` must NOT be
+// misclassified as docs — that would let it skip the validation gate while the
+// tester's isTesterCodeFile() still treats it as code (inconsistent).
+const DOC_ONLY_FILE_RE = /(^|\/)(README|CHANGELOG|LICENSE|NOTICE)(\.(md|mdx|txt|rst|adoc))?$|(^|\/)docs?\/|\.((md|mdx|txt|rst|adoc))$/i;
+// Pure data/asset trees (locale strings, fixtures, snapshots, mocks) have
+// nothing to build or test on their own; exempt them so a data-only edit does
+// not get bounced for "no validation command".
+const DATA_ONLY_DIR_RE = /(^|\/)(locales?|i18n|fixtures?|__fixtures__|__snapshots__|snapshots?|__mocks__|mocks?|testdata|test-data)\//i;
 const VALIDATION_COMMAND_RE = /\b(npm\s+(?:test|run\s+(?:test|build|lint|typecheck|check|ci|verify|validate|smoke))|pnpm\s+(?:test|run\s+(?:test|build|lint|typecheck|check|ci|verify|validate|smoke))|yarn\s+(?:test|run\s+(?:test|build|lint|typecheck|check|ci|verify|validate|smoke))|bun\s+(?:test|run\s+(?:test|build|lint|typecheck|check|ci|verify|validate|smoke))|vitest|jest|mocha|pytest|ruff|mypy|pyright|tsc|eslint|oxlint|cargo\s+(?:check|test|clippy|build)|go\s+(?:test|vet|build)|swift\s+test|gradle\s+(?:test|build|check)|mvn\s+(?:test|verify)|make\b|cmake\b|py_compile|compileall|clippy|fmt\s+--check)\b/i;
-const INSPECTION_ONLY_COMMAND_RE = /^\s*(?:cd\b.*?(?:&&|;)\s*)?(?:rg|grep|sed|cat|ls|find|pwd|git\s+(?:status|diff|show|log|grep)|jq|head|tail|wc|tree|du|file|which)\b/i;
-const SCRIPT_SMOKE_COMMAND_RE = /^\s*(?:cd\b.*?(?:&&|;)\s*)?(?:python3?|node|tsx|ts-node|uv\s+run|npx|bunx|bash|sh)\b.*\b(?:scripts?\/|tests?\/|\.py|\.js|\.ts|\.sh|--help|--dry-run|smoke|verify|validate|check|test|build|compile)\b/i;
-const TESTER_CODE_FILE_RE = /\.(ts|tsx|js|jsx|py|rs|go|java|rb|c|cpp|h|hpp)$/;
+// Anchored at each segment start: a leading inspection verb means that segment
+// ran no validation (e.g. `rg "npm test"` searches for the string, it does not
+// run it), so the segment is skipped rather than the whole command rejected.
+const INSPECTION_ONLY_COMMAND_RE = /^\s*(?:rg|grep|sed|cat|ls|find|pwd|git\s+(?:status|diff|show|log|grep)|jq|head|tail|wc|tree|du|file|which)\b/i;
+const SCRIPT_SMOKE_COMMAND_RE = /^\s*(?:python3?|node|tsx|ts-node|uv\s+run|npx|bunx|bash|sh)\b.*\b(?:scripts?\/|tests?\/|\.py|\.js|\.ts|\.sh|--help|--dry-run|smoke|verify|validate|check|test|build|compile)\b/i;
+const TESTER_CODE_FILE_RE = /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rs|go|java|rb|c|cpp|h|hpp)$/;
 
 function validationRelevantFiles(files: string[]): string[] {
   return files.filter(file => {
     if (/(^|\/)docs?\//i.test(file)) return false;
     if (VALIDATION_RELEVANT_BASENAME_RE.test(file)) return true;
+    // Data/asset trees (locale, fixtures, snapshots, mocks) are exempt ONLY for
+    // non-code assets. A real source module under such a dir (e.g.
+    // src/__mocks__/api.ts, test/fixtures/helper.ts) still needs a check —
+    // exempting the whole directory would be a gate bypass.
+    if (DATA_ONLY_DIR_RE.test(file) && !TESTER_CODE_FILE_RE.test(file)) return false;
     return VALIDATION_RELEVANT_FILE_RE.test(file) && !DOC_ONLY_FILE_RE.test(file);
   });
 }
 
 function commandLooksLikeValidation(command: string): boolean {
-  if (INSPECTION_ONLY_COMMAND_RE.test(command)) return false;
-  if (VALIDATION_COMMAND_RE.test(command)) return true;
-  return SCRIPT_SMOKE_COMMAND_RE.test(command);
+  // Workers routinely chain inspection then validation in one string
+  // (e.g. "git diff && npm test"). Evaluate each shell segment independently so
+  // a leading inspection verb does not mask a real validation command in a later
+  // segment, while an inspection-only segment (which may merely *mention* a test
+  // command as a search string) still counts as no validation.
+  const segments = command.split(/&&|\|\||;|\|/).map(s => s.trim()).filter(Boolean);
+  const candidates = segments.length > 0 ? segments : [command];
+  return candidates.some(seg => {
+    if (INSPECTION_ONLY_COMMAND_RE.test(seg)) return false;
+    return VALIDATION_COMMAND_RE.test(seg) || SCRIPT_SMOKE_COMMAND_RE.test(seg);
+  });
 }
 
 export function missingWorkerValidationIssues(result: WorkerResult): string[] {

--- a/src/automation/autonomousRunner.enable.test.ts
+++ b/src/automation/autonomousRunner.enable.test.ts
@@ -3,7 +3,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { AutonomousRunner, decisionSelectionBudget } from './autonomousRunner.js';
 import type { AutonomousConfig } from './runnerTypes.js';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
@@ -74,6 +74,62 @@ describe('AutonomousRunner project-selection gating (INT-2207)', () => {
     const r = new AutonomousRunner(cfg());
     r.disableProject('/x/a');
     expect(filtersOn(r)).toBe(true);
+  });
+});
+
+describe('AutonomousRunner per-project candidate cap', () => {
+  const makeTask = (id: string, projectPath: string): TaskItem => ({
+    id,
+    source: 'linear',
+    title: `Task ${id}`,
+    priority: 3,
+    projectPath,
+    issueId: id,
+    issueIdentifier: id.toUpperCase(),
+    linearState: 'Todo',
+    createdAt: Date.now(),
+  });
+
+  it('does not enqueue same-project heartbeat candidates past maxConcurrentPerProject', async () => {
+    const repo = '/x/a';
+    const other = '/x/b';
+    const tasks = [
+      makeTask('repo-1', repo),
+      makeTask('repo-2', repo),
+      makeTask('repo-3', repo),
+      makeTask('other-1', other),
+    ];
+    const r = new AutonomousRunner(cfg({
+      allowedProjects: [repo, other],
+      autoExecute: true,
+      maxConcurrentTasks: 3,
+      allowSameProjectConcurrent: true,
+      worktreeMode: true,
+      maxConcurrentPerProject: 2,
+    }));
+    const internal = r as unknown as {
+      engine: {
+        heartbeatMultiple: ReturnType<typeof vi.fn>;
+      };
+      heartbeatParallel(tasks: TaskItem[]): Promise<void>;
+      resolveProjectPath(task: TaskItem): Promise<string | null>;
+      detectSafeCandidateIds(candidates: Array<{ task: TaskItem }>): Promise<Set<string>>;
+      runAvailableTasks(): Promise<void>;
+    };
+    internal.engine.heartbeatMultiple = vi.fn(async () => ({
+      action: 'execute',
+      tasks: tasks.map(task => ({ task, workflow: {} })),
+      reason: 'test',
+      skippedCount: 0,
+    }));
+    internal.resolveProjectPath = vi.fn(async task => task.projectPath ?? null);
+    internal.detectSafeCandidateIds = vi.fn(async candidates => new Set(candidates.map(c => c.task.id)));
+    internal.runAvailableTasks = vi.fn(async () => {});
+
+    await internal.heartbeatParallel(tasks);
+
+    expect(r.getQueuedTasks().map(q => q.task.id)).toEqual(['repo-1', 'repo-2', 'other-1']);
+    expect(r.getQueuedTasks().filter(q => q.projectPath === repo)).toHaveLength(2);
   });
 });
 

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -32,7 +32,7 @@ import {
 import { checkWorkAllowed } from '../support/timeWindow.js';
 import { recordTaskOutcome } from '../memory/repoKnowledge.js';
 import { updateProjectAfterTask } from '../linear/projectUpdater.js';
-import { TaskScheduler, initScheduler } from '../orchestration/taskScheduler.js';
+import { TaskScheduler, initScheduler, normalizeProjectPath } from '../orchestration/taskScheduler.js';
 import {
   PipelineResult,
   formatPipelineResultEmbed,
@@ -140,6 +140,31 @@ export class AutonomousRunner {
     return this.projectSelectionTouched || this.enabledProjects.size > 0;
   }
 
+  private sameProjectCandidateCap(): number | null {
+    const sameProjectParallel = (this.config.allowSameProjectConcurrent ?? true) && (this.config.worktreeMode ?? false);
+    if (!sameProjectParallel || this.config.maxConcurrentPerProject == null) return null;
+    const cap = Math.floor(this.config.maxConcurrentPerProject);
+    const maxConcurrent = this.config.maxConcurrentTasks ?? 1;
+    return Math.max(1, Math.min(cap, maxConcurrent));
+  }
+
+  private currentProjectLoad(projectPath: string): number {
+    const target = normalizeProjectPath(projectPath);
+    const queued = this.scheduler.getQueuedTasks()
+      .filter(task => normalizeProjectPath(task.projectPath) === target)
+      .length;
+    const running = this.scheduler.getRunningTasks()
+      .filter(task => normalizeProjectPath(task.projectPath) === target)
+      .length;
+    return queued + running;
+  }
+
+  private canQueueProjectCandidate(projectPath: string): boolean {
+    const cap = this.sameProjectCandidateCap();
+    if (cap == null) return true;
+    return this.currentProjectLoad(projectPath) < cap;
+  }
+
   /** Persist the project selection so it survives a restart. No-op under dryRun
    * (tests) to avoid touching the real ~/.openswarm. (INT-2208) */
   private persistSelection(): void {
@@ -227,6 +252,7 @@ export class AutonomousRunner {
     this.scheduler = initScheduler({
       maxConcurrent: config.maxConcurrentTasks ?? 1,
       allowSameProjectConcurrent: config.allowSameProjectConcurrent ?? true,
+      maxConcurrentPerProject: config.maxConcurrentPerProject,
       worktreeMode: config.worktreeMode ?? false,
     });
 
@@ -1108,6 +1134,10 @@ export class AutonomousRunner {
       for (const { task, projectPath } of candidates) {
         if (enqueuedCount >= maxSlots) break;
         if (!safeTasks.has(task.id)) continue;
+        if (!this.canQueueProjectCandidate(projectPath)) {
+          this.syslog(`  Project cap reached: ${projectPath}`);
+          continue;
+        }
 
         this.enqueueCandidate(task, projectPath);
         enqueuedCount++;

--- a/src/automation/runnerTypes.ts
+++ b/src/automation/runnerTypes.ts
@@ -26,6 +26,7 @@ export interface AutonomousConfig {
   reviewerTimeoutMs?: number;
   triggerNow?: boolean;
   maxConcurrentTasks?: number;
+  maxConcurrentPerProject?: number;
   defaultRoles?: DefaultRolesConfig;
   projectAgents?: ProjectAgentConfig[];
   enableDecomposition?: boolean;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -278,6 +278,8 @@ const AutonomousConfigSchema = z.object({
   reviewerTimeoutMs: z.number().min(0).default(0),
   /** Max concurrent tasks */
   maxConcurrentTasks: z.number().min(1).max(10).default(1),
+  /** Max concurrent tasks from the same project when same-project parallelism is enabled. */
+  maxConcurrentPerProject: z.number().int().min(1).max(10).optional(),
   /** Default role configuration */
   defaultRoles: DefaultRolesConfigSchema,
   /** Per-project agent configuration */
@@ -576,6 +578,7 @@ function transformConfig(raw: RawConfig): SwarmConfig {
       workerTimeoutMs: raw.autonomous.workerTimeoutMs,
       reviewerTimeoutMs: raw.autonomous.reviewerTimeoutMs,
       maxConcurrentTasks: raw.autonomous.maxConcurrentTasks,
+      maxConcurrentPerProject: raw.autonomous.maxConcurrentPerProject,
       defaultRoles: raw.autonomous.defaultRoles,
       projectAgents: raw.autonomous.projectAgents?.map(pa => ({
         ...pa,

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -219,6 +219,8 @@ export async function startService(config: SwarmConfig): Promise<void> {
       reviewerTimeoutMs: config.autonomous.reviewerTimeoutMs || 0, // 0 = unlimited
       triggerNow: true,  // Execute immediately on start
       maxConcurrentTasks: config.autonomous.maxConcurrentTasks,
+      maxConcurrentPerProject: config.autonomous.maxConcurrentPerProject,
+      allowSameProjectConcurrent: config.autonomous.allowSameProjectConcurrent,
       defaultRoles: config.autonomous.defaultRoles,
       projectAgents: config.autonomous.projectAgents,
       // Task decomposition (Planner) configuration

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -513,6 +513,8 @@ export type AutonomousStartupConfig = {
   reviewerTimeoutMs?: number;
   /** Max concurrent tasks */
   maxConcurrentTasks?: number;
+  /** Max concurrent tasks from the same project when same-project parallelism is enabled. */
+  maxConcurrentPerProject?: number;
   /** Default role configuration */
   defaultRoles?: DefaultRolesConfig;
   /** Per-project agent configuration */

--- a/src/orchestration/taskScheduler.concurrency.test.ts
+++ b/src/orchestration/taskScheduler.concurrency.test.ts
@@ -47,6 +47,31 @@ describe('TaskScheduler same-project concurrency (INT-1975)', () => {
     expect(s.getNextExecutable()?.task.id).toBe('b');
   });
 
+  it('caps same-repo parallelism when maxConcurrentPerProject is set', () => {
+    const s = new TaskScheduler({
+      maxConcurrent: 4,
+      worktreeMode: true,
+      allowSameProjectConcurrent: true,
+      maxConcurrentPerProject: 2,
+    });
+    s.enqueue(task('a'), '/repo');
+    s.enqueue(task('b'), '/repo');
+    s.enqueue(task('c'), '/repo');
+    s.enqueue(task('d'), '/other');
+
+    const first = s.getNextExecutable();
+    s.startTask(first!.task, first!.projectPath, pendingExecutor());
+    expect(s.isProjectBusy('/repo')).toBe(false);
+
+    const second = s.getNextExecutable();
+    s.startTask(second!.task, second!.projectPath, pendingExecutor());
+    expect(s.isProjectBusy('/repo')).toBe(true);
+    expect(s.getBusyProjects()).toEqual(['/repo']);
+
+    // Third same-repo task is held back, but another project can still use slots.
+    expect(s.getNextExecutable()?.task.id).toBe('d');
+  });
+
   it('reapplies the same-project worktree guard when config is updated', () => {
     const s = new TaskScheduler({ maxConcurrent: 4, worktreeMode: true, allowSameProjectConcurrent: true });
     s.updateConfig({ worktreeMode: false, allowSameProjectConcurrent: true });

--- a/src/orchestration/taskScheduler.ts
+++ b/src/orchestration/taskScheduler.ts
@@ -9,7 +9,7 @@ import { resolve } from 'node:path';
 import type { TaskItem } from './decisionEngine.js';
 import type { PipelineResult } from '../agents/pairPipeline.js';
 
-function normalizeProjectPath(path: string): string {
+export function normalizeProjectPath(path: string): string {
   // Guard: resolve('') returns process.cwd(), so an accidental empty-string
   // cancellation would match every task under the daemon's cwd. Keep the
   // pre-#192 no-op behavior ('/' matches nothing in practice) instead.
@@ -53,6 +53,8 @@ export interface SchedulerConfig {
   maxConcurrent: number;
   /** Allow concurrent execution on same project */
   allowSameProjectConcurrent?: boolean;
+  /** Maximum concurrent tasks per project when same-project parallelism is enabled. */
+  maxConcurrentPerProject?: number;
   /** Git worktree mode: each task runs in its own isolated worktree (bypasses project busy check) */
   worktreeMode?: boolean;
 }
@@ -82,6 +84,11 @@ function normalizeSchedulerConfig(config: SchedulerConfig): SchedulerConfig {
         'Set worktreeMode:true to enable same-project parallelism.'
     );
     normalized.allowSameProjectConcurrent = false;
+  }
+
+  if (normalized.maxConcurrentPerProject != null) {
+    const cap = Math.floor(normalized.maxConcurrentPerProject);
+    normalized.maxConcurrentPerProject = Math.max(1, Math.min(cap, normalized.maxConcurrent));
   }
 
   return normalized;
@@ -196,17 +203,38 @@ export class TaskScheduler extends EventEmitter {
    * but no longer implies same-project parallelism.
    */
   isProjectBusy(projectPath: string): boolean {
-    if (this.config.allowSameProjectConcurrent) {
-      return false;
-    }
-
     const normalizedProject = normalizeProjectPath(projectPath);
+    let runningCount = 0;
     for (const running of this.runningTasks.values()) {
       if (normalizeProjectPath(running.projectPath) === normalizedProject) {
-        return true;
+        runningCount++;
       }
     }
-    return false;
+
+    if (this.config.allowSameProjectConcurrent) {
+      const cap = this.config.maxConcurrentPerProject;
+      return cap != null ? runningCount >= cap : false;
+    }
+
+    return runningCount > 0;
+  }
+
+  private runningCountByProject(): Map<string, number> {
+    const counts = new Map<string, number>();
+    for (const running of this.runningTasks.values()) {
+      const key = normalizeProjectPath(running.projectPath);
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return counts;
+  }
+
+  private displayPathForNormalizedProject(normalizedProject: string): string {
+    for (const running of this.runningTasks.values()) {
+      if (normalizeProjectPath(running.projectPath) === normalizedProject) {
+        return running.projectPath;
+      }
+    }
+    return normalizedProject;
   }
 
   /**
@@ -214,14 +242,15 @@ export class TaskScheduler extends EventEmitter {
    */
   getBusyProjects(): string[] {
     if (this.config.allowSameProjectConcurrent) {
-      return [];
+      const cap = this.config.maxConcurrentPerProject;
+      if (cap == null) return [];
+      return Array.from(this.runningCountByProject().entries())
+        .filter(([, count]) => count >= cap)
+        .map(([project]) => this.displayPathForNormalizedProject(project));
     }
 
-    const projects = new Set<string>();
-    for (const running of this.runningTasks.values()) {
-      projects.add(running.projectPath);
-    }
-    return Array.from(projects);
+    return Array.from(this.runningCountByProject().keys())
+      .map(project => this.displayPathForNormalizedProject(project));
   }
 
   // ============================================
@@ -350,7 +379,7 @@ export class TaskScheduler extends EventEmitter {
   ): Promise<number> {
     let started = 0;
 
-    console.log(`[Scheduler] runAvailable: paused=${this.paused}, running=${this.runningTasks.size}/${this.config.maxConcurrent}, queue=${this.taskQueue.length}, worktreeMode=${this.config.worktreeMode}`);
+    console.log(`[Scheduler] runAvailable: paused=${this.paused}, running=${this.runningTasks.size}/${this.config.maxConcurrent}, queue=${this.taskQueue.length}, worktreeMode=${this.config.worktreeMode}, perProject=${this.config.maxConcurrentPerProject ?? 'unlimited'}`);
 
     while (this.hasAvailableSlot()) {
       const next = this.getNextExecutable();


### PR DESCRIPTION
## Summary
- add adaptive worker fan-out support and harden the fan-out sandbox clone path
- add a pre-review worker validation-evidence gate for code/config/manifest edits
- cap same-project worktree fan-out with maxConcurrentPerProject and wire it through service config

## Verification
- npm test -- src/agents/pairPipeline.test.ts src/automation/autonomousRunner.enable.test.ts src/orchestration/taskScheduler.concurrency.test.ts src/agents/reflection.test.ts
- npm run typecheck
- npm run lint
- npm run build
- git diff --check
- OpenSwarm review --path .: approve
- OpenSwarm review also reran the full Vitest suite with an isolated temp HOME: 136 test files, 1573 passed, 1 skipped

## Notes
- Default HOME full-suite execution hit the existing ~/.openswarm write-permission sandbox issue; isolated HOME passed.
