### PR TITLE
fix(agentic-loop): preserve typed RateLimitError — codex usage limit no longer faked as 55% HALT → false STUCK (INT-2519)

### DIFF
--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -8,7 +8,7 @@
 
 import { TOOL_DEFINITIONS, APPLY_PATCH_TOOL, executeToolCalls, createReadCache, validatePath, type ToolCall, type ToolResult, type ToolDefinition } from './tools.js';
 import { WEB_TOOL_DEFINITIONS } from './webTools.js';
-import { detectRateLimit } from './rateLimitError.js';
+import { detectRateLimit, RateLimitError } from './rateLimitError.js';
 import { parseSearchReplaceBlocks, applyEditBlock, type EditFormat } from '../support/editParser.js';
 import type { CliRunResult } from './types.js';
 
@@ -317,12 +317,23 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
         finalText = finalText || '(stopped)';
         break;
       }
-      const msg = err instanceof Error ? err.message : String(err);
       // A 429/usage-limit raised by the in-process API caller (gpt/local/
       // openrouter/codex-responses) would otherwise be swallowed into finalText
       // here and returned as a normal result — the scheduler never learns it was
-      // rate-limited. Re-throw it as a typed RateLimitError so it propagates up to
-      // the pipeline, which pauses instead of failing/spamming. (INT-1906)
+      // rate-limited. Re-throw it so it propagates up to the pipeline, which
+      // pauses instead of failing/spamming. (INT-1906)
+      //
+      // The caller already throws a TYPED RateLimitError (codexResponses 429 →
+      // rateLimitFromCodexHeaders). Preserve the type FIRST: its human-readable
+      // message ("Codex 100% used of 300min window — resets at …") does NOT
+      // contain the raw tokens detectRateLimit scans for, so stringifying it
+      // silently downgraded a rate limit into a 2s empty "success" → 55%
+      // confidence HALT → false STUCK. (INT-2519)
+      if (err instanceof RateLimitError) {
+        onLog?.(`■ ${err.message}`);
+        throw err;
+      }
+      const msg = err instanceof Error ? err.message : String(err);
       const rl = detectRateLimit('', msg);
       if (rl) {
         onLog?.(`■ ${rl.message}`);
@@ -542,7 +553,15 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
       apiCallCount++;
       finalText = response.choices?.[0]?.message?.content ?? '';
     } catch (err) {
-      onLog?.(`✖ Final answer turn failed: ${err instanceof Error ? err.message : String(err)}`);
+      // A rate limit on the salvage call must still propagate — swallowing it
+      // here would return an empty result the scheduler reads as a plain failure
+      // instead of pausing. Mirror the main call path: preserve a typed
+      // RateLimitError, then re-detect an untyped one from the message. (INT-2519)
+      if (err instanceof RateLimitError) throw err;
+      const msg = err instanceof Error ? err.message : String(err);
+      const rl = detectRateLimit('', msg);
+      if (rl) throw rl;
+      onLog?.(`✖ Final answer turn failed: ${msg}`);
     }
   }
 

--- a/src/adapters/rateLimitError.test.ts
+++ b/src/adapters/rateLimitError.test.ts
@@ -34,6 +34,18 @@ describe('detectRateLimit (INT-1906)', () => {
     expect(detectRateLimit('listening on port 4290; processed 429 rows', '')).toBeNull();
   });
 
