### PR TITLE
fix(stuck): a repeating infra error is not a stuck loop (INT-2521)

### DIFF
--- a/src/support/stuckDetector.test.ts
+++ b/src/support/stuckDetector.test.ts
@@ -22,6 +22,27 @@ describe('StuckDetector', () => {
     expect(detector.check()).toMatchObject({ isStuck: true });
   });
 
+  it('does NOT treat a repeating INFRA error as a stuck loop (INT-2521)', () => {
+    // An infra/capacity error recurring a few times is a retryable outage, not a
+    // genuine stuck loop — it backs off and is excluded from STUCK elsewhere.
+    const detector = new StuckDetector({ sameErrorRepeat: 2 });
+    detector.addEntry(entry({ success: false, error: 'codex CLI failed with code 1: timed out' }));
+    detector.addEntry(entry({ success: false, error: 'codex CLI failed with code 1: timed out' }));
+    expect(detector.check()).toEqual({ isStuck: false });
+
+    const d2 = new StuckDetector({ sameErrorRepeat: 2 });
+    d2.addEntry(entry({ success: false, error: 'connect ECONNREFUSED 127.0.0.1:1234' }));
+    d2.addEntry(entry({ success: false, error: 'connect ECONNREFUSED 127.0.0.1:1234' }));
+    expect(d2.check()).toEqual({ isStuck: false });
+  });
+
+  it('still flags a repeating genuine (non-infra) task error as stuck', () => {
+    const detector = new StuckDetector({ sameErrorRepeat: 2 });
+    detector.addEntry(entry({ success: false, error: 'TypeError: cannot read property x of undefined' }));
+    detector.addEntry(entry({ success: false, error: 'TypeError: cannot read property x of undefined' }));
+    expect(detector.check()).toMatchObject({ isStuck: true });
+  });
+
   it('does not treat historical matching errors as consecutive after progress', () => {
     const detector = new StuckDetector({ sameErrorRepeat: 2 });
 

--- a/src/support/stuckDetector.ts
+++ b/src/support/stuckDetector.ts
@@ -3,6 +3,8 @@
 // OpenHands-style infinite loop detection
 // ============================================
 
+import { isInfraError } from '../adapters/errorClassification.js';
+
 export interface StuckThresholds {
   sameOutputRepeat: number;    // Same output repeat threshold
   sameErrorRepeat: number;     // Same error repeat threshold
@@ -105,6 +107,14 @@ export class StuckDetector {
     );
 
     if (allSame) {
+      // A repeating INFRA/capacity error (rate limit, 5xx, connection drop, CLI
+      // exit) is not a genuine stuck loop — it's a retryable outage that backs off
+      // and is excluded from STUCK elsewhere (INT-2010). Counting it here would
+      // re-introduce the false STUCK: an infra hiccup that recurs a few times
+      // would trip the loop detector even though the task never got a fair run. (INT-2521)
+      if (isInfraError(recentErrors[0].error)) {
+        return { isStuck: false };
+      }
       return {
         isStuck: true,
         reason: `Same error repeated ${recentErrors.length} times`,


### PR DESCRIPTION
`detectErrorLoop` treated N identical failures as a stuck loop regardless of WHAT failed. A recurring **infra/capacity** error (rate limit, 5xx, connection drop, CLI exit) is a retryable outage that backs off and is excluded from STUCK elsewhere (INT-2010) — but recurring a few times would trip the loop detector and re-introduce the **false STUCK**. Now an infra-classified repeated error → not-stuck; a genuine (non-infra) repeated error still trips it.

Found by the INT-2521 harness audit (**P5**). tsc clean + full vitest **1702 passed**, `openswarm review` APPROVE (ran stuckDetector tests 8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)