### PR TITLE
fix(draft): size the draft budget to the repo (file count), not a fixed 30s

### DIFF
--- a/src/agents/draftAnalyzer.test.ts
+++ b/src/agents/draftAnalyzer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { CliAdapter, CliRunResult } from '../adapters/types.js';
-import { runDraftAnalysis, isDraftSufficient } from './draftAnalyzer.js';
+import { runDraftAnalysis, isDraftSufficient, draftBudgetFor } from './draftAnalyzer.js';
 import * as adapterModule from '../adapters/index.js';
 import * as knowledgeModule from '../knowledge/index.js';
 import * as registryModule from '../registry/sqliteStore.js';
@@ -187,6 +187,31 @@ describe('isDraftSufficient — drafter hard gate (INT-1917)', () => {
 
   it('fails on an empty draft', () => {
     expect(isDraftSufficient({})).toBe(false);
+  });
+});
+
+describe('draftBudgetFor (file-count-adaptive read/analyze budget, INT-2485)', () => {
+  it('gives a small repo the base budget (still > the old 30s that timed out)', () => {
+    // WAVE = 306 files, kyte-portal = 874, most repos 300-900 → base tier.
+    expect(draftBudgetFor(306)).toEqual({ timeoutMs: 60_000, maxTurns: 4 });
+    expect(draftBudgetFor(0)).toEqual({ timeoutMs: 60_000, maxTurns: 4 });
+  });
+
+  it('scales up with file count', () => {
+    expect(draftBudgetFor(400).timeoutMs).toBe(90_000);
+    expect(draftBudgetFor(1_200).timeoutMs).toBe(120_000);
+    // STONKS = 2253 files → still the 1200 tier; a very large repo → top tier.
+    expect(draftBudgetFor(2_253).timeoutMs).toBe(120_000);
+    expect(draftBudgetFor(5_000)).toEqual({ timeoutMs: 180_000, maxTurns: 8 });
+  });
+
+  it('is monotonic in timeout and turns', () => {
+    const sizes = [0, 400, 1_200, 3_000, 10_000];
+    const budgets = sizes.map(draftBudgetFor);
+    for (let i = 1; i < budgets.length; i++) {
+      expect(budgets[i].timeoutMs).toBeGreaterThanOrEqual(budgets[i - 1].timeoutMs);
+      expect(budgets[i].maxTurns).toBeGreaterThanOrEqual(budgets[i - 1].maxTurns);
+    }
   });
 });
 

--- a/src/agents/draftAnalyzer.ts
+++ b/src/agents/draftAnalyzer.ts
@@ -5,6 +5,8 @@
 //          Planner/Worker에 enriched context를 제공하여 첫 시도 정확도 향상
 // ============================================
 
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { getAdapter, getDefaultAdapterName, spawnCli } from '../adapters/index.js';
 import { analyzeIssue } from '../knowledge/index.js';
 import { getRegistryStore } from '../registry/sqliteStore.js';
