### PR TITLE
fix(pipeline): pause on a draft/planner rate limit instead of hammering the exhausted provider (INT-2521)

### DIFF
--- a/src/agents/draftAnalyzer.test.ts
+++ b/src/agents/draftAnalyzer.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import * as adapterModule from '../adapters/index.js';
 import * as knowledgeModule from '../knowledge/index.js';
 import * as registryModule from '../registry/sqliteStore.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
 
 describe('runDraftAnalysis fallback', () => {
   const makeAdapter = (name: string): CliAdapter => ({
@@ -85,6 +86,19 @@ describe('runDraftAnalysis fallback', () => {
     expect(adapterModule.spawnCli).toHaveBeenCalledTimes(1);
     // Pipeline continues with a best-effort (insufficient) draft.
     expect(result.sufficient).toBe(false);
+  });
+
+  it('re-throws a typed RateLimitError instead of swallowing it into a best-effort draft (INT-2521)', async () => {
+    // A rate limit during draft must reach the pipeline so the scheduler pauses,
+    // not be swallowed as non-blocking (which lets planner + worker keep hammering).
+    vi.spyOn(adapterModule, 'getDefaultAdapterName').mockReturnValue('codex');
+    vi.spyOn(adapterModule, 'getAdapter').mockImplementation((name) => makeAdapter(name));
+    vi.spyOn(adapterModule, 'spawnCli')
+      .mockRejectedValue(new RateLimitError(1782824950, 'Codex usage limit reached'));
+
+    await expect(
+      runDraftAnalysis({ taskTitle: 'Fix edge', taskDescription: 'Test', projectPath: '/tmp/project' }),
+    ).rejects.toBeInstanceOf(RateLimitError);
   });
 
   it('drafter hard gate: retries on the same adapter when the brief is insufficient', async () => {

--- a/src/agents/draftAnalyzer.ts
+++ b/src/agents/draftAnalyzer.ts
@@ -10,6 +10,7 @@ import { promisify } from 'node:util';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getAdapter, getDefaultAdapterName, spawnCli } from '../adapters/index.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
 import { analyzeIssue } from '../knowledge/index.js';
 import { getRegistryStore } from '../registry/sqliteStore.js';
 import type { ImpactAnalysis } from '../knowledge/types.js';
@@ -615,6 +616,10 @@ export async function runDraftAnalysis(options: DraftAnalyzerOptions): Promise<D
           onLog?.('[Draft] Brief insufficient — retrying with a stricter prompt');
         }
       } catch (err) {
+        // A typed rate limit must NOT be swallowed into a best-effort draft — it
+        // has to reach the pipeline so the scheduler pauses instead of the planner
+        // + worker continuing to hammer the exhausted provider. (INT-2521)
+        if (err instanceof RateLimitError) throw err;
         lastError = err;
         const errMsg = err instanceof Error ? err.message : String(err);
         onLog?.(`[Draft] analysis failed (${adapterName}): ${errMsg}`);

--- a/src/automation/runnerExecution.followups.test.ts
+++ b/src/automation/runnerExecution.followups.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { fileReviewerFollowups } from './runnerExecution.js';
+import { fileReviewerFollowups, rateLimitedPipelineResult } from './runnerExecution.js';
 import type { ReviewResult } from '../agents/agentPair.js';
 import type { ITaskSource } from './taskSource.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
 
 const mockSource = (createSubIssue = vi.fn(async () => ({}))) =>
   ({ createSubIssue } as unknown as ITaskSource);
@@ -78,5 +79,23 @@ describe('fileReviewerFollowups (INT-1704)', () => {
 
   it('handles a null task source gracefully', async () => {
     expect(await fileReviewerFollowups(null, 'INT-1', review(), { autoFile: true })).toBe(0);
+  });
+});
+
+// The scheduler contract for a pre-pipeline (draft/planner) rate limit: a
+// RateLimitError becomes a rate_limited PipelineResult carrying the reset (ms) so
+// the runner pauses without counting toward STUCK. (INT-2521)
+describe('rateLimitedPipelineResult (INT-2521)', () => {
+  it('maps a RateLimitError to a rate_limited result with resetsAt in ms', () => {
+    const r = rateLimitedPipelineResult(new RateLimitError(1782824950, 'Codex usage limit reached'));
+    expect(r.finalStatus).toBe('rate_limited');
+    expect(r.success).toBe(false);
+    expect(r.rateLimitResetsAt).toBe(1782824950 * 1000);
+  });
+
+  it('leaves resetsAt undefined when the error has none', () => {
+    const r = rateLimitedPipelineResult(new RateLimitError(undefined, 'Rate limit reached'));
+    expect(r.finalStatus).toBe('rate_limited');
+    expect(r.rateLimitResetsAt).toBeUndefined();
   });
 });

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -34,6 +34,7 @@ import {
 } from '../support/worktreeManager.js';
 import type { WorktreeInfo } from '../support/worktreeManager.js';
 import { loadRepoMetadata } from '../support/repoMetadata.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
 import {
   getDecompositionDepth,
   getChildrenCount,
@@ -639,6 +640,23 @@ export async function decomposeTask(
 
 // Pipeline Execution
 
+/**
+ * The 'rate_limited' PipelineResult the scheduler reads to pause: finalStatus +
+ * rateLimitResetsAt (ms) so the runner backs off until the reset without counting
+ * toward STUCK. Built here for a pre-pipeline (draft/planner) rate limit. (INT-2521)
+ */
+export function rateLimitedPipelineResult(err: RateLimitError): PipelineResult {
+  return {
+    success: false,
+    sessionId: `rate-limited-${Date.now()}`,
+    iterations: 0,
+    totalDuration: 0,
+    finalStatus: 'rate_limited',
+    rateLimitResetsAt: err.resetsAt ? err.resetsAt * 1000 : undefined,
+    stages: [],
+  };
+}
+
 export async function executePipeline(
   ctx: ExecutionContext,
   task: TaskItem,
@@ -652,6 +670,11 @@ export async function executePipeline(
   // Planner + Worker에 enriched context 제공
   // ============================================
   let draftResult: DraftAnalysis | undefined;
+  // A rate limit during the pre-pipeline phase (draft analysis or the decomposition
+  // planner) must PAUSE the scheduler immediately — not be swallowed into a
+  // best-effort draft or a silent direct-execution fallback that keeps hammering the
+  // exhausted provider until the worker finally re-hits it. (INT-2521)
+  try {
   if (ctx.enableDraftAnalysis !== false) {
     try {
       const taskId = task.issueIdentifier || task.issueId || task.id;
@@ -679,6 +702,7 @@ export async function executePipeline(
       broadcastEvent({ type: 'pipeline:stage', data: { taskId, stage: 'draft', status: 'complete', durationMs: draftResult.durationMs, ...metadata } });
       console.log(`[AutonomousRunner] Draft: type=${draftResult.taskType}, files=${draftResult.relevantFiles.length}, ${draftResult.durationMs}ms`);
     } catch (err) {
+      if (err instanceof RateLimitError) throw err; // → outer catch → rate_limited (INT-2521)
       console.warn('[AutonomousRunner] Draft analysis failed (non-blocking):', err);
     }
   }
@@ -712,6 +736,15 @@ export async function executePipeline(
         console.log('[AutonomousRunner] Decomposition failed, falling back to direct execution');
       }
     }
+  }
+  } catch (err) {
+    // Pre-pipeline rate limit → pause the scheduler (finalStatus 'rate_limited'
+    // carries the reset so the runner backs off until then, no STUCK). (INT-2521)
+    if (err instanceof RateLimitError) {
+      console.warn(`[AutonomousRunner] Rate limit during pre-pipeline phase — pausing: ${err.message}`);
+      return rateLimitedPipelineResult(err);
+    }
+    throw err;
   }
 
   // ============================================

--- a/src/support/planner.test.ts
+++ b/src/support/planner.test.ts
@@ -9,6 +9,7 @@ vi.mock('../adapters/index.js', () => ({
 
 import { runPlanner } from './planner.js';
 import * as adapters from '../adapters/index.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
 
 const mockedSpawnCli = vi.mocked(adapters.spawnCli);
 
@@ -74,5 +75,14 @@ describe('runPlanner — agentic loop migration', () => {
     mockedSpawnCli.mockResolvedValue(cliResult(PLAN_JSON) as never);
     await runPlanner({ taskTitle: 't', taskDescription: 'd', projectPath: '/tmp/x', model: 'sonnet' });
     expect(mockedSpawnCli.mock.calls[0][1].model).toBe('sonnet');
+  });
+
+  it('re-throws a RateLimitError instead of flattening it to {success:false} (INT-2521)', async () => {
+    // A swallowed rate limit made decomposeTask fall back to direct execution,
+    // which hammered the exhausted provider. It must propagate so the pipeline pauses.
+    mockedSpawnCli.mockRejectedValue(new RateLimitError(1782824950, 'Codex usage limit reached') as never);
+    await expect(
+      runPlanner({ taskTitle: 't', taskDescription: 'd', projectPath: '/tmp/x' }),
+    ).rejects.toBeInstanceOf(RateLimitError);
   });
 });

--- a/src/support/planner.ts
+++ b/src/support/planner.ts
@@ -10,6 +10,7 @@ import type { ImpactAnalysis } from '../knowledge/types.js';
 import type { AdapterName } from '../adapters/types.js';
 import { getAdapter, spawnCli } from '../adapters/index.js';
 import { mapModelForProvider } from '../adapters/modelCompat.js';
+import { RateLimitError } from '../adapters/rateLimitError.js';
 import { expandPath } from '../core/config.js';
 
 // Types
@@ -127,6 +128,10 @@ export async function runPlanner(options: PlannerOptions): Promise<PlannerResult
 
     return parsePlannerOutput(raw.stdout, options.taskTitle);
   } catch (error) {
+    // A rate limit here must propagate so the scheduler pauses — flattening it to
+    // {success:false} made decomposeTask fall back to direct execution, which then
+    // hammered the exhausted provider with the worker. (INT-2521)
+    if (error instanceof RateLimitError) throw error;
     return {
       success: false,
       originalIssue: options.taskTitle,


### PR DESCRIPTION
The draft analyzer and decomposition planner both **swallowed** a `RateLimitError`: draft → best-effort (non-blocking); planner → `{success:false}` → decomposeTask false → executePipeline **direct-execution fallback**. So the scheduler only paused 1-2 spawns later when the *worker* re-hit the limit, after draft + planner had already hammered the exhausted provider.

Now the typed `RateLimitError` propagates: draftAnalyzer + planner **re-throw** it (like worker/reviewer already do), and executePipeline wraps the pre-pipeline phase in a try/catch returning `rateLimitedPipelineResult(err)` — `finalStatus:'rate_limited'` + reset in ms — so the runner **pauses immediately**, no STUCK.

Found by the INT-2521 harness audit (**⑤**). Tests: planner re-throw, draftAnalyzer re-throw, result-shape (`rateLimitResetsAt = resetsAt*1000`). tsc clean + full vitest **1706 passed**. The `instanceof RateLimitError` pattern matches worker/reviewer/agenticLoop throughout (intra-process, no serialization boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)