### PR TITLE
fix(provider): honor an explicit claude override instead of silently ignoring it

### DIFF
--- a/src/core/providerOverride.test.ts
+++ b/src/core/providerOverride.test.ts
@@ -40,25 +40,14 @@ describe('providerOverride', () => {
     expect(readProviderOverride()).toBeUndefined();
   });
 
-  it('does not persist claude overrides', async () => {
+  it('persists and reads back a claude override — an explicit operator switch must not silently no-op', async () => {
     const fs = await import('node:fs');
     fs.rmSync('/tmp/openswarm-home', { recursive: true, force: true });
 
     const { writeProviderOverride, readProviderOverride } = await import('./providerOverride.js');
     writeProviderOverride('claude');
 
-    expect(fs.existsSync('/tmp/openswarm-home/.config/openswarm/provider-override.json')).toBe(false);
-    expect(readProviderOverride()).toBeUndefined();
-  });
-
-  it('ignores claude persisted values if the file is present', async () => {
-    const fs = await import('node:fs');
-    fs.rmSync('/tmp/openswarm-home', { recursive: true, force: true });
-    fs.mkdirSync('/tmp/openswarm-home/.config/openswarm', { recursive: true });
-    fs.writeFileSync('/tmp/openswarm-home/.config/openswarm/provider-override.json', JSON.stringify({ provider: 'claude' }), 'utf8');
-
-    const { readProviderOverride } = await import('./providerOverride.js');
-    expect(readProviderOverride()).toBeUndefined();
+    expect(readProviderOverride()).toBe('claude');
   });
 
   it('formats a loud mismatch warning naming both providers and the override file (INT-2408)', async () => {

--- a/src/core/providerOverride.ts
+++ b/src/core/providerOverride.ts
@@ -11,17 +11,20 @@ import type { AdapterName } from '../adapters/types.js';
 
 const OVERRIDE_DIR = join(homedir(), '.config', 'openswarm');
 const OVERRIDE_PATH = join(OVERRIDE_DIR, 'provider-override.json');
-// `claude` is intentionally excluded: it is an opt-in fallback provider, not a primary the operator
-// should be able to pin via a persisted toggle (a stale claude pin with no credits hangs the loop).
-const VALID: readonly Exclude<AdapterName, 'claude'>[] = ['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter'];
-const VALID_SET = new Set<Exclude<AdapterName, 'claude'>>(VALID);
+// `claude` WAS excluded (a stale claude pin with no credits hangs the loop), but that guard also
+// made an operator's EXPLICIT switch silently no-op — the daemon stayed on the old provider with
+// zero feedback (observed 2026-07-05: override={"provider":"claude"} → no switch, no log). Honor
+// the operator's choice; the startup mismatch warning still prints loudly, and a credit-less pin
+// surfaces as visible worker failures rather than a silent revert.
+const VALID: readonly AdapterName[] = ['claude', 'codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter'];
+const VALID_SET = new Set<AdapterName>(VALID);
 
 /** The provider the user last selected via the dashboard, or undefined if never toggled. */
 export function readProviderOverride(): AdapterName | undefined {
   try {
     if (!existsSync(OVERRIDE_PATH)) return undefined;
     const { provider } = JSON.parse(readFileSync(OVERRIDE_PATH, 'utf8')) as { provider?: string };
-    return VALID_SET.has(provider as Exclude<AdapterName, 'claude'>) ? (provider as Exclude<AdapterName, 'claude'>) : undefined;
+    return VALID_SET.has(provider as AdapterName) ? (provider as AdapterName) : undefined;
   } catch {
     return undefined;
   }
@@ -48,7 +51,6 @@ export function formatProviderOverrideMismatchWarning(
 /** Record the user's provider choice so it survives a restart. Best-effort — never blocks the toggle. */
 export function writeProviderOverride(provider: AdapterName): void {
   try {
-    if (provider === 'claude') return;
     mkdirSync(OVERRIDE_DIR, { recursive: true });
     writeFileSync(OVERRIDE_PATH, `${JSON.stringify({ provider }, null, 2)}\n`, 'utf8');
   } catch {


### PR DESCRIPTION
The override layer excluded 'claude' (stale credit-less pin protection), but that made an operator's explicit switch a silent no-op — override={"provider":"claude"} produced no switch and no log (observed live). Allow claude in read+write; the loud startup mismatch warning remains, and a credit-less pin now surfaces as visible worker failures instead of a silent revert. Tests updated.