### PR TITLE
feat(worktree): preserved-worktree lifecycle — STUCK cleanup + 7-day age sweep (INT-2506)

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -48,7 +48,7 @@ import { t } from '../locale/index.js';
 import { broadcastEvent, type SwarmStats } from '../core/eventHub.js';
 import { writeProviderOverride } from '../core/providerOverride.js';
 import { getTaskState } from '../taskState/store.js';
-import { pruneWorktrees } from '../support/worktreeManager.js';
+import { pruneWorktrees, removePreservedWorktreeAt } from '../support/worktreeManager.js';
 import { loadRepoMetadata } from '../support/repoMetadata.js';
 import { STUCK_LABEL } from '../linear/index.js';
 import { refreshGraph, toProjectSlug } from '../knowledge/index.js';
@@ -435,6 +435,12 @@ export class AutonomousRunner {
           this.completedTaskIds.add(task.issueId); // Prevent re-selection
           clearRetryTime(task.issueId, this.failedTaskRetryTimes); // Clear retry time
           this.saveTaskState();
+          // Terminally stuck → no retry will resume the preserved tree; commit
+          // the partial work to the branch and free the disk (INT-2506).
+          if (result.taskContext?.projectPath) {
+            await removePreservedWorktreeAt(result.taskContext.projectPath)
+              .catch((err) => console.warn('[Worktree] STUCK cleanup failed:', err));
+          }
 
           try {
             await execution.syncFailureState(task, `Max rejection limit reached (${rejectionCount} attempts): ${feedback}`);
@@ -491,6 +497,11 @@ export class AutonomousRunner {
           clearRetryTime(task.issueId, this.failedTaskRetryTimes); // Clear retry time
           this.saveTaskState();
           console.log(`[Scheduler] Task failure count: ${count}/${AutonomousRunner.MAX_RETRY_COUNT} for ${taskCtx} — STUCK`);
+          // Terminally stuck → commit partial work to the branch, free the disk (INT-2506).
+          if (result.taskContext?.projectPath) {
+            await removePreservedWorktreeAt(result.taskContext.projectPath)
+              .catch((err) => console.warn('[Worktree] STUCK cleanup failed:', err));
+          }
           try {
             await execution.syncFailureState(task, `Autonomous execution failed ${count} times: ${failureDetail}`);
             await getTaskSource()?.logStuck(task.issueId, 'autonomous-runner',

--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -3,7 +3,7 @@ import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, w
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { createWorktree, preserveWorktree, removeWorktree, resolveSharedPaths, computeFileOverlaps, formatOverlapReport, type WorktreeInfo } from './worktreeManager.js';
+import { createWorktree, preserveWorktree, removePreservedWorktreeAt, removeWorktree, resolveSharedPaths, computeFileOverlaps, formatOverlapReport, type WorktreeInfo } from './worktreeManager.js';
 
 describe('worktreeManager path safety', () => {
   let root: string;
@@ -267,5 +267,52 @@ describe('file-overlap report (INT-2392)', () => {
       expect(section).toContain('12 file(s)');
       expect(section).toContain('(+4 more)');
     });
+  });
+});
+
+describe('removePreservedWorktreeAt (INT-2506)', () => {
+  let root: string;
+  let repo: string;
+
+  const git = (cwd: string, ...args: string[]) =>
+    execFileSync('git', ['-C', cwd, ...args], { stdio: 'pipe' });
+
+  beforeEach(() => {
+    root = join(tmpdir(), `openswarm-wt-lifecycle-${process.pid}-${Date.now()}`);
+    repo = join(root, 'repo');
+    mkdirSync(repo, { recursive: true });
+    const originBare = join(root, 'origin.git');
+    execFileSync('git', ['init', '--bare', '-b', 'main', originBare], { stdio: 'pipe' });
+    execFileSync('git', ['init', '-b', 'main', repo], { stdio: 'pipe' });
+    git(repo, 'config', 'user.email', 't@t.com');
+    git(repo, 'config', 'user.name', 'T');
+    git(repo, 'config', 'commit.gpgsign', 'false');
+    writeFileSync(join(repo, 'app.py'), 'base\n');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-m', 'init');
+    git(repo, 'remote', 'add', 'origin', originBare);
+    git(repo, 'push', 'origin', 'main');
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('commits the partial work to the branch, then removes the tree', async () => {
+    const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+    writeFileSync(join(info.worktreePath, 'app.py'), 'base\npartial\n');
+    await preserveWorktree(info, 'stuck test');
+
+    await removePreservedWorktreeAt(info.worktreePath);
+
+    expect(existsSync(info.worktreePath)).toBe(false);
+    // The partial work survives on the branch for human inspection.
+    const show = execFileSync('git', ['-C', repo, 'show', 'swarm/INT-9-test:app.py'], { encoding: 'utf8' });
+    expect(show).toBe('base\npartial\n');
+  });
+
+  it('no-ops on paths that are not managed worktrees', async () => {
+    await removePreservedWorktreeAt(repo); // repo root — no /worktree/ segment
+    expect(existsSync(repo)).toBe(true);
   });
 });

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -5,7 +5,7 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { registerOwnedPR } from '../automation/prOwnership.js';
 import { runConventionalCommitGuard } from '../agents/pipelineGuards.js';
@@ -170,6 +170,44 @@ async function linkSharedPaths(repoPath: string, worktreePath: string): Promise<
  * them; a successful run still removes the worktree as before.
  */
 const PRESERVE_MARKER = '.openswarm-preserved';
+/** Preserved trees older than this are abandoned (task STUCK or issue closed) — swept. */
+const PRESERVE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+function preserveMarkerAgeMs(worktreePath: string): number | null {
+  try {
+    const raw = JSON.parse(readFileSync(join(worktreePath, PRESERVE_MARKER), 'utf8')) as { at?: string };
+    const at = raw.at ? Date.parse(raw.at) : NaN;
+    return Number.isFinite(at) ? Date.now() - at : null;
+  } catch {
+    return null; // unreadable marker → treat as expired (swept)
+  }
+}
+
+/**
+ * Discard a preserved worktree, keeping the partial work reachable: best-effort
+ * commit it onto the tree's swarm branch (survives worktree removal, human can
+ * inspect), then remove the directory. Used when a task goes terminally STUCK
+ * and by the age sweep. Accepts the worktree path itself — the repo root is the
+ * segment before `/worktree/<id>`. No-op for paths that don't match. (INT-2506)
+ */
+export async function removePreservedWorktreeAt(worktreePath: string): Promise<void> {
+  const m = worktreePath.replace(/\/+$/, '').match(/^(.*)\/worktree\/[^/]+$/);
+  if (!m || !existsSync(worktreePath)) return;
+  const repoRoot = m[1];
+  try {
+    await git(worktreePath, 'add', '-A');
+    await git(
+      worktreePath,
+      '-c', 'user.email=swarm@openswarm.local', '-c', 'user.name=OpenSwarm',
+      'commit', '--no-verify', '-m', 'wip: preserved partial work (auto, pre-cleanup)',
+    );
+    console.log(`[Worktree] WIP committed to branch before cleanup: ${worktreePath}`);
+  } catch { /* clean tree or commit failure — proceed with removal */ }
+  await git(repoRoot, 'worktree', 'remove', '--force', worktreePath).catch(() => {
+    rmSync(worktreePath, { recursive: true, force: true });
+  });
+  console.log(`[Worktree] Removed preserved worktree: ${worktreePath}`);
+}
 
 /**
  * Preserve a failed session's worktree when it holds actual work: drop the
@@ -477,16 +515,24 @@ export async function pruneWorktrees(repoPath: string, activeWorktreePaths: Set<
   try {
     const out = await git(repoPath, 'worktree', 'list', '--porcelain');
     const prefix = `${repoPath}/worktree/`;
-    const orphans = out
+    const candidates = out
       .split('\n')
       .filter((l) => l.startsWith('worktree '))
       .map((l) => l.slice('worktree '.length).trim())
       .filter((p) => p.startsWith(prefix))
-      .filter((p) => !activeWorktreePaths.has(p)) // keep worktrees of running tasks
-      // Preserved failed-session worktrees carry the retry's partial work —
-      // they must survive daemon restarts and heartbeat sweeps (INT-2503).
-      .filter((p) => !existsSync(join(p, PRESERVE_MARKER)));
-    for (const p of orphans) {
+      .filter((p) => !activeWorktreePaths.has(p)); // keep worktrees of running tasks
+    for (const p of candidates) {
+      // Preserved failed-session worktrees carry the retry's partial work — they
+      // survive restarts and sweeps (INT-2503) until they age out (abandoned:
+      // task went STUCK or the issue was closed). Expired ones get their work
+      // committed to the branch, then removed (INT-2506).
+      if (existsSync(join(p, PRESERVE_MARKER))) {
+        const age = preserveMarkerAgeMs(p);
+        if (age !== null && age <= PRESERVE_MAX_AGE_MS) continue; // still fresh — keep
+        console.log(`[Worktree] Preserved worktree expired (${age === null ? 'unreadable marker' : Math.round(age / 3_600_000) + 'h'}) — sweeping: ${p}`);
+        await removePreservedWorktreeAt(p).catch((e) => console.warn(`[Worktree] Expired-preserve sweep failed for ${p}:`, e));
+        continue;
+      }
       await git(repoPath, 'worktree', 'remove', '--force', p)
         .then(() => console.log(`[Worktree] Swept orphan worktree: ${p}`))
         .catch((e) => console.warn(`[Worktree] Orphan sweep failed for ${p}:`, e));


### PR DESCRIPTION
INT-2503 preservation only removed worktrees on success — terminally STUCK tasks leaked their preserved trees (GBs each with Rust target/). removePreservedWorktreeAt() commits the partial work onto the swarm branch (human-inspectable) then removes the dir; both STUCK-final paths call it; pruneWorktrees ages out markers older than 7 days via the same path. Tests: branch retains work post-cleanup, non-worktree no-op, preserve/resume roundtrip unaffected. Closes INT-2506