### PR TITLE
fix(pipeline): a post-success non-blocking stage never reverts the approved task (INT-2521)

### DIFF
--- a/src/agents/pairPipeline.test.ts
+++ b/src/agents/pairPipeline.test.ts
@@ -11,6 +11,7 @@ import { RateLimitError } from '../adapters/rateLimitError.js';
 
 const runWorker = vi.fn();
 const runReviewer = vi.fn();
+const runDocumenter = vi.fn();
 const broadcastEvent = vi.fn();
 const getDefaultModel = vi.fn();
 
@@ -27,6 +28,11 @@ vi.mock('./reviewer.js', async () => {
     ...actual,
     runReviewer,
   };
+});
+
+vi.mock('./documenter.js', async () => {
+  const actual = await vi.importActual<typeof import('./documenter.js')>('./documenter.js');
+  return { ...actual, runDocumenter };
 });
 
 vi.mock('../knowledge/index.js', () => ({
@@ -125,6 +131,29 @@ describe('PairPipeline model selection', () => {
     expect(runReviewer).toHaveBeenCalledWith(expect.objectContaining<Partial<ReviewerOptions>>({
       model: 'profile-reviewer',
     }));
+  });
+
+  it('a post-success documenter rate-limit does NOT revert the approved task (INT-2521)', async () => {
+    // Worker approved, reviewer approved — the task is DONE. A documenter (post-
+    // success, non-blocking) rate-limit must not discard that success.
+    // Once-only so the rejection can't leak into later tests (clearAllMocks keeps impls).
+    runDocumenter.mockRejectedValueOnce(new RateLimitError(1782824950, 'Codex usage limit reached'));
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker', 'reviewer', 'documenter'],
+      maxIterations: 1,
+      roles: {
+        worker: { enabled: true, timeoutMs: 0 },
+        reviewer: { enabled: true, timeoutMs: 0 },
+        documenter: { enabled: true, timeoutMs: 0 },
+      },
+    });
+
+    const result = await pipeline.run(task(), process.cwd());
+
+    expect(result.success).toBe(true);
+    expect(result.finalStatus).toBe('approved');
+    expect(runDocumenter).toHaveBeenCalled();
   });
 
   it('falls back to role models when no jobProfile matches', async () => {

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -196,36 +196,26 @@ export class PairPipeline extends EventEmitter {
 
       // Run Documenter after all stages pass
       if (this.hasStage('documenter') && context.workerResult?.success) {
-        if (
-          this.config.skipDocumenterIfNoChange &&
-          (!context.workerResult.filesChanged || context.workerResult.filesChanged.length === 0)
-        ) {
+        if (this.config.skipDocumenterIfNoChange && !context.workerResult.filesChanged?.length) {
           console.log(`[${context.taskPrefix}] Skipping documenter: no files changed`);
         } else {
-          const documenterResult = await this.runStage('documenter', context);
-          stages.push(documenterResult);
-          // Documenter failure does not cause overall failure
+          await this.runPostSuccessStage('documenter', context, stages);
         }
       }
 
       // Auditor (post-success, non-blocking)
       if (this.hasStage('auditor') && context.workerResult?.success) {
-        const auditorFileThreshold = this.config.skipAuditorUnderFileCount ?? 3;
-        const auditorChangedFiles = context.workerResult.filesChanged || [];
-        if (auditorChangedFiles.length < auditorFileThreshold) {
-          console.log(`[${context.taskPrefix}] Skipping auditor: ${auditorChangedFiles.length} files changed (threshold: ${auditorFileThreshold})`);
+        const auditorFiles = context.workerResult.filesChanged?.length ?? 0;
+        if (auditorFiles < (this.config.skipAuditorUnderFileCount ?? 3)) {
+          console.log(`[${context.taskPrefix}] Skipping auditor: ${auditorFiles} files changed`);
         } else {
-          const auditorResult = await this.runStage('auditor', context);
-          stages.push(auditorResult);
-          // Auditor failure does not affect overall success
+          await this.runPostSuccessStage('auditor', context, stages);
         }
       }
 
       // Skill Documenter (post-success, non-blocking)
       if (this.hasStage('skill-documenter') && context.workerResult?.success) {
-        const sdResult = await this.runStage('skill-documenter', context);
-        stages.push(sdResult);
-        // Skill Documenter failure does not affect overall success
+        await this.runPostSuccessStage('skill-documenter', context, stages);
       }
 
       // Success
@@ -396,6 +386,16 @@ export class PairPipeline extends EventEmitter {
    */
   private hasStage(stage: PipelineStage): boolean {
     return this.config.stages.includes(stage);
+  }
+
+  /** Post-success non-blocking stage: its failure (incl. rate-limit/infra) must
+   *  NEVER revert the approved task; only cancellation propagates. (INT-2521) */
+  private async runPostSuccessStage(stage: PipelineStage, context: PipelineContext, stages: StageResult[]): Promise<void> {
+    try { stages.push(await this.runStage(stage, context)); }
+    catch (err) {
+      if (err instanceof PipelineCancelledError || this.abortSignal?.aborted) throw err;
+      console.warn(`[${context.taskPrefix}] ${stage} skipped (non-blocking failure): ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
 
   /**


### PR DESCRIPTION
`documenter` / `auditor` / `skill-documenter` run AFTER worker+reviewer approve and are documented non-blocking. But a **thrown** error from them (RateLimitError, infra) bypassed that intent — it propagated to the run() top catch, which flipped the **already-approved** task to `rate_limited`/`failed` and discarded the completed work. A documenter rate-limit threw away a finished task.

`runPostSuccessStage` now wraps these stages: any failure is logged and skipped (task stays approved); only user cancellation propagates. A persistent rate-limit still pauses via the next task's worker.

Found by the INT-2521 harness audit (**P7**). Test: a documenter RateLimitError leaves finalStatus `approved`. tsc clean + full vitest **1707 passed**, `openswarm review` APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)