### PR TITLE
feat(adapters): cost/token/duration parity for loop adapters + planner model pin (INT-2508, INT-2509)

### DIFF
--- a/src/adapters/agenticLoop.test.ts
+++ b/src/adapters/agenticLoop.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { compactPriorTurns, toolCallKey, allToolCallsSeen, shouldNudgeReadLoop, READ_LOOP_NUDGE_AT, runAgenticLoop, type ChatMessage } from './agenticLoop.js';
+import { compactPriorTurns, toolCallKey, allToolCallsSeen, shouldNudgeReadLoop, READ_LOOP_NUDGE_AT, runAgenticLoop, loopResultToCliResult, type ChatMessage, type AgenticLoopResult } from './agenticLoop.js';
 import type { ToolCall } from './tools.js';
 
 /** Scripted API response carrying a single tool call. */
@@ -279,5 +279,32 @@ describe('runAgenticLoop read cache vs compaction (INT-1929)', () => {
     const seen = await runTwoReads({ compactAfterMessages: 2, compactTokenThreshold: 1, keepRecentMessages: 999 });
     expect(seen.filter((c) => c.includes('ALPHA_CONTENT')).length).toBeGreaterThanOrEqual(2);
     expect(seen.some((c) => c.includes('already read'))).toBe(false);
+  });
+});
+
+describe('loopResultToCliResult costInfo (INT-2508)', () => {
+  it('carries loop-measured tokens/duration as costInfo with zero (subscription) cost', () => {
+    const loop: AgenticLoopResult = {
+      text: 'done',
+      toolCallCount: 3,
+      apiCallCount: 4,
+      totalTokens: 12000,
+      inputTokens: 10000,
+      outputTokens: 2000,
+      cachedTokens: 8000,
+      durationMs: 45200,
+      executedCommands: ['npm test'],
+    };
+    const cli = loopResultToCliResult(loop);
+    expect(cli.costInfo).toEqual({
+      costUsd: 0,
+      inputTokens: 10000,
+      outputTokens: 2000,
+      cacheReadTokens: 8000,
+      cacheCreationTokens: 0,
+      durationMs: 45200,
+    });
+    expect(cli.stdout).toBe('done');
+    expect(cli.executedCommands).toEqual(['npm test']);
   });
 });

