### PR TITLE
fix(worktree): a full disk must not crash the daemon — guard preserve-marker write + classify ENOSPC as infra (INT-2521)

### DIFF
--- a/src/adapters/errorClassification.test.ts
+++ b/src/adapters/errorClassification.test.ts
@@ -62,6 +62,16 @@ describe('isInfraError (INT-2010)', () => {
     expect(isInfraError(new Error('the reviewer stage should reject empty diffs'))).toBe(false);
   });
 
+  it('recognises host resource exhaustion (disk full / OOM) as infra, not a task failure (INT-2521)', () => {
+    // A full disk crashed the daemon in production; ENOSPC must backoff-retry, not STUCK.
+    expect(isInfraError(new Error('ENOSPC: no space left on device, open \'/repo/worktree/.openswarm-preserved\''))).toBe(true);
+    expect(isInfraError(new Error('write failed: no space left on device'))).toBe(true);
+    expect(isInfraError(Object.assign(new Error('spawn failed'), { cause: { code: 'ENOSPC' } }))).toBe(true);
+    expect(isInfraError(new Error('ENOMEM: not enough memory'))).toBe(true);
+    // …but ordinary prose mentioning space is NOT infra
+    expect(isInfraError(new Error('the layout leaves no space left for the label'))).toBe(false);
+  });
+
   it('recognises local server capacity failures (5xx / loading / overloaded) (INT-2520)', () => {
     expect(isInfraError(new Error('Local API error (503): model is loading'))).toBe(true);
     expect(isInfraError(new Error('Local API error (502): bad gateway'))).toBe(true);

--- a/src/adapters/errorClassification.ts
+++ b/src/adapters/errorClassification.ts
@@ -33,6 +33,9 @@ const INFRA_ERROR_PATTERNS = [
   'enotfound',
   'socket hang up',
   'network error',
+  'enospc', // disk full — an environment condition, not a task verdict; backoff-retry once space frees (INT-2521)
+  'no space left on device', // the human-readable form of ENOSPC (full phrase, so prose like "no space left for the label" is not mis-flagged)
+  'enomem', // out of memory — same class: host resource exhaustion, not a bad edit
   'git-tracker:', // git snapshot/diff failed mid-run — infra, not a task verdict (colon-anchored to avoid prose) (INT-2521)
   'reviewer-stage:', // reviewer ran but its output couldn't be parsed into a verdict — infra, not a quality reject (INT-2521)
   'fetch failed', // undici: the real code hides in error.cause.code (checked below)

--- a/src/adapters/errorClassificationContract.test.ts
+++ b/src/adapters/errorClassificationContract.test.ts
@@ -54,6 +54,7 @@ const CASES: Array<{ name: string; err: string | Error; bucket: Bucket }> = [
   { name: 'git-tracker snapshot/diff failure', err: 'git-tracker: diff since snapshot failed: fatal: bad object', bucket: 'infra_error' },
   { name: 'reviewer parse crash', err: 'reviewer-stage: produced no parseable verdict: TypeError x', bucket: 'infra_error' },
   { name: 'scheduler hard watchdog', err: 'Task timed out after 3600000ms (scheduler hard watchdog)', bucket: 'infra_error' },
+  { name: 'disk full (ENOSPC)', err: "ENOSPC: no space left on device, open '/repo/worktree/.openswarm-preserved'", bucket: 'infra_error' },
 
   // ---- genuine task failures (MUST count toward STUCK) ----
   { name: 'code TypeError', err: 'TypeError: cannot read property foo of undefined', bucket: 'task_failure' },

--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -207,6 +207,24 @@ describe('preserveWorktree → createWorktree resume roundtrip (INT-2503)', () =
     const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
     expect(await preserveWorktree(info, 'test failure')).toBe(false);
     expect(existsSync(info.worktreePath)).toBe(false);
+  });
+
+  it('does NOT crash when the preserve-marker write fails (ENOSPC/EACCES) — reports NOT preserved (INT-2521)', async () => {
+    const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+    writeFileSync(join(info.worktreePath, 'app.py'), 'base\npartial-impl\n'); // dirty work
+    // A read-only worktree dir makes the marker writeFileSync throw — exactly what a
+    // full disk (ENOSPC) did in production, where an unguarded write crashed the whole
+    // daemon via executePipeline. preserveWorktree must swallow it and honestly report
+    // NOT preserved (false): the marker is the only thing that would protect the tree
+    // from the next createWorktree()/sweep, so it must never claim a preservation it
+    // can't back. It also never leaves a marker behind.
+    chmodSync(info.worktreePath, 0o555);
+    try {
+      await expect(preserveWorktree(info, 'disk full')).resolves.toBe(false);
+      expect(existsSync(join(info.worktreePath, '.openswarm-preserved'))).toBe(false); // marker never written
+    } finally {
+      if (existsSync(info.worktreePath)) chmodSync(info.worktreePath, 0o755); // restore for cleanup
+    }
   });
 
   it('PRESERVES (does not delete) when git status FAILS — cannot confirm clean (INT-2521)', async () => {

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -240,11 +240,33 @@ export async function preserveWorktree(info: WorktreeInfo, reason: string): Prom
     return false;
   }
   const fileCount = dirty === null ? 0 : dirty.split('\n').filter(Boolean).length;
-  writeFileSync(
-    join(worktreePath, PRESERVE_MARKER),
-    JSON.stringify({ issueId: info.issueId, branchName: info.branchName, reason, at: new Date().toISOString() }, null, 2),
-    'utf8',
-  );
+  // The resume marker is the ONLY thing that protects this tree from the next
+  // createWorktree() recreate (which deletes the branch + worktree, ~L286/L299) and
+  // the heartbeat orphan-sweep (pruneWorktrees drops marker-less trees). So if we
+  // can't write it, we CANNOT honestly claim the work is preserved. Two rules here:
+  //   1. Never throw. An unguarded writeFileSync threw ENOSPC straight through
+  //      executePipeline and crashed the whole daemon under a full disk (observed
+  //      live: disk 100% → runner crash-loop). (INT-2521)
+  //   2. Don't lie. Best-effort remove the tree to reclaim space — which is exactly
+  //      what helps when the disk is full — and report NOT preserved. ENOSPC is an
+  //      infra error, so the task retries fresh from origin/main once space frees.
+  const markerPath = join(worktreePath, PRESERVE_MARKER);
+  try {
+    writeFileSync(
+      markerPath,
+      JSON.stringify({ issueId: info.issueId, branchName: info.branchName, reason, at: new Date().toISOString() }, null, 2),
+      'utf8',
+    );
+  } catch (err) {
+    console.warn(`[Worktree] Preserve-marker write failed — cannot preserve, reclaiming space: ${worktreePath}`, err instanceof Error ? err.message : err);
+    // A failed write can leave a truncated marker behind. Drop it first so a later
+    // createWorktree()/prune doesn't treat the corpse as a real preserved tree, THEN
+    // best-effort remove the whole worktree to reclaim space. Both are best-effort —
+    // neither may throw (that is the very crash this guard exists to prevent).
+    try { rmSync(markerPath, { force: true }); } catch { /* read-only/ENOSPC — leave it; prune treats an unreadable marker as sweepable */ }
+    await removeWorktree(info).catch((e) => console.warn(`[Worktree] Cleanup after failed preserve also failed: ${worktreePath}`, e instanceof Error ? e.message : e));
+    return false;
+  }
   const label = dirty === null ? 'git status unavailable — preserved to be safe' : `${fileCount} dirty files`;
   console.log(`[Worktree] Preserved for retry (${label}, ${reason}): ${worktreePath}`);
   return true;


### PR DESCRIPTION
## Summary

**Found live:** the disk hit 100% full and the OpenSwarm daemon crash-looped. Root cause: an unguarded `writeFileSync` of the `.openswarm-preserved` marker in `preserveWorktree()` — `ENOSPC` threw straight through `executePipeline` and took the whole runner process down (Node printed its version banner and exited).

This is the INT-2521 invariant applied to a real host-resource condition: **no uncaught infra error may crash the daemon, and a disk-full failure is infra (backoff), not a task failure (STUCK).**

## Changes

**`preserveWorktree()`** — on a marker-write failure it now:
- **never throws** (the crash this guard prevents);
- reports **NOT preserved (`false`)** instead of a false `true`. The marker is the only thing protecting a tree from the next `createWorktree()` recreate and the heartbeat orphan-sweep, so claiming preservation without it would lose the work on retry anyway *(reviewer-caught false contract)*;
- **best-effort drops a truncated partial marker**, then best-effort **removes the worktree to reclaim space** — exactly what helps under ENOSPC. Both steps are guarded so neither re-introduces the crash.

**`isInfraError()`** — classifies `ENOSPC` / `no space left on device` / `ENOMEM` as infrastructure, so a disk-full failure gets a backoff retry instead of counting toward STUCK (the contract `preserveWorktree`'s comment now relies on). Uses the full phrase `no space left on device` so prose like *"no space left for the label"* isn't mis-flagged. Added to the `errorClassificationContract` matrix.

## Verification

- `preserveWorktree` marker-write-failure test (read-only dir → EACCES, simulating ENOSPC): resolves `false`, no crash, no marker left behind
- `isInfraError` ENOSPC/ENOMEM tests + prose-false-positive guard
- tsc + oxlint clean, full suite **148 files / 1756 passed / 1 skipped**
- `openswarm review`: **APPROVE** (2 REVISE rounds first — false-preservation contract + missing ENOSPC classification, both fixed)

## Context

Surfaced while unblocking the daemon (disk 100% full, freed ~28GB of regenerable build caches) during a `/goal` review-and-merge session. Related: INT-2545 (orphan swarm branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)