### PR TITLE
feat(worktree): preserve failed sessions' partial work — retries resume, not restart (INT-2503)

### DIFF
--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -29,6 +29,7 @@ import {
   buildBranchName,
   createWorktree,
   commitAndCreatePR,
+  preserveWorktree,
   removeWorktree,
 } from '../support/worktreeManager.js';
 import type { WorktreeInfo } from '../support/worktreeManager.js';
@@ -712,6 +713,9 @@ export async function executePipeline(
   // ============================================
   let worktreeInfo: WorktreeInfo | null = null;
   let actualPath = projectPath;
+  // Preserve the worktree on non-success so the retry resumes from the partial
+  // work (INT-2503); unexpected throws leave it false → cleanup as before.
+  let keepWorktree = false;
 
   if (ctx.worktreeMode && task.issueId && task.issueIdentifier) {
     const branchName = buildBranchName(task.issueIdentifier, task.title);
@@ -929,13 +933,20 @@ export async function executePipeline(
       console.log(`[Runner] PR not created for ${task.issueIdentifier}: ${reason}`);
     }
 
+    keepWorktree = !result.success;
     return result;
   } finally {
-    // Clean up worktree regardless of success/failure
+    // Success (PR created) → remove as before. Any non-success outcome
+    // (failed / rejected / rate-limited / cancelled) → PRESERVE the worktree
+    // when it holds actual work, so the retry resumes from the partial
+    // implementation instead of re-doing it from scratch (INT-2503).
+    // preserveWorktree removes clean trees itself; unexpected throws
+    // (keepWorktree=false) clean up as before.
     if (worktreeInfo) {
-      await removeWorktree(worktreeInfo).catch((err) =>
-        console.warn('[Worktree] Cleanup failed:', err)
-      );
+      const cleanup = keepWorktree
+        ? preserveWorktree(worktreeInfo, 'session did not succeed')
+        : removeWorktree(worktreeInfo);
+      await cleanup.catch((err) => console.warn('[Worktree] Cleanup failed:', err));
     }
   }
 }