--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -153,6 +153,10 @@ export interface AgenticLoopResult {
   apiCallCount: number;
   /** 총 토큰 사용량 (추적 가능한 경우) */
   totalTokens: number;
+  /** 입력(prompt) 토큰 누적 — costInfo/로그의 in/out 분리 표기용 (INT-2508) */
+  inputTokens: number;
+  /** 출력(completion) 토큰 누적 */
+  outputTokens: number;
   /** 캐시 적중 입력 토큰 누적 (totalTokens의 부분집합) — prompt-cache 효율 측정용 */
   cachedTokens: number;
   /** 소요 시간 (ms) */
@@ -261,6 +265,8 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
   const SR_FAILED_LIMIT = 2;
   let apiCallCount = 0;
   let totalTokens = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
   let cachedTokens = 0;
   let finalText = '';
 
@@ -329,6 +335,8 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
 
     if (response.usage) {
       totalTokens += response.usage.prompt_tokens + response.usage.completion_tokens;
+      inputTokens += response.usage.prompt_tokens;
+      outputTokens += response.usage.completion_tokens;
       cachedTokens += response.usage.cached_tokens ?? 0;
     }
 
@@ -527,6 +535,9 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
       const response = await callApi(messages, []);
       if (response.usage) {
         totalTokens += response.usage.prompt_tokens + response.usage.completion_tokens;
+        inputTokens += response.usage.prompt_tokens;
+        outputTokens += response.usage.completion_tokens;
+        cachedTokens += response.usage.cached_tokens ?? 0;
       }
       apiCallCount++;
       finalText = response.choices?.[0]?.message?.content ?? '';
@@ -540,6 +551,8 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
     toolCallCount,
     apiCallCount,
     totalTokens,
+    inputTokens,
+    outputTokens,
     cachedTokens,
     durationMs: Date.now() - startTime,
     executedCommands,
@@ -548,6 +561,11 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
 
 /**
  * AgenticLoopResult → CliRunResult 변환
+ *
+ * costUsd is 0 by design: the loop cannot price tokens itself — codex-responses
+ * bills through a ChatGPT subscription (no per-token marginal cost) and a
+ * hardcoded price table would go stale. Adapters with real metering (openrouter)
+ * can overwrite costUsd downstream. Tokens and duration are real measurements. (INT-2508)
  */
 export function loopResultToCliResult(result: AgenticLoopResult): CliRunResult {
   return {
@@ -556,6 +574,14 @@ export function loopResultToCliResult(result: AgenticLoopResult): CliRunResult {
     stderr: '',
     durationMs: result.durationMs,
     executedCommands: result.executedCommands,
+    costInfo: {
+      costUsd: 0,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      cacheReadTokens: result.cachedTokens,
+      cacheCreationTokens: 0,
+      durationMs: result.durationMs,
+    },
   };
 }
 

--- a/src/adapters/base.test.ts
+++ b/src/adapters/base.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { extractStreamJsonError } from './base.js';
+
+// The claude CLI (--output-format stream-json) exits non-zero with an empty
+// stderr and reports the real failure in a stdout result event. (INT-2509)
+describe('extractStreamJsonError', () => {
+  it('extracts the error from a result event with is_error', () => {
+    const stdout = [
+      '{"type":"system","subtype":"init","cwd":"/tmp"}',
+      '{"type":"result","subtype":"error_during_execution","is_error":true,"result":"Rate limit reached for the five_hour window"}',
+    ].join('\n');
+    expect(extractStreamJsonError(stdout)).toBe('Rate limit reached for the five_hour window');
+  });
+
+  it('falls back to the subtype when result text is missing', () => {
+    const stdout = '{"type":"result","subtype":"error_max_turns","is_error":true}';
+    expect(extractStreamJsonError(stdout)).toBe('error_max_turns');
+  });
+
+  it('returns empty for a successful run', () => {
+    const stdout = [
+      '{"type":"system","subtype":"init"}',
+      '{"type":"result","subtype":"success","is_error":false,"result":"OK"}',
+    ].join('\n');
+    expect(extractStreamJsonError(stdout)).toBe('');
+  });
+
+  it('ignores non-JSON noise', () => {
+    expect(extractStreamJsonError('plain text output\nno json here')).toBe('');
+  });
+});

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -124,7 +124,11 @@ export async function spawnCli(
             return;
           }
 
-          reject(new Error(`${adapter.name} CLI failed with code ${code}: ${stderrSnippet.slice(0, 200)}`));
+          // stream-json CLIs (claude -p) leave stderr EMPTY and report the
+          // failure in a stdout result event — without this the daemon logs
+          // an unactionable "claude CLI failed with code 1: ". (INT-2509)
+          const detail = stderrSnippet.trim() || extractStreamJsonError(stdout) || '(no stderr)';
+          reject(new Error(`${adapter.name} CLI failed with code ${code}: ${detail.slice(0, 200)}`));
           return;
         }
 
@@ -143,4 +147,27 @@ export async function spawnCli(
       // Ignore cleanup errors
     }
   }
+}
+
+/**
+ * Pull the failure reason out of stream-json stdout. The claude CLI
+ * (--output-format stream-json) exits non-zero with an EMPTY stderr and puts
+ * the actual error in a `{"type":"result","is_error":true,...}` event —
+ * surface it so failures are actionable. Exported for tests. (INT-2509)
+ */
+export function extractStreamJsonError(stdout: string): string {
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.includes('"type":"result"')) continue;
+    try {
+      const ev = JSON.parse(trimmed);
+      if (ev?.type === 'result' && (ev.is_error || (ev.subtype && ev.subtype !== 'success'))) {
+        const reason = typeof ev.result === 'string' && ev.result.trim() ? ev.result : ev.subtype;
+        return String(reason ?? '').trim();
+      }
+    } catch {
+      // not a JSON line
+    }
+  }
+  return '';
 }

--- a/src/adapters/claude.test.ts
+++ b/src/adapters/claude.test.ts
@@ -27,3 +27,25 @@ describe('ClaudeCliAdapter.buildCommand', () => {
     expect(command).not.toContain('--mcp-config');
   });
 });
