### PR TITLE
fix(fanout): promote the winner by copying files, not git apply (79% prod failure)

### DIFF
--- a/src/agents/workerFanout.test.ts
+++ b/src/agents/workerFanout.test.ts
@@ -140,4 +140,54 @@ describe('runWorkerFanout on a dirty worktree', () => {
       await rm(repo, { recursive: true, force: true });
     }
   });
+
+  it('promotes the winner when it deletes a tracked file and adds a new one', async () => {
+    // File-copy promote (not `git apply`) so add/delete/modify all survive
+    // regardless of context — the mode that made the patch route fail in prod.
+    const repo = await mkdtemp(path.join(tmpdir(), 'osw-fanout-adddel-'));
+    try {
+      await writeFile(path.join(repo, 'keep.py'), 'keep\n', 'utf8');
+      await writeFile(path.join(repo, 'obsolete.py'), 'delete me\n', 'utf8');
+      initRepo(repo);
+
+      runWorker.mockImplementation(async (opts: WorkerOptions) => {
+        const isSpark = opts.model === 'gpt-5.3-codex-spark';
+        if (isSpark) {
+          await rm(path.join(opts.projectPath, 'obsolete.py'), { force: true });
+          await writeFile(path.join(opts.projectPath, 'brand_new.py'), 'new\n', 'utf8');
+          await writeFile(path.join(opts.projectPath, 'keep.py'), 'keep\nedited\n', 'utf8');
+          return {
+            success: true, summary: 'spark patch',
+            filesChanged: ['obsolete.py', 'brand_new.py', 'keep.py'],
+            commands: [], output: '', confidencePercent: 95,
+          };
+        }
+        await writeFile(path.join(opts.projectPath, 'primary.txt'), 'primary\n', 'utf8');
+        return {
+          success: true, summary: 'primary patch', filesChanged: ['primary.txt'],
+          commands: [], output: '', confidencePercent: 70,
+        };
+      });
+
+      const { runWorkerFanout } = await import('./workerFanout.js');
+      const result = await runWorkerFanout({
+        projectPath: repo,
+        baseWorkerOptions: { ...baseWorkerOptions, projectPath: repo },
+        candidates: [
+          { id: 'primary', adapter: 'codex-responses', model: 'gpt-5.4-mini' },
+          { id: 'spark-diversity', adapter: 'codex-responses', model: 'gpt-5.3-codex-spark' },
+        ],
+        concurrency: 2,
+      });
+
+      expect(result.fallbackReason).toBeUndefined();
+      expect(result.winner?.id).toBe('spark-diversity');
+      expect(existsSync(path.join(repo, 'obsolete.py'))).toBe(false); // deleted
+      expect(await readFile(path.join(repo, 'brand_new.py'), 'utf8')).toBe('new\n'); // added
+      expect(await readFile(path.join(repo, 'keep.py'), 'utf8')).toBe('keep\nedited\n'); // modified
+      expect(existsSync(path.join(repo, 'primary.txt'))).toBe(false); // loser not promoted
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/agents/workerFanout.ts
+++ b/src/agents/workerFanout.ts
@@ -7,7 +7,7 @@
 
 import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { cp, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { copyFile, cp, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { promisify } from 'node:util';
@@ -159,21 +159,62 @@ async function changedFiles(projectPath: string): Promise<string[]> {
     .filter(Boolean);
 }
 
-async function diffBinary(projectPath: string): Promise<string> {
-  await git(projectPath, ['add', '-A']);
-  return git(projectPath, ['diff', '--cached', '--binary', 'HEAD']);
+/**
+ * The winner's changes relative to the seeded base (sandbox HEAD): tracked
+ * add/modify/delete/rename plus untracked new files. NUL-delimited so paths with
+ * spaces/newlines survive. Returns { write } (paths whose content to copy from
+ * the sandbox) and { remove } (paths to delete from the project).
+ */
+async function winnerChangeSet(sandbox: string): Promise<{ write: string[]; remove: string[] }> {
+  const write = new Set<string>();
+  const remove = new Set<string>();
+
+  const nameStatus = await git(sandbox, ['diff', '--name-status', '-z', 'HEAD']);
+  const tokens = nameStatus.split('\0').filter(Boolean);
+  for (let i = 0; i < tokens.length; ) {
+    const status = tokens[i];
+    if (status.startsWith('R') || status.startsWith('C')) {
+      // rename/copy: <status>\t?<src>\0<dst>\0 → src removed, dst written
+      const src = tokens[i + 1];
+      const dst = tokens[i + 2];
+      if (status.startsWith('R') && src) remove.add(src);
+      if (dst) write.add(dst);
+      i += 3;
+    } else {
+      const path = tokens[i + 1];
+      if (path) (status === 'D' ? remove : write).add(path);
+      i += 2;
+    }
+  }
+
+  const untracked = await git(sandbox, ['ls-files', '--others', '--exclude-standard', '-z']);
+  for (const p of untracked.split('\0').filter(Boolean)) write.add(p);
+
+  return { write: [...write], remove: [...remove] };
 }
 
-async function applyDiff(projectPath: string, patchRoot: string, diff: string): Promise<void> {
-  const patchPath = join(patchRoot, 'winner.patch');
-  await writeFile(patchPath, diff, 'utf8');
-  // Plain worktree apply — NOT --3way. --3way validates the preimage against
-  // the INDEX, but on a dirty project (self-repair retry) the index still holds
-  // HEAD while the patch preimage is the seeded dirty state → "does not match
-  // index" even though the WORKTREE matches the preimage exactly (the sandbox
-  // base was cloned+seeded from it). A 3-way fallback couldn't work anyway: the
-  // sandbox's baseline blobs don't exist in the project's object database.
-  await git(projectPath, ['apply', '--whitespace=nowarn', patchPath]);
+/**
+ * Promote the winner by COPYING its changed files into the project, rather than
+ * reconstructing a patch and `git apply`-ing it. The patch route is inherently
+ * fragile — context/whitespace/binary strictness made it fail ~79% of the time
+ * in production on dirty (self-repair-retry) worktrees. A direct copy of the
+ * exact file set the winner touched cannot fail on context mismatch: the
+ * sandbox file is `seeded-base + winner-edits`, and the project sits at the same
+ * seeded base, so the copy yields `base + winner-edits`, untouched files keep
+ * their project content. Returns the promoted path list.
+ */
+async function promoteWinnerFiles(projectPath: string, sandbox: string): Promise<string[]> {
+  const { write, remove } = await winnerChangeSet(sandbox);
+  for (const rel of remove) {
+    await rm(join(projectPath, rel), { force: true });
+  }
+  for (const rel of write) {
+    const src = join(sandbox, rel);
+    const dst = join(projectPath, rel);
+    await mkdir(dirname(dst), { recursive: true });
+    await copyFile(src, dst);
+  }
+  return [...write, ...remove];
 }
 
 function scoreCandidate(input: {
@@ -324,20 +365,22 @@ export async function runWorkerFanout(options: RunWorkerFanoutOptions): Promise<
       return { candidates, fallbackReason: 'no eligible fan-out candidate produced a guarded diff' };
     }
 
-    const diff = await diffBinary(winner.projectPath);
-    if (!diff.trim()) {
-      return { candidates, fallbackReason: 'selected fan-out candidate had no diff to promote' };
-    }
-
     // A promotion failure (e.g. the project drifted while candidates ran) must
     // not sink the whole worker stage — fall back to a single in-place worker,
     // which is what would have run without fan-out.
+    let copied: string[];
     try {
-      await applyDiff(options.projectPath, root, diff);
+      copied = await promoteWinnerFiles(options.projectPath, winner.projectPath);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      return { candidates, fallbackReason: `winner diff did not apply cleanly: ${msg}` };
+      return { candidates, fallbackReason: `winner promotion failed: ${msg}` };
     }
+    if (copied.length === 0) {
+      return { candidates, fallbackReason: 'selected fan-out candidate had no changes to promote' };
+    }
+    // Report the full accumulated worktree change set (base dirty state + the
+    // winner's increment) so the reviewer/tester see everything the PR carries,
+    // not just this iteration's delta.
     const promotedFiles = await changedFiles(options.projectPath);
     winner.result = {
       ...winner.result,


### PR DESCRIPTION
## Summary
Live monitoring caught fan-out promotion failing **79% of the time** in production (14 executions → 2 promoted, 11 `fallback to single worker: winner diff did not apply cleanly`). Even the earlier `--3way`→plain-`git apply` fix (#230) couldn't survive the context/whitespace/binary strictness introduced by the clone→seed-baseline→diff round-trip on dirty (self-repair-retry) worktrees. Each failed promote wasted a full **2× fan-out compute** on an already resource-saturated host.

Replace the `diff | git apply` promote with a **direct file copy** of the winner's exact change set:
- tracked add/modify/delete/rename via `git diff --name-status -z HEAD`
- untracked new files via `git ls-files --others --exclude-standard -z`
- copy `write` paths sandbox→project, `rm` the `remove` paths

The sandbox file is `seeded-base + winner-edits` and the project sits at the same seeded base, so the copy yields `base + winner-edits` with untouched files kept — there is no context to mismatch. `filesChanged` still reports the full accumulated worktree set for the reviewer.

## Verification
- New test: winner deletes a tracked file + adds a new one + modifies another (the add/delete shapes `git apply` mishandled) — passes
- Existing dirty-overlap + seed tests still pass
- src/agents sweep: 17 files / 395 pass; typecheck / oxlint / build clean
- Root cause reproduced locally: normal seeding promotes fine, but any drift between the seeded base and the project working tree makes `git apply` reject the whole patch — file copy is immune

## Note
Fan-out is currently set to `mode: report` on the saturated primary host (load ~20-28 on 10 cores, swap 93%) — this fix ensures promotion actually works when execute mode is enabled on a host with headroom.