### PR TITLE
fix(codex): populate commands from actual executions, not just self-report

### DIFF
--- a/src/adapters/codex.test.ts
+++ b/src/adapters/codex.test.ts
@@ -85,6 +85,29 @@ describe('CodexCliAdapter', () => {
     expect(result.commands).toEqual(['npm test']);
   });
 
+  it('captures actually-executed commands even when the model self-reports none', () => {
+    // The common failure mode: worker edits code and runs checks, but its JSON
+    // report has commands:[] — the validation gate then bounces it and reviewers
+    // reject on "report the verification command". Ground-truth command_execution
+    // events must backfill commands. (unwraps codex's /bin/zsh -lc '<cmd>' wrapper)
+    const raw = {
+      exitCode: 0,
+      stdout: [
+        '{"type":"item.started","item":{"type":"command_execution","command":"/bin/zsh -lc \'pytest tests/test_x.py\'"}}',
+        '{"type":"item.completed","item":{"type":"command_execution","command":"/bin/zsh -lc \'pytest tests/test_x.py\'","exit_code":0,"status":"completed"}}',
+        '{"type":"item.completed","item":{"type":"command_execution","command":"/bin/zsh -lc \'ruff check .\'","exit_code":0,"status":"completed"}}',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"```json\\n{\\"success\\":true,\\"summary\\":\\"Fixed\\",\\"filesChanged\\":[\\"db/x.py\\"],\\"commands\\":[]}\\n```"}}',
+      ].join('\n'),
+      stderr: '',
+      durationMs: 1,
+    };
+
+    const result = adapter.parseWorkerOutput(raw);
+    expect(result.success).toBe(true);
+    // Deduped, unwrapped, from the real executions — not the empty self-report.
+    expect(result.commands).toEqual(['pytest tests/test_x.py', 'ruff check .']);
+  });
+
   it('parses reviewer output from codex json events', () => {
     const raw = {
       exitCode: 0,

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -101,7 +101,18 @@ export class CodexCliAdapter implements CliAdapter {
 
   parseWorkerOutput(raw: CliRunResult): WorkerResult {
     const resultText = extractCodexMessageText(raw.stdout);
-    return extractWorkerResultJson(resultText) || extractWorkerFromText(resultText);
+    const result = extractWorkerResultJson(resultText) || extractWorkerFromText(resultText);
+    // Ground-truth commands: codex emits an `item.completed`/`command_execution`
+    // event for every shell it actually ran. Self-reported `commands` in the
+    // model's JSON block are frequently empty (the model skips the report), which
+    // made the validation-evidence gate bounce and reviewers reject on
+    // "report the verification command" criteria even though the worker DID run
+    // checks. Merge the real executions so `commands` reflects what happened.
+    const executed = extractCodexExecutedCommands(raw.stdout);
+    if (executed.length > 0) {
+      result.commands = [...new Set([...result.commands, ...executed])].slice(0, 20);
+    }
+    return result;
   }
 
   parseReviewerOutput(raw: CliRunResult): ReviewResult {
@@ -142,6 +153,36 @@ export function coerceCodexModel(requested: string): string {
 
 function isClaudeModel(name: string): boolean {
   return /^claude[-_]/i.test(name);
+}
+
+/**
+ * Extract the shell commands codex actually executed from its `--json` event
+ * stream. Each run emits `item.completed` with `item.type === 'command_execution'`
+ * and `item.command` (codex wraps it as `/bin/zsh -lc '<cmd>'` — unwrap to the
+ * inner command). Ground truth, independent of the model's self-report.
+ */
+function extractCodexExecutedCommands(output: string): string[] {
+  const commands: string[] = [];
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const event = JSON.parse(trimmed);
+      if (
+        event.type === 'item.completed' &&
+        event.item?.type === 'command_execution' &&
+        typeof event.item.command === 'string'
+      ) {
+        const rawCmd: string = event.item.command;
+        const unwrapped = rawCmd.match(/^\/(?:usr\/)?bin\/(?:zsh|bash|sh)\s+-l?c\s+'([\s\S]*)'\s*$/);
+        const cmd = (unwrapped ? unwrapped[1] : rawCmd).trim();
+        if (cmd && !commands.includes(cmd)) commands.push(cmd);
+      }
+    } catch {
+      // Ignore non-JSON lines.
+    }
+  }
+  return commands;
 }
 
 function extractCodexMessageText(output: string): string {


### PR DESCRIPTION
## Summary
Live monitoring root-caused a task stuck at max-iterations (KT-400 → STUCK after 4 failed retries). The codex worker edits code and runs checks, but its JSON report frequently comes back with `commands: []` — the model just skips the structured report. That empty list:
1. makes the `workerValidationEvidence` gate bounce every iteration ("changed code but reported zero validation commands"), burning a self-repair iteration, and
2. makes reviewers reject on acceptance criteria like *"worker report includes the exact verification command used"* — even though the worker demonstrably ran pytest/ruff/etc.

`codex exec --json` already emits an `item.completed` event with `item.type === "command_execution"` and `item.command` (wrapped as `/bin/zsh -lc '<cmd>'`) for every shell it actually runs. `parseWorkerOutput` now extracts + unwraps those and merges them into `commands`, so the field reflects ground truth regardless of the model's self-report.

This is the effective worker adapter: `provider-override.json` pins `provider: codex` (codex CLI), which service.ts re-applies on boot.

## Verification
- New test: model reports `commands: []` but two `command_execution` events → `commands` backfilled to `["pytest tests/test_x.py", "ruff check ."]` (unwrapped, deduped)
- src/adapters sweep: 19 files / 202 pass; typecheck / oxlint / build clean
- Probed real `codex exec --json` output to confirm the exact event shape

## Impact
Directly reduces max-iteration STUCKs caused by the validation gate + command-reporting criteria false-negatives.