### PR TITLE
fix(adapters): reviewer text-fallback false-rejects tasks about "reject"/"approve"

### DIFF
--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -479,12 +479,17 @@ function extractReviewerResultJson(text: string): ReviewResult | null {
 }
 
 function extractReviewerFromText(text: string): ReviewResult {
-  const lower = text.toLowerCase();
-  const decision = lower.includes('approve')
-    ? 'approve'
-    : lower.includes('reject')
-      ? 'reject'
-      : 'revise';
+  // Prefer the reviewer's EXPLICIT verdict over scattered keyword matching — a
+  // task about "reject"/"approve" makes prose matching misclassify a revise as a
+  // reject and kill it. Default to the safe, retryable 'revise'. (INT-2485)
+  const explicit = text.match(
+    /\bdecision\b\s*[:=-]?\s*["'`]?\s*(approve[d]?|reject(?:ed)?|revis(?:e|ion)|request[- ]?changes)/i,
+  );
+  let decision: ReviewResult['decision'] = 'revise';
+  if (explicit) {
+    const verdict = explicit[1].toLowerCase();
+    decision = verdict.startsWith('approv') ? 'approve' : verdict.startsWith('reject') ? 'reject' : 'revise';
+  }
 
   return {
     decision,

--- a/src/adapters/resultParsing.test.ts
+++ b/src/adapters/resultParsing.test.ts
@@ -3,6 +3,28 @@ import { parseReviewerResult } from './resultParsing.js';
 
 const wrap = (obj: unknown) => '```json\n' + JSON.stringify(obj) + '\n```';
 
+describe('parseReviewerResult text-fallback decision (INT-2485 false-reject)', () => {
+  it('does NOT reject a revise whose prose mentions the domain word "reject"', () => {
+    // STO-1451: a financial hard-reject bug. The reviewer's plain-text feedback
+    // begins "Decision: revise" but discusses the reject logic — old parser saw
+    // "reject" and killed the task.
+    const text = 'Decision: revise\nThe DCF/ROE path incorrectly downgrades large-accumulation stocks to a hard reject; fix the stale/missing input handling before this can pass.';
+    expect(parseReviewerResult(text).decision).toBe('revise');
+  });
+
+  it('honors an explicit reject verdict', () => {
+    expect(parseReviewerResult('Decision: reject\nThis fundamentally breaks the API contract.').decision).toBe('reject');
+  });
+
+  it('honors an explicit approve verdict', () => {
+    expect(parseReviewerResult('Decision: approve\nLooks good, ships.').decision).toBe('approve');
+  });
+
+  it('defaults to the safe revise when no explicit verdict is present', () => {
+    expect(parseReviewerResult('The code rejects invalid input and approves valid tokens.').decision).toBe('revise');
+  });
+});
+
 describe('parseReviewerResult recommendedActions (INT-1954)', () => {
   it('parses structured recommendedActions on approve', () => {
     const r = parseReviewerResult(

--- a/src/adapters/resultParsing.ts
+++ b/src/adapters/resultParsing.ts
@@ -100,12 +100,21 @@ function parseRecommendedActions(raw: unknown): ReviewResult['recommendedActions
 
 /** Text fallback when no JSON reviewer result is present. */
 function extractReviewerFromText(text: string): ReviewResult {
-  const lower = text.toLowerCase();
-  const decision = lower.includes('approve')
-    ? 'approve'
-    : lower.includes('reject')
-      ? 'reject'
-      : 'revise';
+  // Prefer the reviewer's EXPLICIT verdict ("Decision: revise") over scattered
+  // keyword matching. A task whose domain is about "reject"/"approve" (e.g. a
+  // financial hard-reject bug, an approval-flow feature) makes prose keyword
+  // matching classify a revise as a reject and kill the task prematurely
+  // (STO-1451 was rejected on feedback that literally started "Decision: revise").
+  // With no explicit verdict, default to the SAFE, retryable 'revise' rather than
+  // the terminal 'reject' or an unearned 'approve'. (INT-2485)
+  const explicit = text.match(
+    /\bdecision\b\s*[:=-]?\s*["'`]?\s*(approve[d]?|reject(?:ed)?|revis(?:e|ion)|request[- ]?changes)/i,
+  );
+  let decision: ReviewResult['decision'] = 'revise';
+  if (explicit) {
+    const verdict = explicit[1].toLowerCase();
+    decision = verdict.startsWith('approv') ? 'approve' : verdict.startsWith('reject') ? 'reject' : 'revise';
+  }
   return {
     decision,
     feedback: extractSummary(text),


### PR DESCRIPTION
## Summary
STO-1451 (a *financial hard-reject* bug) was terminated with "Reviewer rejected" on feedback that literally began **"Decision: revise"**. Root cause: when the reviewer output isn't clean JSON, `extractReviewerFromText` classified the decision by scanning the whole text for the word `"reject"` — so any task whose DOMAIN involves rejection/approval (financial reject logic, approval-flow features) has its *revise* misread as a terminal *reject* and gets killed.

Parse the reviewer's **explicit verdict** (`Decision: <revise|reject|approve>`) first; with no explicit verdict, default to the safe, retryable `revise` rather than terminal `reject` or an unearned `approve`. Applied to both `resultParsing` (codex-responses, the live adapter) and `codex.ts` (CLI).

## Verification
- New tests: revise-with-"reject"-in-prose stays revise; explicit reject/approve honored; ambiguous prose → revise
- src/adapters resultParsing + codex suites pass; typecheck / oxlint / build clean

## Note
Only bites the text-fallback path (reviewer emitted non-JSON). Clean JSON `decision` fields were always parsed correctly. Applies on the next daemon restart.