### PR TITLE
chore(registry+stuck): scanner non-repo guard + error-loop normalization (INT-2507)

### DIFF
--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -95,9 +95,12 @@ export class PairPipeline extends EventEmitter {
       maxReflections: DEFAULT_MAX_REFLECTIONS,
       ...config,
     };
-    // Initialize stuck detector
+    // Initialize stuck detector. sameErrorRepeat 3 (was 2): with errors now
+    // normalized before comparison, 2 identical-after-normalization occurrences
+    // were still occasionally transient (e.g. flaky network in both runs) —
+    // require a third strike before declaring a loop. (INT-2507)
     this.stuckDetector = createStuckDetector({
-      sameErrorRepeat: 2,
+      sameErrorRepeat: 3,
       revisionLoop: 4,
     });
     this.jobProfiles = config.jobProfiles ?? [];

--- a/src/registry/entityScanner.test.ts
+++ b/src/registry/entityScanner.test.ts
@@ -42,7 +42,7 @@ describe('entity scanner', () => {
     await writeProjectFile('tests/test_foo.py', 'def test_foo():\n    assert foo() == 1\n');
 
     const { scanRepository } = await import('./entityScanner.js');
-    const result = await scanRepository(tmp, 'test-project');
+    const result = await scanRepository(tmp, 'test-project', { allowNonRepo: true });
 
     expect(result.testsMapped).toBe(1);
     expect(registered).toContainEqual(expect.objectContaining({
@@ -52,5 +52,22 @@ describe('entity scanner', () => {
       hasTests: true,
       testFile: 'tests/test_foo.py',
     }));
+  });
+});
+
+describe('scanRepository non-repo guard (INT-2507)', () => {
+  it('refuses to scan the home directory', async () => {
+    const { scanRepository } = await import('./entityScanner.js');
+    const { homedir } = await import('node:os');
+    await expect(scanRepository(homedir(), 'junk')).rejects.toThrow(/Refusing to scan the home directory/);
+  });
+
+  it('refuses a non-git directory unless allowNonRepo', async () => {
+    const { scanRepository } = await import('./entityScanner.js');
+    const { mkdtempSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const dir = mkdtempSync(join(tmpdir(), 'osw-nonrepo-'));
+    await expect(scanRepository(dir, 'junk')).rejects.toThrow(/non-git directory/);
   });
 });

--- a/src/registry/entityScanner.ts
+++ b/src/registry/entityScanner.ts
@@ -7,7 +7,9 @@
 // ============================================
 
 import { readdir, readFile, stat } from 'node:fs/promises';
-import { join, extname, dirname } from 'node:path';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, extname, dirname, resolve } from 'node:path';
 import { getRegistryStore } from './sqliteStore.js';
 import type { CodeEntity, EntityKind, RiskLevel } from './schema.js';
 
