### PR TITLE
chore(release): v0.17.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.17.4 — 2026-07-05
+
+### Fixed
+
+- **Reviewer-revise treadmill** — failing sessions could not converge: a task that failed at max iterations or was rejected was re-picked with zero memory of the reviewer's feedback (measured: 4 successes vs 51 max-iteration exhaustions in a recent window; issues re-picked up to 59×). Every failure/rejection now persists its last reviewer feedback (task-state `lastFailures`, cleared on success) and injects it into the worker's first iteration on re-attempt — on both the parallel and serial heartbeat paths. Two consecutive near-identical revise feedbacks also end the session early instead of burning the remaining iterations (the reflection stagnation brake only counted objective sources, so a repeating reviewer never tripped it). (INT-2474, #230)
+- **Fan-out winner promotion died on dirty projects** — `git apply --3way ... does not match index`: `--3way` validates the patch preimage against the index (=HEAD), but on a self-repair retry only the worktree matches the seeded dirty state. Promotion now uses a plain worktree apply, and a promote failure falls back to the single in-place worker instead of failing the whole stage. (#230)
+
 ## 0.17.3 — 2026-07-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -530,11 +530,11 @@ the CLI (fire-and-forget with a short timeout, and failures are silently ignored
 Full version history lives in **[CHANGELOG.md](CHANGELOG.md)** and the
 [GitHub Releases](https://github.com/unohee/OpenSwarm/releases) page.
 
-Latest — **v0.17.3**: no more duplicate daemons next to a launchd-managed
-instance (`:3847` port probe before spawn), adaptive worker fan-out actually
-executes (dirty-worktree seeding instead of a clean-tree bail), and the worker
-validation-evidence gate lost its false-positives. See CHANGELOG.md for the
-rest.
+Latest — **v0.17.4**: the reviewer-revise treadmill is broken — failed
+attempts persist their reviewer feedback and re-attempts start with it
+injected, a repeating reviewer ends the session early, and fan-out winner
+promotion no longer dies on dirty projects. Plus v0.17.3's duplicate-daemon
+prevention and fan-out execution fixes. See CHANGELOG.md for the rest.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.17.3",
+      "version": "0.17.4",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Patch release: reviewer-revise treadmill fix (cross-session feedback persistence + repeat-feedback early abort, INT-2474) and fan-out dirty-project promotion fix (#230).