### PR TITLE
fix(pipeline): persist the REAL last reviewer feedback, not "Unknown error" (INT-2504)

### DIFF
--- a/src/agents/pairPipeline.test.ts
+++ b/src/agents/pairPipeline.test.ts
@@ -368,6 +368,29 @@ describe('PairPipeline model selection', () => {
     expect(runWorker.mock.calls[1][0].reasoningEffort).not.toBe('high');
   });
 
+  it('exposes the last REAL reviewer feedback on a max-iterations failure (INT-2504)', async () => {
+    // Distinct feedback each round (no repeat-escalation), session dies at max-iter.
+    runReviewer
+      .mockResolvedValueOnce({ decision: 'revise', feedback: 'First: the cursor pagination resets between pages.' })
+      .mockResolvedValueOnce({ decision: 'revise', feedback: 'Second: the tenant scoping on cache invalidation is still missing entirely.' });
+
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker', 'reviewer'],
+      maxIterations: 2,
+      roles: {
+        worker: { enabled: true, model: 'worker', timeoutMs: 0 },
+        reviewer: { enabled: true, model: 'reviewer', timeoutMs: 0 },
+      },
+    });
+
+    const result = await pipeline.run(task(), process.cwd());
+
+    expect(result.success).toBe(false);
+    // The retry's injected detail must be the actual last reviewer feedback.
+    expect(result.lastReviewFeedback).toContain('tenant scoping on cache invalidation');
+  });
+
   it('nudges for missing validation at most once, then defers even if the worker keeps editing new files', async () => {
     // Regression: the worker edits a DIFFERENT file every iteration without ever
     // running a validation command. The gate used to bounce each time (each bounce

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -1145,7 +1145,8 @@ export class PairPipeline extends EventEmitter {
         });
 
         if (decision === 'reject') {
-          // reject = terminate immediately
+          // reject = terminate immediately (keep the real feedback for the retry)
+          context.lastReviseFeedback = (reviewerResult.result as ReviewResult).feedback ?? context.lastReviseFeedback;
           console.log(`[${context.taskPrefix}] Reviewer rejected`);
           agentPair.updateSessionStatus(context.session.id, 'rejected');
           return { success: false };
@@ -1284,6 +1285,7 @@ export class PairPipeline extends EventEmitter {
       iterations: context.currentIteration,
       workerResult: context.workerResult,
       reviewResult: context.reviewResult,
+      lastReviewFeedback: context.lastReviseFeedback,
       testerResult: context.testerResult,
       documenterResult: context.documenterResult,
       auditorResult: context.auditorResult,

--- a/src/agents/pairPipelineTypes.ts
+++ b/src/agents/pairPipelineTypes.ts
@@ -71,6 +71,10 @@ export interface PipelineResult {
   iterations: number;
   workerResult?: WorkerResult;
   reviewResult?: ReviewResult;
+  /** The last REAL reviewer revise feedback. `reviewResult` can end up holding a
+   *  synthetic entry (validation nudge / HALT overwrite it), which made failed
+   *  sessions persist "Unknown error"-grade detail for the retry (INT-2504). */
+  lastReviewFeedback?: string;
   testerResult?: TesterResult;
   documenterResult?: DocumenterResult;
   auditorResult?: AuditorResult;

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -19,6 +19,7 @@ import {
   loadProjectSelection,
   saveProjectSelection,
   recordLastFailureDetail,
+  pickFailureDetail,
   type LastFailureEntry,
   type TaskState,
   type ProjectInfo,
@@ -411,7 +412,8 @@ export class AutonomousRunner {
 
       // If rejected, track rejection count and block after max attempts
       if (task.issueId && result.finalStatus === 'rejected') {
-        const feedback = result.reviewResult?.feedback || 'No feedback provided';
+        const feedback = pickFailureDetail([result.lastReviewFeedback, result.reviewResult?.feedback])
+          ?? 'No feedback provided';
         const rejectionCount = incrementRejection(task.issueId, feedback);
         // Persist for prompt injection on the retry (same mechanism as failures).
         recordLastFailureDetail(this.taskStateRef, task.issueId, feedback);
@@ -470,13 +472,17 @@ export class AutonomousRunner {
         const count = (this.failedTaskCounts.get(task.issueId) ?? 0) + 1;
         this.failedTaskCounts.set(task.issueId, count);
 
-        // Surface the underlying failure (worker CLI error / review feedback) so the
-        // stuck comment is actionable instead of an opaque "failed N times", AND
-        // persist it so the NEXT attempt starts with this feedback instead of
-        // blind — re-picked tasks used to repeat the exact same mistake (INT-2474).
-        const failureDetail = result.workerResult?.error
-          || result.reviewResult?.feedback
-          || 'No error detail captured (worker produced no output).';
+        // Surface the underlying failure so the stuck comment is actionable AND
+        // persist it for the next attempt's injection (INT-2474). Prefer the last
+        // REAL reviewer feedback: reviewResult can hold a synthetic entry
+        // (validation nudge / HALT overwrite it), and a junk-but-truthy worker
+        // error ("Unknown error" from the text-fallback parser) used to mask the
+        // reviewer's actionable feedback entirely (INT-2504).
+        const failureDetail = pickFailureDetail([
+          result.lastReviewFeedback,
+          result.reviewResult?.feedback,
+          result.workerResult?.error,
+        ]) ?? 'No error detail captured (worker produced no output).';
         recordLastFailureDetail(this.taskStateRef, task.issueId, failureDetail);
 
         if (count >= AutonomousRunner.MAX_RETRY_COUNT) {

--- a/src/automation/runnerState.coverage.test.ts
+++ b/src/automation/runnerState.coverage.test.ts
@@ -186,3 +186,18 @@ describe('runnerState persistence and helpers', () => {
     expect(mod.formatRetryTime(Date.now() + (2 * 60 + 5) * 60_000)).toBe('in 2h 5m');
   });
 });
+
+describe('pickFailureDetail (INT-2504)', () => {
+  it('skips junk-but-truthy details in favor of real feedback', () => {
+    expect(mod.pickFailureDetail(['Unknown error', 'The cache misses tenant scope; fix and test.']))
+      .toBe('The cache misses tenant scope; fix and test.');
+  });
+
+  it('prefers earlier meaningful candidates (reviewer feedback first)', () => {
+    expect(mod.pickFailureDetail(['Reviewer said X', 'worker error Y'])).toBe('Reviewer said X');
+  });
+
+  it('returns undefined when everything is junk or empty', () => {
+    expect(mod.pickFailureDetail(['Unknown error', '  ', undefined, 'No feedback provided'])).toBeUndefined();
+  });
+});

--- a/src/automation/runnerState.ts
+++ b/src/automation/runnerState.ts
@@ -170,6 +170,29 @@ export interface TaskState {
   lastFailureDetails: Map<string, LastFailureEntry>; // issueId → last failure feedback
 }
 
+/** Placeholder strings that carry zero diagnostic value — never persist these
+ *  as a failure detail when something meaningful is available (INT-2504). */
+const JUNK_DETAILS = new Set([
+  'Unknown error',
+  'No feedback provided',
+  'No summary provided',
+  'Worker execution failed',
+]);
+
+/**
+ * Pick the first MEANINGFUL failure detail. The old chain
+ * (`workerResult.error || reviewResult.feedback`) let a junk-but-truthy error
+ * string ("Unknown error" from the text-fallback parser) mask the reviewer's
+ * actionable feedback — the retry then got injected with garbage (INT-2504).
+ */
+export function pickFailureDetail(candidates: Array<string | undefined>): string | undefined {
+  for (const c of candidates) {
+    const trimmed = c?.trim();
+    if (trimmed && !JUNK_DETAILS.has(trimmed)) return trimmed;
+  }
+  return undefined;
+}
+
 export function recordLastFailureDetail(state: TaskState, issueId: string, detail: string): void {
   const trimmed = detail.trim();
   if (!trimmed) return;


### PR DESCRIPTION
Retry-injection details and STUCK comments were assembled as `workerResult.error || reviewResult.feedback`: junk-but-truthy parser strings ("Unknown error") masked the reviewer's actionable feedback, and validation-nudge/HALT overwrite reviewResult with synthetic entries. Live: INT-2200 persisted "Unknown error" — retries were blind again. Adds PipelineResult.lastReviewFeedback (the tracked real revise/reject feedback) + pickFailureDetail() junk-filtered priority chain, applied to both failure and rejection persistence. Tests: junk-skipping, ordering, max-iter exposure. Closes INT-2504