### PR TITLE
fix(tools): add user tool bins (~/.cargo/bin etc.) to the bash tool PATH

### DIFF
--- a/src/adapters/tools.test.ts
+++ b/src/adapters/tools.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { TOOL_DEFINITIONS, executeTool, createReadCache, ToolCall } from './tools.js';
+import { TOOL_DEFINITIONS, executeTool, createReadCache, ToolCall, buildBashToolEnv } from './tools.js';
+import { homedir } from 'node:os';
 
 // search_memory loads the memory core lazily; stub the shared helper so the tool
 // test stays fast and deterministic (no LanceDB / embedding model).
@@ -512,5 +513,21 @@ describe('ToolExecOptions', () => {
     expect(res.is_error).toBe(true);
     expect(res.content).toContain('TIMEOUT');
     expect(res.content).toContain('NOT evidence');
+  });
+
+  it('buildBashToolEnv prepends user tool bins (cargo/local) to PATH', () => {
+    const env = buildBashToolEnv({ PATH: '/usr/bin:/bin' });
+    const parts = (env.PATH ?? '').split(':');
+    expect(parts).toContain(path.join(homedir(), '.cargo', 'bin'));
+    expect(parts).toContain(path.join(homedir(), '.local', 'bin'));
+    // Base entries survive, and the augmentation comes first so shims win.
+    expect(parts).toContain('/usr/bin');
+    expect(parts.indexOf(path.join(homedir(), '.cargo', 'bin'))).toBeLessThan(parts.indexOf('/usr/bin'));
+  });
+
+  it('buildBashToolEnv does not duplicate a path already present', () => {
+    const env = buildBashToolEnv({ PATH: `${path.join(homedir(), '.cargo', 'bin')}:/usr/bin` });
+    const cargo = path.join(homedir(), '.cargo', 'bin');
+    expect((env.PATH ?? '').split(':').filter((p) => p === cargo)).toHaveLength(1);
   });
 });

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -8,12 +8,37 @@
 import fs from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { homedir } from 'node:os';
 import path from 'node:path';
 import { webFetch, webSearch } from './webTools.js';
 import { isMcpTool, callMcpTool } from '../mcp/mcpClient.js';
 import { applyV4APatch } from './applyPatch.js';
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * The daemon's launchd PATH is minimal (/usr/bin:/bin:/opt/homebrew/bin, no
+ * ~/.cargo/bin or ~/.local/bin), and the `bash` tool runs non-login (`bash -c`),
+ * so it never sources the user's shell profile. Result: `cargo`/`uv`/`pyenv`
+ * shims are "command not found", the worker cannot build/test its Rust/Python
+ * changes, and the validation gate + reviewer reject it → Max-iteration STUCK
+ * (observed live on every WAVE Rust task: "cargo: command not found"). Prepend
+ * the common user tool bins a login shell would have added. (INT-2485)
+ */
+export function buildBashToolEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const home = homedir();
+  const extra = [
+    path.join(home, '.cargo', 'bin'),
+    path.join(home, '.local', 'bin'),
+    path.join(home, 'go', 'bin'),
+    path.join(home, '.bun', 'bin'),
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+  ];
+  const current = (base.PATH ?? '').split(':').filter(Boolean);
+  const merged = [...extra.filter((p) => !current.includes(p)), ...current];
+  return { ...base, PATH: merged.join(':') };
+}
 
 // ============ 도구 정의 (OpenAI function calling 포맷) ============
 
@@ -524,7 +549,7 @@ export async function executeTool(
             cwd,
             timeout: execOptions?.bashTimeoutMs ?? DEFAULT_BASH_TIMEOUT_MS,
             maxBuffer: 1024 * 512,
-            env: process.env,
+            env: buildBashToolEnv(),
           });
           const output = stdout + (stderr ? `\n[stderr] ${stderr}` : '');
           // 출력이 너무 길면 잘라냄


### PR DESCRIPTION
## Summary
Every WAVE (Rust) task was STUCK at max-iterations with the reviewer rejecting *"cannot verify/build"*. Root cause found in the worker output: **`cargo: command not found`**.

The daemon's launchd PATH is minimal (`/usr/bin:/bin:/opt/homebrew/bin`) and the `bash` tool runs **non-login** (`bash -c` with `env: process.env`), so it never sources the user's shell profile. Tools installed under `~/.cargo/bin` (cargo), `~/.local/bin` (uv/pip), etc. are invisible — the worker literally cannot build or test its Rust/Python changes, so the validation gate + reviewer reject it → STUCK.

`buildBashToolEnv()` prepends the common user tool bins a login shell would have added (`~/.cargo/bin`, `~/.local/bin`, `~/go/bin`, `~/.bun/bin`, `/opt/homebrew/bin`, `/usr/local/bin`), deduped, base PATH preserved.

## Verification
- New tests: cargo/local bins prepended ahead of base PATH; no duplication when already present
- src/adapters/tools suite: 43 pass; typecheck / oxlint / build clean

## Impact
Unblocks Rust (cargo) and Python (uv/pyenv) validation in the agentic-loop bash tool — the direct cause of the WAVE Rust STUCK wave. Complements the gate fix (#238): #238 stops the gate wasting iterations; this lets the worker actually run the check the gate/reviewer want.