### PR TITLE
fix(cli): every command honors config adapter + provider-override, not hardcoded codex CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,8 @@ import { writeFileSync, existsSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { runCli } from './runners/cliRunner.js';
+import { setDefaultAdapter } from './adapters/index.js';
+import { readProviderOverride } from './core/providerOverride.js';
 import { loadConfig, validateConfig, generateSampleConfig } from './core/config.js';
 import { loadEnvFile } from './core/envFile.js';
 import { initTelemetry, track } from './telemetry/telemetry.js';
@@ -62,6 +64,16 @@ program.hook('preAction', (_thisCommand, actionCommand) => {
     initTelemetry({ version: VERSION, enabled: loadTelemetryEnabledQuietly(quietConfigLoad) });
   } catch {
     /* no/invalid config — leave the opt-out default */
+  }
+  // Align EVERY command's adapter with config + provider-override, so review/fix/run
+  // don't fall back to the hardcoded 'codex' CLI default (only the daemon service &
+  // dashboard called setDefaultAdapter). Without this, `review --max` spawned codex
+  // CLI subprocesses even while the daemon ran codex-responses. Best-effort: a
+  // command with no config (init) keeps the built-in default. (INT-2485)
+  try {
+    setDefaultAdapter(readProviderOverride() ?? loadConfig().adapter ?? 'codex');
+  } catch {
+    /* no/invalid config — keep the built-in default */
   }
   void track({ command: actionCommand.name() });
 });


### PR DESCRIPTION
## Summary
Only the daemon `startService` and the dashboard called `setDefaultAdapter`, so every **CLI command** (`review`, `review --max`, `fix`, `run`) fell back to the built-in `'codex'` (CLI) default via `getAdapter(undefined)`. That meant `openswarm review --max` spawned `codex exec` subprocesses even after the daemon was switched to `codex-responses` — the review path bypassed the Responses API and re-introduced the `~/.codex/config.toml` MCP fragility.

Set the default adapter from `provider-override ?? config.adapter` in the program's `preAction` hook, so it applies to **every** command uniformly (best-effort: a command with no config keeps the built-in default).

## Verification
- Live E2E: `openswarm review` now runs OpenSwarm's own agentic loop (`🔧 bash` / `🔧 read_file` tool calls = codex-responses) instead of a `codex exec` black box
- typecheck / oxlint / build clean

## Note
A `review --max` already running from before this change keeps its CLI adapter (adapter is resolved at process start) — re-run it to pick up codex-responses.