### PR TITLE
fix(tester): empty/degenerate output is not a PASS (blocking-stage fake-pass) (INT-2521)

### DIFF
--- a/src/agents/tester.test.ts
+++ b/src/agents/tester.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { parseTesterOutput } from './tester.js';
+
+// The tester is a BLOCKING stage. Its text fallback used "no error keyword ⇒
+// success", so an empty/degenerate run faked a PASS and let unverified code
+// through. Only genuinely empty output is now flagged — short-but-real output
+// (e.g. "collected 0 items") must still pass. (INT-2521)
+describe('parseTesterOutput fake-pass guard (INT-2521)', () => {
+  it('empty output is NOT a pass — unverified', () => {
+    const r = parseTesterOutput('');
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/unverified|no output/i);
+  });
+
+  it('whitespace-only output is NOT a pass', () => {
+    expect(parseTesterOutput('   \n\t  ').success).toBe(false);
+  });
+
+  it('real "N passed" output IS a pass', () => {
+    expect(parseTesterOutput('5 passed, 0 failed in 1.2s').success).toBe(true);
+  });
+
+  it('a legitimate short "no tests" run still passes (not mis-flagged)', () => {
+    expect(parseTesterOutput('collected 0 items').success).toBe(true);
+  });
+
+  it('a failing run is not a pass', () => {
+    expect(parseTesterOutput('2 failed, 3 passed').success).toBe(false);
+  });
+});

--- a/src/agents/tester.ts
+++ b/src/agents/tester.ts
@@ -140,7 +140,7 @@ export async function runTester(options: TesterOptions): Promise<TesterResult> {
 /**
  * Parse Tester output
  */
-function parseTesterOutput(output: string): TesterResult {
+export function parseTesterOutput(output: string): TesterResult {
   try {
     const costInfo = extractCostFromStreamJson(output);
     if (costInfo) {
@@ -272,14 +272,19 @@ function extractFromText(text: string): TesterResult {
     }
   }
 
+  // A tester that produced NO output verified nothing — the "no error keyword ⇒
+  // success" default would fake a PASS on an empty/degenerate run and let
+  // unverified code through the blocking test gate. Only genuinely empty output is
+  // flagged, so a short-but-real run ("collected 0 items") is unaffected. (INT-2521)
+  const noOutput = text.trim().length === 0;
   return {
-    success: !hasError || (hasSuccess && testsFailed === 0),
+    success: !noOutput && (!hasError || (hasSuccess && testsFailed === 0)),
     testsPassed,
     testsFailed,
     coverage,
     output: text,
     failedTests: failedTests.length > 0 ? failedTests : undefined,
-    error: hasError ? extractErrorMessage(text) : undefined,
+    error: hasError ? extractErrorMessage(text) : (noOutput ? 'Tester produced no output — result unverified' : undefined),
   };
 }
 


### PR DESCRIPTION
The tester's text fallback used "no error keyword ⇒ success", so an **empty/whitespace-only run** (tester exited 0 producing nothing) was scored `success:true` — a **fake PASS that let unverified code through the blocking test gate**. Now genuinely empty output is flagged not-success ('unverified'); short-but-real output (`collected 0 items`) is unaffected, so legitimate no-tests runs still pass.

Found by the INT-2521 harness audit (**P3**). `parseTesterOutput` exported for coverage. tsc clean + full vitest **1700 passed**, `openswarm review` APPROVE (ran tester tests + typecheck). documenter/auditor share the pattern but are non-blocking — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)