### PR TITLE
fix(codex-responses): backfill commands from agentic-loop bash executions (INT-2485)

### DIFF
--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -157,6 +157,9 @@ export interface AgenticLoopResult {
   cachedTokens: number;
   /** 소요 시간 (ms) */
   durationMs: number;
+  /** Shell commands the worker actually ran via the `bash` tool — ground truth
+   *  for the validation-evidence gate (self-reported `commands` is often empty). */
+  executedCommands: string[];
 }
 
 // ============ 에이전틱 루프 ============
@@ -238,6 +241,7 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
   const readCache = createReadCache(); // 루프 단위 read 캐시 (중복 read 차단)
   let toolCallCount = 0;
   let editToolCount = 0; // edit_file/write_file 호출 수 (no-edit 가드용)
+  const executedCommands: string[] = []; // `bash` 도구로 실제 실행한 명령 (검증 증거 ground truth)
   // 진전 정체 감지: 이번 턴의 도구 호출이 모두 이전과 동일(name+args)하면 새 정보·변경
   // 없는 반복이다. N턴 연속이면 루프로 보고 조기 종료한다 — 고정 turn 한도(작업 제한)가
   // 아니라 진전 기반 중단. maxTurns는 비상 천장으로만 남는다.
@@ -446,6 +450,19 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
       (tc.function.name === 'edit_file' || tc.function.name === 'write_file' || tc.function.name === 'apply_patch') && !results[i]?.is_error,
     ).length;
 
+    // Capture the shell commands the worker actually ran (ground truth for the
+    // validation-evidence gate — the model's self-reported `commands` is often
+    // empty). Only successful bash calls; deduped, capped. (INT-2485)
+    toolCalls.forEach((tc, i) => {
+      if (tc.function.name !== 'bash' || results[i]?.is_error) return;
+      try {
+        const cmd = String(JSON.parse(tc.function.arguments).command ?? '').trim();
+        if (cmd && !executedCommands.includes(cmd) && executedCommands.length < 20) {
+          executedCommands.push(cmd);
+        }
+      } catch { /* ignore unparseable args */ }
+    });
+
     // Progress-based stop: if every tool call this turn repeats a prior one
     // (same name+args → no new info or change), count it as a stalled turn.
     // N consecutive stalled turns → wrap up via the final-answer turn.
@@ -525,6 +542,7 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
     totalTokens,
     cachedTokens,
     durationMs: Date.now() - startTime,
+    executedCommands,
   };
 }
 
@@ -537,6 +555,7 @@ export function loopResultToCliResult(result: AgenticLoopResult): CliRunResult {
     stdout: result.text,
     stderr: '',
     durationMs: result.durationMs,
+    executedCommands: result.executedCommands,
   };
 }
 

--- a/src/adapters/codexResponses.test.ts
+++ b/src/adapters/codexResponses.test.ts
@@ -17,6 +17,46 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+describe('parseWorkerOutput command backfill', () => {
+  const adapter = new CodexResponsesAdapter();
+
+  it('backfills empty self-reported commands with the agentic loop executed commands', () => {
+    const raw = {
+      exitCode: 0,
+      stdout: '```json\n{"success":true,"summary":"Fixed","filesChanged":["db/x.py"],"commands":[]}\n```',
+      stderr: '',
+      durationMs: 1,
+      executedCommands: ['pytest tests/test_x.py', 'ruff check .'],
+    };
+    const result = adapter.parseWorkerOutput(raw);
+    expect(result.commands).toEqual(['pytest tests/test_x.py', 'ruff check .']);
+  });
+
+  it('merges + dedupes self-reported and executed commands', () => {
+    const raw = {
+      exitCode: 0,
+      stdout: '```json\n{"success":true,"summary":"ok","filesChanged":["a.ts"],"commands":["npm test"]}\n```',
+      stderr: '',
+      durationMs: 1,
+      executedCommands: ['npm test', 'npm run lint'],
+    };
+    const result = adapter.parseWorkerOutput(raw);
+    expect(result.commands).toEqual(['npm test', 'npm run lint']);
+  });
+
+  it('leaves commands empty when the worker ran no shell commands', () => {
+    const raw = {
+      exitCode: 0,
+      stdout: '```json\n{"success":true,"summary":"edit only","filesChanged":["a.ts"],"commands":[]}\n```',
+      stderr: '',
+      durationMs: 1,
+      executedCommands: [],
+    };
+    const result = adapter.parseWorkerOutput(raw);
+    expect(result.commands).toEqual([]);
+  });
+});
+
 describe('selectDefaultCodexResponseModel', () => {
   it('prefers the stable default when the live catalog includes it', () => {
     expect(selectDefaultCodexResponseModel(['gpt-5.3-codex-spark', 'gpt-5.4-mini', 'gpt-5.5'])).toBe('gpt-5.5');

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -494,7 +494,14 @@ export class CodexResponsesAdapter implements CliAdapter {
   }
 
   parseWorkerOutput(raw: CliRunResult): WorkerResult {
-    return parseWorkerResult(raw.stdout);
+    const result = parseWorkerResult(raw.stdout);
+    // Backfill the model's frequently-empty self-reported `commands` with the
+    // shell commands the agentic loop actually ran, so the validation-evidence
+    // gate and reviewers see the real checks. (INT-2485)
+    if (raw.executedCommands && raw.executedCommands.length > 0) {
+      result.commands = [...new Set([...result.commands, ...raw.executedCommands])].slice(0, 20);
+    }
+    return result;
   }
 
   parseReviewerOutput(raw: CliRunResult): ReviewResult {

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -19,6 +19,14 @@ export interface CliRunResult {
   stdout: string;
   stderr: string;
   durationMs: number;
+  /**
+   * Shell commands the worker actually ran (OpenSwarm's own agentic loop executes
+   * the `bash` tool, so it is ground truth — unlike the model's self-reported
+   * `commands`, which is frequently empty). Adapters that run their own loop
+   * populate this; parseWorkerOutput merges it into WorkerResult.commands so the
+   * validation-evidence gate and reviewers see the real checks. (INT-2485)
+   */
+  executedCommands?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary
Follow-up to #235 (which fixed the codex **CLI** adapter). The daemon's effective adapter is now **codex-responses** (`provider-override` synced to config's intended `codex-responses` to drop the codex CLI path entirely — it was accidentally toggled to the CLI via the dashboard, which also caused the MCP-401 poison).

codex-responses has the **same empty-commands defect**: the model's self-reported `commands` is frequently `[]`, which bounces the `workerValidationEvidence` gate and trips reviewer "report the verification command" criteria. Observed live right after the switch: KT-394 / STO-1452 completed (`success=true`, ~120s — 3-8× faster than the CLI's 400-1000s) but bounced immediately on validation.

Unlike the CLI (a black box), codex-responses runs OpenSwarm's **own agentic loop**, so the `bash` tool executions are ground truth:
- `runAgenticLoop` collects successful `bash` commands into `AgenticLoopResult.executedCommands`
- threaded through `CliRunResult.executedCommands`
- `parseWorkerOutput` merges them into `WorkerResult.commands`

## Verification
- New tests: empty self-report + executed → backfilled; merge/dedupe with self-report; empty stays empty when no shell ran
- src/adapters sweep: 19 files / 205 pass; typecheck / oxlint / build clean

## Context
This completes the CLI→Responses-API migration: no codex CLI spawned (verified live, 0 `codex exec` from the new daemon), no `~/.codex/config.toml` MCP fragility, and ~3-8× faster workers.