### PR TITLE
fix(hang): enforce wall-clock timeouts on every stage, git op, and task (INT-2521 #1)

### DIFF
--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -69,6 +69,8 @@ export type {
 } from './pairPipelineTypes.js';
 
 export { buildTaskPrefix } from './pipelineTaskPrefix.js';
+export { stageTimeoutMs } from './stageTimeouts.js';
+import { stageTimeoutMs } from './stageTimeouts.js';
 
 // Pair Pipeline
 
@@ -480,7 +482,7 @@ export class PairPipeline extends EventEmitter {
             taskDescription: context.task.description || '',
             projectPath: context.projectPath,
             previousFeedback: combinedFeedback,
-            timeoutMs: this.config.roles?.worker?.timeoutMs ?? 0,
+            timeoutMs: stageTimeoutMs('worker', this.config.roles?.worker?.timeoutMs),
             // getModelForRole gives the matched jobProfile's model precedence (config's
             // light/heavy → gpt-5.5/5.4), falling back to roles.worker.model. Reading
             // roles.worker.model directly here silently dropped the jobProfile model, so a
@@ -566,7 +568,7 @@ export class PairPipeline extends EventEmitter {
             taskDescription: context.task.description || '',
             workerResult: context.workerResult,
             projectPath: context.projectPath,
-            timeoutMs: this.config.roles?.reviewer?.timeoutMs ?? 0,
+            timeoutMs: stageTimeoutMs('reviewer', this.config.roles?.reviewer?.timeoutMs),
             // jobProfile model precedence (see worker stage above). (INT-1599)
             model: this.getModelForRole('reviewer', context.task),
             maxTurns: reviewerMaxTurns,
@@ -610,7 +612,7 @@ export class PairPipeline extends EventEmitter {
             taskDescription: context.task.description || '',
             workerResult: context.workerResult,
             projectPath: context.projectPath,
-            timeoutMs: this.config.roles?.tester?.timeoutMs ?? 0,
+            timeoutMs: stageTimeoutMs('tester', this.config.roles?.tester?.timeoutMs),
             model: this.config.roles?.tester?.model,
             maxTurns: this.config.roles?.tester?.maxTurns,
             adapterName: this.config.roles?.tester?.adapter,
@@ -633,7 +635,7 @@ export class PairPipeline extends EventEmitter {
             taskDescription: context.task.description || '',
             workerResult: context.workerResult,
             projectPath: context.projectPath,
-            timeoutMs: this.config.roles?.documenter?.timeoutMs ?? 0,
+            timeoutMs: stageTimeoutMs('documenter', this.config.roles?.documenter?.timeoutMs),
             model: this.config.roles?.documenter?.model,
             maxTurns: this.config.roles?.documenter?.maxTurns,
             adapterName: this.config.roles?.documenter?.adapter,
@@ -650,7 +652,7 @@ export class PairPipeline extends EventEmitter {
             taskDescription: context.task.description || '',
             workerResult: context.workerResult,
             projectPath: context.projectPath,
-            timeoutMs: this.config.roles?.auditor?.timeoutMs ?? 0,
+            timeoutMs: stageTimeoutMs('auditor', this.config.roles?.auditor?.timeoutMs),
             model: this.config.roles?.auditor?.model,
             maxTurns: this.config.roles?.auditor?.maxTurns,
             adapterName: this.config.roles?.auditor?.adapter,
@@ -667,7 +669,7 @@ export class PairPipeline extends EventEmitter {
             taskDescription: context.task.description || '',
             workerResult: context.workerResult,
             projectPath: context.projectPath,
-            timeoutMs: this.config.roles?.['skill-documenter']?.timeoutMs ?? 0,
+            timeoutMs: stageTimeoutMs('skill-documenter', this.config.roles?.['skill-documenter']?.timeoutMs),
             model: this.config.roles?.['skill-documenter']?.model,
             maxTurns: this.config.roles?.['skill-documenter']?.maxTurns,
             adapterName: this.config.roles?.['skill-documenter']?.adapter,

--- a/src/agents/pairPipelineTimeout.test.ts
+++ b/src/agents/pairPipelineTimeout.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { stageTimeoutMs } from './pairPipeline.js';
+
+// A stage timeout of 0/undefined must NOT mean "unlimited" — that let a stalled
+// CLI/loop hang the whole daemon (INT-2521). It falls back to a per-stage ceiling.
+describe('stageTimeoutMs (INT-2521)', () => {
+  it('falls back to a positive per-stage ceiling for 0 / undefined (never unlimited)', () => {
+    expect(stageTimeoutMs('worker', 0)).toBeGreaterThan(0);
+    expect(stageTimeoutMs('worker', undefined)).toBeGreaterThan(0);
+    expect(stageTimeoutMs('reviewer', 0)).toBeGreaterThan(0);
+    expect(stageTimeoutMs('tester', 0)).toBeGreaterThan(0);
+  });
+
+  it('gives the worker a longer ceiling than the reviewer', () => {
+    expect(stageTimeoutMs('worker', 0)).toBeGreaterThan(stageTimeoutMs('reviewer', 0));
+  });
+
+  it('honors a positive configured value verbatim', () => {
+    expect(stageTimeoutMs('worker', 90_000)).toBe(90_000);
+    expect(stageTimeoutMs('reviewer', 45_000)).toBe(45_000);
+  });
+
+  it('an unknown stage still gets a positive ceiling', () => {
+    expect(stageTimeoutMs('mystery-stage', 0)).toBeGreaterThan(0);
+  });
+});

--- a/src/agents/stageTimeouts.ts
+++ b/src/agents/stageTimeouts.ts
@@ -1,0 +1,23 @@
+// Per-stage wall-clock ceilings for the pair pipeline.
+//
+// A stage timeout of 0/undefined USED to mean "unlimited" (config default
+// workerTimeoutMs/reviewerTimeoutMs = 0). base.ts / agenticLoop then never armed a
+// kill timer, so a stalled CLI turn or agentic loop hung forever — and with
+// maxConcurrentTasks=1 that wedged the WHOLE daemon (no slot ever freed). Never
+// allow 0: floor to these ceilings. Generous vs observed runtimes (worker 2-5min,
+// reviewer 40-140s) so real work is never cut, but a genuine stall is reclaimed and
+// classified infra_error. (INT-2521)
+const STAGE_TIMEOUT_DEFAULTS_MS: Readonly<Record<string, number>> = {
+  worker: 20 * 60_000,
+  reviewer: 6 * 60_000,
+  tester: 6 * 60_000,
+  documenter: 6 * 60_000,
+  auditor: 6 * 60_000,
+  'skill-documenter': 6 * 60_000,
+};
+
+/** Effective stage timeout: the configured value if >0, else the stage ceiling — never 0/unlimited. */
+export function stageTimeoutMs(stage: string, configured: number | undefined): number {
+  if (typeof configured === 'number' && configured > 0) return configured;
+  return STAGE_TIMEOUT_DEFAULTS_MS[stage] ?? 10 * 60_000;
+}

--- a/src/agents/workerFanout.ts
+++ b/src/agents/workerFanout.ts
@@ -61,12 +61,17 @@ function safeCandidateId(id: string, index: number): string {
   return safe || `candidate-${index + 1}`;
 }
 
+// git clone (used for sandbox seeding) can stall; bound it so a hung clone becomes
+// an infra timeout instead of wedging the fan-out. (INT-2521)
+const FANOUT_GIT_TIMEOUT_MS = 5 * 60_000;
+
 async function git(cwd: string, args: string[], opts?: { env?: NodeJS.ProcessEnv }): Promise<string> {
   const { stdout } = await exec('git', args, {
     cwd,
     encoding: 'utf8',
     env: opts?.env,
     maxBuffer: 20 * 1024 * 1024,
+    timeout: FANOUT_GIT_TIMEOUT_MS,
   } as Parameters<typeof exec>[2]);
   return String(stdout);
 }

--- a/src/automation/scheduler.ts
+++ b/src/automation/scheduler.ts
@@ -64,6 +64,10 @@ const activeJobs: Map<string, Cron> = new Map();
 // Running processes (to prevent concurrent execution)
 const runningProcesses: Map<string, ReturnType<typeof spawn>> = new Map();
 
+/** Wall-clock ceiling for a scheduled claude job — a hang here would silently
+ *  wedge the schedule (every later fire skipped "already running"). (INT-2521) */
+const CRON_JOB_TIMEOUT_MS = 20 * 60_000;
+
 // Recent results (for reporting)
 const recentResults: JobResult[] = [];
 const MAX_RESULTS = 50;
@@ -168,6 +172,24 @@ async function runClaudeCli(
 
     let stdout = '';
     let stderr = '';
+    let settled = false;
+    const finish = (r: { success: boolean; output: string; error?: string }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(watchdog);
+      runningProcesses.delete(jobId);
+      resolve(r);
+    };
+    // Without this a hung `claude` never resolves → the job stays in
+    // runningProcesses forever → every later fire is skipped "already running"
+    // and the schedule is silently dead until restart. Kill + resolve as a
+    // failure so the consecutive-failure auto-pause can engage. (INT-2521)
+    const watchdog = setTimeout(() => {
+      if (settled) return;
+      console.warn(`[Scheduler] Job ${jobId} exceeded ${Math.round(CRON_JOB_TIMEOUT_MS / 60_000)}min — killing`);
+      proc.kill('SIGKILL');
+      finish({ success: false, output: '', error: `Job timed out after ${CRON_JOB_TIMEOUT_MS}ms` });
+    }, CRON_JOB_TIMEOUT_MS);
 
     proc.stdout?.on('data', (data) => {
       stdout = appendBounded(stdout, data.toString());
@@ -199,7 +221,7 @@ async function runClaudeCli(
         // Use original on parse failure
       }
 
-      resolve({
+      finish({
         success: code === 0,
         output: resultText.slice(0, 2000), // max 2000 chars
         error: stderr || undefined,
@@ -207,8 +229,7 @@ async function runClaudeCli(
     });
 
     proc.on('error', (err) => {
-      runningProcesses.delete(jobId);
-      resolve({
+      finish({
         success: false,
         output: '',
         error: err.message,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -272,9 +272,11 @@ const AutonomousConfigSchema = z.object({
   includeBacklog: z.boolean().optional(),
   /** Model configuration (legacy) */
   models: ModelConfigSchema,
-  /** Worker timeout (ms) - 0 = unlimited (legacy) */
+  /** Worker timeout (ms). 0/unset = use the pipeline's per-stage ceiling
+   *  (stageTimeoutMs) — it is NO LONGER "unlimited": an unbounded stage could hang
+   *  the whole daemon. Set a positive value to override. (INT-2521) */
   workerTimeoutMs: z.number().min(0).default(0),
-  /** Reviewer timeout (ms) - 0 = unlimited (legacy) */
+  /** Reviewer timeout (ms). 0/unset = pipeline per-stage ceiling (not unlimited). */
   reviewerTimeoutMs: z.number().min(0).default(0),
   /** Max concurrent tasks */
   maxConcurrentTasks: z.number().min(1).max(10).default(1),

--- a/src/orchestration/taskScheduler.cancel.test.ts
+++ b/src/orchestration/taskScheduler.cancel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import { TaskScheduler } from './taskScheduler.js';
@@ -110,5 +110,25 @@ describe('TaskScheduler cancellation', () => {
     sched.startTask(task('t'), '/repo', deferredExecutor().exec);
     sched.setTaskStage('t', 'reviewer');
     expect(sched.getRunningTasks().find((r) => r.task.id === 't')?.stage).toBe('reviewer');
+  });
+
+  it('hard watchdog aborts + frees the slot when a task never settles (INT-2521)', async () => {
+    vi.useFakeTimers();
+    try {
+      const d = deferredExecutor(); // never resolves → simulates a hang
+      let slotFreed = false;
+      sched.on('slotFreed', () => { slotFreed = true; });
+      sched.startTask(task('hung'), '/repo', d.exec);
+      expect(sched.isTaskRunning('hung')).toBe(true);
+
+      // Advance past the 60-min hard watchdog.
+      await vi.advanceTimersByTimeAsync(60 * 60_000 + 1_000);
+
+      expect(d.wasAborted()).toBe(true);          // executor was signaled to stop
+      expect(sched.isTaskRunning('hung')).toBe(false); // slot reclaimed
+      expect(slotFreed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/orchestration/taskScheduler.ts
+++ b/src/orchestration/taskScheduler.ts
@@ -9,6 +9,15 @@ import { resolve } from 'node:path';
 import type { TaskItem } from './decisionEngine.js';
 import type { PipelineResult } from '../agents/pairPipeline.js';
 
+// Absolute upper bound on a single task's wall-clock time — a LAST-RESORT backstop.
+// The fast reclaiming is done by per-stage timeouts (pairPipeline: worker 20min,
+// reviewer/tester 6min) and git-op timeouts; this only catches a hang OUTSIDE those
+// (e.g. non-stage code). Set above realistic multi-iteration work (observed worker
+// runs 2-5min) but low enough to reclaim a genuine hang within the hour. A rare
+// false-kill of a pathologically long-but-progressing task just retries — the
+// watchdog's reject frees the slot and does NOT count toward STUCK. (INT-2521)
+const HARD_TASK_TIMEOUT_MS = 60 * 60_000;
+
 export function normalizeProjectPath(path: string): string {
   // Guard: resolve('') returns process.cwd(), so an accidental empty-string
   // cancellation would match every task under the daemon's cwd. Keep the
@@ -309,6 +318,25 @@ export class TaskScheduler extends EventEmitter {
     console.log(`[Scheduler] Started task: ${task.title}`);
     this.emit('started', runningTask);
 
+    // Hard wall-clock backstop. Per-stage timeouts (pairPipeline stageTimeoutMs) and
+    // git-op timeouts normally reclaim a stall; this catches a hang OUTSIDE those.
+    // We abort (lets the pipeline unwind to 'cancelled' if it's responsive) AND
+    // reject after the ceiling so the slot is freed even if the executor is truly
+    // unresponsive. We deliberately do NOT wait for the executor to confirm it
+    // stopped — that would reintroduce the very hang this guards against; per-task
+    // worktree isolation bounds what a lingering executor can touch, and the abort
+    // signal is its stop request. On reject → handleTaskError: it frees the slot and
+    // emits 'error' (log/Discord only). It does NOT touch the STUCK counters
+    // (failedTaskCounts/incrementRejection live in autonomousRunner, driven by the
+    // 'failed' event's finalStatus, not 'error'), so the task simply stays In
+    // Progress and is re-selected next heartbeat. (INT-2521)
+    const watchdog = setTimeout(() => {
+      if (!this.runningTasks.has(task.id)) return;
+      console.warn(`[Scheduler] Task "${task.title}" exceeded the ${Math.round(HARD_TASK_TIMEOUT_MS / 60_000)}min hard watchdog — aborting and freeing the slot`);
+      abortController.abort();
+      rejectTask(new Error(`Task timed out after ${HARD_TASK_TIMEOUT_MS}ms (scheduler hard watchdog)`));
+    }, HARD_TASK_TIMEOUT_MS);
+
     // Completion handling
     runningTask.promise
       .then((result) => {
@@ -316,7 +344,8 @@ export class TaskScheduler extends EventEmitter {
       })
       .catch((error) => {
         this.handleTaskError(task.id, error);
-      });
+      })
+      .finally(() => clearTimeout(watchdog));
 
     try {
       Promise.resolve(executor(abortController.signal)).then(resolveTask, rejectTask);

--- a/src/support/gitTracker.ts
+++ b/src/support/gitTracker.ts
@@ -222,17 +222,30 @@ export async function getWorkingDiffDetail(projectPath: string): Promise<FileDif
 /**
  * Git command execution utility
  */
+// Bound each snapshot/diff git call so a stuck git (index lock, corrupt repo)
+// rejects with a timeout instead of hanging the worker's "did real work" check
+// forever. "timed out" → isInfraError → infra_error backoff. (INT-2521)
+const GIT_CMD_TIMEOUT_MS = 5 * 60_000;
+
 function runGitCommand(cwd: string, args: string[], env?: NodeJS.ProcessEnv): Promise<string> {
   return new Promise((resolve, reject) => {
     const proc = spawn('git', args, { cwd, env: env ? { ...process.env, ...env } : process.env });
 
     let stdout = '';
     let stderr = '';
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      proc.kill('SIGKILL');
+      reject(new Error(`git ${args.join(' ')} timed out after ${GIT_CMD_TIMEOUT_MS}ms`));
+    }, GIT_CMD_TIMEOUT_MS);
 
     proc.stdout.on('data', (data) => { stdout += data.toString(); });
     proc.stderr.on('data', (data) => { stderr += data.toString(); });
 
     proc.on('close', (code) => {
+      settled = true;
+      clearTimeout(timer);
       if (code === 0) {
         resolve(stdout);
       } else {
@@ -240,7 +253,7 @@ function runGitCommand(cwd: string, args: string[], env?: NodeJS.ProcessEnv): Pr
       }
     });
 
-    proc.on('error', reject);
+    proc.on('error', (err) => { settled = true; clearTimeout(timer); reject(err); });
   });
 }
 

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -13,9 +13,15 @@ import { loadRepoMetadata } from './repoMetadata.js';
 
 const execFileAsync = promisify(execFile);
 
-/** Safe git command execution (no shell) */
+/** Wall-clock ceiling for a single git invocation (fetch/push/clone included).
+ *  Without it a stalled network git op hangs the whole task before the pipeline's
+ *  own timeouts can engage. A timed-out git rejects with ETIMEDOUT/"timed out",
+ *  which isInfraError classifies → infra_error backoff, not STUCK. (INT-2521) */
+const GIT_TIMEOUT_MS = 5 * 60_000;
+
+/** Safe git command execution (no shell), bounded by GIT_TIMEOUT_MS. */
 async function git(cwd: string, ...args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync('git', ['-C', cwd, ...args]);
+  const { stdout } = await execFileAsync('git', ['-C', cwd, ...args], { timeout: GIT_TIMEOUT_MS });
   return stdout;
 }
 
@@ -28,7 +34,7 @@ async function git(cwd: string, ...args: string[]): Promise<string> {
  * branches with no PR. (INT-2321)
  */
 async function gh(cwd: string, ...args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync('gh', args, { cwd });
+  const { stdout } = await execFileAsync('gh', args, { cwd, timeout: GIT_TIMEOUT_MS });
   return stdout;
 }
 


### PR DESCRIPTION
The **#1 finding** of the exception-handling audit, flagged independently by all 3 harness auditors: nothing bounds a stalled task. Stage `timeoutMs` defaulted to **0 = unlimited**, so a stalled CLI turn / API stream hung forever — and with `maxConcurrentTasks=1` one hung task wedged the whole daemon. Git ops and the cron claude job had no timeout either.

- **pairPipeline**: `stageTimeoutMs()` floors every stage to a ceiling (worker 20min, reviewer/tester/doc/audit 6min) — 0/undefined is no longer unlimited. All 6 stage calls routed through it.
- **TaskScheduler**: a 60-min hard wall-clock watchdog per task — aborts + frees the slot even if the executor never settles, **without counting toward STUCK** (task retries next heartbeat). Per-task worktree isolation bounds a lingering executor.
- **git helpers**: 5-min timeout on worktreeManager `git()`/`gh()`, workerFanout `git()` (clone), gitTracker `runGitCommand` — a stalled/locked git rejects (→ `isInfraError` → backoff) instead of hanging.
- **cron `runClaudeCli`**: 20-min watchdog so a hung job no longer wedges the schedule permanently.

## Verification
- `tsc` clean + full vitest **1694 passed**. New: `stageTimeoutMs` floor/override matrix; scheduler hard-watchdog **fake-timer test** (never-settling executor → abort fired + slot reclaimed).
- `openswarm review`: round 1 caught watchdog comment accuracy + testability → fixed (accurate STUCK-neutral comment + blast-radius doc + fake-timer test). The 0=unlimited contract change is **intentional + user-approved**.

Part of INT-2521. 🤖 Generated with [Claude Code](https://claude.com/claude-code)