### PR TITLE
fix(worktree): resolve real remote+default branch, not hardcoded origin/main (INT-2545)

### DIFF
--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -3,7 +3,7 @@ import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, realpathSync
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { createWorktree, preserveWorktree, removePreservedWorktreeAt, removeWorktree, resolveSharedPaths, computeFileOverlaps, formatOverlapReport, type WorktreeInfo } from './worktreeManager.js';
+import { createWorktree, preserveWorktree, removePreservedWorktreeAt, removeWorktree, resolveSharedPaths, computeFileOverlaps, formatOverlapReport, resolveBaseRef, commitAndCreatePR, type WorktreeInfo } from './worktreeManager.js';
 
 describe('worktreeManager path safety', () => {
   let root: string;
@@ -346,5 +346,101 @@ describe('removePreservedWorktreeAt (INT-2506)', () => {
   it('no-ops on paths that are not managed worktrees', async () => {
     await removePreservedWorktreeAt(repo); // repo root — no /worktree/ segment
     expect(existsSync(repo)).toBe(true);
+  });
+});
+
+describe('resolveBaseRef / createWorktree on non-main-default repos (INT-2545)', () => {
+  let root: string;
+  const git = (cwd: string, ...args: string[]) => execFileSync('git', ['-C', cwd, ...args], { stdio: 'pipe' });
+
+  // Build a repo whose origin default branch is `defaultBranch`, pushed to a bare
+  // remote named `remoteName`. Returns the repo path.
+  function makeRepo(name: string, defaultBranch: string, remoteName: string): string {
+    const repo = join(root, name);
+    const bare = join(root, `${name}.git`);
+    mkdirSync(repo, { recursive: true });
+    execFileSync('git', ['init', '--bare', '-b', defaultBranch, bare], { stdio: 'pipe' });
+    execFileSync('git', ['init', '-b', defaultBranch, repo], { stdio: 'pipe' });
+    git(repo, 'config', 'user.email', 'test@example.com');
+    git(repo, 'config', 'user.name', 'Test');
+    git(repo, 'config', 'commit.gpgsign', 'false');
+    writeFileSync(join(repo, 'app.py'), 'base\n');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-m', 'init');
+    git(repo, 'remote', 'add', remoteName, bare);
+    git(repo, 'push', remoteName, defaultBranch);
+    // Set <remote>/HEAD so symbolic-ref resolves (mirrors a normal clone).
+    git(repo, 'remote', 'set-head', remoteName, defaultBranch);
+    return repo;
+  }
+
+  beforeEach(() => {
+    root = join(tmpdir(), `openswarm-baseref-${process.pid}-${Date.now()}`);
+    mkdirSync(root, { recursive: true });
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('resolves origin/main, origin/master, and a non-origin remote', async () => {
+    const mainRepo = makeRepo('mainrepo', 'main', 'origin');
+    expect(await resolveBaseRef(mainRepo)).toEqual({ remote: 'origin', branch: 'main', ref: 'origin/main' });
+
+    const masterRepo = makeRepo('masterrepo', 'master', 'origin');
+    expect(await resolveBaseRef(masterRepo)).toEqual({ remote: 'origin', branch: 'master', ref: 'origin/master' });
+
+    const forkRepo = makeRepo('forkrepo', 'main', 'unohee'); // remote not named origin (vega-agent case)
+    expect(await resolveBaseRef(forkRepo)).toEqual({ remote: 'unohee', branch: 'main', ref: 'unohee/main' });
+  });
+
+  it('createWorktree succeeds on a master-default repo (was: fatal invalid reference origin/main)', async () => {
+    const repo = makeRepo('masterrepo', 'master', 'origin');
+    const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+    expect(existsSync(info.worktreePath)).toBe(true);
+    // Branched from origin/master — app.py from the base commit is present.
+    expect(existsSync(join(info.worktreePath, 'app.py'))).toBe(true);
+    expect(execFileSync('git', ['-C', info.worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD'], { encoding: 'utf8' }).trim())
+      .toBe('swarm/INT-9-test');
+    git(repo, 'worktree', 'remove', '--force', info.worktreePath);
+  });
+
+  it('createWorktree succeeds on a repo whose remote is not named origin', async () => {
+    const repo = makeRepo('forkrepo', 'main', 'unohee');
+    const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+    expect(existsSync(info.worktreePath)).toBe(true);
+    expect(existsSync(join(info.worktreePath, 'app.py'))).toBe(true);
+    git(repo, 'worktree', 'remove', '--force', info.worktreePath);
+  });
+
+  it('commitAndCreatePR pushes to the RESOLVED remote and PRs against the resolved base (non-origin)', async () => {
+    const repo = makeRepo('forkrepo', 'main', 'unohee');
+    const bare = join(root, 'forkrepo.git');
+    const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+    writeFileSync(join(info.worktreePath, 'feature.py'), 'new work\n'); // a change to commit + PR
+
+    // Fake `gh` on PATH: record its args, return a non-/pull/ URL so registerOwnedPR
+    // (which parses github.com/owner/repo#/pull/N) is skipped — no state written.
+    const bin = join(root, 'bin');
+    mkdirSync(bin, { recursive: true });
+    const ghLog = join(root, 'gh-args.log');
+    writeFileSync(join(bin, 'gh'),
+      `#!/bin/sh\nprintf '%s\\n' "$*" >> "${ghLog}"\ncase "$*" in *"pr create"*) echo "https://example.test/created";; esac\n`);
+    chmodSync(join(bin, 'gh'), 0o755);
+
+    const prevPath = process.env.PATH;
+    process.env.PATH = `${bin}:${prevPath}`;
+    try {
+      const url = await commitAndCreatePR(info, 'test title', 'INT-9', 'desc');
+      expect(url).toBe('https://example.test/created');
+    } finally {
+      process.env.PATH = prevPath;
+    }
+
+    // The push landed on the NON-origin remote (had base ref stayed origin/main, the
+    // commits-ahead count would be 0 and it would have bailed BEFORE pushing).
+    expect(execFileSync('git', ['-C', bare, 'branch', '--list', 'swarm/INT-9-test'], { encoding: 'utf8' }))
+      .toContain('swarm/INT-9-test');
+    // gh pr create used the resolved base branch, not a hardcoded 'main'-that-happens-to-match.
+    expect(readFileSync(ghLog, 'utf8')).toMatch(/pr create .*--base main/);
+
+    git(repo, 'worktree', 'remove', '--force', info.worktreePath);
   });
 });

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -38,6 +38,38 @@ async function gh(cwd: string, ...args: string[]): Promise<string> {
   return stdout;
 }
 
+/**
+ * Resolve the base remote + default branch to branch worktrees and PRs from.
+ * OpenSwarm hardcoded `origin/main` everywhere, which silently broke every repo that
+ * doesn't match BOTH assumptions: a repo whose default branch is `master`
+ * (pykiwoom-rest, ArtifactNet) died at `git worktree add … origin/main` with
+ * `fatal: invalid reference: origin/main` → creation failed → the issue could NEVER be
+ * worked; a repo whose remote isn't named `origin` (vega-agent uses `unohee`) failed
+ * the same way. Prefer the remote's own HEAD (`<remote>/HEAD`), fall back to main then
+ * master. Works from a repo path or a worktree path (both share the repo's refs).
+ * (INT-2545)
+ */
+export async function resolveBaseRef(gitDir: string): Promise<{ remote: string; branch: string; ref: string }> {
+  const remotes = (await git(gitDir, 'remote').catch(() => ''))
+    .split('\n').map((s) => s.trim()).filter(Boolean);
+  const remote = remotes.includes('origin') ? 'origin' : (remotes[0] || 'origin');
+  let branch = '';
+  try {
+    const head = (await git(gitDir, 'symbolic-ref', `refs/remotes/${remote}/HEAD`)).trim();
+    branch = head.replace(`refs/remotes/${remote}/`, '');
+  } catch { /* <remote>/HEAD not set locally — fall through to probing */ }
+  if (!branch) {
+    for (const cand of ['main', 'master']) {
+      if (await git(gitDir, 'rev-parse', '--verify', `${remote}/${cand}`).then(() => true).catch(() => false)) {
+        branch = cand;
+        break;
+      }
+    }
+  }
+  if (!branch) branch = 'main'; // last resort — a bare repo with no fetched default
+  return { remote, branch, ref: `${remote}/${branch}` };
+}
+
 // Types
 
 export interface WorktreeInfo {
@@ -312,14 +344,17 @@ export async function createWorktree(
     );
   }
 
-  // Update main to latest
-  await git(repoPath, 'fetch', 'origin', 'main').catch((e) =>
-    console.warn(`[Worktree] Failed to fetch origin/main:`, e)
+  // Resolve the repo's real base ref (remote + default branch) — NOT hardcoded
+  // origin/main, which fataled on master-default / non-origin repos and blocked every
+  // task in them. (INT-2545)
+  const base = await resolveBaseRef(repoPath);
+  await git(repoPath, 'fetch', base.remote, base.branch).catch((e) =>
+    console.warn(`[Worktree] Failed to fetch ${base.ref}:`, e)
   );
 
-  // Create fresh worktree from origin/main
-  await git(repoPath, 'worktree', 'add', '-b', branchName, worktreePath, 'origin/main');
-  console.log(`[Worktree] Created: ${worktreePath} (branch: ${branchName})`);
+  // Create fresh worktree from the resolved base ref
+  await git(repoPath, 'worktree', 'add', '-b', branchName, worktreePath, base.ref);
+  console.log(`[Worktree] Created: ${worktreePath} (branch: ${branchName}, base: ${base.ref})`);
 
   // Share the original repo's gitignored deps/data into the fresh worktree so the
   // worker can actually install / run tests / verify against real data. (INT-2415)
@@ -405,13 +440,14 @@ async function collectActiveScopes(worktreePath: string, selfBranch: string): Pr
 
   // Active swarm/* branches without their own PR yet (exclude self + PR'd branches).
   try {
-    const branches = toLines(await git(worktreePath, 'branch', '-r', '--list', 'origin/swarm/*'))
-      .map(b => b.replace(/^origin\//, ''));
+    const base = await resolveBaseRef(worktreePath);
+    const branches = toLines(await git(worktreePath, 'branch', '-r', '--list', `${base.remote}/swarm/*`))
+      .map(b => b.replace(new RegExp(`^${base.remote}/`), ''));
     for (const b of branches) {
       if (b === selfBranch || prBranches.has(b)) continue;
       try {
-        const files = toLines(await git(worktreePath, 'diff', '--name-only', `origin/main...origin/${b}`));
-        if (files.length) scopes.push({ label: `branch origin/${b}`, files });
+        const files = toLines(await git(worktreePath, 'diff', '--name-only', `${base.ref}...${base.remote}/${b}`));
+        if (files.length) scopes.push({ label: `branch ${base.remote}/${b}`, files });
       } catch { /* skip this branch */ }
     }
   } catch { /* git unavailable — skip branch scopes */ }
@@ -425,7 +461,8 @@ async function collectActiveScopes(worktreePath: string, selfBranch: string): Pr
  */
 async function buildFileOverlapSection(worktreePath: string, selfBranch: string): Promise<string> {
   try {
-    const selfFiles = toLines(await git(worktreePath, 'diff', '--name-only', 'origin/main...HEAD'));
+    const base = await resolveBaseRef(worktreePath);
+    const selfFiles = toLines(await git(worktreePath, 'diff', '--name-only', `${base.ref}...HEAD`));
     if (selfFiles.length === 0) return '';
     const others = await collectActiveScopes(worktreePath, selfBranch);
     return formatOverlapReport(computeFileOverlaps(selfFiles, others));
@@ -463,20 +500,22 @@ export async function commitAndCreatePR(
     console.log(`[Worktree] Committed uncommitted changes (${branchName})`);
   }
 
-  // Check if there are any commits ahead of origin/main (including worker-made commits)
-  const commitsAhead = await git(worktreePath, 'rev-list', '--count', 'origin/main..HEAD')
+  // Check if there are any commits ahead of the base ref (including worker-made
+  // commits) — resolved, not hardcoded origin/main (INT-2545).
+  const base = await resolveBaseRef(worktreePath);
+  const commitsAhead = await git(worktreePath, 'rev-list', '--count', `${base.ref}..HEAD`)
     .then((out) => parseInt(out.trim(), 10))
     .catch(() => 0);
 
   if (commitsAhead === 0) {
-    console.log(`[Worktree] No commits ahead of origin/main (${branchName}) - nothing to PR`);
-    throw new Error('No commits to create PR from - branch has no changes compared to main');
+    console.log(`[Worktree] No commits ahead of ${base.ref} (${branchName}) - nothing to PR`);
+    throw new Error(`No commits to create PR from - branch has no changes compared to ${base.branch}`);
   }
 
-  console.log(`[Worktree] Branch ${branchName} has ${commitsAhead} commit(s) ahead of origin/main`);
+  console.log(`[Worktree] Branch ${branchName} has ${commitsAhead} commit(s) ahead of ${base.ref}`);
 
-  // Push branch to remote (always push since we have commits ahead)
-  await git(worktreePath, 'push', '-u', 'origin', branchName, '--force-with-lease');
+  // Push branch to the resolved remote (always push since we have commits ahead)
+  await git(worktreePath, 'push', '-u', base.remote, branchName, '--force-with-lease');
   console.log(`[Worktree] Pushed branch ${branchName}`);
 
   // If PR already exists, just return the URL
@@ -504,7 +543,7 @@ export async function commitAndCreatePR(
     '🤖 Generated with [OpenSwarm](https://github.com/Intrect-io/OpenSwarm)',
   ].join('\n');
 
-  const prUrl = await gh(worktreePath, 'pr', 'create', '--head', branchName, '--base', 'main', '--title', title, '--body', prBody);
+  const prUrl = await gh(worktreePath, 'pr', 'create', '--head', branchName, '--base', base.branch, '--title', title, '--body', prBody);
 
   const url = prUrl.trim();
   console.log(`[Worktree] PR created: ${url}`);


### PR DESCRIPTION
## Summary

**The daemon could not do code work on entire repos.** `createWorktree()` + `commitAndCreatePR()` hardcoded `origin/main` everywhere, so any repo that doesn't match BOTH assumptions failed at the very first step:

- **default branch is `master`** (pykiwoom-rest, ArtifactNet) → `git worktree add … origin/main` died with `fatal: invalid reference: origin/main` → worktree creation failed → the issue could **never** be worked. This was the **dominant daemon error** in the live logs (every STO-* task stuck).
- **remote isn't named `origin`** (vega-agent uses `unohee`) → same failure.

## Fix

`resolveBaseRef(gitDir)` resolves `{remote, branch, ref}`: prefer `<remote>/HEAD`, fall back to `main` then `master`; pick `origin` if present else the first configured remote. Wired through the **whole create → commits-ahead → push → PR chain** and the overlap report, so master-default and non-origin repos work end to end (branch from the real base, push to the real remote, PR against the real base branch).

## Tests

- `resolveBaseRef` over origin/main, origin/master, and a non-origin (`unohee`) remote
- `createWorktree` succeeds on a **master-default** repo and a **non-origin** repo (both previously fataled)
- `commitAndCreatePR` (fake `gh` on PATH) **pushes to the resolved remote** and **PRs against the resolved base** — proving completed work isn't stranded

tsc + oxlint clean, full suite **148 files / 1760 passed / 1 skipped**, `openswarm review` **APPROVE**.

## Context

Found while fixing OpenSwarm so the daemon actually does code work (`/goal` session). This is the #1 reason the pykiwoom-rest/ArtifactNet/vega-agent In Progress issues weren't being processed. Related: INT-2545 (orphan branches), INT-2548 (ENOSPC crash), INT-2521 (exception handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)