### PR TITLE
fix(pipeline): validation-evidence gate nudges once per session, then defers (STUCK wave)

### DIFF
--- a/src/agents/pairPipeline.test.ts
+++ b/src/agents/pairPipeline.test.ts
@@ -368,6 +368,41 @@ describe('PairPipeline model selection', () => {
     expect(runWorker.mock.calls[1][0].reasoningEffort).not.toBe('high');
   });
 
+  it('nudges for missing validation at most once, then defers even if the worker keeps editing new files', async () => {
+    // Regression: the worker edits a DIFFERENT file every iteration without ever
+    // running a validation command. The gate used to bounce each time (each bounce
+    // "progressed" so stagnation-defer never fired), burning the whole iteration
+    // budget → Max-iteration STUCK. It must nudge once, then defer to the reviewer.
+    let n = 0;
+    runWorker.mockImplementation(async () => ({
+      success: true,
+      summary: 'edited without validating',
+      filesChanged: [`src/file_${n++}.ts`], // different file each call
+      commands: [],
+      output: '',
+      confidencePercent: 95,
+    }));
+    runReviewer.mockResolvedValue({ decision: 'approve', feedback: 'ok' });
+
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker', 'reviewer'],
+      maxIterations: 3,
+      roles: {
+        worker: { enabled: true, model: 'worker', timeoutMs: 0 },
+        reviewer: { enabled: true, model: 'reviewer', timeoutMs: 0 },
+      },
+    });
+
+    const result = await pipeline.run(task(), process.cwd());
+
+    // Nudge on iter 1 (bounce), defer on iter 2 → reviewer approves → success,
+    // WITHOUT exhausting all 3 iterations on validation bounces.
+    expect(result.success).toBe(true);
+    expect(runWorker).toHaveBeenCalledTimes(2);
+    expect(runReviewer).toHaveBeenCalledTimes(1);
+  });
+
   it('lets an escalated worker attempt succeed after repeated revise feedback', async () => {
     runReviewer
       .mockResolvedValueOnce({ decision: 'revise', feedback: 'Pagination cursor handling is wrong: the offset resets between pages, fix and add a test.' })

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -982,24 +982,19 @@ export class PairPipeline extends EventEmitter {
       )) {
         const validationIssues = missingWorkerValidationIssues(context.workerResult);
         if (validationIssues.length > 0) {
-          const { progressed } = recordReflection(context.reflection, {
-            iteration: context.currentIteration,
-            source: 'validation',
-            errors: validationIssues,
-          });
-
-          // Missing validation evidence is a nudge, not a verdict: the worker may
-          // simply be unable to self-report its commands (e.g. git-detected
-          // changes with no JSON block — worker.ts promotes those to success with
-          // commands=[]). Bounce it back to re-run with validation while that can
-          // still make progress; once it stagnates or the reflection budget is
-          // spent, DEFER to the reviewer (pre-gate behavior) rather than
-          // hard-failing the whole task. This is a pure predicate — do NOT reuse
-          // shouldAbortSelfRepair here: it marks the session 'failed' as a side
-          // effect (see ~L795), which would sink an otherwise-approvable task.
-          const reflectionBudget = this.config.maxReflections ?? DEFAULT_MAX_REFLECTIONS;
-          const canRetryForValidation = progressed && !shouldStopReflecting(context.reflection, reflectionBudget);
-          if (canRetryForValidation) {
+          // Missing validation evidence is a nudge, not a verdict, and it must
+          // cost AT MOST ONE iteration. A per-iteration bounce consumed the whole
+          // budget when the worker kept editing DIFFERENT files without running a
+          // check (each bounce "progresses", so the stagnation-defer never trips)
+          // → widespread Max-iteration STUCKs. Nudge once, then DEFER to the
+          // reviewer (the real quality gate) for the rest of the session. (INT-2485)
+          if (!context.validationNudged) {
+            context.validationNudged = true;
+            recordReflection(context.reflection, {
+              iteration: context.currentIteration,
+              source: 'validation',
+              errors: validationIssues,
+            });
             console.log(`[${context.taskPrefix}] Missing worker validation evidence: ${validationIssues.join('; ')}`);
             context.reviewResult = {
               decision: 'revise',
@@ -1017,7 +1012,7 @@ export class PairPipeline extends EventEmitter {
             agentPair.updateSessionStatus(context.session.id, 'revising');
             continue;
           }
-          console.log(`[${context.taskPrefix}] Validation evidence still missing after retries — deferring to reviewer`);
+          console.log(`[${context.taskPrefix}] Validation evidence still missing — deferring to reviewer (already nudged once)`);
           this.emit('log', { line: '⚠️ Validation evidence missing; deferring to reviewer' });
         }
       }

--- a/src/agents/pairPipelineTypes.ts
+++ b/src/agents/pairPipelineTypes.ts
@@ -106,6 +106,8 @@ export interface PipelineContext {
   lastReviseFeedback?: string;
   /** One-shot worker escalation triggered by repeated similar revise feedback: higher model and/or effort for the retry (INT-2475). */
   workerEscalation?: { model?: string; reasoningEffort?: 'low' | 'medium' | 'high' };
+  /** The missing-validation-evidence gate has already nudged once this session — after that it defers to the reviewer instead of consuming more iterations (INT-2485). */
+  validationNudged?: boolean;
 }
 
 export type PipelineEventType = 'stage:start' | 'stage:complete' | 'stage:fail' | 'iteration:start' | 'iteration:complete' | 'iteration:fail' | 'pipeline:complete' | 'pipeline:fail' | 'fanout:gate' | 'halt';


### PR DESCRIPTION
## Summary
Live monitoring caught a **wave of Max-iteration STUCKs** (KT-387/389/394, INT-2193/2194/2062, …). Root cause: the missing-validation-evidence gate bounced **every iteration**. When the worker edits a *different* file each pass without running a check, each bounce records a different validation error, so `recordReflection` always reports `progressed=true` and the stagnation-defer never fires — the gate consumes the entire `maxIterations` budget before the reviewer (the real quality gate) ever runs.

Cap the gate at **one nudge per session** (`context.validationNudged`): first missing-validation → bounce once; afterward → defer to the reviewer for the rest of the session.

## Verification
- New regression test: worker edits a new file every iteration with `commands: []` → gate nudges once, defers, reviewer approves → succeeds in 2 worker runs instead of burning all 3 on validation bounces
- src/agents/pairPipeline suite: 25 pass; typecheck / oxlint / build clean

## Context
Complements the command-capture fixes (#235/#236) — those populate `commands` from real executions; this bounds the gate's cost when a worker genuinely runs no check. The reviewer still catches unvalidated code.