### PR TITLE
fix(pipeline): break the reviewer-revise treadmill + fanout dirty-promote fix (INT-2474)

### DIFF
--- a/src/agents/pairPipeline.test.ts
+++ b/src/agents/pairPipeline.test.ts
@@ -315,6 +315,55 @@ describe('PairPipeline model selection', () => {
     }));
   });
 
+  it('injects prior-session failure feedback into the first worker iteration', async () => {
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker', 'reviewer'],
+      maxIterations: 1,
+      roles: {
+        worker: { enabled: true, model: 'worker', timeoutMs: 0 },
+        reviewer: { enabled: true, model: 'reviewer', timeoutMs: 0 },
+      },
+    });
+
+    const result = await pipeline.run(
+      task({ priorAttemptFeedback: 'Previous run: the config parser silently drops unknown keys — fix and add a test.' }),
+      process.cwd(),
+    );
+
+    expect(result.success).toBe(true);
+    expect(runWorker.mock.calls[0][0]).toEqual(expect.objectContaining({
+      previousFeedback: expect.stringContaining('config parser silently drops unknown keys'),
+    }));
+    expect(runWorker.mock.calls[0][0].previousFeedback).toContain('Previous attempt failed');
+  });
+
+  it('aborts the session early when the reviewer repeats the same revise feedback', async () => {
+    // Reviewer says the same thing twice → the worker is not absorbing it;
+    // burning the remaining iterations is pure waste (INT-2474).
+    runReviewer.mockResolvedValue({
+      decision: 'revise',
+      feedback: 'The cache invalidation misses the tenant scope; invalidate per tenant and cover it with a test.',
+    });
+
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker', 'reviewer'],
+      maxIterations: 5,
+      roles: {
+        worker: { enabled: true, model: 'worker', timeoutMs: 0 },
+        reviewer: { enabled: true, model: 'reviewer', timeoutMs: 0 },
+      },
+    });
+
+    const result = await pipeline.run(task(), process.cwd());
+
+    expect(result.success).toBe(false);
+    // Iteration 1 review + iteration 2's near-identical review → abort before iteration 3.
+    expect(runWorker).toHaveBeenCalledTimes(2);
+    expect(runReviewer).toHaveBeenCalledTimes(2);
+  });
+
   it('defers to the reviewer instead of hard-failing when validation evidence stays missing', async () => {
     // A worker whose git changes were promoted to success with commands=[]
     // (no JSON block) must not be killed after a couple of retries — the gate is

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -23,6 +23,7 @@ import {
   recordReflection,
   shouldStopReflecting,
   buildReflectionFeedback,
+  similarReviewFeedback,
   DEFAULT_MAX_REFLECTIONS,
 } from './reflection.js';
 import { hasRepoSnapshot, scanAndCache, analyzeIssue } from '../knowledge/index.js';
@@ -456,8 +457,19 @@ export class PairPipeline extends EventEmitter {
           const reviewPart = includeReview
             ? reviewerAgent.buildRevisionPrompt(context.reviewResult!)
             : undefined;
+          // Cross-SESSION feedback: a re-picked task that failed/was rejected
+          // before carries the last reviewer feedback (persisted in task state).
+          // Without this the new session starts blind and repeats the exact
+          // mistake the reviewer already called out (INT-2474). First iteration
+          // only — later iterations have fresher in-session feedback above.
+          const priorSessionPart =
+            context.currentIteration === 1 && context.task.priorAttemptFeedback
+              ? '## Previous attempt failed (feedback from an earlier session)\n'
+                + 'A prior run of this task did not pass. Address these points first and do not repeat them:\n'
+                + context.task.priorAttemptFeedback
+              : undefined;
           const combinedFeedback =
-            [reflectionPart, reviewPart].filter(Boolean).join('\n\n') || undefined;
+            [priorSessionPart, reflectionPart, reviewPart].filter(Boolean).join('\n\n') || undefined;
 
           const workerOptions: WorkerOptions = {
             taskTitle: context.task.title,
@@ -1152,6 +1164,32 @@ export class PairPipeline extends EventEmitter {
         }
 
         if (decision === 'revise') {
+          const reviseFeedback = (reviewerResult.result as ReviewResult).feedback ?? '';
+
+          // The reflection stagnation detector only counts OBJECTIVE sources, so
+          // a reviewer that keeps saying the same thing never trips it — failing
+          // sessions used to burn every remaining iteration on feedback the
+          // worker demonstrably isn't absorbing (measured: 146 max-iteration
+          // exhaustions vs 21 objective aborts). Two consecutive near-identical
+          // revise feedbacks → end the session now; the runner persists this
+          // feedback and the NEXT attempt starts with it injected (INT-2474).
+          if (
+            context.lastReviseFeedback
+            && similarReviewFeedback(context.lastReviseFeedback, reviseFeedback)
+          ) {
+            const reason = 'reviewer repeated the same revise feedback — worker is not absorbing it';
+            console.log(`[${context.taskPrefix}] Aborting session early: ${reason}`);
+            this.emit('log', { line: `🛑 ${reason}` });
+            this.emit('iteration:fail', {
+              iteration: context.currentIteration,
+              stage: 'reviewer',
+              context,
+            });
+            agentPair.updateSessionStatus(context.session.id, 'failed');
+            return { success: false };
+          }
+          context.lastReviseFeedback = reviseFeedback;
+
           // revise = next iteration. Reviewer feedback is subjective → it travels
           // through the reviewer channel and is dropped on a fresh-context reset.
           console.log(`[${context.taskPrefix}] Reviewer requested revision`);

--- a/src/agents/pairPipelineTypes.ts
+++ b/src/agents/pairPipelineTypes.ts
@@ -102,6 +102,8 @@ export interface PipelineContext {
   reflection: ReflectionState;
   feedbackSource?: 'objective' | 'review';
   workerFanoutDecision?: WorkerFanoutGateDecision;
+  /** Feedback of the previous reviewer 'revise' — compared against the next one to detect a repeating reviewer (INT-2474). */
+  lastReviseFeedback?: string;
 }
 
 export type PipelineEventType = 'stage:start' | 'stage:complete' | 'stage:fail' | 'iteration:start' | 'iteration:complete' | 'iteration:fail' | 'pipeline:complete' | 'pipeline:fail' | 'fanout:gate' | 'halt';

--- a/src/agents/reflection.test.ts
+++ b/src/agents/reflection.test.ts
@@ -9,6 +9,7 @@ import {
   recordReflection,
   shouldStopReflecting,
   buildReflectionFeedback,
+  similarReviewFeedback,
   DEFAULT_MAX_REFLECTIONS,
   MAX_TRAIL_ENTRIES,
   type ReflectionState,
@@ -191,6 +192,26 @@ describe('reflection', () => {
       const repeat = recordReflection(s, { iteration: 2, source: 'lint', errors: ['same'] });
       expect(repeat.progressed).toBe(false); // stagnation signal fires at count=2 of 3
       expect(shouldStopReflecting(s, 3)).toBe(false);
+    });
+  });
+
+  describe('similarReviewFeedback', () => {
+    it('matches identical and lightly reworded feedback', () => {
+      const a = 'The error handling in fetchUser is missing: add a try/catch around the network call and return a typed error.';
+      expect(similarReviewFeedback(a, a)).toBe(true);
+      const b = 'Error handling in fetchUser is still missing — add try/catch around the network call and return a typed error.';
+      expect(similarReviewFeedback(a, b)).toBe(true);
+    });
+
+    it('does not match feedback about different problems', () => {
+      const a = 'The error handling in fetchUser is missing: add a try/catch around the network call.';
+      const b = 'The pagination cursor is off by one; the last page repeats the first item of the next page.';
+      expect(similarReviewFeedback(a, b)).toBe(false);
+    });
+
+    it('returns false for empty or trivial feedback', () => {
+      expect(similarReviewFeedback('', 'anything at all here')).toBe(false);
+      expect(similarReviewFeedback('a b', 'a b')).toBe(false); // all tokens too short
     });
   });
 });

--- a/src/agents/reflection.ts
+++ b/src/agents/reflection.ts
@@ -86,6 +86,31 @@ function sameErrors(a: string[], b: string[]): boolean {
 }
 
 /**
+ * Fuzzy match for consecutive reviewer revise feedback: prose never repeats
+ * verbatim, so exact matching (sameErrors) can't catch a reviewer saying the
+ * same thing twice. Token-set Jaccard over normalized words — two feedbacks
+ * above the threshold mean the worker isn't absorbing the review and further
+ * iterations will only burn tokens (INT-2474).
+ */
+export function similarReviewFeedback(a: string, b: string, threshold = 0.6): boolean {
+  const tokens = (s: string): Set<string> =>
+    new Set(
+      s
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}]+/gu, ' ')
+        .split(' ')
+        .filter((w) => w.length > 2),
+    );
+  const ta = tokens(a);
+  const tb = tokens(b);
+  if (ta.size === 0 || tb.size === 0) return false;
+  let intersection = 0;
+  for (const w of ta) if (tb.has(w)) intersection++;
+  const union = ta.size + tb.size - intersection;
+  return union > 0 && intersection / union >= threshold;
+}
+
+/**
  * Record a failure as a reflection entry.
  *
  * For objective sources this increments the self-repair count and reports

--- a/src/agents/workerFanout.test.ts
+++ b/src/agents/workerFanout.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
@@ -28,6 +28,59 @@ const baseWorkerOptions = {
 } as unknown as WorkerOptions;
 
 describe('runWorkerFanout on a dirty worktree', () => {
+  beforeEach(() => {
+    runWorker.mockReset();
+  });
+
+  it('promotes a winner that modifies a file which is itself dirty in the project', async () => {
+    // Production failure (kyte-portal): the winner patched files that were part
+    // of the pre-existing dirty state. `git apply --3way` validates the preimage
+    // against the INDEX (= HEAD), not the worktree, so the promote died with
+    // "does not match index" even though the worktree matched exactly.
+    const repo = await mkdtemp(path.join(tmpdir(), 'osw-fanout-dirty-overlap-'));
+    try {
+      await writeFile(path.join(repo, 'README.md'), 'base\n', 'utf8');
+      initRepo(repo);
+      await writeFile(path.join(repo, 'README.md'), 'base\npreexisting-edit\n', 'utf8');
+
+      runWorker.mockImplementation(async (opts: WorkerOptions) => {
+        const isSpark = opts.model === 'gpt-5.3-codex-spark';
+        if (isSpark) {
+          // Winner edits the SAME file that is dirty in the project.
+          const current = await readFile(path.join(opts.projectPath, 'README.md'), 'utf8');
+          await writeFile(path.join(opts.projectPath, 'README.md'), `${current}winner-edit\n`, 'utf8');
+          return {
+            success: true, summary: 'spark patch', filesChanged: ['README.md'],
+            commands: [], output: '', confidencePercent: 95,
+          };
+        }
+        await writeFile(path.join(opts.projectPath, 'primary.txt'), 'primary\n', 'utf8');
+        return {
+          success: true, summary: 'primary patch', filesChanged: ['primary.txt'],
+          commands: [], output: '', confidencePercent: 70,
+        };
+      });
+
+      const { runWorkerFanout } = await import('./workerFanout.js');
+      const result = await runWorkerFanout({
+        projectPath: repo,
+        baseWorkerOptions: { ...baseWorkerOptions, projectPath: repo },
+        candidates: [
+          { id: 'primary', adapter: 'codex-responses', model: 'gpt-5.4-mini' },
+          { id: 'spark-diversity', adapter: 'codex-responses', model: 'gpt-5.3-codex-spark' },
+        ],
+        concurrency: 2,
+      });
+
+      expect(result.fallbackReason).toBeUndefined();
+      expect(result.winner?.id).toBe('spark-diversity');
+      expect(await readFile(path.join(repo, 'README.md'), 'utf8')).toBe('base\npreexisting-edit\nwinner-edit\n');
+      expect(existsSync(path.join(repo, 'primary.txt'))).toBe(false);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it('seeds pre-existing uncommitted changes and promotes only the incremental winner diff', async () => {
     const repo = await mkdtemp(path.join(tmpdir(), 'osw-fanout-dirty-'));
     try {

--- a/src/agents/workerFanout.ts
+++ b/src/agents/workerFanout.ts
@@ -167,7 +167,13 @@ async function diffBinary(projectPath: string): Promise<string> {
 async function applyDiff(projectPath: string, patchRoot: string, diff: string): Promise<void> {
   const patchPath = join(patchRoot, 'winner.patch');
   await writeFile(patchPath, diff, 'utf8');
-  await git(projectPath, ['apply', '--3way', '--whitespace=nowarn', patchPath]);
+  // Plain worktree apply — NOT --3way. --3way validates the preimage against
+  // the INDEX, but on a dirty project (self-repair retry) the index still holds
+  // HEAD while the patch preimage is the seeded dirty state → "does not match
+  // index" even though the WORKTREE matches the preimage exactly (the sandbox
+  // base was cloned+seeded from it). A 3-way fallback couldn't work anyway: the
+  // sandbox's baseline blobs don't exist in the project's object database.
+  await git(projectPath, ['apply', '--whitespace=nowarn', patchPath]);
 }
 
 function scoreCandidate(input: {
@@ -323,7 +329,15 @@ export async function runWorkerFanout(options: RunWorkerFanoutOptions): Promise<
       return { candidates, fallbackReason: 'selected fan-out candidate had no diff to promote' };
     }
 
-    await applyDiff(options.projectPath, root, diff);
+    // A promotion failure (e.g. the project drifted while candidates ran) must
+    // not sink the whole worker stage — fall back to a single in-place worker,
+    // which is what would have run without fan-out.
+    try {
+      await applyDiff(options.projectPath, root, diff);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { candidates, fallbackReason: `winner diff did not apply cleanly: ${msg}` };
+    }
     const promotedFiles = await changedFiles(options.projectPath);
     winner.result = {
       ...winner.result,

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -18,6 +18,8 @@ import {
   recordProjectCompletion,
   loadProjectSelection,
   saveProjectSelection,
+  recordLastFailureDetail,
+  type LastFailureEntry,
   type TaskState,
   type ProjectInfo,
 } from './runnerState.js';
@@ -187,6 +189,10 @@ export class AutonomousRunner {
   private completedTaskIds = new Set<string>();
   private failedTaskCounts = new Map<string, number>();
   private failedTaskRetryTimes = new Map<string, number>(); // issueId → next retry timestamp (ms)
+  // Last failure feedback per issue — re-injected into the next attempt's worker
+  // prompt so re-picked tasks don't restart blind and repeat the same mistake
+  // the reviewer already called out (INT-2474). Persisted; cleared on success.
+  private lastFailureDetails = new Map<string, LastFailureEntry>();
   private static readonly MAX_RETRY_COUNT = 4; // Increased from 2 to allow more retries with backoff
 
   // Rate-limit hold: epoch ms until which all task execution is paused.
@@ -204,6 +210,7 @@ export class AutonomousRunner {
       completedTaskIds: this.completedTaskIds,
       failedTaskCounts: this.failedTaskCounts,
       failedTaskRetryTimes: this.failedTaskRetryTimes,
+      lastFailureDetails: this.lastFailureDetails,
     };
   }
 
@@ -279,6 +286,7 @@ export class AutonomousRunner {
         this.completedTaskIds.add(task.issueId);
         clearRejection(task.issueId); // Clear rejection count on success
         clearRetryTime(task.issueId, this.failedTaskRetryTimes); // Clear retry backoff time
+        this.lastFailureDetails.delete(task.issueId); // Stale feedback must not haunt future work
         this.saveTaskState();
         // Track project-level pace (5h rolling window)
         const projectName = task.linearProject?.name ?? 'unknown';
@@ -405,6 +413,8 @@ export class AutonomousRunner {
       if (task.issueId && result.finalStatus === 'rejected') {
         const feedback = result.reviewResult?.feedback || 'No feedback provided';
         const rejectionCount = incrementRejection(task.issueId, feedback);
+        // Persist for prompt injection on the retry (same mechanism as failures).
+        recordLastFailureDetail(this.taskStateRef, task.issueId, feedback);
 
         // Store the rejection reason as a repo pitfall (constraint) — blocks repeating the same mistake
         if (result.taskContext?.projectPath) {
@@ -460,17 +470,21 @@ export class AutonomousRunner {
         const count = (this.failedTaskCounts.get(task.issueId) ?? 0) + 1;
         this.failedTaskCounts.set(task.issueId, count);
 
+        // Surface the underlying failure (worker CLI error / review feedback) so the
+        // stuck comment is actionable instead of an opaque "failed N times", AND
+        // persist it so the NEXT attempt starts with this feedback instead of
+        // blind — re-picked tasks used to repeat the exact same mistake (INT-2474).
+        const failureDetail = result.workerResult?.error
+          || result.reviewResult?.feedback
+          || 'No error detail captured (worker produced no output).';
+        recordLastFailureDetail(this.taskStateRef, task.issueId, failureDetail);
+
         if (count >= AutonomousRunner.MAX_RETRY_COUNT) {
           // Max retries exceeded - permanently block
           this.completedTaskIds.add(task.issueId); // Prevent re-selection
           clearRetryTime(task.issueId, this.failedTaskRetryTimes); // Clear retry time
           this.saveTaskState();
           console.log(`[Scheduler] Task failure count: ${count}/${AutonomousRunner.MAX_RETRY_COUNT} for ${taskCtx} — STUCK`);
-          // Surface the underlying failure (worker CLI error / review feedback) so the
-          // stuck comment is actionable instead of an opaque "failed N times".
-          const failureDetail = result.workerResult?.error
-            || result.reviewResult?.feedback
-            || 'No error detail captured (worker produced no output).';
           try {
             await execution.syncFailureState(task, `Autonomous execution failed ${count} times: ${failureDetail}`);
             await getTaskSource()?.logStuck(task.issueId, 'autonomous-runner',
@@ -1245,7 +1259,20 @@ export class AutonomousRunner {
     return safeTasks;
   }
 
+  /**
+   * Re-attempt of a previously failed/rejected issue: carry the last failure
+   * feedback into the run so the worker's first iteration addresses it instead
+   * of repeating the same mistake blind (INT-2474). Called on BOTH execution
+   * paths — parallel enqueue and the serial (maxConcurrentTasks=1) heartbeat.
+   */
+  private attachPriorFeedback(task: TaskItem): void {
+    if (!task.issueId) return;
+    const prior = this.lastFailureDetails.get(task.issueId);
+    if (prior) task.priorAttemptFeedback = prior.detail;
+  }
+
   private enqueueCandidate(task: TaskItem, projectPath: string): void {
+    this.attachPriorFeedback(task);
     this.scheduler.enqueue(task, projectPath);
     broadcastEvent({ type: 'task:queued', data: { taskId: task.id, title: task.title, projectPath, issueIdentifier: task.issueIdentifier } });
     this.syslog(`✓ Queued: ${task.issueIdentifier || ''} ${task.title} → ${projectPath.split('/').slice(-2).join('/')}`);
@@ -1260,6 +1287,10 @@ export class AutonomousRunner {
 
   /** Execute task in pair mode */
   private async executeTaskPairMode(task: TaskItem): Promise<void> {
+    // Serial path (maxConcurrentTasks=1) bypasses enqueueCandidate — attach the
+    // prior-session feedback here too so both paths inject it (INT-2474).
+    this.attachPriorFeedback(task);
+
     // Auto-resolve project path
     const projectPath = await this.resolveProjectPath(task);
 

--- a/src/automation/runnerState.coverage.test.ts
+++ b/src/automation/runnerState.coverage.test.ts
@@ -79,21 +79,43 @@ describe('runnerState persistence and helpers', () => {
       completed: ['done-1'],
       failed: { bad: 2 },
       retryTimes: { bad: 12345 },
+      lastFailures: { bad: { detail: 'reviewer said: missing tests', at: '2026-07-05T00:00:00.000Z' } },
     }));
-    const state = { completedTaskIds: new Set<string>(), failedTaskCounts: new Map<string, number>(), failedTaskRetryTimes: new Map<string, number>() };
+    const state = {
+      completedTaskIds: new Set<string>(),
+      failedTaskCounts: new Map<string, number>(),
+      failedTaskRetryTimes: new Map<string, number>(),
+      lastFailureDetails: new Map<string, { detail: string; at: string }>(),
+    };
     mod.loadTaskState(state);
     expect([...state.completedTaskIds]).toEqual(['done-1']);
     expect(state.failedTaskCounts.get('bad')).toBe(2);
     expect(state.failedTaskRetryTimes.get('bad')).toBe(12345);
+    expect(state.lastFailureDetails.get('bad')?.detail).toBe('reviewer said: missing tests');
 
     state.completedTaskIds.add('done-2');
     state.failedTaskCounts.set('worse', 3);
     state.failedTaskRetryTimes.set('worse', 999);
+    mod.recordLastFailureDetail(state, 'worse', 'reviewer said: wrong API shape');
     mod.saveTaskState(state);
     const saved = JSON.parse(readFileSync(mod.TASK_STATE_FILE, 'utf8'));
     expect(saved.completed).toContain('done-2');
     expect(saved.failed.worse).toBe(3);
     expect(saved.retryTimes.worse).toBe(999);
+    expect(saved.lastFailures.worse.detail).toBe('reviewer said: wrong API shape');
+  });
+
+  it('caps recorded failure detail and ignores blank details', () => {
+    const state = {
+      completedTaskIds: new Set<string>(),
+      failedTaskCounts: new Map<string, number>(),
+      failedTaskRetryTimes: new Map<string, number>(),
+      lastFailureDetails: new Map<string, { detail: string; at: string }>(),
+    };
+    mod.recordLastFailureDetail(state, 'big', 'x'.repeat(5000));
+    expect(state.lastFailureDetails.get('big')!.detail.length).toBe(2000);
+    mod.recordLastFailureDetail(state, 'blank', '   ');
+    expect(state.lastFailureDetails.has('blank')).toBe(false);
   });
 
   it('tracks rejection entries and trims reasons', () => {

--- a/src/automation/runnerState.ts
+++ b/src/automation/runnerState.ts
@@ -153,10 +153,30 @@ export function getDailyPaceInfo(): DailyPaceState {
   return { completedToday: totalToday, dateKey: today, lastCompletionAt: lastCompletion, projectCounts };
 }
 
+/** Last failure detail per issue — injected into the next attempt's worker
+ * prompt so a re-picked task doesn't repeat the exact mistake the reviewer
+ * already called out (INT-2474). Capped and cleared on success. */
+export interface LastFailureEntry {
+  detail: string;
+  at: string; // ISO-8601
+}
+
+const MAX_FAILURE_DETAIL_CHARS = 2000;
+
 export interface TaskState {
   completedTaskIds: Set<string>;
   failedTaskCounts: Map<string, number>;
   failedTaskRetryTimes: Map<string, number>; // issueId → next retry timestamp (ms)
+  lastFailureDetails: Map<string, LastFailureEntry>; // issueId → last failure feedback
+}
+
+export function recordLastFailureDetail(state: TaskState, issueId: string, detail: string): void {
+  const trimmed = detail.trim();
+  if (!trimmed) return;
+  state.lastFailureDetails.set(issueId, {
+    detail: trimmed.slice(0, MAX_FAILURE_DETAIL_CHARS),
+    at: new Date().toISOString(),
+  });
 }
 
 export function loadTaskState(state: TaskState): void {
@@ -167,6 +187,7 @@ export function loadTaskState(state: TaskState): void {
       completed?: string[];
       failed?: Record<string, number>;
       retryTimes?: Record<string, number>;
+      lastFailures?: Record<string, LastFailureEntry>;
     };
     if (Array.isArray(data.completed)) {
       for (const id of data.completed) state.completedTaskIds.add(id);
@@ -181,6 +202,11 @@ export function loadTaskState(state: TaskState): void {
         state.failedTaskRetryTimes.set(id, time as number);
       }
     }
+    if (data.lastFailures && typeof data.lastFailures === 'object') {
+      for (const [id, entry] of Object.entries(data.lastFailures)) {
+        if (entry && typeof entry.detail === 'string') state.lastFailureDetails.set(id, entry);
+      }
+    }
     console.log(`[AutonomousRunner] Loaded task state: ${state.completedTaskIds.size} completed, ${state.failedTaskCounts.size} failed`);
   } catch (err) {
     console.warn('[AutonomousRunner] Failed to load task state:', err);
@@ -193,6 +219,7 @@ export function saveTaskState(state: TaskState): void {
       completed: Array.from(state.completedTaskIds),
       failed: Object.fromEntries(state.failedTaskCounts),
       retryTimes: Object.fromEntries(state.failedTaskRetryTimes),
+      lastFailures: Object.fromEntries(state.lastFailureDetails),
       updatedAt: new Date().toISOString(),
     };
     ensureParentDir(TASK_STATE_FILE);

--- a/src/orchestration/decisionEngine.ts
+++ b/src/orchestration/decisionEngine.ts
@@ -59,6 +59,7 @@ export interface TaskItem {
   fileScope?: string[];    // Files/modules this task modifies (planner-declared) — for parallel conflict detection
   impactAnalysis?: ImpactAnalysis;  // Knowledge graph impact analysis
   estimatedMinutes?: number;
+  priorAttemptFeedback?: string;  // Last failure/rejection feedback from a previous session — injected into the worker's first iteration (INT-2474)
 }
 
 /**


### PR DESCRIPTION
## Summary
Two production defects measured on the live daemon:

**1. Reviewer-revise treadmill (INT-2474)** — 4 successes vs 51 max-iteration exhaustions in the recent window; issues re-picked up to 59×.
- Cross-session amnesia: failed/rejected tasks now persist their last reviewer feedback (`task-state lastFailures`, 2KB cap, cleared on success) and it is injected into the worker's first iteration on re-attempt — on BOTH the parallel enqueue path and the serial heartbeat path (the latter was caught by the openswarm review self-gate).
- Subjective stagnation brake: two consecutive near-identical revise feedbacks (token-set Jaccard ≥ 0.6) end the session early instead of burning every remaining iteration (146 exhaustions vs 21 objective aborts before).

**2. Fan-out winner promotion died on dirty projects** — production error `git apply --3way ... does not match index`: `--3way` validates the preimage against the INDEX (=HEAD) while only the WORKTREE matches the seeded dirty state. Now a plain worktree apply + graceful single-worker fallback on promote failure.

## Verification
- vitest: agents+automation sweep 444 pass (incl. new: prior-feedback injection, repeated-feedback early abort, similarReviewFeedback unit, task-state round-trip, dirty-overlap promote regression)
- The dirty-overlap regression test **reproduces the exact production error under `--3way`** and passes with the fix (verified by temporary revert)
- typecheck / oxlint / build clean
- openswarm review self-gate: found the serial-path injection gap → fixed in this PR

Closes INT-2474