--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -1,9 +1,9 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, lstatSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { createWorktree, removeWorktree, resolveSharedPaths, computeFileOverlaps, formatOverlapReport, type WorktreeInfo } from './worktreeManager.js';
+import { createWorktree, preserveWorktree, removeWorktree, resolveSharedPaths, computeFileOverlaps, formatOverlapReport, type WorktreeInfo } from './worktreeManager.js';
 
 describe('worktreeManager path safety', () => {
   let root: string;
@@ -153,6 +153,71 @@ describe('createWorktree shared-path symlinks (INT-2415)', () => {
     const wtSrc = join(info.worktreePath, 'src');
     expect(existsSync(join(wtSrc, 'index.ts'))).toBe(true);
     expect(lstatSync(wtSrc).isSymbolicLink()).toBe(false);
+  });
+});
+
+describe('preserveWorktree → createWorktree resume roundtrip (INT-2503)', () => {
+  let root: string;
+  let repo: string;
+
+  const git = (cwd: string, ...args: string[]) =>
+    execFileSync('git', ['-C', cwd, ...args], { stdio: 'pipe' });
+
+  beforeEach(() => {
+    root = join(tmpdir(), `openswarm-worktree-preserve-${process.pid}-${Date.now()}`);
+    repo = join(root, 'repo');
+    mkdirSync(repo, { recursive: true });
+
+    const originBare = join(root, 'origin.git');
+    execFileSync('git', ['init', '--bare', '-b', 'main', originBare], { stdio: 'pipe' });
+    execFileSync('git', ['init', '-b', 'main', repo], { stdio: 'pipe' });
+    git(repo, 'config', 'user.email', 'test@example.com');
+    git(repo, 'config', 'user.name', 'Test');
+    git(repo, 'config', 'commit.gpgsign', 'false');
+    writeFileSync(join(repo, 'app.py'), 'base\n');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-m', 'init');
+    git(repo, 'remote', 'add', 'origin', originBare);
+    git(repo, 'push', 'origin', 'main');
+  });
+
+  afterEach(() => {
+    try { git(repo, 'worktree', 'remove', '--force', join(repo, 'worktree', 'INT-9')); } catch { /* ignore */ }
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('preserves a dirty failed worktree and resumes it with the partial work intact', async () => {
+    const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+    // Failed session left partial work: a tracked edit + a new file.
+    writeFileSync(join(info.worktreePath, 'app.py'), 'base\npartial-impl\n');
+    writeFileSync(join(info.worktreePath, 'newmod.py'), 'wip\n');
+
+    expect(await preserveWorktree(info, 'test failure')).toBe(true);
+    expect(existsSync(join(info.worktreePath, '.openswarm-preserved'))).toBe(true);
+
+    // Retry resumes the SAME worktree — partial work intact, marker consumed.
+    const resumed = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+    expect(resumed.worktreePath).toBe(info.worktreePath);
+    expect(readFileSync(join(resumed.worktreePath, 'app.py'), 'utf8')).toBe('base\npartial-impl\n');
+    expect(existsSync(join(resumed.worktreePath, 'newmod.py'))).toBe(true);
+    expect(existsSync(join(resumed.worktreePath, '.openswarm-preserved'))).toBe(false);
+  });
+
+  it('removes a clean worktree instead of preserving it', async () => {
+    const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+    expect(await preserveWorktree(info, 'test failure')).toBe(false);
+    expect(existsSync(info.worktreePath)).toBe(false);
+  });
+
+  it('recreates fresh when the preserved branch does not match', async () => {
+    const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+    writeFileSync(join(info.worktreePath, 'app.py'), 'base\nstale-work\n');
+    await preserveWorktree(info, 'test failure');
+
+    // Task title changed → different branch → preserved tree is stale; recreate.
+    const recreated = await createWorktree(repo, 'INT-9', 'swarm/INT-9-renamed');
+    expect(recreated.branchName).toBe('swarm/INT-9-renamed');
+    expect(readFileSync(join(recreated.worktreePath, 'app.py'), 'utf8')).toBe('base\n');
   });
 });
 

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -5,7 +5,7 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { existsSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { registerOwnedPR } from '../automation/prOwnership.js';
 import { runConventionalCommitGuard } from '../agents/pipelineGuards.js';
@@ -163,12 +163,56 @@ async function linkSharedPaths(repoPath: string, worktreePath: string): Promise<
 // Worktree Lifecycle
 
 /** Create git worktree + checkout branch */
+/**
+ * Marker dropped into a failed session's worktree so its partial implementation
+ * survives cleanup and the retry RESUMES from it instead of re-implementing from
+ * scratch (INT-2503). pruneWorktrees skips marked dirs; createWorktree reuses
+ * them; a successful run still removes the worktree as before.
+ */
+const PRESERVE_MARKER = '.openswarm-preserved';
+
+/**
+ * Preserve a failed session's worktree when it holds actual work: drop the
+ * marker and leave the tree in place. A clean tree has nothing worth keeping —
+ * remove it as before. Returns true when preserved.
+ */
+export async function preserveWorktree(info: WorktreeInfo, reason: string): Promise<boolean> {
+  const worktreePath = assertManagedWorktreePath(info.originalPath, info.worktreePath);
+  const dirty = await git(worktreePath, 'status', '--porcelain').catch(() => '');
+  if (!dirty.trim()) {
+    await removeWorktree(info);
+    return false;
+  }
+  const fileCount = dirty.split('\n').filter(Boolean).length;
+  writeFileSync(
+    join(worktreePath, PRESERVE_MARKER),
+    JSON.stringify({ issueId: info.issueId, branchName: info.branchName, reason, at: new Date().toISOString() }, null, 2),
+    'utf8',
+  );
+  console.log(`[Worktree] Preserved for retry (${fileCount} dirty files, ${reason}): ${worktreePath}`);
+  return true;
+}
+
 export async function createWorktree(
   repoPath: string,
   issueId: string,
   branchName: string,
 ): Promise<WorktreeInfo> {
   const worktreePath = resolveWorktreePath(repoPath, issueId);
+
+  // Retry of a preserved failure: RESUME from the previous attempt's partial
+  // work (and its build caches) instead of wiping it (INT-2503). Consume the
+  // marker — if this attempt fails again it gets re-preserved by the runner.
+  if (existsSync(worktreePath) && existsSync(join(worktreePath, PRESERVE_MARKER))) {
+    const valid = await git(worktreePath, 'status', '--porcelain').then(() => true).catch(() => false);
+    const branch = await git(worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD').then((b) => b.trim()).catch(() => '');
+    if (valid && branch === branchName) {
+      rmSync(join(worktreePath, PRESERVE_MARKER), { force: true });
+      console.log(`[Worktree] Resuming preserved worktree: ${worktreePath} (branch: ${branchName})`);
+      return { worktreePath, branchName, originalPath: repoPath, issueId };
+    }
+    console.warn(`[Worktree] Preserved worktree invalid (valid=${valid}, branch=${branch}) — recreating: ${worktreePath}`);
+  }
 
   // Clean up existing worktree (retry case)
   if (existsSync(worktreePath)) {
@@ -438,7 +482,10 @@ export async function pruneWorktrees(repoPath: string, activeWorktreePaths: Set<
       .filter((l) => l.startsWith('worktree '))
       .map((l) => l.slice('worktree '.length).trim())
       .filter((p) => p.startsWith(prefix))
-      .filter((p) => !activeWorktreePaths.has(p)); // keep worktrees of running tasks
+      .filter((p) => !activeWorktreePaths.has(p)) // keep worktrees of running tasks
+      // Preserved failed-session worktrees carry the retry's partial work —
+      // they must survive daemon restarts and heartbeat sweeps (INT-2503).
+      .filter((p) => !existsSync(join(p, PRESERVE_MARKER)));
     for (const p of orphans) {
       await git(repoPath, 'worktree', 'remove', '--force', p)
         .then(() => console.log(`[Worktree] Swept orphan worktree: ${p}`))


### PR DESCRIPTION
## Summary
A failed session's worktree was removed in the runner's `finally`, and `createWorktree` wiped any existing dir on retry — so a task whose reviewer said *"partially implements X"* (live: STO-1451 — stale/fresh gating wired, 2 DoD items left) still restarted from **zero code** every attempt, re-implementing the same 60-80%. This was the cross-session convergence bottleneck for hard tasks.

- `preserveWorktree()`: on any non-success outcome, if the tree is dirty, drop an `.openswarm-preserved` marker and keep it (clean trees removed as before)
- `createWorktree()`: a preserved tree with a matching branch is **resumed** — partial work and build caches (cargo `target/`, node_modules links) intact; marker consumed so a repeat failure re-preserves
- `pruneWorktrees()`: skips marked dirs → preserved work survives daemon restarts and heartbeat sweeps
- Pairs with INT-2474 feedback injection: the retry now gets the previous reviewer feedback **and the code it reviewed**

## Verification
- New tests: dirty-preserve → resume roundtrip (work intact, marker consumed); clean tree removed not preserved; branch-mismatch (title changed) recreates fresh — real git repos with bare origin
- src/support + src/automation sweep: 30 files / 210 pass; typecheck / oxlint / build clean

Closes INT-2503