### PR TITLE
fix(worktree): infra_error on creation failure, not a fake success on the shared repo (INT-2521)

### DIFF
--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -737,7 +737,23 @@ export async function executePipeline(
         },
       });
     } catch (err) {
-      console.warn('[Worktree] Failed to create worktree, falling back to main repo:', err);
+      // Do NOT fall back to the shared main repo. A non-isolated run leaves the
+      // edits uncommitted on main with NO branch/PR (stranded work) while the issue
+      // may still be marked done — a fake success — and it breaks parallel isolation
+      // (two tasks mutating one tree). A `git worktree add` failure (disk full,
+      // .git lock, corrupt repo) is infra: return an infra_error result so the
+      // runner applies backoff and does NOT count it toward STUCK (the proper
+      // finalStatus path — a bare throw would only hit the log-only 'error'
+      // handler with no backoff). The pipeline never runs. (INT-2521)
+      console.error(`[Worktree] Creation failed for ${task.issueIdentifier} — infra_error, NOT falling back to the shared repo:`, err);
+      return {
+        success: false,
+        sessionId: `worktree-fail-${Date.now()}`,
+        iterations: 0,
+        totalDuration: 0,
+        finalStatus: 'infra_error',
+        stages: [],
+      };
     }
   }
 


### PR DESCRIPTION
When `git worktree add` failed (disk full / .git lock / corrupt repo), the catch **silently fell back to the shared MAIN repo** — a non-isolated run that strands edits on main with no branch/PR while the issue may be marked done (fake success), and breaks parallel isolation.

Now it returns `finalStatus:'infra_error'` (pipeline never runs) → runner applies retry backoff, **not** counted toward STUCK (reviewer-confirmed proper path, vs the log-only 'error' handler a bare throw would hit).

Found by the INT-2521 harness audit (**F1 — HIGH**). tsc clean + full vitest **1695 passed**, `openswarm review` APPROVE. Focused executePipeline integration test deferred (heavy harness; the infra_error path is proven by the existing 'decomposed' return).

🤖 Generated with [Claude Code](https://claude.com/claude-code)