### PR TITLE
fix(worktree): preserve (never delete) a failed worktree when git status fails (INT-2521)

### DIFF
--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -209,6 +209,20 @@ describe('preserveWorktree → createWorktree resume roundtrip (INT-2503)', () =
     expect(existsSync(info.worktreePath)).toBe(false);
   });
 
+  it('PRESERVES (does not delete) when git status FAILS — cannot confirm clean (INT-2521)', async () => {
+    const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+    writeFileSync(join(info.worktreePath, 'app.py'), 'base\nreal-partial-work\n');
+    // Break the worktree's git linkage so `git status` errors (a lock / corruption
+    // analog). The old `.catch(() => '')` treated that error as "clean" and DELETED
+    // the tree — losing real partial work. It must now preserve.
+    writeFileSync(join(info.worktreePath, '.git'), 'gitdir: /nonexistent/broken\n');
+
+    expect(await preserveWorktree(info, 'test failure')).toBe(true);
+    expect(existsSync(info.worktreePath)).toBe(true); // tree NOT deleted
+    expect(existsSync(join(info.worktreePath, '.openswarm-preserved'))).toBe(true);
+    expect(readFileSync(join(info.worktreePath, 'app.py'), 'utf8')).toBe('base\nreal-partial-work\n');
+  });
+
   it('recreates fresh when the preserved branch does not match', async () => {
     const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
     writeFileSync(join(info.worktreePath, 'app.py'), 'base\nstale-work\n');

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -222,18 +222,31 @@ export async function removePreservedWorktreeAt(worktreePath: string): Promise<v
  */
 export async function preserveWorktree(info: WorktreeInfo, reason: string): Promise<boolean> {
   const worktreePath = assertManagedWorktreePath(info.originalPath, info.worktreePath);
-  const dirty = await git(worktreePath, 'status', '--porcelain').catch(() => '');
-  if (!dirty.trim()) {
+  // Distinguish a genuinely clean tree from a git-status FAILURE (index/ref lock
+  // under parallel load, transient corruption). The old `.catch(() => '')` treated
+  // an error as "clean" → removeWorktree DELETED trees that may hold real partial
+  // work whenever git merely errored, defeating the preserve-for-resume guarantee.
+  // On any doubt, PRESERVE — never delete unconfirmed work. (INT-2521)
+  let dirty: string | null;
+  try {
+    dirty = await git(worktreePath, 'status', '--porcelain');
+  } catch (err) {
+    if (!existsSync(worktreePath)) return false; // tree gone — nothing to preserve or remove
+    console.warn(`[Worktree] git status failed — preserving the tree to be safe: ${worktreePath}`, err instanceof Error ? err.message : err);
+    dirty = null;
+  }
+  if (dirty !== null && !dirty.trim()) {
     await removeWorktree(info);
     return false;
   }
-  const fileCount = dirty.split('\n').filter(Boolean).length;
+  const fileCount = dirty === null ? 0 : dirty.split('\n').filter(Boolean).length;
   writeFileSync(
     join(worktreePath, PRESERVE_MARKER),
     JSON.stringify({ issueId: info.issueId, branchName: info.branchName, reason, at: new Date().toISOString() }, null, 2),
     'utf8',
   );
-  console.log(`[Worktree] Preserved for retry (${fileCount} dirty files, ${reason}): ${worktreePath}`);
+  const label = dirty === null ? 'git status unavailable — preserved to be safe' : `${fileCount} dirty files`;
+  console.log(`[Worktree] Preserved for retry (${label}, ${reason}): ${worktreePath}`);
   return true;
 }
 


### PR DESCRIPTION
`preserveWorktree` used `git status --porcelain .catch(() => '')`, so a git-status **failure** (index/ref lock under parallel load, transient corruption) was indistinguishable from a clean tree — and the '' → removeWorktree path **DELETED a worktree that may hold real partial work**, defeating the preserve-for-resume guarantee. Now: a git error → preserve (write marker, keep tree); only a git-status **success returning empty** removes it.

Found by the INT-2521 harness audit (finding **F2 — HIGH, destructive**). Test: a broken .git link makes git status fail → tree preserved with partial work intact. tsc clean + full vitest **1695 passed**, `openswarm review` APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)