### PR TITLE
fix(error-classification): tighten 401/403 + read claude camelCase resetsAt (INT-2521)

### DIFF
--- a/src/adapters/errorClassification.test.ts
+++ b/src/adapters/errorClassification.test.ts
@@ -11,10 +11,21 @@ describe('isInfraError (INT-2010)', () => {
   it('flags spawn / auth / timeout / network failures', () => {
     expect(isInfraError(new Error('spawn codex ENOENT'))).toBe(true);
     expect(isInfraError(new Error('Request failed: 401 Unauthorized'))).toBe(true);
+    expect(isInfraError(new Error('403 Forbidden'))).toBe(true);
+    expect(isInfraError(new Error('OpenAI API error (401): invalid key'))).toBe(true);
+    expect(isInfraError(new Error('request rejected with status 403'))).toBe(true);
     expect(isInfraError(new Error('connect ETIMEDOUT'))).toBe(true);
     expect(isInfraError(new Error('codex timeout after 300000ms'))).toBe(true);
     expect(isInfraError(new Error('read ECONNRESET'))).toBe(true);
     expect(isInfraError('getaddrinfo ENOTFOUND api.openai.com')).toBe(true);
+  });
+
+  it('does NOT flag a bare 401/403 number in prose (needs auth word or wrapper) (INT-2521)', () => {
+    expect(isInfraError(new Error('assertion failed at line 401 of the parser'))).toBe(false);
+    expect(isInfraError(new Error('the error code 4013 is not a real HTTP status'))).toBe(false);
+    expect(isInfraError(new Error('expected 403 rows in the fixture'))).toBe(false);
+    // a generic application "error code 401" is NOT an HTTP/auth infra failure
+    expect(isInfraError(new Error('validation error code 401: form field missing'))).toBe(false);
   });
 
   it('does NOT flag genuine task/code failures', () => {

--- a/src/adapters/errorClassification.ts
+++ b/src/adapters/errorClassification.ts
@@ -36,12 +36,14 @@ const INFRA_ERROR_PATTERNS = [
   'fetch failed', // undici: the real code hides in error.cause.code (checked below)
   'terminated', // undici mid-stream socket drop
   'unauthorized',
+  'forbidden',
   'not authenticated',
   'authentication failed',
   'invalid api key',
   'permission denied',
-  '401',
-  '403',
+  // NOTE: bare '401'/'403' were removed — they matched prose like "line 401" or
+  // "error 4013". Real auth failures carry a word ('unauthorized'/'forbidden'/…)
+  // or an adapter/HTTP-status wrapper, both covered here + in INFRA_ERROR_REGEXES. (INT-2521)
   // Server-side capacity / gateway failures — the model server was reachable but
   // could not serve (model loading, overloaded, upstream down). Not a verdict on
   // the task. 429/402 are handled as RateLimitError, not here. Use unambiguous
@@ -59,11 +61,15 @@ const INFRA_ERROR_PATTERNS = [
 // wrapper like "Local API error (503)", or "HTTP 503" / "status 503"), so a bare
 // number in task/reviewer prose is not mistaken for an infra failure. (INT-2520)
 const INFRA_ERROR_REGEXES: readonly RegExp[] = [
-  // Adapter error wrappers only ("OpenAI API error (503)", "Local API error (502)",
+  // Adapter error wrappers only ("OpenAI API error (503)", "Local API error (401)",
   // "Codex responses error (504)") — NOT a bare "(503)" in prose, so a task/reviewer
-  // message like "expected (503)" is not mis-flagged.
-  /(?:api|responses) error \((50[234])\)/,
-  /\b(?:http|status|code)\s*[:=]?\s*(50[234])\b/,
+  // message like "expected (503)" is not mis-flagged. Covers auth (401/403) and
+  // server-capacity (5xx) status codes. (INT-2520, INT-2521)
+  /(?:api|responses) error \((40[13]|50[234])\)/,
+  // "http"/"status" only — NOT "code", which collides with generic application
+  // error codes ("error code 401: invalid form field"). Real HTTP failures say
+  // http/status or carry an adapter wrapper / auth word. (INT-2521)
+  /\b(?:http|status)\s*[:=]?\s*(40[13]|50[234])\b/,
 ];
 
 /**

--- a/src/adapters/rateLimitError.test.ts
+++ b/src/adapters/rateLimitError.test.ts
@@ -63,6 +63,19 @@ describe('rateLimitFromHttpResponse (INT-2520)', () => {
   });
 });
 
+describe('reset-time extraction — snake_case AND camelCase (INT-2521)', () => {
+  it('detectRateLimit reads claude camelCase "resetsAt" (was defaulting to 60s)', () => {
+    const claudeEvent = '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetsAt":1783249200,"overageDisabledReason":"out_of_credits"}}';
+    const err = detectRateLimit(claudeEvent, '');
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err?.resetsAt).toBe(1783249200);
+  });
+  it('detectRateLimit still reads codex/OpenAI snake_case "resets_at"', () => {
+    const err = detectRateLimit('error: usage_limit_reached "resets_at": 1782343811', '');
+    expect(err?.resetsAt).toBe(1782343811);
+  });
+});
+
 describe('detectRateLimit (INT-1906)', () => {
   it('detects a Codex usage_limit_reached payload and parses resets_at', () => {
     const stdout =

--- a/src/adapters/rateLimitError.ts
+++ b/src/adapters/rateLimitError.ts
@@ -87,6 +87,17 @@ export function matchesRateLimitMessage(text: string): boolean {
 
 // ---- Reset-time extraction (shared) ----
 
+/**
+ * Pull a unix reset timestamp (seconds) out of a JSON body. Accepts BOTH
+ * snake_case "resets_at" (codex / OpenAI) and camelCase "resetsAt" (claude's
+ * rate_limit_event) — matching only snake_case left claude's pause defaulting to
+ * 60s so it immediately re-hit the limit. (INT-2521)
+ */
+export function parseResetsAtFromBody(text: string): number | undefined {
+  const m = text.match(/"resets?_?at"\s*:\s*(\d+)/i);
+  return m ? parseInt(m[1], 10) : undefined;
+}
+
 /** Pull a unix reset timestamp (seconds) out of headers or a JSON body, if present. */
 function extractResetsAt(headers: Headers | undefined, body: string): number | undefined {
   const fromHeader = (k: string): number | undefined => {
@@ -106,8 +117,7 @@ function extractResetsAt(headers: Headers | undefined, body: string): number | u
   if (codexReset != null) return codexReset;
   const retryAfter = fromHeader('retry-after');
   if (retryAfter != null) return Math.floor(Date.now() / 1000) + retryAfter;
-  const bodyResets = body.match(/"resets_at"\s*:\s*(\d+)/);
-  return bodyResets ? parseInt(bodyResets[1], 10) : undefined;
+  return parseResetsAtFromBody(body);
 }
 
 /**
@@ -174,8 +184,7 @@ export function detectRateLimit(stdout: string, stderr: string): RateLimitError 
   const combined = stdout + '\n' + stderr;
   if (!matchesRateLimitMessage(combined)) return null;
 
-  const resetsAtMatch = combined.match(/"resets_at"\s*:\s*(\d+)/);
-  const resetsAt = resetsAtMatch ? parseInt(resetsAtMatch[1], 10) : undefined;
+  const resetsAt = parseResetsAtFromBody(combined);
 
   const label = resetsAt
     ? `Rate limit reached (resets at ${new Date(resetsAt * 1000).toISOString()})`


### PR DESCRIPTION
Two adapter-layer residue items from the INT-2521 exception-handling audit:

- **401/403 no longer bare substrings** (they matched prose like 'line 401' / 'error code 4013'). Real auth failures carry an auth word (unauthorized/forbidden/invalid api key) or an adapter-wrapper / `http|status` form. 'code' dropped from the status regex (collided with generic app error codes).
- **detectRateLimit reads camelCase `resetsAt`** (claude's rate_limit_event) in addition to snake_case `resets_at` (codex/OpenAI). Matching only snake_case left claude's pause defaulting to 60s → immediate re-hit; now it honors the real reset.

Verification: tsc clean + full vitest **1689 passed**; `openswarm review` APPROVE. Prose negatives + auth-word/wrapper positives + camelCase reset tests added.

Part of INT-2521 (100% infra+harness exception handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)