### PR TITLE
feat(runner): early needs-human STUCK for a DoD infeasible in the sandbox (INT-2521 ⑦)

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -9,6 +9,7 @@ import {
   getPipelineHistory,
   incrementRejection,
   clearRejection,
+  getRejectionCount,
   isRejectionLimitReached,
   canRetryNow,
   setRetryTime,
@@ -33,6 +34,7 @@ import {
 } from '../orchestration/decisionEngine.js';
 // ExecutorResult used via execution.reportExecutionResult
 import { checkWorkAllowed } from '../support/timeWindow.js';
+import { shouldEarlyStuckForInfeasibility } from '../support/feasibilityDetector.js';
 import { recordTaskOutcome } from '../memory/repoKnowledge.js';
 import { updateProjectAfterTask } from '../linear/projectUpdater.js';
 import { TaskScheduler, initScheduler, normalizeProjectPath } from '../orchestration/taskScheduler.js';
@@ -414,6 +416,58 @@ export class AutonomousRunner {
       broadcastEvent({ type: 'task:completed', data: { taskId: task.id, success: false, duration: result.totalDuration } });
       this.recordPipelineHistory(task, result);
       await reportToDiscord(formatPipelineResultEmbed(result));
+
+      // Structural infeasibility (⑦, INT-2521): the failure text says the DoD can't
+      // be met in this sandbox — it needs a human, a manual step, or an absent
+      // environment resource (real DB / live network / production access). The
+      // pipeline ran fine and the reviewer *correctly* rejected, so this IS a real
+      // task_failure; but re-running against an environmental wall only burns the
+      // remaining rejection/failure budget (3–4 full attempts) before the same STUCK.
+      // When the task has hit an infeasibility wall on two consecutive attempts, mark
+      // it STUCK now — labelled needs-human, blocker surfaced — instead of exhausting
+      // the budget. The guard (current AND the previously-recorded failure both carry a
+      // high-precision infeasibility marker; the two markers need not be identical) is
+      // what keeps a merely-hard task — which keeps making progress and won't stably
+      // emit the marker — or a one-off false-positive after an UNRELATED prior failure
+      // from being cut early. No new
+      // external state: this is the existing STUCK, reached sooner. NOTE: this path
+      // intentionally SKIPS the rejection-count / repo-pitfall accounting below — it is
+      // a terminal needs-human transition, not a retry, so a rejection tally is moot;
+      // it still persists the deciding failure detail. (INT-2521 ⑦)
+      if (task.issueId) {
+        const infeasDetail = pickFailureDetail([
+          result.lastReviewFeedback,
+          result.reviewResult?.feedback,
+          result.workerResult?.error,
+        ]) ?? '';
+        const priorDetail = this.lastFailureDetails.get(task.issueId)?.detail ?? '';
+        const infeasible = shouldEarlyStuckForInfeasibility(infeasDetail, priorDetail);
+        if (infeasible.earlyStuck) {
+          const attempts = getRejectionCount(task.issueId) + (this.failedTaskCounts.get(task.issueId) ?? 0) + 1;
+          this.completedTaskIds.add(task.issueId); // no retry can move an environmental wall
+          clearRetryTime(task.issueId, this.failedTaskRetryTimes);
+          clearRejection(task.issueId);
+          recordLastFailureDetail(this.taskStateRef, task.issueId, infeasDetail);
+          this.saveTaskState();
+          if (result.taskContext?.projectPath) {
+            await removePreservedWorktreeAt(result.taskContext.projectPath)
+              .catch((err) => console.warn('[Worktree] STUCK cleanup failed:', err));
+          }
+          try {
+            await execution.syncFailureState(task,
+              `Needs human — DoD appears unsatisfiable in the sandbox (marker: "${infeasible.marker}") after ${attempts} attempts`);
+            await getTaskSource()?.logStuck(task.issueId, 'autonomous-runner',
+              `**Needs human — the DoD appears unsatisfiable in this sandbox.**\n\n` +
+              `Detected blocker phrase: "${infeasible.marker}". Re-running can't fix an environmental ` +
+              `impossibility (missing DB / network / credentials, or a manual/human step), so automatic ` +
+              `retries were stopped early after ${attempts} attempts.\n\n**Latest failure:**\n${infeasDetail}`);
+            console.log(`[Scheduler] Issue ${task.issueId} marked STUCK (needs-human: infeasible in sandbox) — ${attempts} attempts`);
+          } catch (err) {
+            console.error(`[Scheduler] Failed to update issue state:`, err);
+          }
+          return;
+        }
+      }
 
       // If rejected, track rejection count and block after max attempts
       if (task.issueId && result.finalStatus === 'rejected') {

--- a/src/support/feasibilityDetector.test.ts
+++ b/src/support/feasibilityDetector.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { detectInfeasibleDoD, shouldEarlyStuckForInfeasibility } from './feasibilityDetector.js';
+
+describe('detectInfeasibleDoD (INT-2521 ⑦)', () => {
+  it('flags explicit human/manual requirements', () => {
+    expect(detectInfeasibleDoD('This step needs human review before it can proceed.').infeasible).toBe(true);
+    expect(detectInfeasibleDoD('Requires manual database seeding on a real server.').infeasible).toBe(true);
+    expect(detectInfeasibleDoD('This cannot be automated; a person must run the migration.').infeasible).toBe(true);
+    expect(detectInfeasibleDoD('Deployment requires human intervention.').infeasible).toBe(true);
+  });
+
+  it('flags explicit impossibility of the DoD in the sandbox', () => {
+    expect(detectInfeasibleDoD('The idempotency check cannot be verified in this environment (DB is 0 bytes).').infeasible).toBe(true);
+    expect(detectInfeasibleDoD('This is structurally impossible without the production data.').infeasible).toBe(true);
+    expect(detectInfeasibleDoD('The acceptance criteria are not possible in the sandbox.').infeasible).toBe(true);
+    expect(detectInfeasibleDoD('This task is infeasible in this environment.').infeasible).toBe(true);
+  });
+
+  it('flags absent environment resources the DoD needs (impossibility-anchored)', () => {
+    expect(detectInfeasibleDoD('The test needs a live API but there is no network access here.').infeasible).toBe(true);
+    expect(detectInfeasibleDoD('This requires access to production to reproduce.').infeasible).toBe(true);
+    expect(detectInfeasibleDoD('There is no database available to run the migration against.').infeasible).toBe(true);
+  });
+
+  it('returns the matched marker for the STUCK diagnostic', () => {
+    const v = detectInfeasibleDoD('Verifying idempotency here is structurally impossible without the real table.');
+    expect(v.infeasible).toBe(true);
+    expect(v.marker).toBe('structurally impossible');
+  });
+
+  it('does NOT flag a merely-hard-but-doable task (progress, not a wall)', () => {
+    expect(detectInfeasibleDoD('The null check is missing on line 42; add it and re-run the tests.').infeasible).toBe(false);
+    expect(detectInfeasibleDoD('Reviewer rejected: the function returns the wrong shape.').infeasible).toBe(false);
+    expect(detectInfeasibleDoD('Tests failed: expected 3 to equal 4.').infeasible).toBe(false);
+    expect(detectInfeasibleDoD('This is a hard refactor but the approach is sound; keep going.').infeasible).toBe(false);
+  });
+
+  it('does NOT false-positive on ordinary feedback that merely mentions the resource nouns', () => {
+    // bare nouns must NOT match — only impossibility-anchored phrases do
+    expect(detectInfeasibleDoD('Add a retry to the network access layer.').infeasible).toBe(false);
+    expect(detectInfeasibleDoD('Do not hardcode the production database URL; read it from env.').infeasible).toBe(false);
+    expect(detectInfeasibleDoD('The manual explains the database schema well.').infeasible).toBe(false);
+    expect(detectInfeasibleDoD('Implement human-friendly error messages.').infeasible).toBe(false);
+  });
+
+  it('handles empty / non-string inputs safely', () => {
+    expect(detectInfeasibleDoD('').infeasible).toBe(false);
+    expect(detectInfeasibleDoD('   ').infeasible).toBe(false);
+    expect(detectInfeasibleDoD(undefined).infeasible).toBe(false);
+    expect(detectInfeasibleDoD(null).infeasible).toBe(false);
+    expect(detectInfeasibleDoD(new Error('needs human review')).infeasible).toBe(true);
+  });
+});
+
+describe('shouldEarlyStuckForInfeasibility (INT-2521 ⑦)', () => {
+  const INFEASIBLE = 'The idempotency guarantee cannot be verified in this environment: the database is 0 bytes.';
+  const INFEASIBLE_2 = 'This requires access to production to reproduce; no database available here.';
+  const HARD_BUT_DOABLE = 'Reviewer rejected: the dedup key is wrong — use (trade_id, filled_at) and re-run.';
+  const UNRELATED_FAIL = 'Tests failed: expected 3 to equal 4.';
+
+  it('short-circuits when the current AND prior failures are both infeasible (markers may differ)', () => {
+    // Two consecutive infeasibility signals — the markers need NOT be identical
+    // ("cannot verify in this environment" then "requires access to production" are
+    // both facets of the same wall); what matters is that infeasibility recurred.
+    expect(shouldEarlyStuckForInfeasibility(INFEASIBLE, INFEASIBLE_2).earlyStuck).toBe(true);
+    expect(shouldEarlyStuckForInfeasibility(INFEASIBLE, INFEASIBLE).earlyStuck).toBe(true);
+  });
+
+  it('never short-circuits on the very FIRST attempt (no prior detail yet)', () => {
+    const v = shouldEarlyStuckForInfeasibility(INFEASIBLE, '');
+    expect(v.earlyStuck).toBe(false);
+    expect(v.infeasible).toBe(true); // detected on the current failure, but not yet trusted
+    expect(shouldEarlyStuckForInfeasibility(INFEASIBLE, undefined).earlyStuck).toBe(false);
+  });
+
+  it('never short-circuits when the PRIOR failure was unrelated (the false-positive to avoid)', () => {
+    // A single (possibly false-positive) infeasibility marker that merely FOLLOWS an
+    // ordinary failure must keep retrying — the prior failure was a different problem.
+    expect(shouldEarlyStuckForInfeasibility(INFEASIBLE, UNRELATED_FAIL).earlyStuck).toBe(false);
+    expect(shouldEarlyStuckForInfeasibility(INFEASIBLE, HARD_BUT_DOABLE).earlyStuck).toBe(false);
+  });
+
+  it('never short-circuits when the current failure is a merely-hard-but-doable one', () => {
+    expect(shouldEarlyStuckForInfeasibility(HARD_BUT_DOABLE, INFEASIBLE).earlyStuck).toBe(false);
+    expect(shouldEarlyStuckForInfeasibility(HARD_BUT_DOABLE, HARD_BUT_DOABLE).earlyStuck).toBe(false);
+  });
+
+  it('surfaces the CURRENT failure marker for the STUCK diagnostic', () => {
+    const v = shouldEarlyStuckForInfeasibility('This requires human intervention now.', INFEASIBLE);
+    expect(v.earlyStuck).toBe(true);
+    expect(v.marker).toBe('requires human');
+  });
+});

--- a/src/support/feasibilityDetector.ts
+++ b/src/support/feasibilityDetector.ts
@@ -1,0 +1,111 @@
+// ============================================
+// OpenSwarm - DoD feasibility detector (INT-2521 ⑦)
+// ============================================
+//
+// Some tasks cannot be completed in the daemon's sandbox no matter how many times
+// the pipeline retries: the definition-of-done needs a real database, live network,
+// production credentials, or a manual/human step. The worker+reviewer run fine and
+// the reviewer *correctly* rejects (the DoD genuinely isn't met), so it is a real
+// `task_failure` — not a misclassification. But re-running a full pipeline against
+// an environmental wall just burns the whole rejection/failure budget (3–4 attempts)
+// before the issue lands STUCK with a generic "retries exhausted" note.
+//
+// This detector lets the runner recognise that wall EARLY from the failure text and
+// mark the issue STUCK sooner, labelled needs-human, instead of exhausting the
+// budget. It is deliberately a HIGH-PRECISION / best-effort-recall heuristic: it only
+// fires on phrases that assert impossibility or a human/manual requirement, never on
+// a merely-hard task (which keeps making progress and won't stably emit these). When
+// no marker is present it returns not-infeasible and the existing retry accounting is
+// unchanged — so a miss costs nothing, a false-positive is what we guard against.
+
+// Phrases (matched case-insensitively as substrings) that assert the DoD cannot be
+// met in an automated sandbox. Every entry anchors on an impossibility verb
+// ("cannot"/"impossible"/"not possible"/"infeasible"), an absent-resource claim
+// ("no network access"), or an explicit human/manual requirement — NOT on a bare
+// resource noun ("database", "network", "production"), which would false-positive on
+// ordinary review feedback that merely mentions them. Keep it conservative; grow it
+// only from real observed STUCK reasons.
+const INFEASIBLE_MARKERS = [
+  // explicit human / manual requirement
+  'needs human',
+  'need a human',
+  'needs a human',
+  'requires human',
+  'human intervention',
+  'manual intervention',
+  'requires manual',
+  'must be done manually',
+  'can only be done manually',
+  'cannot be automated',
+  // explicit impossibility of the definition-of-done
+  'structurally impossible',
+  'impossible to satisfy',
+  'impossible to complete in this',
+  'impossible to complete in the sandbox',
+  'cannot be satisfied in this',
+  'cannot be verified in this environment',
+  'cannot be verified in the sandbox',
+  'cannot be completed in this environment',
+  'cannot be completed in the sandbox',
+  'cannot be done in this environment',
+  'cannot be done in the sandbox',
+  'not feasible in this environment',
+  'not feasible in the sandbox',
+  'infeasible in this environment',
+  'infeasible in the sandbox',
+  'not possible in this environment',
+  'not possible in the sandbox',
+  // absent environment resources the DoD requires (impossibility-anchored forms only)
+  'no network access',
+  'network is unavailable',
+  'without network access',
+  'requires access to production',
+  'requires production access',
+  'no database available',
+] as const;
+
+export interface FeasibilityVerdict {
+  /** True when the failure text asserts the DoD is unsatisfiable in the sandbox. */
+  infeasible: boolean;
+  /** The marker phrase that matched (for the STUCK diagnostic), or null. */
+  marker: string | null;
+}
+
+/**
+ * Inspect a failure detail (reviewer feedback / worker error / halt reason) for a
+ * high-precision signal that the task's DoD is structurally infeasible in the
+ * sandbox — needs a human, a manual step, or an absent environment resource. Returns
+ * the matched marker so the caller can surface WHY in the needs-human STUCK note.
+ * Pure; empty/whitespace input is never infeasible. (INT-2521 ⑦)
+ */
+export function detectInfeasibleDoD(text: unknown): FeasibilityVerdict {
+  const msg = (text instanceof Error ? text.message : String(text ?? '')).toLowerCase();
+  if (!msg.trim()) return { infeasible: false, marker: null };
+  const marker = INFEASIBLE_MARKERS.find((m) => msg.includes(m)) ?? null;
+  return { infeasible: marker !== null, marker };
+}
+
+export interface EarlyStuckDecision extends FeasibilityVerdict {
+  /** True → mark the issue needs-human STUCK now instead of spending more retries. */
+  earlyStuck: boolean;
+}
+
+/**
+ * Decide whether the runner should short-circuit a failing task to a needs-human
+ * STUCK instead of burning the rest of its retry budget. True ONLY when the DECIDING
+ * failure AND the immediately preceding recorded failure BOTH assert infeasibility —
+ * i.e. the task hit an environmental wall on two consecutive attempts. (The two
+ * markers need not be identical: "no database available" then "requires human" are
+ * both genuine facets of the same wall — what matters is that infeasibility recurred,
+ * not that the wording repeated.) A lone infeasibility message — a first attempt, or a
+ * one-off that merely follows an UNRELATED prior failure — is never trusted, so a
+ * merely-hard task (which keeps making progress and won't stably emit the marker) is
+ * not cut early. The verdict's `marker` is the current failure's marker, for the STUCK
+ * diagnostic. Pure; `priorDetail` is '' / undefined on the first attempt → never
+ * early-stuck. (INT-2521 ⑦)
+ */
+export function shouldEarlyStuckForInfeasibility(currentDetail: unknown, priorDetail: unknown): EarlyStuckDecision {
+  const current = detectInfeasibleDoD(currentDetail);
+  const prior = detectInfeasibleDoD(priorDetail);
+  return { ...current, earlyStuck: current.infeasible && prior.infeasible };
+}


### PR DESCRIPTION
## Summary

Closes the last INT-2521 item (⑦). Some tasks can't be completed no matter how many retries: the DoD needs a real DB, live network, production credentials, or a manual/human step (e.g. STO-1452's 0-byte-DB idempotency check). The pipeline runs fine and the reviewer **correctly** rejects — a genuine `task_failure`, not a misclassification — but re-running against an environmental wall just burns the whole rejection/failure budget (3–4 full attempts) before a generic "retries exhausted" STUCK.

This recognises the wall from the failure text and marks the issue STUCK **sooner**, labelled needs-human with the blocker surfaced — **no new external Linear state**, just the existing STUCK reached earlier. (User picked the heuristic approach over a full needs-human state + feasibility pre-gate.)

## How

- **`detectInfeasibleDoD(text)`** — high-precision / best-effort-recall marker set: impossibility, human/manual, and absent-resource phrases only. Never bare resource nouns, so ordinary review feedback that merely mentions a DB / network / production isn't mis-flagged.
- **`shouldEarlyStuckForInfeasibility(current, prior)`** — fires ONLY when the deciding failure **and** the previously-recorded failure BOTH assert infeasibility (two consecutive infeasibility signals; the markers need not be identical). That "twice in a row" guard is what keeps a merely-hard task (which keeps progressing and won't stably emit a marker) and a one-off false-positive after an unrelated failure from being cut early.
- **Runner wiring** (`autonomousRunner.ts`) — on a failed/rejected result, reads the persisted prior failure detail, and if the guard fires marks the issue STUCK now (needs-human, blocker phrase in the note) and stops re-picking it. Intentionally skips the rejection-count / repo-pitfall accounting (terminal transition, not a retry); still persists the deciding detail.

## False-positive minimisation (the user's key constraint)

Two independent guards: (a) high-precision markers only, (b) requires two consecutive infeasibility-marked failures. A task that would succeed on a later attempt won't emit an infeasibility marker on two attempts in a row.

## Testing note

Decision logic is a **pure, deterministically-tested helper** (12 cases incl. the "unrelated prior failure → keep retrying" case a reviewer flagged). The runner integration harness was deliberately NOT used for assertions: `runnerState.ts` hardcodes `~/.claude/openswarm-task-state.json` (the `OPENSWARM_TASK_STATE_FILE` env stub these tests set is a no-op — it belongs to a different store), so those tests write **real** production state and share global singletons + live timers → flaky and polluting. Filed separately as a test-hygiene follow-up.

## Verification

- `npx vitest run src/support/feasibilityDetector.test.ts` → 12 passed
- full suite: 148 files, 1753 passed / 1 skipped
- tsc clean, oxlint clean
- `openswarm review`: the same-way correctness finding and the wording-alignment finding were both addressed; remaining flags ("no tests run", "CLAUDE.md not found at repo root") are reviewer-sandbox limitations (tests verified locally; only a global ~/.claude/CLAUDE.md exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)