### PR TITLE
feat(adapters): add GPT-5.6 (sol/terra/luna) to Codex OAuth model catalog

### DIFF
--- a/src/adapters/codexModels.test.ts
+++ b/src/adapters/codexModels.test.ts
@@ -21,6 +21,23 @@ describe('addForwardCompatModels', () => {
   it('does not synthesize when no template matches', () => {
     expect(addForwardCompatModels(['gpt-5-codex'])).toEqual(['gpt-5-codex']);
   });
+
+  it('tiers the gpt-5.6 family: sol synthesizes from any legacy signal (mirrors gpt-5.5), terra/luna are narrower', () => {
+    // gpt-5.4-mini alone: broad net (sol, mirroring gpt-5.5's old template) + the matching
+    // narrow tier (luna); terra requires 5.4/5.5 specifically, so it's absent here.
+    expect(addForwardCompatModels(['gpt-5.4-mini'])).toEqual([
+      'gpt-5.4-mini',
+      'gpt-5.6-sol',
+      'gpt-5.6-luna',
+      'gpt-5.5',
+    ]);
+    // gpt-5.4 alone: sol + terra synthesize; luna needs gpt-5.4-mini specifically, so it's absent.
+    expect(addForwardCompatModels(['gpt-5.4'])).toEqual(['gpt-5.4', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.5']);
+    const fromCodex = addForwardCompatModels(['gpt-5.3-codex']);
+    expect(fromCodex).toContain('gpt-5.6-sol');
+    expect(fromCodex).not.toContain('gpt-5.6-terra');
+    expect(fromCodex).not.toContain('gpt-5.6-luna');
+  });
 });
 
 describe('getCodexModelIds — offline sources', () => {

--- a/src/adapters/codexModels.ts
+++ b/src/adapters/codexModels.ts
@@ -29,9 +29,20 @@ const FETCH_TIMEOUT_MS = 10_000;
  * hermes) are deliberately excluded so the picker never leaks a model selection
  * will reject. Live discovery (the primary path when authenticated) overrides
  * this list entirely.
+ *
+ * GPT-5.6 (sol/terra/luna) launched with a new naming scheme (no `-codex`
+ * suffix), verified against a live account's ~/.codex/models_cache.json on
+ * 2026-07-10 (priority 1/2/3, ahead of gpt-5.5). That live cache no longer
+ * listed gpt-5-codex or gpt-5.3-codex, but this is a single account's
+ * snapshot, not confirmation the backend rejects them fleet-wide (unlike the
+ * gpt-5.2-codex/etc slugs above, which were verified dead) — both stay in the
+ * fallback until that's independently confirmed.
  */
 export const DEFAULT_CODEX_MODELS: string[] = [
   'gpt-5-codex',
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
   'gpt-5.5',
   'gpt-5.4',
   'gpt-5.4-mini',
@@ -47,6 +58,9 @@ export const DEFAULT_CODEX_MODELS: string[] = [
  * present (mirrors Clawdbot's forward-compat catalog for GPT-5 Codex variants).
  */
 const FORWARD_COMPAT_TEMPLATES: Array<[synthetic: string, templates: string[]]> = [
+  ['gpt-5.6-sol', ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex']],
+  ['gpt-5.6-terra', ['gpt-5.5', 'gpt-5.4']],
+  ['gpt-5.6-luna', ['gpt-5.4-mini']],
   ['gpt-5.5', ['gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex']],
   ['gpt-5.4-mini', ['gpt-5.3-codex']],
   ['gpt-5.4', ['gpt-5.3-codex']],


### PR DESCRIPTION
## Summary
- Add gpt-5.6-sol/terra/luna to the offline `DEFAULT_CODEX_MODELS` fallback catalog and `FORWARD_COMPAT_TEMPLATES` synthesis rules, verified against a live account's `~/.codex/models_cache.json`.
- Scope intentionally limited to the discovery catalog — the actual default execution models (`codex.ts`, `codexResponses.ts`, `chatBackend.ts`) are unchanged.

## Test plan
- [x] `npx vitest run src/adapters/codexModels.test.ts` — 10/10 pass (includes new gpt-5.6 tiering tests)
- [x] `npx tsc --noEmit` clean
- [x] `openswarm review --adapter claude` — APPROVE (after fixing an overclaiming comment + adding dedicated tiering tests from a first-pass REVISE)

INT-2622