### PR TITLE
feat(pipeline): escalate the worker on repeated revise feedback before giving up (INT-2475)

### DIFF
--- a/src/agents/pairPipeline.test.ts
+++ b/src/agents/pairPipeline.test.ts
@@ -338,9 +338,10 @@ describe('PairPipeline model selection', () => {
     expect(runWorker.mock.calls[0][0].previousFeedback).toContain('Previous attempt failed');
   });
 
-  it('aborts the session early when the reviewer repeats the same revise feedback', async () => {
-    // Reviewer says the same thing twice → the worker is not absorbing it;
-    // burning the remaining iterations is pure waste (INT-2474).
+  it('escalates the worker once on repeated revise feedback, then aborts if it still repeats', async () => {
+    // Reviewer says the same thing twice → escalate the worker (effort bump);
+    // if the ESCALATED attempt gets the same feedback again, stop burning
+    // iterations (INT-2474 + INT-2475).
     runReviewer.mockResolvedValue({
       decision: 'revise',
       feedback: 'The cache invalidation misses the tenant scope; invalidate per tenant and cover it with a test.',
@@ -349,7 +350,7 @@ describe('PairPipeline model selection', () => {
     const { PairPipeline } = await import('./pairPipeline.js');
     const pipeline = new PairPipeline({
       stages: ['worker', 'reviewer'],
-      maxIterations: 5,
+      maxIterations: 6,
       roles: {
         worker: { enabled: true, model: 'worker', timeoutMs: 0 },
         reviewer: { enabled: true, model: 'reviewer', timeoutMs: 0 },
@@ -359,9 +360,62 @@ describe('PairPipeline model selection', () => {
     const result = await pipeline.run(task(), process.cwd());
 
     expect(result.success).toBe(false);
-    // Iteration 1 review + iteration 2's near-identical review → abort before iteration 3.
-    expect(runWorker).toHaveBeenCalledTimes(2);
-    expect(runReviewer).toHaveBeenCalledTimes(2);
+    // it1 review f, it2 review f≈ → escalate, it3 (escalated) review f≈ → abort.
+    expect(runWorker).toHaveBeenCalledTimes(3);
+    expect(runReviewer).toHaveBeenCalledTimes(3);
+    // The escalated (3rd) worker run got the effort bump.
+    expect(runWorker.mock.calls[2][0]).toEqual(expect.objectContaining({ reasoningEffort: 'high' }));
+    expect(runWorker.mock.calls[1][0].reasoningEffort).not.toBe('high');
+  });
+
+  it('lets an escalated worker attempt succeed after repeated revise feedback', async () => {
+    runReviewer
+      .mockResolvedValueOnce({ decision: 'revise', feedback: 'Pagination cursor handling is wrong: the offset resets between pages, fix and add a test.' })
+      .mockResolvedValueOnce({ decision: 'revise', feedback: 'Pagination cursor handling is still wrong — the offset resets between pages; fix it and add a test.' })
+      .mockResolvedValueOnce({ decision: 'approve', feedback: 'fixed' });
+
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker', 'reviewer'],
+      maxIterations: 6,
+      roles: {
+        worker: { enabled: true, model: 'worker', timeoutMs: 0 },
+        reviewer: { enabled: true, model: 'reviewer', timeoutMs: 0 },
+      },
+    });
+
+    const result = await pipeline.run(task(), process.cwd());
+
+    expect(result.success).toBe(true);
+    expect(runWorker).toHaveBeenCalledTimes(3);
+    expect(runWorker.mock.calls[2][0]).toEqual(expect.objectContaining({ reasoningEffort: 'high' }));
+  });
+
+  it('escalates to the configured worker escalateModel on repeated revise feedback', async () => {
+    runReviewer
+      .mockResolvedValueOnce({ decision: 'revise', feedback: 'The retry loop swallows the abort signal; propagate cancellation to the adapter call.' })
+      .mockResolvedValueOnce({ decision: 'revise', feedback: 'Retry loop still swallows the abort signal — propagate the cancellation into the adapter call.' })
+      .mockResolvedValueOnce({ decision: 'approve', feedback: 'ok' });
+
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker', 'reviewer'],
+      maxIterations: 6,
+      roles: {
+        // escalateAfterIteration pushed out of reach → isolates the signal path
+        worker: { enabled: true, model: 'worker', timeoutMs: 0, escalateModel: 'bigger-model', escalateAfterIteration: 99 },
+        reviewer: { enabled: true, model: 'reviewer', timeoutMs: 0 },
+      },
+    });
+
+    const result = await pipeline.run(task(), process.cwd());
+
+    expect(result.success).toBe(true);
+    expect(runWorker.mock.calls[1][0].model).toBe('worker');
+    expect(runWorker.mock.calls[2][0]).toEqual(expect.objectContaining({
+      model: 'bigger-model',
+      reasoningEffort: 'high',
+    }));
   });
 
   it('defers to the reviewer instead of hard-failing when validation evidence stays missing', async () => {

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -26,6 +26,7 @@ import {
   similarReviewFeedback,
   DEFAULT_MAX_REFLECTIONS,
 } from './reflection.js';
+import { buildRepeatEscalation, resolveWorkerStageOverrides } from './workerEscalation.js';
 import { hasRepoSnapshot, scanAndCache, analyzeIssue } from '../knowledge/index.js';
 import { getRegistryStore } from '../registry/sqliteStore.js';
 import { recallRepoKnowledge } from '../memory/repoKnowledge.js';
@@ -398,7 +399,7 @@ export class PairPipeline extends EventEmitter {
   private async runStage(
     stage: PipelineStage,
     context: PipelineContext,
-    overrides?: { model?: string }
+    overrides?: { model?: string; reasoningEffort?: 'low' | 'medium' | 'high' }
   ): Promise<StageResult> {
     const startTime = Date.now();
     // Display model: explicit override → configured (jobProfile/role) → adapter
@@ -484,8 +485,8 @@ export class PairPipeline extends EventEmitter {
             model: overrides?.model ?? this.getModelForRole('worker', context.task),
             maxTurns: this.config.roles?.worker?.maxTurns,
             adapterName: this.config.roles?.worker?.adapter,
-            reasoningEffort: this.getEffortForTask(context.task),
-            bashTimeoutMs: await workerAgent.resolveWorkerBashTimeout(context.projectPath, this.getEffortForTask(context.task)), // INT-2415
+            reasoningEffort: overrides?.reasoningEffort ?? this.getEffortForTask(context.task),
+            bashTimeoutMs: await workerAgent.resolveWorkerBashTimeout(context.projectPath, overrides?.reasoningEffort ?? this.getEffortForTask(context.task)), // INT-2415
             // No-edit guard (re-applied from stranded feat/v0.7.0 commit 2eea3bc):
             // reasoning workers frequently end with analysis only and never call
             // edit_file. Without this the guard defaults to 0 (disabled) — measured:
@@ -862,24 +863,16 @@ export class PairPipeline extends EventEmitter {
       console.log(`[${context.taskPrefix}] Iteration ${context.currentIteration}/${maxIterations}`);
 
       // ========== WORKER (with escalation) ==========
-      const workerCfg = this.config.roles?.worker;
-      const escalateThreshold = workerCfg?.escalateAfterIteration ?? 2;
-      const escalateModel = workerCfg?.escalateModel;
-      const shouldEscalate = context.currentIteration >= escalateThreshold && !!escalateModel;
-      const baseWorkerModel = this.getModelForRole('worker', context.task);
-      const workerOverrides = shouldEscalate
-        ? { model: escalateModel }
-        : (baseWorkerModel ? { model: baseWorkerModel } : undefined);
-
-      if (shouldEscalate && escalateModel) {
-        console.log(`[${context.taskPrefix}] Escalating worker model → ${escalateModel} (iteration ${context.currentIteration})`);
-        broadcastEvent({ type: 'pipeline:escalation', data: {
-          taskId: context.task.id,
-          iteration: context.currentIteration,
-          fromModel: workerCfg?.model,
-          toModel: escalateModel,
-        } });
-      }
+      // Iteration-count escalation + one-shot signal escalation (INT-2475) —
+      // policy lives in workerEscalation.ts; the signal takes precedence.
+      const workerOverrides = resolveWorkerStageOverrides({
+        workerCfg: this.config.roles?.worker,
+        iteration: context.currentIteration,
+        baseModel: this.getModelForRole('worker', context.task),
+        signalEscalation: context.workerEscalation,
+        taskId: context.task.id,
+        taskPrefix: context.taskPrefix,
+      });
 
       const fanoutDecision = evaluateWorkerFanoutGate({
         task: context.task,
@@ -1171,22 +1164,52 @@ export class PairPipeline extends EventEmitter {
           // sessions used to burn every remaining iteration on feedback the
           // worker demonstrably isn't absorbing (measured: 146 max-iteration
           // exhaustions vs 21 objective aborts). Two consecutive near-identical
-          // revise feedbacks → end the session now; the runner persists this
-          // feedback and the NEXT attempt starts with it injected (INT-2474).
+          // revise feedbacks → first ESCALATE the worker once (higher model
+          // and/or effort — the current tier has proven it can't absorb this
+          // feedback, INT-2475); if it repeats even after escalation, end the
+          // session — the runner persists the feedback and the NEXT attempt
+          // starts with it injected (INT-2474).
           if (
             context.lastReviseFeedback
             && similarReviewFeedback(context.lastReviseFeedback, reviseFeedback)
           ) {
-            const reason = 'reviewer repeated the same revise feedback — worker is not absorbing it';
-            console.log(`[${context.taskPrefix}] Aborting session early: ${reason}`);
-            this.emit('log', { line: `🛑 ${reason}` });
-            this.emit('iteration:fail', {
-              iteration: context.currentIteration,
-              stage: 'reviewer',
-              context,
-            });
-            agentPair.updateSessionStatus(context.session.id, 'failed');
-            return { success: false };
+            const escalation = !context.workerEscalation
+              ? buildRepeatEscalation({
+                  workerCfg: this.config.roles?.worker,
+                  currentIteration: context.currentIteration,
+                  currentModel: this.getModelForRole('worker', context.task),
+                  currentEffort: this.getEffortForTask(context.task),
+                })
+              : undefined;
+            if (escalation) {
+              context.workerEscalation = escalation;
+              const target = [
+                escalation.model ? `model→${escalation.model}` : '',
+                escalation.reasoningEffort ? `effort→${escalation.reasoningEffort}` : '',
+              ].filter(Boolean).join(', ');
+              console.log(`[${context.taskPrefix}] Reviewer repeated the same feedback — escalating worker (${target})`);
+              this.emit('log', { line: `⬆️ Worker escalation on repeated review feedback (${target})` });
+              broadcastEvent({ type: 'pipeline:escalation', data: {
+                taskId: context.task.id,
+                iteration: context.currentIteration,
+                reason: 'repeated-review-feedback',
+                toModel: escalation.model,
+                toEffort: escalation.reasoningEffort,
+              } });
+            } else {
+              const reason = context.workerEscalation
+                ? 'reviewer repeated the same revise feedback even after worker escalation'
+                : 'reviewer repeated the same revise feedback — no escalation tier available';
+              console.log(`[${context.taskPrefix}] Aborting session early: ${reason}`);
+              this.emit('log', { line: `🛑 ${reason}` });
+              this.emit('iteration:fail', {
+                iteration: context.currentIteration,
+                stage: 'reviewer',
+                context,
+              });
+              agentPair.updateSessionStatus(context.session.id, 'failed');
+              return { success: false };
+            }
           }
           context.lastReviseFeedback = reviseFeedback;
 

--- a/src/agents/pairPipelineTypes.ts
+++ b/src/agents/pairPipelineTypes.ts
@@ -104,6 +104,8 @@ export interface PipelineContext {
   workerFanoutDecision?: WorkerFanoutGateDecision;
   /** Feedback of the previous reviewer 'revise' — compared against the next one to detect a repeating reviewer (INT-2474). */
   lastReviseFeedback?: string;
+  /** One-shot worker escalation triggered by repeated similar revise feedback: higher model and/or effort for the retry (INT-2475). */
+  workerEscalation?: { model?: string; reasoningEffort?: 'low' | 'medium' | 'high' };
 }
 
 export type PipelineEventType = 'stage:start' | 'stage:complete' | 'stage:fail' | 'iteration:start' | 'iteration:complete' | 'iteration:fail' | 'pipeline:complete' | 'pipeline:fail' | 'fanout:gate' | 'halt';

--- a/src/agents/workerEscalation.test.ts
+++ b/src/agents/workerEscalation.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { buildRepeatEscalation } from './workerEscalation.js';
+import type { RoleConfig } from '../core/types.js';
+
+const workerCfg = (extra: Partial<RoleConfig> = {}): RoleConfig => ({
+  enabled: true,
+  model: 'base-model',
+  timeoutMs: 0,
+  ...extra,
+});
+
+describe('buildRepeatEscalation', () => {
+  it('bumps effort to high when no escalateModel is configured (zero-config default)', () => {
+    expect(buildRepeatEscalation({
+      workerCfg: workerCfg(),
+      currentIteration: 2,
+      currentModel: 'base-model',
+      currentEffort: 'low',
+    })).toEqual({ model: undefined, reasoningEffort: 'high' });
+  });
+
+  it('escalates model and effort when escalateModel differs and effort is not high', () => {
+    expect(buildRepeatEscalation({
+      workerCfg: workerCfg({ escalateModel: 'bigger-model', escalateAfterIteration: 99 }),
+      currentIteration: 2,
+      currentModel: 'base-model',
+      currentEffort: 'medium',
+    })).toEqual({ model: 'bigger-model', reasoningEffort: 'high' });
+  });
+
+  it('treats an already-active iteration escalation as a model no-op (effort only)', () => {
+    // Default escalateAfterIteration=2: iteration 3 would run escalateModel
+    // anyway — re-targeting it adds nothing, only the effort bump counts.
+    expect(buildRepeatEscalation({
+      workerCfg: workerCfg({ escalateModel: 'bigger-model' }),
+      currentIteration: 2,
+      currentModel: 'base-model',
+      currentEffort: 'low',
+    })).toEqual({ model: undefined, reasoningEffort: 'high' });
+  });
+
+  it('returns undefined when nothing is left to escalate (abort path)', () => {
+    // Iteration escalation already in effect AND effort already high.
+    expect(buildRepeatEscalation({
+      workerCfg: workerCfg({ escalateModel: 'bigger-model' }),
+      currentIteration: 2,
+      currentModel: 'base-model',
+      currentEffort: 'high',
+    })).toBeUndefined();
+  });
+});

--- a/src/agents/workerEscalation.ts
+++ b/src/agents/workerEscalation.ts
@@ -1,0 +1,91 @@
+// ============================================
+// OpenSwarm - Worker escalation policy
+// ============================================
+//
+// Two escalation triggers share this module:
+// - iteration-count: config `worker.escalateAfterIteration` (default 2) with
+//   `worker.escalateModel` — every iteration at/past the threshold runs the
+//   escalated model.
+// - repeated-review-feedback signal (INT-2475): the reviewer said the same
+//   thing twice, proving the current tier can't absorb the feedback; escalate
+//   ONCE (higher model and/or effort bump) before giving up on the session.
+
+import type { RoleConfig } from '../core/types.js';
+import { broadcastEvent } from '../core/eventHub.js';
+
+export type WorkerReasoningEffort = 'low' | 'medium' | 'high';
+
+export interface WorkerStageOverrides {
+  model?: string;
+  reasoningEffort?: WorkerReasoningEffort;
+}
+
+/**
+ * Compute the worker stage overrides for the upcoming iteration: base model,
+ * iteration-count escalation, then the one-shot signal escalation on top
+ * (it takes precedence — the reviewer demonstrated the lower tier failed).
+ * Emits the iteration-escalation event/log exactly like the old inline block.
+ */
+export function resolveWorkerStageOverrides(input: {
+  workerCfg: RoleConfig | undefined;
+  iteration: number;
+  baseModel: string | undefined;
+  signalEscalation: WorkerStageOverrides | undefined;
+  taskId: string;
+  taskPrefix: string;
+}): WorkerStageOverrides | undefined {
+  const { workerCfg, iteration, baseModel, signalEscalation } = input;
+  const escalateThreshold = workerCfg?.escalateAfterIteration ?? 2;
+  const escalateModel = workerCfg?.escalateModel;
+  const shouldEscalate = iteration >= escalateThreshold && !!escalateModel;
+
+  let overrides: WorkerStageOverrides | undefined = shouldEscalate
+    ? { model: escalateModel }
+    : (baseModel ? { model: baseModel } : undefined);
+
+  if (shouldEscalate && escalateModel) {
+    console.log(`[${input.taskPrefix}] Escalating worker model → ${escalateModel} (iteration ${iteration})`);
+    broadcastEvent({ type: 'pipeline:escalation', data: {
+      taskId: input.taskId,
+      iteration,
+      fromModel: workerCfg?.model,
+      toModel: escalateModel,
+    } });
+  }
+
+  if (signalEscalation) {
+    overrides = { ...overrides, ...signalEscalation };
+  }
+  return overrides;
+}
+
+/**
+ * What is left to escalate to when the reviewer repeats itself (INT-2475):
+ * a configured higher worker model and/or a reasoning-effort bump to 'high'.
+ *
+ * The model comparison is against the model the NEXT iteration would use
+ * anyway: when the iteration-count escalation is already in effect,
+ * re-targeting the same escalateModel is a no-op — only the effort bump would
+ * add anything, and if that's spent too the caller aborts instead of burning
+ * an iteration on an escalation that changes nothing.
+ *
+ * Returns undefined when no meaningful escalation remains.
+ */
+export function buildRepeatEscalation(input: {
+  workerCfg: RoleConfig | undefined;
+  currentIteration: number;
+  currentModel: string | undefined;
+  currentEffort: WorkerReasoningEffort | undefined;
+}): WorkerStageOverrides | undefined {
+  const { workerCfg, currentIteration, currentModel, currentEffort } = input;
+  const nextIteration = currentIteration + 1;
+  const iterationEscalated =
+    !!workerCfg?.escalateModel && nextIteration >= (workerCfg?.escalateAfterIteration ?? 2);
+  const effectiveNextModel = iterationEscalated ? workerCfg!.escalateModel : currentModel;
+  const model = workerCfg?.escalateModel && workerCfg.escalateModel !== effectiveNextModel
+    ? workerCfg.escalateModel
+    : undefined;
+  const reasoningEffort = currentEffort !== 'high' ? 'high' as const : undefined;
+  if (!model && !reasoningEffort) return undefined;
+  return { model, reasoningEffort };
+}

--- a/src/core/eventHub.ts
+++ b/src/core/eventHub.ts
@@ -68,7 +68,7 @@ export type HubEvent =
       error?: string;
     } }
   | { type: 'pipeline:iteration'; data: { taskId: string; iteration: number } }
-  | { type: 'pipeline:escalation'; data: { taskId: string; iteration: number; fromModel?: string; toModel: string } }
+  | { type: 'pipeline:escalation'; data: { taskId: string; iteration: number; fromModel?: string; toModel?: string; toEffort?: string; reason?: string } }
   | { type: 'pipeline:fanout'; data: {
       taskId: string;
       iteration: number;


### PR DESCRIPTION
## Summary
Follow-up to #230: when the reviewer repeats near-identical revise feedback (the INT-2474 signal), first **escalate the worker once and retry in-session** instead of aborting immediately:

- `worker.escalateModel` (existing config field) when it differs from what the next iteration would run anyway (no-op guard vs. the iteration-count escalation), plus a **reasoning-effort bump to `high`** — so the zero-config default still escalates meaningfully.
- One signal escalation per session; same feedback after escalation (or nothing left to escalate to) → early abort as before, feedback persisted for next-attempt injection.
- Escalation policy extracted to `workerEscalation.ts` (shared by iteration-count + signal paths; keeps pairPipeline under the 1500-line pre-commit cap).
- `runStage` overrides now carry `reasoningEffort`; `pipeline:escalation` events carry `reason`/`toEffort`.

## Verification
- vitest src/agents sweep: 17 files / 394 pass (new: effort-bump retry success, escalated-but-still-repeating abort with 3rd run at effort high, escalateModel signal path isolated via `escalateAfterIteration: 99`, buildRepeatEscalation no-op/abort matrix)
- typecheck / oxlint / build clean
- openswarm review self-gate: flagged the no-op-escalation overlap with iteration-count escalation → fixed (effective-next-model comparison) + covered by unit test

Closes INT-2475