+  it('detects the human-readable Codex usage-limit phrasing (INT-2519)', () => {
+    // rateLimitFromCodexHeaders output that reached a CLI/string path.
+    expect(detectRateLimit('API error: Codex 100% used of 300min window — resets at 2026-06-30T12:00:00Z', ''))
+      .toBeInstanceOf(RateLimitError);
+    expect(detectRateLimit('', 'Codex usage limit reached — resets at …')).toBeInstanceOf(RateLimitError);
+    expect(detectRateLimit('overageStatus: out_of_credits', '')).toBeInstanceOf(RateLimitError);
+  });
+
+  it('does not treat ordinary "used"/"window" wording as a rate limit (no false positive)', () => {
+    expect(detectRateLimit('the cache window is 5min; 80% used of the disk', '')).toBeNull();
+  });
+
   it('scans both stdout and stderr (signal split across streams)', () => {
     const err = detectRateLimit('partial output', 'error: usage_limit_reached "resets_at": 1782343811');
     expect(err).toBeInstanceOf(RateLimitError);
@@ -58,6 +70,44 @@ describe('runAgenticLoop rate-limit propagation (INT-1906 blocker)', () => {
     const callApi = async () => { throw new Error('500 Internal Server Error'); };
     const res = await runAgenticLoop({ prompt: 'x', cwd: process.cwd(), model: 't', callApi, webTools: false, maxTurns: 2 });
     expect(res.text).toContain('API error');
+  });
+
+  it('preserves a TYPED RateLimitError whose human message detectRateLimit would miss (INT-2519)', async () => {
+    // codexResponses throws rateLimitFromCodexHeaders → a typed RateLimitError whose
+    // message ("Codex 100% used of 300min window — resets at …") lacks the raw tokens
+    // detectRateLimit scans for. Before the instanceof guard this was stringified,
+    // failed re-detection, and became a 2s empty "success" → 55% HALT → false STUCK.
+    const callApi = async () => {
+      throw new RateLimitError(1782824950, 'Codex 100% used of 300min window — resets at 2026-06-30T12:00:00.000Z', 100, 300);
+    };
+    await expect(
+      runAgenticLoop({ prompt: 'x', cwd: process.cwd(), model: 't', callApi, webTools: false, maxTurns: 2 }),
+    ).rejects.toBeInstanceOf(RateLimitError);
+  });
+
+  it('propagates an UNTYPED rate limit thrown from the final-answer salvage turn (INT-2519)', async () => {
+    // Drive the loop to exhaust maxTurns with no final text (tool calls only), so the
+    // final-answer salvage call fires. That call throws an untyped 429 — it must
+    // propagate, not be swallowed like an ordinary error.
+    let n = 0;
+    const callApi = async (_messages: unknown, tools: unknown[]) => {
+      if (Array.isArray(tools) && tools.length === 0) {
+        // salvage call (tools stripped) → untyped rate-limit error
+        throw new Error('HTTP 429 — rate limit exceeded, retry later');
+      }
+      n += 1;
+      return {
+        choices: [{
+          message: { role: 'assistant', content: null, tool_calls: [
+            { id: `c${n}`, type: 'function' as const, function: { name: 'read_file', arguments: JSON.stringify({ path: `nope${n}.ts` }) } },
+          ] },
+          finish_reason: 'tool_calls',
+        }],
+      };
+    };
+    await expect(
+      runAgenticLoop({ prompt: 'x', cwd: process.cwd(), model: 't', callApi: callApi as never, webTools: false, maxTurns: 2 }),
+    ).rejects.toBeInstanceOf(RateLimitError);
   });
 });
 

--- a/src/adapters/rateLimitError.ts
+++ b/src/adapters/rateLimitError.ts
@@ -49,11 +49,20 @@ export function rateLimitFromCodexHeaders(headers: Headers, body: string): RateL
 export function detectRateLimit(stdout: string, stderr: string): RateLimitError | null {
   const combined = stdout + '\n' + stderr;
 
+  const lower = combined.toLowerCase();
   const hasSignal =
     combined.includes('usage_limit_reached') ||
     combined.includes('rate_limit_exceeded') ||
     combined.includes('"rate_limit_error"') ||
-    (combined.includes('429') && /rate.{0,15}limit/i.test(combined));
+    (combined.includes('429') && /rate.{0,15}limit/i.test(combined)) ||
+    // Human-readable Codex usage-limit phrasing (rateLimitFromCodexHeaders output:
+    // "Codex 100% used of 300min window — resets at …" / "Codex usage limit reached").
+    // Stringifying a typed RateLimitError strips the raw tokens above, so a CLI /
+    // string path must still recognise these. (INT-2519)
+    lower.includes('usage limit reached') ||
+    /\d+%\s*used\s+of\s+\d+min\s+window/.test(lower) ||
+    lower.includes('out of credits') ||
+    lower.includes('out_of_credits');
 
   if (!hasSignal) return null;
 


### PR DESCRIPTION
## Summary
Hard-cohort STUCK investigation found workers **'completing' in ~2s with success=true and 0 files**, summary `API error: Codex 100% used of 300min window`. 

**Root cause**: `codexResponses` throws a **typed** `RateLimitError` on 429, but the agentic-loop catch only re-detected rate limits by scanning the **stringified message** — and the human-readable codex message (`Codex N% used of Mmin window — resets at …`) contains none of the raw tokens (`usage_limit_reached`/`429`) `detectRateLimit` scans for. So a real usage limit was downgraded to `finalText='API error: …'` → parsed as an empty success → `calculateConfidence` scored it **55%** (no files −25, short output −20) → confidence HALT → **counted toward STUCK → false STUCK**. Regression of the INT-2010/1906 infra-error-vs-STUCK separation.

- agentic-loop **main + final-answer** catches: re-throw a typed `RateLimitError` first, then string-detect (both paths identical now)
- `detectRateLimit` also matches human-readable codex phrasing (`N% used of Mmin window`, `usage limit reached`, `out of credits`) for CLI/string paths, with a no-false-positive guard against ordinary `used`/`window` prose
- tests: typed propagation, untyped 429 on the salvage turn, human-readable detection, no-false-positive

## Verification
- `tsc --noEmit` clean, full vitest **1664 passed**
- `openswarm review`: caught an incomplete salvage-path fix (typed-only, swallowed untyped 429) → fixed → re-review **APPROVE**

🤖 Generated with [Claude Code](https://claude.com/claude-code)