+
+describe('ClaudeCliAdapter.buildCommand model pinning (INT-2509)', () => {
+  it('pins --model to the adapter default when the caller omits model', () => {
+    // Omitting --model would run the user's PERSONAL default (can be the most
+    // expensive tier) — the planner path hits this because it drops claude-* ids.
+    const { command } = new ClaudeCliAdapter().buildCommand({
+      prompt: '/tmp/prompt.txt',
+      cwd: '/tmp/project',
+    });
+    expect(command).toContain('--model sonnet');
+  });
+
+  it('keeps an explicit model', () => {
+    const { command } = new ClaudeCliAdapter().buildCommand({
+      prompt: '/tmp/prompt.txt',
+      cwd: '/tmp/project',
+      model: 'opus',
+    });
+    expect(command).toContain('--model opus');
+    expect(command).not.toContain('--model sonnet');
+  });
+});

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -21,6 +21,13 @@ import { writeClaudeMcpConfig } from './memoryMcp.js';
 
 const execFileAsync = promisify(execFile);
 
+/**
+ * Version-agnostic model alias — the claude CLI resolves "sonnet" to the
+ * current Sonnet, so it never goes stale the way a pinned model id would.
+ * Single source for both getDefaultModel() and the buildCommand fallback. (INT-2509)
+ */
+const CLAUDE_DEFAULT_MODEL = 'sonnet';
+
 // Claude CLI Adapter
 
 export class ClaudeCliAdapter implements CliAdapter {
@@ -46,7 +53,10 @@ export class ClaudeCliAdapter implements CliAdapter {
   buildCommand(options: CliRunOptions): { command: string; args: string[] } {
     // options.prompt is the temp file path (set by spawnCli)
     const promptFile = options.prompt;
-    const modelFlag = options.model ? ` --model ${options.model}` : '';
+    // Always pin a model: omitting --model runs the user's PERSONAL default,
+    // which can be the most expensive tier (observed: planner calls landing on
+    // claude-fable-5 at ~$0.64 per trivial call). (INT-2509)
+    const modelFlag = ` --model ${options.model ?? CLAUDE_DEFAULT_MODEL}`;
     const maxTurnsFlag = options.maxTurns ? ` --max-turns ${options.maxTurns}` : '';
     // Register OpenSwarm's memory MCP server unless the caller needs an isolated run.
     // bypassPermissions auto-allows its tool when present.
@@ -57,12 +67,8 @@ export class ClaudeCliAdapter implements CliAdapter {
     return { command: cmd, args: [] };
   }
 
-  /**
-   * Version-agnostic alias — the claude CLI resolves "sonnet" to the current
-   * Sonnet, so it never goes stale the way a pinned model id would.
-   */
   async getDefaultModel(): Promise<string> {
-    return 'sonnet';
+    return CLAUDE_DEFAULT_MODEL;
   }
 
   parseWorkerOutput(raw: CliRunResult): WorkerResult {

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -16,6 +16,7 @@ import type {
 import { AuthProfileStore, ensureValidToken } from '../auth/index.js';
 import { runAgenticLoop, loopResultToCliResult, type ChatMessage, type AgenticLoopOptions } from './agenticLoop.js';
 import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
+import { formatCost } from '../support/costTracker.js';
 import type { ToolDefinition } from './tools.js';
 import { RateLimitError, rateLimitFromCodexHeaders } from './rateLimitError.js';
 
@@ -388,7 +389,9 @@ export class CodexResponsesAdapter implements CliAdapter {
         const pct = result.totalTokens > 0 ? Math.round((result.cachedTokens / result.totalTokens) * 100) : 0;
         options.onLog(`[Codex ${model}] ${result.apiCallCount} API calls, ${result.toolCallCount} tool uses, ${result.totalTokens} tokens (${result.cachedTokens} cached, ${pct}%)`);
       }
-      return loopResultToCliResult(result);
+      const cli = loopResultToCliResult(result);
+      if (cli.costInfo) cli.costInfo.model = model;
+      return cli;
     } catch (err) {
       // Rate-limit must propagate so the scheduler pauses (INT-1906).
       if (err instanceof RateLimitError) throw err;
@@ -501,11 +504,21 @@ export class CodexResponsesAdapter implements CliAdapter {
     if (raw.executedCommands && raw.executedCommands.length > 0) {
       result.commands = [...new Set([...result.commands, ...raw.executedCommands])].slice(0, 20);
     }
+    // Same tokens/duration visibility as the claude adapter (INT-2508).
+    if (raw.costInfo) {
+      console.log(`[Worker] Cost: ${formatCost(raw.costInfo)}`);
+      result.costInfo = raw.costInfo;
+    }
     return result;
   }
 
   parseReviewerOutput(raw: CliRunResult): ReviewResult {
-    return parseReviewerResult(raw.stdout);
+    const result = parseReviewerResult(raw.stdout);
+    if (raw.costInfo) {
+      console.log(`[Reviewer] Cost: ${formatCost(raw.costInfo)}`);
+      result.costInfo = raw.costInfo;
+    }
+    return result;
   }
 }
 

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -5,6 +5,7 @@
 
 import type { WorkerResult, ReviewResult } from '../agents/agentPair.js';
 import type { ToolDefinition } from './tools.js';
+import type { CostInfo } from '../support/costTracker.js';
 
 // Re-export for convenience
 export type { WorkerResult, ReviewResult };
@@ -27,6 +28,13 @@ export interface CliRunResult {
    * validation-evidence gate and reviewers see the real checks. (INT-2485)
    */
   executedCommands?: string[];
+  /**
+   * Token/duration usage measured by the adapter's own loop (codex-responses,
+   * gpt, …). parseWorkerOutput/parseReviewerOutput attach it to the stage result
+   * so the pipeline's per-stage cost logs and totals work on every provider,
+   * not just the claude CLI. costUsd stays 0 for subscription-billed providers. (INT-2508)
+   */
+  costInfo?: CostInfo;
 }
 
 /**

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -694,7 +694,8 @@ export class PairPipeline extends EventEmitter {
       const costInfo = (result as { costInfo?: CostInfo }).costInfo;
 
       if (this.config.verbose) {
-        this.emit('log', { line: `[verbose] Stage ${stage} completed in ${(stageResult.duration / 1000).toFixed(1)}s${costInfo ? ` | cost: $${costInfo.costUsd.toFixed(4)} (${costInfo.inputTokens}in/${costInfo.outputTokens}out)` : ''}` });
+        // formatCost omits the misleading "$0.0000" for zero-cost (subscription) providers (INT-2508)
+        this.emit('log', { line: `[verbose] Stage ${stage} completed in ${(stageResult.duration / 1000).toFixed(1)}s${costInfo ? ` | cost: ${formatCost(costInfo)}` : ''}` });
       }
       broadcastEvent({ type: 'pipeline:stage', data: {
         taskId: context.task.id, stage, status: 'complete',

--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -248,7 +248,12 @@ export async function runReviewer(options: ReviewerOptions): Promise<ReviewResul
     });
 
     // Parse result via adapter
-    return adapter.parseReviewerOutput(raw);
+    const parsedResult = adapter.parseReviewerOutput(raw);
+    // Backfill loop-measured usage for adapters that don't extract their own. (INT-2508)
+    if (raw.costInfo && !parsedResult.costInfo) {
+      parsedResult.costInfo = raw.costInfo;
+    }
+    return parsedResult;
   } catch (error) {
     // Rate limit errors must propagate so the scheduler can pause.
     if (error instanceof RateLimitError) throw error;

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -249,6 +249,13 @@ export async function runWorker(options: WorkerOptions): Promise<WorkerResult> {
     // Parse result via adapter
     const parsedResult = adapter.parseWorkerOutput(raw);
 
+    // Backfill usage measured by the adapter's own loop (codex-responses/gpt/
+    // openrouter/local) so per-stage cost logs work on every provider; adapters
+    // that extract their own costInfo (claude) keep theirs. (INT-2508)
+    if (raw.costInfo && !parsedResult.costInfo) {
+      parsedResult.costInfo = raw.costInfo;
+    }
+
     // Git diff is the source of truth for "did real work happen" — independent of
     // whether the model emitted a well-formed JSON success block. LLMs are weak at
     // structured output, so we never let a missing/malformed JSON block alone mark

--- a/src/support/costTracker.test.ts
+++ b/src/support/costTracker.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { formatCost, aggregateCosts, type CostInfo } from './costTracker.js';
+
+const base: CostInfo = {
+  costUsd: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  durationMs: 0,
+};
+
+describe('formatCost (INT-2508)', () => {
+  it('includes the dollar amount for API-billed runs', () => {
+    const s = formatCost({ ...base, costUsd: 0.0432, inputTokens: 1200, outputTokens: 800, durationMs: 12300 });
+    expect(s).toBe('$0.0432 | 1.2k in / 800 out | 12.3s');
+  });
+
+  it('omits the misleading $0.0000 for subscription-billed runs', () => {
+    const s = formatCost({ ...base, inputTokens: 15000, outputTokens: 2000, durationMs: 45200 });
+    expect(s).toBe('15.0k in / 2.0k out | 45.2s');
+    expect(s).not.toContain('$');
+  });
+
+  it('shows cache-read tokens when present', () => {
+    const s = formatCost({ ...base, inputTokens: 20000, outputTokens: 1000, cacheReadTokens: 15100, durationMs: 5000 });
+    expect(s).toBe('20.0k in / 1.0k out (15.1k cached) | 5.0s');
+  });
+});
+
+describe('aggregateCosts', () => {
+  it('sums fields and skips undefined entries', () => {
+    const total = aggregateCosts([
+      { ...base, costUsd: 0.01, inputTokens: 100, outputTokens: 10, durationMs: 1000 },
+      undefined,
+      { ...base, costUsd: 0.02, inputTokens: 200, outputTokens: 20, cacheReadTokens: 50, durationMs: 2000 },
+    ]);
+    expect(total.costUsd).toBeCloseTo(0.03);
+    expect(total.inputTokens).toBe(300);
+    expect(total.outputTokens).toBe(30);
+    expect(total.cacheReadTokens).toBe(50);
+    expect(total.durationMs).toBe(3000);
+  });
+});

--- a/src/support/costTracker.ts
+++ b/src/support/costTracker.ts
@@ -119,11 +119,14 @@ function formatTokens(n: number): string {
 
 /**
  * Format CostInfo as a human-readable log string
- * Example: "$0.0432 | 1.2k in / 0.8k out | 12.3s"
+ * Example: "$0.0432 | 1.2k in / 0.8k out (15.1k cached) | 12.3s"
+ * Subscription-billed providers (codex-responses) report costUsd 0 — the
+ * misleading "$0.0000" is omitted and only real measurements remain. (INT-2508)
  */
 export function formatCost(cost: CostInfo): string {
-  const usd = `$${cost.costUsd.toFixed(4)}`;
+  const usd = cost.costUsd > 0 ? `$${cost.costUsd.toFixed(4)} | ` : '';
   const tokens = `${formatTokens(cost.inputTokens)} in / ${formatTokens(cost.outputTokens)} out`;
+  const cached = cost.cacheReadTokens > 0 ? ` (${formatTokens(cost.cacheReadTokens)} cached)` : '';
   const duration = `${(cost.durationMs / 1000).toFixed(1)}s`;
-  return `${usd} | ${tokens} | ${duration}`;
+  return `${usd}${tokens}${cached} | ${duration}`;
 }


### PR DESCRIPTION
## Summary
- **INT-2508**: codex-responses (and every agentic-loop adapter) now reports per-stage tokens/duration like the claude adapter — `AgenticLoopResult` splits input/output tokens, `CliRunResult.costInfo` carries them, worker/reviewer call sites backfill generically, `[Worker]/[Reviewer] Cost:` logs added. `formatCost` omits the misleading $0.0000 for subscription-billed runs and shows cached tokens.
- **INT-2509**: claude `buildCommand` pins `--model sonnet` when the caller omits a model (planner path was silently running the user's personal default — measured claude-fable-5 at ~$0.64/trivial call); `spawnCli` failure messages now include the stream-json result-event reason instead of the always-empty stderr.

## Verification
- `tsc --noEmit` clean, full vitest **142 files / 1651 passed** (new: costTracker.test.ts, base.test.ts, buildCommand + loopResultToCliResult cases)
- `openswarm review` revise finding (verbose stage log reintroducing $0.0000) fixed by reusing formatCost; suggestions applied (comment accuracy, CLAUDE_DEFAULT_MODEL single source, split commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)