### PR TITLE
chore(release): v0.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.17.3 — 2026-07-05
+
+### Fixed
+
+- **Duplicate daemons are no longer spawned next to a launchd-managed instance** — daemon detection was PID-file-only, but a launchd (or manually started) daemon never writes the PID file, so every bare `openswarm` launch auto-started a second daemon working the same Linear queue in parallel (observed live: 8 duplicated in-flight tasks). `startDaemon` now probes the `:3847` API before spawning and refuses with a `launchctl` hint; `status` reports externally managed daemons as running; `stop` points at `launchctl` instead of a misleading "not running". (INT-2473, #228)
+- **Adaptive worker fan-out actually executes now** — the fan-out gate's threshold-crossing signals fire almost exclusively on self-repair retries, but the runner hard-required a clean worktree, which a retry never has — so fan-out was recommended 53× and executed 0× in production. The runner now snapshots the dirty worktree state via a throwaway temp index, seeds it into each sandbox, and promotes only the incremental winner diff; execution/promotion/fallback are logged to stdout. (#227)
+- **Worker validation-evidence gate false-positives** — chained commands with a leading inspection verb (`git diff && npm test`) counted as "no validation"; `.mts`/`.cts` sources slipped the gate; data-only trees (locale/fixtures/snapshots) were over-blocked while real source modules under mock/fixture dirs bypassed it; and a tester-less pipeline hard-failed workers that could not self-report commands instead of deferring to the reviewer. (#227)
+
+### Added
+
+- **Per-project concurrency cap** — optional `autonomous.maxConcurrentPerProject` (1–10) bounds same-project worktree fan-out at both the scheduler and runner candidate-selection layers; unset means uncapped (KG file-conflict detection still gates overlapping tasks). (#227)
+
 ## 0.17.2 — 2026-07-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -530,11 +530,11 @@ the CLI (fire-and-forget with a short timeout, and failures are silently ignored
 Full version history lives in **[CHANGELOG.md](CHANGELOG.md)** and the
 [GitHub Releases](https://github.com/unohee/OpenSwarm/releases) page.
 
-Latest — **v0.17.1**: worktree PRs are actually created now — `gh` used to run
-outside the repo and silently strand completed work on remote branches. Plus
-v0.17.0's same-project parallel agents (round-robin selection, worktree-isolated,
-KG conflict detection) and the removal of the per-project 5h task cap. See
-CHANGELOG.md for the rest.
+Latest — **v0.17.3**: no more duplicate daemons next to a launchd-managed
+instance (`:3847` port probe before spawn), adaptive worker fan-out actually
+executes (dirty-worktree seeding instead of a clean-tree bail), and the worker
+validation-evidence gate lost its false-positives. See CHANGELOG.md for the
+rest.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Patch release: daemon duplicate-spawn prevention (INT-2473, #228), fan-out dirty-worktree execution + validation-gate fixes (#227), per-project concurrency cap (#227).