### PR TITLE
refactor(adapters): consolidate provider usage-limit detection + close per-provider gaps (INT-2520)

### DIFF
--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -9,6 +9,7 @@
 import { TOOL_DEFINITIONS, APPLY_PATCH_TOOL, executeToolCalls, createReadCache, validatePath, type ToolCall, type ToolResult, type ToolDefinition } from './tools.js';
 import { WEB_TOOL_DEFINITIONS } from './webTools.js';
 import { detectRateLimit, RateLimitError } from './rateLimitError.js';
+import { isInfraError } from './errorClassification.js';
 import { parseSearchReplaceBlocks, applyEditBlock, type EditFormat } from '../support/editParser.js';
 import type { CliRunResult } from './types.js';
 
@@ -339,6 +340,16 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
         onLog?.(`■ ${rl.message}`);
         throw rl;
       }
+      // An infra/capacity failure (connection refused, 5xx, model not loaded,
+      // socket drop) must ALSO propagate — the CLI path re-throws these via
+      // worker.ts/reviewer.ts's isInfraError gate, but in-process adapters never
+      // reach that gate because this catch used to swallow everything into a fake
+      // exitCode:0 "success" → reviewer rejects the empty diff → false STUCK.
+      // Re-throw here so it is classified as infra_error (backoff, not STUCK). (INT-2520)
+      if (isInfraError(err)) {
+        onLog?.(`✖ Infra error: ${msg}`);
+        throw err;
+      }
       onLog?.(`✖ API error: ${msg}`);
       finalText = `API error: ${msg}`;
       break;
@@ -561,6 +572,7 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
       const msg = err instanceof Error ? err.message : String(err);
       const rl = detectRateLimit('', msg);
       if (rl) throw rl;
+      if (isInfraError(err)) throw err; // infra on the salvage call → infra_error, not fake result (INT-2520)
       onLog?.(`✖ Final answer turn failed: ${msg}`);
     }
   }

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -19,6 +19,7 @@ import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
 import { formatCost } from '../support/costTracker.js';
 import type { ToolDefinition } from './tools.js';
 import { RateLimitError, rateLimitFromCodexHeaders } from './rateLimitError.js';
+import { isInfraError } from './errorClassification.js';
 
 import { getCodexModelIds } from './codexModels.js';
 
