### PR TITLE
fix(pipeline): add locale noSummary literals to the junk-detail filter (INT-2504 follow-up)

### DIFF
--- a/src/automation/runnerState.coverage.test.ts
+++ b/src/automation/runnerState.coverage.test.ts
@@ -201,3 +201,8 @@ describe('pickFailureDetail (INT-2504)', () => {
     expect(mod.pickFailureDetail(['Unknown error', '  ', undefined, 'No feedback provided'])).toBeUndefined();
   });
 });
+
+it('pickFailureDetail skips locale noSummary fallbacks (INT-2504 follow-up)', () => {
+  expect(mod.pickFailureDetail(['(no summary)', 'real feedback here'])).toBe('real feedback here');
+  expect(mod.pickFailureDetail(['(요약 없음)'])).toBeUndefined();
+});

--- a/src/automation/runnerState.ts
+++ b/src/automation/runnerState.ts
@@ -177,6 +177,11 @@ const JUNK_DETAILS = new Set([
   'No feedback provided',
   'No summary provided',
   'Worker execution failed',
+  // t('common.fallback.noSummary') literals — the reviewer parse fallback emits
+  // these as `feedback` and they leaked through as a persisted "detail" (live:
+  // INT-2193 lastFailure === '(no summary)').
+  '(no summary)',
+  '(요약 없음)',
 ]);
 
 /**


### PR DESCRIPTION
Live: INT-2193 persisted lastFailure '(no summary)' — the reviewer parse fallback emits t('common.fallback.noSummary') as feedback; the junk set only had a guessed variant. Adds the real locale literals for en/ko + test.