@@ -36,6 +38,34 @@ const DRAFT_MODELS: Partial<Record<AdapterName, string>> = {
 const DRAFT_MIN_CRITERIA = 1;
 /** Max attempts to coax a sufficient draft out of one adapter before falling back. */
 const DRAFT_MAX_ATTEMPTS = 2;
+
+/**
+ * Scale the draft's read/analyze budget to codebase size — by TRACKED FILE COUNT,
+ * a robust filesystem proxy (registry entity count is unreliable: it's global
+ * when projectId is absent, and undercounts repos the scanner didn't fully index,
+ * e.g. WAVE's Rust crates). A fixed 30s / 3 turns left the model no room to read
+ * across a real repo and emit the JSON brief → type=unknown, files=[] → the worker
+ * started blind. An explicit options.timeoutMs still overrides. (INT-2485)
+ */
+export function draftBudgetFor(fileCount: number): { timeoutMs: number; maxTurns: number } {
+  if (fileCount >= 3_000) return { timeoutMs: 180_000, maxTurns: 8 };
+  if (fileCount >= 1_200) return { timeoutMs: 120_000, maxTurns: 6 };
+  if (fileCount >= 400) return { timeoutMs: 90_000, maxTurns: 5 };
+  return { timeoutMs: 60_000, maxTurns: 4 };
+}
+
+/** Cheap tracked-file count for the repo — `git ls-files`, one exec, cached-free. */
+async function countTrackedFiles(projectPath: string): Promise<number> {
+  try {
+    const { stdout } = await promisify(execFile)('git', ['ls-files'], {
+      cwd: projectPath,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    return stdout.split('\n').filter(Boolean).length;
+  } catch {
+    return 0; // not a git repo / error → floor budget
+  }
+}
 
 /** Appended on retry when the first brief was too thin (INT-1917 hard gate). */
 const DRAFT_RETRY_NUDGE = `
@@ -139,15 +169,17 @@ function collectCodebaseState(
   projectPath: string,
   projectId?: string,
   impactAnalysis?: ImpactAnalysis | null,
-): { registrySnapshot: RegistryBrief[]; projectStats?: string } {
+): { registrySnapshot: RegistryBrief[]; projectStats?: string; totalEntities: number } {
   const registrySnapshot: RegistryBrief[] = [];
   let projectStats: string | undefined;
+  let totalEntities = 0;
 
   try {
     const store = getRegistryStore();
 
     // 1. 프로젝트 전체 통계
     const stats = store.getStats(projectId);
+    totalEntities = stats.total;
     const statParts: string[] = [`${stats.total} entities`];
     if (stats.deprecated > 0) statParts.push(`${stats.deprecated} deprecated`);
     if (stats.untested > 0) statParts.push(`${stats.untested} untested`);
@@ -208,7 +240,7 @@ function collectCodebaseState(
     // Registry 미초기화 — 빈 상태로 진행
   }
 
-  return { registrySnapshot, projectStats };
+  return { registrySnapshot, projectStats, totalEntities };
 }
 
 // ============ drafter 의도 분석 ============
@@ -421,6 +453,12 @@ export async function runDraftAnalysis(options: DraftAnalyzerOptions): Promise<D
     onLog?.(`[Draft] Registry: ${codeContext.projectStats}`);
   }
 
+  // Size the read/analyze budget to the codebase (explicit timeout still wins).
+  const fileCount = await countTrackedFiles(options.projectPath);
+  const budget = draftBudgetFor(fileCount);
+  const draftTimeoutMs = options.timeoutMs ?? budget.timeoutMs;
+  onLog?.(`[Draft] Budget: ${fileCount} tracked files → timeout ${Math.round(draftTimeoutMs / 1000)}s, ${budget.maxTurns} turns`);
+
   // 3. Fast model draft analysis (~3s) — model resolves from the adapter when unset
   const prompt = buildDraftPrompt(options, codeContext, impactAnalysis);
 
@@ -455,9 +493,9 @@ export async function runDraftAnalysis(options: DraftAnalyzerOptions): Promise<D
         const raw = await spawnCli(adapter, {
           prompt: attemptPrompt,
           cwd: options.projectPath, // read the real repo (INT-1917) — was '/tmp'
-          timeoutMs: options.timeoutMs ?? 30000,
+          timeoutMs: draftTimeoutMs, // size-adaptive: 30s timed out on large repos → type=unknown (INT-2485)
           model: resolvedModel,
-          maxTurns: 3, // allow read_file/search_files — was 1 (couldn't read code)
+          maxTurns: budget.maxTurns, // size-adaptive: 3 ran out reading a real repo before emitting the brief (INT-2485)
         });
 
         haikuResult = parseDraftResponse(raw.stdout);

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -662,7 +662,10 @@ export async function executePipeline(
         taskDescription: task.description || '',
         projectPath,
         model: ctx.draftModel,
-        timeoutMs: 30000,
+        // No fixed timeout: the draft scales its own read/analyze budget to the
+        // codebase size (registry entity count). A fixed 30s timed out on large
+        // repos (WAVE ~600k entities) → type=unknown, files=[] → the worker starts
+        // BLIND and burns its iteration budget rediscovering scope. (INT-2485)
         onLog: (line) => broadcastEvent({ type: 'log', data: { taskId, stage: 'draft', line } }),
       });
 


### PR DESCRIPTION
## Summary
~73% of drafts came back `type=unknown, files=[]` (177/233 all-time, 32/44 on codex-responses). Reproduced live: **`codex timeout after 30000ms`** — 30s/3-turns leaves no room to read a real repo and emit the JSON brief. A blind draft means the worker starts with no relevant files / completion criteria and burns its iteration budget rediscovering scope — the upstream cause of the revise churn.

- `draftBudgetFor(fileCount)`: tiers by `git ls-files` count (60s/4t base → 90s/5t at 400+ → 120s/6t at 1200+ → 180s/8t at 3000+)
- File count is the robust size proxy — registry entity count is NOT (global when projectId absent; undercounts unindexed repos, e.g. WAVE's Rust crates)
- `runnerExecution` no longer pins `timeoutMs: 30000`; explicit timeouts still win
- Logs `[Draft] Budget: N tracked files → Xs, Y turns` for production telemetry

## Verification
- Unit tests: tier boundaries against real repo sizes (WAVE=306→60s, STONKS=2253→120s), monotonicity — 12 pass
- typecheck / oxlint / build clean
- Effectiveness will be confirmed via the new Budget log line + draft type=unknown rate in production

## Known follow-up (separate issue)
Registry stores `project_id` as the **repo name** (`'WAVE'`, 937 entities) while the pipeline passes the **Linear project UUID** → `getStats(projectId)` misses → draft registry context is empty or global-polluted (563k-entity 'unohee' bucket). Being tracked separately.