@@ -393,8 +394,10 @@ export class CodexResponsesAdapter implements CliAdapter {
       if (cli.costInfo) cli.costInfo.model = model;
       return cli;
     } catch (err) {
-      // Rate-limit must propagate so the scheduler pauses (INT-1906).
+      // Rate-limit AND infra/capacity errors must propagate (pause / infra_error),
+      // not be buried in a fake failed result the worker reads as an empty success. (INT-1906, INT-2520)
       if (err instanceof RateLimitError) throw err;
+      if (isInfraError(err)) throw err;
       return {
         exitCode: 1,
         stdout: '',

--- a/src/adapters/errorClassification.test.ts
+++ b/src/adapters/errorClassification.test.ts
@@ -29,6 +29,33 @@ describe('isInfraError (INT-2010)', () => {
     expect(isInfraError(null)).toBe(false);
     expect(isInfraError('')).toBe(false);
   });
+
+  it('recognises undici "fetch failed" via error.cause.code (INT-2520)', () => {
+    // undici surfaces connection failures as `TypeError: fetch failed` with the
+    // real code on `.cause.code` — the top-level message alone would be missed.
+    const refused = Object.assign(new TypeError('fetch failed'), { cause: { code: 'ECONNREFUSED' } });
+    expect(isInfraError(refused)).toBe(true);
+    const undErr = Object.assign(new TypeError('fetch failed'), { cause: { code: 'UND_ERR_SOCKET' } });
+    expect(isInfraError(undErr)).toBe(true);
+    // "fetch failed" alone is also treated as infra (server unreachable).
+    expect(isInfraError(new TypeError('fetch failed'))).toBe(true);
+  });
+
+  it('recognises local server capacity failures (5xx / loading / overloaded) (INT-2520)', () => {
+    expect(isInfraError(new Error('Local API error (503): model is loading'))).toBe(true);
+    expect(isInfraError(new Error('Local API error (502): bad gateway'))).toBe(true);
+    expect(isInfraError(new Error('Server overloaded, try again'))).toBe(true);
+  });
+
+  it('does NOT flag a bare 5xx number in task/reviewer prose (needs adapter/HTTP context) (INT-2520)', () => {
+    expect(isInfraError(new Error('assertion failed: expected 503 records, got 502'))).toBe(false);
+    expect(isInfraError(new Error('the retry loop caps at 504 attempts'))).toBe(false);
+    expect(isInfraError(new Error('validation error (503) is the wrong code to return here'))).toBe(false);
+    // …but the same code inside an adapter error wrapper IS infra:
+    expect(isInfraError(new Error('OpenAI API error (503): upstream'))).toBe(true);
+    expect(isInfraError(new Error('Codex responses error (502): bad gateway'))).toBe(true);
+    expect(isInfraError(new Error('HTTP 504 gateway timeout'))).toBe(true);
+  });
 });
 
 describe('codexMcpAuthHint (INT-2408)', () => {

--- a/src/adapters/errorClassification.ts
+++ b/src/adapters/errorClassification.ts
@@ -33,6 +33,8 @@ const INFRA_ERROR_PATTERNS = [
   'enotfound',
   'socket hang up',
   'network error',
+  'fetch failed', // undici: the real code hides in error.cause.code (checked below)
+  'terminated', // undici mid-stream socket drop
   'unauthorized',
   'not authenticated',
   'authentication failed',
@@ -40,6 +42,28 @@ const INFRA_ERROR_PATTERNS = [
   'permission denied',
   '401',
   '403',
+  // Server-side capacity / gateway failures — the model server was reachable but
+  // could not serve (model loading, overloaded, upstream down). Not a verdict on
+  // the task. 429/402 are handled as RateLimitError, not here. Use unambiguous
+  // reason phrases (not bare "503") so task text like "expected 503 rows" is not
+  // mis-flagged; the numeric-status forms go through INFRA_ERROR_REGEXES. (INT-2520)
+  'service unavailable',
+  'bad gateway',
+  'gateway timeout',
+  'overloaded',
+  'model is loading',
+  'model not loaded',
+];
+
+// Numeric HTTP status matched ONLY with surrounding context (an adapter error
+// wrapper like "Local API error (503)", or "HTTP 503" / "status 503"), so a bare
+// number in task/reviewer prose is not mistaken for an infra failure. (INT-2520)
+const INFRA_ERROR_REGEXES: readonly RegExp[] = [
+  // Adapter error wrappers only ("OpenAI API error (503)", "Local API error (502)",
+  // "Codex responses error (504)") — NOT a bare "(503)" in prose, so a task/reviewer
+  // message like "expected (503)" is not mis-flagged.
+  /(?:api|responses) error \((50[234])\)/,
+  /\b(?:http|status|code)\s*[:=]?\s*(50[234])\b/,
 ];
 
 /**
@@ -50,8 +74,17 @@ const INFRA_ERROR_PATTERNS = [
  */
 export function isInfraError(error: unknown): boolean {
   const msg = (error instanceof Error ? error.message : String(error ?? '')).toLowerCase();
+  // undici wraps connection failures as `TypeError: fetch failed` with the real
+  // code (ECONNREFUSED / ECONNRESET / UND_ERR_*) on `error.cause.code` — the
+  // top-level message alone would be classed a task failure. (INT-2520)
+  const causeCode =
+    error && typeof error === 'object' && 'cause' in error
+      ? String((error as { cause?: { code?: unknown } }).cause?.code ?? '').toLowerCase()
+      : '';
+  if (causeCode && INFRA_ERROR_PATTERNS.some((p) => causeCode.includes(p))) return true;
+  if (causeCode.startsWith('und_err')) return true; // any undici transport error
   if (!msg) return false;
-  return INFRA_ERROR_PATTERNS.some((p) => msg.includes(p));
+  return INFRA_ERROR_PATTERNS.some((p) => msg.includes(p)) || INFRA_ERROR_REGEXES.some((r) => r.test(msg));
 }
 
 /**

--- a/src/adapters/gpt.ts
+++ b/src/adapters/gpt.ts
@@ -18,7 +18,8 @@ import { resolveMcpTools } from '../mcp/mcpClient.js';
 import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
 import { consumeChatCompletionsStream } from './chatStream.js';
 import type { ToolDefinition } from './tools.js';
-import { RateLimitError } from './rateLimitError.js';
+import { RateLimitError, rateLimitFromHttpResponse } from './rateLimitError.js';
+import { isInfraError } from './errorClassification.js';
 
 const OPENAI_API_BASE = 'https://api.openai.com/v1';
 const DEFAULT_MODEL = 'gpt-4o';
@@ -109,9 +110,11 @@ export class GptCliAdapter implements CliAdapter {
       }
       return loopResultToCliResult(result);
     } catch (err) {
-      // Rate-limit must propagate so the scheduler pauses (INT-1906) — don't bury
-      // it in a failed CliRunResult.
+      // Rate-limit AND infra/capacity errors must propagate so the pipeline
+      // classifies them (pause / infra_error backoff) instead of burying them in a
+      // fake failed CliRunResult that the worker reads as an empty success → STUCK. (INT-1906, INT-2520)
       if (err instanceof RateLimitError) throw err;
+      if (isInfraError(err)) throw err;
       return {
         exitCode: 1,
         stdout: '',
@@ -168,6 +171,12 @@ export class GptCliAdapter implements CliAdapter {
             token = await refreshAndRetry(store);
             return doCall(token);
           }
+
+          // Usage/rate limit → TYPED RateLimitError at the source so the scheduler
+          // pauses instead of the loop swallowing a 429 into a fake empty success.
+          // Covers 429 rate_limit_exceeded AND 429 insufficient_quota. (INT-2520)
+          const rl = rateLimitFromHttpResponse(res.status, res.headers, errText);
+          if (rl) throw rl;
 
           throw new Error(`OpenAI API error (${res.status}): ${errText.slice(0, 500)}`);
         }

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -18,6 +18,7 @@ import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
 import { consumeChatCompletionsStream } from './chatStream.js';
 import type { ToolDefinition } from './tools.js';
 import { RateLimitError } from './rateLimitError.js';
+import { isInfraError } from './errorClassification.js';
 
 // 로컬 프로바이더 기본 URL 후보 (우선순위 순)
 const DEFAULT_ENDPOINTS = [
@@ -188,8 +189,12 @@ export class LocalModelAdapter implements CliAdapter {
       }
       return loopResultToCliResult(result);
     } catch (err) {
-      // Rate-limit must propagate so the scheduler pauses (INT-1906).
+      // Rate-limit AND infra/capacity errors (connection refused, 5xx, model not
+      // loaded, socket drop) must propagate so the pipeline classifies them
+      // (pause / infra_error) instead of a fake empty success → STUCK. Local
+      // servers produce these most often. (INT-1906, INT-2520)
       if (err instanceof RateLimitError) throw err;
+      if (isInfraError(err)) throw err;
       const message = err instanceof Error ? err.message : String(err);
       const isTimeout = message.includes('abort') || message.includes('timeout');
 

--- a/src/adapters/openrouter.test.ts
+++ b/src/adapters/openrouter.test.ts
@@ -8,6 +8,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { OpenRouterCliAdapter, createApiCaller, applyPromptCaching } from './openrouter.js';
+import { RateLimitError } from './rateLimitError.js';
 import { getAdapter } from './index.js';
 import type { ChatMessage } from './agenticLoop.js';
 
@@ -21,6 +22,27 @@ describe('OpenRouterCliAdapter', () => {
     expect(adapter.name).toBe('openrouter');
     expect(adapter.capabilities.supportsModelSelection).toBe(true);
     expect(adapter.capabilities.supportsJsonOutput).toBe(true);
+  });
+
+  it('run() REJECTS (does not bury as exitCode:1) on an infra fetch failure — INT-2520', async () => {
+    // The run() catch must re-throw infra errors just like RateLimitError, so the
+    // pipeline classifies infra_error instead of the worker reading an empty
+    // exitCode:1 result as a false success → STUCK.
+    const prevKey = process.env.OPENROUTER_API_KEY;
+    process.env.OPENROUTER_API_KEY = 'sk-or-test';
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw Object.assign(new TypeError('fetch failed'), { cause: { code: 'ECONNREFUSED' } });
+    }));
+    try {
+      const adapter = new OpenRouterCliAdapter();
+      await expect(adapter.run({
+        prompt: 'x', cwd: process.cwd(), model: 'openai/gpt-4o',
+        webTools: false, memoryTools: false, mcpTools: [], enableTools: false, maxTurns: 1,
+      } as never)).rejects.toThrow(/fetch failed/);
+    } finally {
+      if (prevKey === undefined) delete process.env.OPENROUTER_API_KEY;
+      else process.env.OPENROUTER_API_KEY = prevKey;
+    }
   });
 
   it('reports unavailable when no profile is stored', async () => {
@@ -177,15 +199,30 @@ describe('OpenRouterCliAdapter', () => {
     expect(out).toEqual(msgs);
   });
 
-  it('throws on non-2xx responses with status code in the error message', async () => {
+  it('throws a generic error (with status code) on an ordinary non-2xx', async () => {
     const fetchMock = vi.fn(async () =>
-      new Response('rate limited', { status: 429 }),
+      new Response('upstream exploded', { status: 500 }),
     );
     vi.stubGlobal('fetch', fetchMock);
 
     const callApi = createApiCaller('sk-or-test-key', 'openai/gpt-4o');
     await expect(
       callApi([{ role: 'user', content: 'x' }], []),
-    ).rejects.toThrow(/OpenRouter API error \(429\)/);
+    ).rejects.toThrow(/OpenRouter API error \(500\)/);
+  });
+
+  it('throws a typed RateLimitError on 429 (rate limit) — INT-2520', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('Rate limit exceeded', { status: 429 })));
+    const callApi = createApiCaller('sk-or-test-key', 'openai/gpt-4o');
+    await expect(callApi([{ role: 'user', content: 'x' }], [])).rejects.toBeInstanceOf(RateLimitError);
+  });
+
+  it('throws a typed RateLimitError on 402 out-of-credits — INT-2520', async () => {
+    // OpenRouter signals out-of-credits with 402, not 429.
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ error: { code: 402, message: 'Insufficient credits. Add more to continue.' } }), { status: 402 }),
+    ));
+    const callApi = createApiCaller('sk-or-test-key', 'openai/gpt-4o');
+    await expect(callApi([{ role: 'user', content: 'x' }], [])).rejects.toBeInstanceOf(RateLimitError);
   });
 });

--- a/src/adapters/openrouter.ts
+++ b/src/adapters/openrouter.ts
@@ -21,7 +21,8 @@ import {
 } from './agenticLoop.js';
 import { resolveMcpTools } from '../mcp/mcpClient.js';
 import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
-import { RateLimitError } from './rateLimitError.js';
+import { RateLimitError, rateLimitFromHttpResponse } from './rateLimitError.js';
+import { isInfraError } from './errorClassification.js';
 import { consumeChatCompletionsStream } from './chatStream.js';
 import type { ToolDefinition } from './tools.js';
 
@@ -128,8 +129,10 @@ export class OpenRouterCliAdapter implements CliAdapter {
       );
       return loopResultToCliResult(result);
     } catch (err) {
-      // Rate-limit must propagate so the scheduler pauses (INT-1906).
+      // Rate-limit AND infra/capacity errors must propagate (pause / infra_error),
+      // not be buried in a fake failed result the worker reads as an empty success. (INT-1906, INT-2520)
       if (err instanceof RateLimitError) throw err;
+      if (isInfraError(err)) throw err;
       return {
         exitCode: 1,
         stdout: '',
@@ -202,6 +205,12 @@ export function createApiCaller(apiKey: string, model: string, opts: ApiCallerOp
 
     if (!res.ok) {
       const errText = await res.text().catch(() => '');
+      // OpenRouter signals out-of-credits with HTTP 402 "Insufficient credits"
+      // (NOT 429) and rate limits with 429. Throw a TYPED RateLimitError at the
+      // source so both pause the scheduler instead of the loop swallowing them
+      // into a fake empty success → false STUCK. (INT-2520)
+      const rl = rateLimitFromHttpResponse(res.status, res.headers, errText);
+      if (rl) throw rl;
       throw new Error(`OpenRouter API error (${res.status}): ${errText.slice(0, 500)}`);
     }
 

--- a/src/adapters/rateLimitError.test.ts
+++ b/src/adapters/rateLimitError.test.ts
@@ -1,6 +1,67 @@
 import { describe, it, expect } from 'vitest';
-import { detectRateLimit, rateLimitFromCodexHeaders, RateLimitError } from './rateLimitError.js';
+import { detectRateLimit, rateLimitFromCodexHeaders, rateLimitFromHttpResponse, matchesRateLimitMessage, RateLimitError } from './rateLimitError.js';
 import { runAgenticLoop } from './agenticLoop.js';
+
+// Every provider's REAL usage/rate-limit wire string must be recognised (audit
+// INT-2520). Grounded in actual observed output, not invented. A missed limit
+// becomes a false STUCK (in-process) or loses the scheduler pause (CLI).
+describe('per-provider usage-limit recognition (INT-2520 audit)', () => {
+  const REAL_LIMIT_OUTPUTS: Array<[string, string]> = [
+    ['codex CLI', `{"type":"error","message":"You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 1:20 PM."}`],
+    ['claude CLI (human phrase)', 'claude CLI failed with code 1: Limit reached · resets 8pm (Asia/Seoul) · add funds to continue with extra usage'],
+    ['claude rate_limit_event', '{"type":"rate_limit_event","rate_limit_info":{"overageStatus":"rejected","overageDisabledReason":"out_of_credits"}}'],
+    ['codex-responses header phrase', 'API error: Codex 100% used of 300min window — resets at 2026-06-30T12:00:00Z'],
+    ['OpenAI 429 rate_limit_exceeded', '{"error":{"code":"rate_limit_exceeded","message":"Rate limit reached for gpt-5 …"}}'],
+    ['OpenAI 429 insufficient_quota', '{"error":{"type":"insufficient_quota","message":"You exceeded your current quota, please check your plan and billing details."}}'],
+    ['OpenRouter 402 insufficient credits', '{"error":{"code":402,"message":"Insufficient credits. Add more to continue."}}'],
+    ['HTTP 429 too many requests (local)', 'Local API error (429): Too Many Requests'],
+  ];
+  for (const [name, output] of REAL_LIMIT_OUTPUTS) {
+    it(`detects: ${name}`, () => {
+      expect(matchesRateLimitMessage(output)).toBe(true);
+      expect(detectRateLimit(output, '')).toBeInstanceOf(RateLimitError);
+    });
+  }
+
+  it('does NOT false-positive on ordinary prose that mentions these words', () => {
+    // A worker's own output about a rate-limit / credits / usage feature.
+    const benign = [
+      'Added a usage dashboard; the plan limit is configurable per tenant.',
+      'Implemented credit purchase flow and out-of-stock handling.',
+      'The cache window is 5min; processed 429 rows in the batch.',
+      'Refactored rateLimiter.ts to reset the counter each window.',
+    ];
+    for (const b of benign) {
+      expect(matchesRateLimitMessage(b)).toBe(false);
+      expect(detectRateLimit(b, '')).toBeNull();
+    }
+  });
+});
+
+describe('rateLimitFromHttpResponse (INT-2520)', () => {
+  it('429 → RateLimitError regardless of body wording', () => {
+    expect(rateLimitFromHttpResponse(429, new Headers(), 'server busy')).toBeInstanceOf(RateLimitError);
+  });
+  it('402 → RateLimitError (openrouter out-of-credits)', () => {
+    expect(rateLimitFromHttpResponse(402, new Headers(), 'Insufficient credits')).toBeInstanceOf(RateLimitError);
+  });
+  it('parses Retry-After (seconds) into resetsAt', () => {
+    const err = rateLimitFromHttpResponse(429, new Headers({ 'retry-after': '120' }), '');
+    expect(err?.resetsAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+  it('ignores OpenAI duration-style x-ratelimit-reset-* (not epoch) — no 1970 timestamp (INT-2520 review)', () => {
+    // "1s"/"6ms" are durations; parseInt-ing them as epoch would give resetsAt≈1.
+    const err = rateLimitFromHttpResponse(429, new Headers({ 'x-ratelimit-reset-requests': '1s', 'x-ratelimit-reset-tokens': '6ms' }), '');
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err?.resetsAt).toBeUndefined(); // falls back to the safe 60s default downstream
+  });
+  it('non-limit status with a quota body still fires (e.g. 400 insufficient_quota)', () => {
+    expect(rateLimitFromHttpResponse(400, new Headers(), '{"code":"insufficient_quota"}')).toBeInstanceOf(RateLimitError);
+  });
+  it('ordinary 500 with no quota wording → null', () => {
+    expect(rateLimitFromHttpResponse(500, new Headers(), 'internal error')).toBeNull();
+  });
+});
 
 describe('detectRateLimit (INT-1906)', () => {
   it('detects a Codex usage_limit_reached payload and parses resets_at', () => {
@@ -66,8 +127,20 @@ describe('runAgenticLoop rate-limit propagation (INT-1906 blocker)', () => {
     ).rejects.toBeInstanceOf(RateLimitError);
   });
 
-  it('does NOT re-throw an ordinary (non-rate-limit) API error', async () => {
-    const callApi = async () => { throw new Error('500 Internal Server Error'); };
+  it('re-throws an INFRA error (undici fetch failed) instead of a fake empty success (INT-2520)', async () => {
+    // Local/in-process adapters used to have a connection-refused swallowed into a
+    // finalText='API error…' → exitCode:0 fake success → reviewer reject → STUCK.
+    // It must now propagate so the pipeline classifies it infra_error (not STUCK).
+    const callApi = async () => {
+      throw Object.assign(new TypeError('fetch failed'), { cause: { code: 'ECONNREFUSED' } });
+    };
+    await expect(
+      runAgenticLoop({ prompt: 'x', cwd: process.cwd(), model: 't', callApi, webTools: false, maxTurns: 2 }),
+    ).rejects.toThrow(/fetch failed/);
+  });
+
+  it('does NOT re-throw an ordinary (non-rate-limit, non-infra) API error', async () => {
+    const callApi = async () => { throw new Error('the model returned malformed JSON'); };
     const res = await runAgenticLoop({ prompt: 'x', cwd: process.cwd(), model: 't', callApi, webTools: false, maxTurns: 2 });
     expect(res.text).toContain('API error');
   });

--- a/src/adapters/rateLimitError.ts
+++ b/src/adapters/rateLimitError.ts
@@ -1,7 +1,27 @@
 // ============================================
-// OpenSwarm - Rate Limit Error
-// Typed error for 429 / usage_limit_reached from CLI adapters
+// OpenSwarm - Rate Limit / Usage Limit detection — SINGLE SOURCE OF TRUTH
 // ============================================
+//
+// Every provider signals "you hit a usage/rate/quota limit" differently:
+//   - codex-responses (HTTP): 429 + x-codex-* headers → "Codex N% used of Mmin window"
+//   - codex CLI: stdout event {"type":"error","message":"You've hit your usage limit … purchase more credits …"}
+//   - claude CLI: stream-json result "Limit reached · resets 8pm (Asia/Seoul) · add funds …"
+//                 + a rate_limit_event carrying "out_of_credits"
+//   - gpt (OpenAI HTTP): 429 body {"code":"rate_limit_exceeded"} OR {"code":"insufficient_quota"}
+//   - openrouter (HTTP): 429 "Rate limit exceeded" OR **402** "Insufficient credits"
+//   - local/lmstudio (HTTP): 429 "Too Many Requests" / server "overloaded"
+//
+// Historically each adapter grew its own ad-hoc handling, so new phrasings kept
+// slipping through and getting mis-classified (INT-2519: codex 300min-window
+// laundered into a 55% HALT → false STUCK; the audit for INT-2520 found the same
+// class in gpt/openrouter/local/codex-CLI/claude-CLI). This module is the ONE
+// place that knows every provider's limit signature. Two entry points:
+//   - detectRateLimit(stdout, stderr)      — string scan (CLI stdout/stderr, error messages)
+//   - rateLimitFromHttpResponse(status, …) — HTTP boundary (in-process adapters), preferred: typed at source
+//
+// A missed limit is never harmless: for in-process adapters it becomes a fake
+// empty "success" → reviewer reject → STUCK; for CLI adapters it loses the global
+// scheduler pause and keeps hammering the exhausted quota. (INT-2519, INT-2520)
 
 export class RateLimitError extends Error {
   constructor(
@@ -18,10 +38,81 @@ export class RateLimitError extends Error {
   }
 }
 
+// ---- The single registry of usage/rate-limit message signatures ----
+//
+// These are SPECIFIC enough to scan raw CLI stdout (which contains model-generated
+// text) without false-positiving on a task that merely *mentions* rate limits /
+// usage / credits in code or prose. That is why we do NOT use the broad
+// "usage" + "limit" co-occurrence heuristic here (isProviderQuotaError uses that,
+// but only to gate a fallback, not on raw output). Each entry cites its provider.
+const RATE_LIMIT_SUBSTRINGS: readonly string[] = [
+  'usage_limit_reached',        // codex / OpenAI structured code
+  'rate_limit_exceeded',        // OpenAI / openrouter structured code
+  '"rate_limit_error"',         // Anthropic structured type
+  'insufficient_quota',         // OpenAI 429 quota-exhausted code
+  'insufficient credits',       // openrouter 402 body
+  'requires more credits',      // openrouter 402 (max_tokens vs balance) body
+  'out of credits',             // generic
+  'out_of_credits',             // claude rate_limit_event overageDisabledReason
+  'usage limit reached',        // codex-responses header fallback phrasing
+  "you've hit your usage limit",// codex CLI stdout error event
+  'hit your usage limit',       // codex CLI (contraction-agnostic)
+  'purchase more credits',      // codex CLI stdout error event
+  'exceeded your current quota',// OpenAI insufficient_quota human message
+  'too many requests',          // HTTP 429 standard reason (local/lmstudio/others)
+];
+
+// Regex signatures that need structure (co-occurrence / numeric context) to stay
+// specific. Each cites its provider.
+const RATE_LIMIT_REGEXES: readonly RegExp[] = [
+  /\d+%\s*used\s+of\s+\d+min\s+window/, // codex-responses header phrasing
+  // claude CLI human phrase: "Limit reached · resets 8pm … · add funds … extra usage".
+  // Require "limit reached" to co-occur with a reset/billing cue so ordinary prose
+  // ("the rate limit reached its cap in the test") doesn't trip it.
+  /limit reached[\s\S]{0,80}(resets|add funds|extra usage)/,
+  // bare "429" only counts alongside a rate-limit / too-many-requests / quota cue,
+  // or as an "(429)" status echo from an adapter's error wrapper.
+  /\b429\b[\s\S]{0,30}(rate.?limit|too many|quota)/,
+  /error \(429\)/,
+];
+
+/** True when `text` carries any provider's usage/rate/quota-limit signature. */
+export function matchesRateLimitMessage(text: string): boolean {
+  const lower = text.toLowerCase();
+  return (
+    RATE_LIMIT_SUBSTRINGS.some((s) => lower.includes(s)) ||
+    RATE_LIMIT_REGEXES.some((r) => r.test(lower))
+  );
+}
+
+// ---- Reset-time extraction (shared) ----
+
+/** Pull a unix reset timestamp (seconds) out of headers or a JSON body, if present. */
+function extractResetsAt(headers: Headers | undefined, body: string): number | undefined {
+  const fromHeader = (k: string): number | undefined => {
+    const v = headers?.get(k);
+    const n = v == null ? NaN : parseInt(v, 10);
+    return Number.isFinite(n) ? n : undefined;
+  };
+  // Only headers/fields that are genuinely UNIX-epoch seconds or seconds-from-now:
+  //  - x-codex-primary-reset-at: epoch seconds
+  //  - Retry-After: seconds-from-now (→ convert to epoch)
+  //  - body "resets_at": epoch seconds
+  // Deliberately NOT x-ratelimit-reset-requests/-tokens: OpenAI returns those as
+  // DURATION strings ("1s", "6ms", "2m59s"), not epoch — parseInt would yield a
+  // 1970 timestamp and defeat the pause. Omitting them falls back to the safe
+  // 60s default, which is correct rather than wrong. (INT-2520 review)
+  const codexReset = fromHeader('x-codex-primary-reset-at');
+  if (codexReset != null) return codexReset;
+  const retryAfter = fromHeader('retry-after');
+  if (retryAfter != null) return Math.floor(Date.now() / 1000) + retryAfter;
+  const bodyResets = body.match(/"resets_at"\s*:\s*(\d+)/);
+  return bodyResets ? parseInt(bodyResets[1], 10) : undefined;
+}
+
 /**
  * Build a RateLimitError from a codex-responses 429. The x-codex-* headers carry
- * far more than the body: primary window usage %, reset time, window length. We
- * prefer the header reset, falling back to the body's resets_at. (INT-2192)
+ * far more than the body: primary window usage %, reset time, window length. (INT-2192)
  */
 export function rateLimitFromCodexHeaders(headers: Headers, body: string): RateLimitError {
   const num = (k: string): number | undefined => {
@@ -29,8 +120,7 @@ export function rateLimitFromCodexHeaders(headers: Headers, body: string): RateL
     const n = v == null ? NaN : parseInt(v, 10);
     return Number.isFinite(n) ? n : undefined;
   };
-  const bodyResets = body.match(/"resets_at"\s*:\s*(\d+)/);
-  const resetsAt = num('x-codex-primary-reset-at') ?? (bodyResets ? parseInt(bodyResets[1], 10) : undefined);
+  const resetsAt = extractResetsAt(headers, body);
   const usedPercent = num('x-codex-primary-used-percent');
   const windowMinutes = num('x-codex-primary-window-minutes');
 
@@ -41,30 +131,48 @@ export function rateLimitFromCodexHeaders(headers: Headers, body: string): RateL
 }
 
 /**
- * Scan combined stdout+stderr output for rate-limit signals.
- * Handles Codex format: JSON stream event with type=error carrying a message
- * that embeds the usage_limit_reached JSON (with resets_at timestamp).
- * Returns a RateLimitError if a rate-limit pattern is found, null otherwise.
+ * The unified HTTP-boundary detector for in-process adapters (gpt, openrouter,
+ * codex-responses, local, …). Prefer this over string-scanning the error later:
+ * throwing a TYPED RateLimitError at `if (!res.ok)` is the INT-2519 lesson.
+ *
+ * Recognises:
+ *   - 429 (any provider) → rate limit
+ *   - 402 (openrouter out-of-credits) → rate limit, no reset
+ *   - any other status whose body carries a usage/quota signature (e.g. a 400 that
+ *     wraps "insufficient_quota")
+ * Returns null when the response is not a usage/rate limit. (INT-2520)
+ */
+export function rateLimitFromHttpResponse(
+  status: number,
+  headers: Headers | undefined,
+  body: string,
+): RateLimitError | null {
+  // 429 is unambiguously a rate limit. For every OTHER status (including 402
+  // "Payment Required", which some providers reuse for non-quota auth/payment
+  // conditions) require the body to actually carry a usage/credit signature, so
+  // we don't mis-pause on a payment/auth 402. OpenRouter's out-of-credits 402
+  // always says "Insufficient credits", which matches. (INT-2520 review)
+  const isRateLimit = status === 429 || matchesRateLimitMessage(body);
+  if (!isRateLimit) return null;
+
+  const resetsAt = extractResetsAt(headers, body);
+  const reason =
+    status === 402
+      ? 'out of credits'
+      : status === 429
+        ? 'rate limit reached'
+        : 'usage limit reached';
+  const when = resetsAt ? ` — resets at ${new Date(resetsAt * 1000).toISOString()}` : '';
+  return new RateLimitError(resetsAt, `HTTP ${status} ${reason}${when}`);
+}
+
+/**
+ * Scan combined stdout+stderr (CLI adapters) or an error message for a usage/rate
+ * limit. Returns a RateLimitError if any provider's signature is present. (INT-1906, INT-2520)
  */
 export function detectRateLimit(stdout: string, stderr: string): RateLimitError | null {
   const combined = stdout + '\n' + stderr;
-
-  const lower = combined.toLowerCase();
-  const hasSignal =
-    combined.includes('usage_limit_reached') ||
-    combined.includes('rate_limit_exceeded') ||
-    combined.includes('"rate_limit_error"') ||
-    (combined.includes('429') && /rate.{0,15}limit/i.test(combined)) ||
-    // Human-readable Codex usage-limit phrasing (rateLimitFromCodexHeaders output:
-    // "Codex 100% used of 300min window — resets at …" / "Codex usage limit reached").
-    // Stringifying a typed RateLimitError strips the raw tokens above, so a CLI /
-    // string path must still recognise these. (INT-2519)
-    lower.includes('usage limit reached') ||
-    /\d+%\s*used\s+of\s+\d+min\s+window/.test(lower) ||
-    lower.includes('out of credits') ||
-    lower.includes('out_of_credits');
-
-  if (!hasSignal) return null;
+  if (!matchesRateLimitMessage(combined)) return null;
 
   const resetsAtMatch = combined.match(/"resets_at"\s*:\s*(\d+)/);
   const resetsAt = resetsAtMatch ? parseInt(resetsAtMatch[1], 10) : undefined;


### PR DESCRIPTION
## Summary
Audit of all 6 remaining adapters found the **INT-2519 class recurring** across providers. A usage/rate limit that isn't thrown as a typed `RateLimitError` and isn't matched by the string scanner falls through — **in-process adapters** → fake empty success → reviewer reject → **false STUCK**; **CLI adapters** → lose the global scheduler pause and keep hammering the exhausted quota.

### Gap matrix (from the audit)
| Provider | Missed form | Was |
|---|---|---|
| gpt | 429 `insufficient_quota` | fake success → STUCK |
| openrouter | **402** "Insufficient credits" (not 429) | fake success → STUCK |
| local/lmstudio | every capacity error (429/503/context/conn-refused/OOM) | fake success → STUCK |
| codex CLI | "You've hit your usage limit" | infra_error, no pause |
| claude CLI | "Limit reached · resets 8pm" (short runs) | infra_error, no pause |

### Single source of truth (`rateLimitError.ts`)
- A documented registry of **every provider's real wire signature**, plus `matchesRateLimitMessage()` and `rateLimitFromHttpResponse(status, headers, body)` (429 always; other statuses require a quota signature so a payment/auth 402 isn't mis-paused; reset parsed only from true epoch/seconds fields, not OpenAI's duration-style `x-ratelimit-reset-*`).

### Closes the gaps
- gpt / openrouter throw a typed `RateLimitError` at the HTTP boundary via the shared helper
- `agenticLoop` catch (main + salvage) re-throws **both** `RateLimitError` and `isInfraError` instead of swallowing infra into a fake `exitCode:0` success
- all in-process adapter `run()` catches re-throw `isInfraError` too (so it isn't undone one layer up)
- `isInfraError` recognises undici `fetch failed` via `error.cause.code` and 5xx capacity (adapter-wrapper/HTTP-context regex, not bare numbers)

## Verification
- `tsc --noEmit` clean, full vitest **1686 passed**; every provider's real limit string asserted; no-false-positive guards for prose; adapter `run()` rejects (not exitCode:1) on infra fetch failure
- `openswarm review`: **3 rounds caught real defects** (duration reset headers, over-broad 402, adapter run() not re-throwing, parenthesized 5xx regex) — all fixed. 4th round's remaining items are the reviewer's own test-run limitation (verified here) + pre-existing 401/403 breadth, folded into the follow-on "100% infra+harness exception handling" goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)