@@ -625,8 +627,22 @@ export interface ScanResult {
 export async function scanRepository(
   projectPath: string,
   projectId: string,
-  options?: { maxDepth?: number; timeoutMs?: number; verbose?: boolean },
+  options?: { maxDepth?: number; timeoutMs?: number; verbose?: boolean; allowNonRepo?: boolean },
 ): Promise<ScanResult> {
+  // Guard: a scan launched from $HOME (or any non-git directory) walks the whole
+  // home tree and floods the registry with junk buckets — measured 563k rows
+  // under project_id 'unohee' (.atom compile caches etc.), ~90% of the DB.
+  // Refuse unless explicitly opted in. (INT-2507)
+  const resolvedScanPath = resolve(projectPath);
+  if (!options?.allowNonRepo) {
+    if (resolvedScanPath === homedir()) {
+      throw new Error(`Refusing to scan the home directory (${resolvedScanPath}) — run from a project repo or pass allowNonRepo.`);
+    }
+    if (!existsSync(join(resolvedScanPath, '.git'))) {
+      throw new Error(`Refusing to scan a non-git directory (${resolvedScanPath}) — it floods the registry with junk. Pass allowNonRepo to override.`);
+    }
+  }
+
   const startTime = Date.now();
   const maxDepth = options?.maxDepth ?? MAX_DEPTH;
   const timeoutMs = options?.timeoutMs ?? SCAN_TIMEOUT_MS;

--- a/src/support/stuckDetector.test.ts
+++ b/src/support/stuckDetector.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { StuckDetector, type HistoryEntry } from './stuckDetector.js';
+import { StuckDetector, normalizeErrorForLoop, type HistoryEntry } from './stuckDetector.js';
 
 let ts = 0;
 
@@ -51,5 +51,18 @@ describe('StuckDetector', () => {
     detector.addEntry(entry({ output: 'same output' }));
 
     expect(detector.check()).toEqual({ isStuck: false });
+  });
+});
+
+describe('normalizeErrorForLoop (INT-2507)', () => {
+  it('equates the same logical error across volatile tokens', () => {
+    const a = 'Error at /Users/u/dev/WAVE/worktree/abc123/src/main.rs:42:7 — build failed in 3.2s (2026-07-05T01:02:03Z)';
+    const b = 'Error at /Users/u/dev/WAVE/worktree/def456/src/main.rs:99:1 — build failed in 12s (2026-07-05T09:08:07Z)';
+    expect(normalizeErrorForLoop(a)).toBe(normalizeErrorForLoop(b));
+  });
+
+  it('keeps genuinely different errors distinct', () => {
+    expect(normalizeErrorForLoop('cargo build failed: missing symbol foo'))
+      .not.toBe(normalizeErrorForLoop('pytest failed: assertion error in test_bar'));
   });
 });

--- a/src/support/stuckDetector.ts
+++ b/src/support/stuckDetector.ts
@@ -95,10 +95,13 @@ export class StuckDetector {
       return { isStuck: false };
     }
 
-    // Check if all errors are the same (compare first 100 chars)
-    const firstError = recentErrors[0].error?.slice(0, 100);
+    // Normalize before comparing: raw prefix-equality on the first 100 chars
+    // mistook transient errors that embed timestamps/paths/ids for "the same
+    // error twice" (INT-2010 follow-up ①). Strip volatile tokens first so only
+    // genuinely identical failures count as a loop.
+    const firstError = normalizeErrorForLoop(recentErrors[0].error);
     const allSame = recentErrors.every(e =>
-      e.error?.slice(0, 100) === firstError
+      normalizeErrorForLoop(e.error) === firstError
     );
 
     if (allSame) {
@@ -224,6 +227,25 @@ export class StuckDetector {
   getHistory(): HistoryEntry[] {
     return [...this.history];
   }
+}
+
+/**
+ * Strip volatile tokens (timestamps, absolute paths, hex ids, line/col numbers)
+ * so two occurrences of the SAME logical error compare equal, while transient
+ * errors that only share a prefix don't (INT-2010 follow-up ①, INT-2507).
+ */
+export function normalizeErrorForLoop(error?: string): string {
+  return (error ?? '')
+    .toLowerCase()
+    .replace(/\d{4}-\d{2}-\d{2}[t ]\d{2}:\d{2}:\d{2}[.\d]*z?/g, '<ts>') // ISO timestamps
+    .replace(/\/[\w./~-]+/g, '<path>') // absolute/relative paths
+    .replace(/0x[0-9a-f]+/g, '<hex>')
+    .replace(/\b[0-9a-f]{8,}\b/g, '<id>') // hashes / uuids fragments
+    .replace(/:\d+(:\d+)?/g, ':<n>') // line:col
+    .replace(/\b\d+(\.\d+)?(ms|s)\b/g, '<dur>')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 200);
 }
 
 /**


### PR DESCRIPTION
Two hygiene items: (1) scanRepository refuses $HOME/non-git dirs (a home-dir scan created the 563k-row 'unohee' junk bucket = ~90% of the 705MB registry DB); one-time junk DELETE+VACUUM happens at the next daemon maintenance window. (2) stuck-detector same-error loop now normalizes volatile tokens (timestamps/paths/ids) before comparing and requires 3 strikes instead of 2 — raw prefix equality mistook transient errors for loops (INT-2010 follow-up). Tests included. Closes INT-2507