### PR TITLE
fix(draft): scope registry stats to the repo — stop feeding global junk to the draft (INT-2502)

### DIFF
--- a/src/agents/draftAnalyzer.test.ts
+++ b/src/agents/draftAnalyzer.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { CliAdapter, CliRunResult } from '../adapters/types.js';
-import { runDraftAnalysis, isDraftSufficient, draftBudgetFor } from './draftAnalyzer.js';
+import { runDraftAnalysis, isDraftSufficient, draftBudgetFor, deriveRegistryProjectId } from './draftAnalyzer.js';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import * as adapterModule from '../adapters/index.js';
 import * as knowledgeModule from '../knowledge/index.js';
 import * as registryModule from '../registry/sqliteStore.js';
@@ -215,3 +218,34 @@ describe('draftBudgetFor (file-count-adaptive read/analyze budget, INT-2485)', (
   });
 });
 
+
+describe('deriveRegistryProjectId (INT-2502 read-side)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'osw-draft-pid-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('uses the package.json name (scope stripped) when present', () => {
+    const repo = join(root, 'SomeDir');
+    mkdirSync(repo, { recursive: true });
+    writeFileSync(join(repo, 'package.json'), JSON.stringify({ name: '@intrect/openswarm' }));
+    expect(deriveRegistryProjectId(repo)).toBe('openswarm');
+  });
+
+  it('falls back to the dir basename without package.json (Rust/Python repos)', () => {
+    const repo = join(root, 'WAVE');
+    mkdirSync(repo, { recursive: true });
+    expect(deriveRegistryProjectId(repo)).toBe('WAVE');
+  });
+
+  it('keys a worktree path under its parent repo, not the worktree uuid', () => {
+    const wt = join(root, 'WAVE', 'worktree', 'c771f200-5cdf-485e-80c6');
+    mkdirSync(wt, { recursive: true });
+    expect(deriveRegistryProjectId(wt)).toBe('WAVE');
+  });
+});

--- a/src/agents/draftAnalyzer.ts
+++ b/src/agents/draftAnalyzer.ts
@@ -7,6 +7,8 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { getAdapter, getDefaultAdapterName, spawnCli } from '../adapters/index.js';
 import { analyzeIssue } from '../knowledge/index.js';
 import { getRegistryStore } from '../registry/sqliteStore.js';
@@ -165,6 +167,27 @@ export interface DraftAnalyzerOptions {
  * Code Registry + Knowledge Graph에서 코드베이스 상태를 수집
  * LLM 호출 없이 로컬 DB 조회만으로 완료
  */
+/**
+ * Registry rows are keyed by the SCAN-time project id (package.json name, else
+ * the repo dir basename) — NOT the Linear project UUID the pipeline carries.
+ * The daemon never passed a projectId here, so getStats(undefined) returned the
+ * GLOBAL count across every scanned directory (624k entities incl. a 563k
+ * 'unohee' home-dir junk bucket) and polluted the draft prompt with cross-repo
+ * noise. Derive the registry key from projectPath with the same rule the
+ * scanner uses, and NEVER fall back to global stats. (INT-2502 read-side)
+ */
+export function deriveRegistryProjectId(projectPath: string): string {
+  // A worktree path (…/<repo>/worktree/<uuid>) keys under the parent repo.
+  const normalized = projectPath.replace(/\/+$/, '');
+  const wt = normalized.match(/^(.*)\/worktree\/[^/]+$/);
+  const repoRoot = wt ? wt[1] : normalized;
+  try {
+    const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8')) as { name?: unknown };
+    if (typeof pkg.name === 'string' && pkg.name) return pkg.name.replace(/^@[^/]+\//, '');
+  } catch { /* no/invalid package.json → basename */ }
+  return repoRoot.split('/').pop() ?? repoRoot;
+}
+
 function collectCodebaseState(
   projectPath: string,
   projectId?: string,
@@ -173,12 +196,13 @@ function collectCodebaseState(
   const registrySnapshot: RegistryBrief[] = [];
   let projectStats: string | undefined;
   let totalEntities = 0;
+  const registryKey = projectId ?? deriveRegistryProjectId(projectPath);
 
   try {
     const store = getRegistryStore();
 
-    // 1. 프로젝트 전체 통계
-    const stats = store.getStats(projectId);
+    // 1. 프로젝트 전체 통계 — always scoped; global stats are cross-repo noise.
+    const stats = store.getStats(registryKey);
     totalEntities = stats.total;
     const statParts: string[] = [`${stats.total} entities`];
     if (stats.deprecated > 0) statParts.push(`${stats.deprecated} deprecated`);
@@ -225,7 +249,7 @@ function collectCodebaseState(
 
     // 3. 검색으로 못 찾은 high-risk entity가 있으면 추가 (상위 5개)
     if (registrySnapshot.length < 3) {
-      const highRisk = store.highRiskEntities(projectId).slice(0, 5);
+      const highRisk = store.highRiskEntities(registryKey).slice(0, 5);
       for (const e of highRisk) {
         if (!affectedFiles.has(e.filePath)) {
           registrySnapshot.push({


### PR DESCRIPTION
## Summary
User-spotted in live logs: every draft printed `[Draft] Registry: 624650 entities, 623890 untested` — for **every** repo. The daemon never passed a `projectId` to `runDraftAnalysis`, so `collectCodebaseState` called `getStats(undefined)` → the **global** count across every directory ever scanned, including a 563k-entity `'unohee'` home-dir junk bucket (`.atom` compile caches). Every draft prompt was fed cross-repo noise.

Registry rows are keyed by the scan-time id (`package.json` name, else the repo dir basename) — not the Linear UUID the pipeline carries. This PR:
- `deriveRegistryProjectId()`: derives the registry key from `projectPath` with the scanner's rule; worktree paths (`…/<repo>/worktree/<uuid>`) key under the parent repo
- `collectCodebaseState` uses it whenever no explicit projectId is given — **no more global fallback** for `getStats` or `highRiskEntities`

## Verification
- Real-DB spot check: `getStats('WAVE')` = 937 real Rust entities (vs 624k global)
- New tests: package.json name (scope stripped) / basename fallback / worktree→parent-repo key — 15 pass
- typecheck / oxlint / build clean

## Remaining (INT-2502 stays open)
Write-side junk buckets (`'unohee'` 563k, `'dev'` 31k — scans run from `$HOME`) still need cleanup; tracked in the issue.