### PR TITLE
feat(config): enable deterministic verification (INT-2664)

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -4,10 +4,13 @@ name: OpenSwarm Review
 # the daemon's own swarm/* branches) and posts the verdict as a PR comment under
 # the openswarm-review[bot] identity. (INT-2552)
 #
-# Requires (set up once, outside this file):
+# Optional preferred identity (set up once, outside this file):
 #   - GitHub App `openswarm-review` (webhook disabled, no callback URL) with
 #     Pull requests: Read & write, Contents: Read, Checks: Read & write.
 #   - Repo secrets OPENSWARM_REVIEW_APP_ID / OPENSWARM_REVIEW_APP_PRIVATE_KEY.
+#     Until these exist (or during key rotation), the job falls back to the
+#     scoped GITHUB_TOKEN and comments as github-actions[bot].
+# Required execution host:
 #   - A self-hosted runner labeled `openswarm-review` with an already-authenticated
 #     claude/codex CLI (same credentials the daemon itself uses) — the review step
 #     below does not perform its own CLI login.
@@ -45,6 +48,7 @@ jobs:
 
       - name: Generate openswarm-review[bot] token
         id: app-token
+        continue-on-error: true
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.OPENSWARM_REVIEW_APP_ID }}
@@ -65,14 +69,20 @@ jobs:
       - name: Post review comment
         if: always()
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # App identity wins when configured. GITHUB_TOKEN keeps the review
+          # gate operational during bootstrap or App-key rotation.
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: |
           {
-            echo "### 🤖 OpenSwarm Review"
+            echo "### OpenSwarm Review"
             echo
             echo '```'
             # Strip ANSI codes — the CLI colors for terminals, not markdown.
-            sed -E 's/\x1b\[[0-9;]*m//g' review-output.txt
+            if [ -f review-output.txt ]; then
+              sed -E 's/\x1b\[[0-9;]*m//g' review-output.txt
+            else
+              echo "Review command did not produce output. Inspect the preceding workflow steps."
+            fi
             echo '```'
           } > comment-body.md
           gh pr comment "${{ github.event.pull_request.number }}" --body-file comment-body.md

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ openswarm annotate "funcName" --tag "needs-refactor"
 openswarm annotate "funcName" --warn "error/security: SQL injection"
 ```
 
+### Deterministic verification
+
+Autonomous pipelines enable baseline-diff verification by default: OpenSwarm runs repository test/typecheck commands once, compares a failing head against the merge base, and gives the reviewer structured evidence so pre-existing failures do not block unrelated work. Add `.openswarm/verify.yaml` for repository-specific commands (see [`templates/verify.example.yaml`](templates/verify.example.yaml)), or let OpenSwarm discover standard Node, Python, Rust, and Go checks. Configure the behavior under `autonomous.verify`; the legacy `guards.qualityGate` whole-tree check is deprecated.
+
 ### `openswarm exec` options
 
 | Option | Description |

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -105,9 +105,16 @@ autonomous:
       model: gemma-4-e4b-it
       timeoutMs: 120000   # 2 minutes
 
+  # Deterministic baseline-diff verification (enabled by default).
+  # Define repo-specific commands in .openswarm/verify.yaml; see templates/verify.example.yaml.
+  verify:
+    enabled: true
+    blockOnNewFailures: true
+    maxCommands: 4
+
   # Pipeline guards
   guards:
-    qualityGate: true       # bad-edit lint gate: tsc/ruff on changed files (blocking)
+    qualityGate: false      # deprecated whole-tree gate; prefer verify above
     fakeDataGuard: true
     conventionalCommits: true
     branchValidation: true

--- a/src/agents/deterministicTester.ts
+++ b/src/agents/deterministicTester.ts
@@ -3,30 +3,55 @@ import { discoverVerifyCommands } from '../verify/discover.js';
 import { loadVerifyManifest } from '../verify/manifest.js';
 import { runVerify } from '../verify/runner.js';
 import type { TesterResult } from './tester.js';
+import type { VerifyConfig } from '../core/types.js';
+import { isInfraError } from '../adapters/errorClassification.js';
 
 /** Returns null only when the repository exposes no deterministic verify commands. */
-export async function runDeterministicTester(projectPath: string): Promise<TesterResult | null> {
+export async function runDeterministicTester(projectPath: string, config: VerifyConfig): Promise<TesterResult | null> {
+  if (!config.enabled) return null;
   const loaded = await loadVerifyManifest(projectPath);
-  if (loaded.error) throw new Error(`verify-runner: ${loaded.error}`);
-  const commands = loaded.manifest?.commands ?? await discoverVerifyCommands(projectPath);
+  // A checked-in manifest error is a task/configuration failure, not transient
+  // infrastructure: fail closed instead of silently falling back to an LLM.
+  if (loaded.error) throw new Error(`verify-config: ${loaded.error}`);
+  const commands = (loaded.manifest?.commands ?? await discoverVerifyCommands(projectPath)).slice(0, config.maxCommands);
   if (commands.length === 0) return null;
 
   const base = await resolveBaseRef(projectPath).catch((error) => {
     throw new Error(`verify-runner: failed to resolve base ref: ${error instanceof Error ? error.message : String(error)}`);
   });
   const evidence = await runVerify({ projectPath, commands, baseRef: base.ref });
-  const infra = evidence.find((item) => item.headStatus === 'infra');
+  const infra = evidence.find((item) => item.headStatus === 'infra'
+    || (item.headStatus === 'fail' && item.baseStatus === 'infra'));
   if (infra) {
     throw new Error(`verify-runner: ${infra.command.name} infrastructure failure: ${infra.rawOutputTail}`);
   }
-  const failures = evidence.filter((item) => item.newFailure);
+  const headFailures = evidence.filter((item) => item.headStatus === 'fail');
+  const newFailures = headFailures.filter((item) => item.newFailure);
   return {
-    success: failures.length === 0,
-    testsPassed: evidence.length - failures.length,
-    testsFailed: failures.length,
+    success: !config.blockOnNewFailures || newFailures.length === 0,
+    testsPassed: evidence.filter((item) => item.headStatus === 'pass').length,
+    testsFailed: headFailures.length,
     output: evidence.map((item) => `[${item.command.name}] ${item.rawOutputTail}`).join('\n'),
-    failedTests: failures.map((item) => item.command.name),
+    failedTests: headFailures.map((item) => item.command.name),
     deterministic: true,
     verificationEvidence: evidence,
   };
+}
+
+export async function runTesterWithVerification(options: {
+  projectPath: string;
+  verify?: VerifyConfig;
+  fallback: () => Promise<TesterResult>;
+  onInfra?: (error: unknown) => void;
+}): Promise<TesterResult> {
+  if (options.verify?.enabled) {
+    try {
+      const deterministic = await runDeterministicTester(options.projectPath, options.verify);
+      if (deterministic) return deterministic;
+    } catch (error) {
+      if (!isInfraError(error)) throw error;
+      options.onInfra?.(error);
+    }
+  }
+  return await options.fallback();
 }

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -49,10 +49,11 @@ import { StuckDetector, createStuckDetector } from '../support/stuckDetector.js'
 import { RateLimitError } from '../adapters/rateLimitError.js';
 import { isInfraError } from '../adapters/errorClassification.js';
 import { resolveAdapterDefaultModel } from './stageModelResolver.js';
-import { runDeterministicTester } from './deterministicTester.js';
+import { runTesterWithVerification } from './deterministicTester.js';
 import { isClassifiedStageError, rethrowClassified, extractClassifiedStageResult, PipelineCancelledError } from './stageErrorClassification.js';
 import {
   isTesterCodeFile,
+  isValidationRelevantFile,
   missingWorkerValidationIssues,
   testerWouldRunForWorkerResult,
 } from './workerValidationEvidence.js';
@@ -68,7 +69,6 @@ export type {
 export { buildTaskPrefix } from './pipelineTaskPrefix.js';
 export { stageTimeoutMs } from './stageTimeouts.js';
 import { stageTimeoutMs } from './stageTimeouts.js';
-// Pair Pipeline
 export class PairPipeline extends EventEmitter {
   private config: PipelineConfig;
   private stuckDetector: StuckDetector;
@@ -375,9 +375,7 @@ export class PairPipeline extends EventEmitter {
     }
   }
 
-  /**
-   * Check if a stage is enabled
-   */
+  /** Check if a stage is enabled. */
   private hasStage(stage: PipelineStage): boolean {
     return this.config.stages.includes(stage);
   }
@@ -393,23 +391,21 @@ export class PairPipeline extends EventEmitter {
 
   private async runTester(context: PipelineContext): Promise<TesterResult> {
     if (!context.workerResult) throw new Error('Worker result required for tester');
-    const deterministic = await runDeterministicTester(context.projectPath);
-    if (deterministic) return deterministic;
-    return await testerAgent.runTester({
-      taskTitle: context.task.title,
-      taskDescription: context.task.description || '',
-      workerResult: context.workerResult,
+    return await runTesterWithVerification({
       projectPath: context.projectPath,
-      timeoutMs: stageTimeoutMs('tester', this.config.roles?.tester?.timeoutMs),
-      model: this.config.roles?.tester?.model,
-      maxTurns: this.config.roles?.tester?.maxTurns,
-      adapterName: this.config.roles?.tester?.adapter,
+      verify: this.config.verify,
+      onInfra: (error) => console.warn(`[${context.taskPrefix}] Deterministic verify unavailable; falling back to LLM tester: ${error instanceof Error ? error.message : String(error)}`),
+      fallback: () => testerAgent.runTester({
+        taskTitle: context.task.title, taskDescription: context.task.description || '',
+        workerResult: context.workerResult!, projectPath: context.projectPath,
+        timeoutMs: stageTimeoutMs('tester', this.config.roles?.tester?.timeoutMs),
+        model: this.config.roles?.tester?.model, maxTurns: this.config.roles?.tester?.maxTurns,
+        adapterName: this.config.roles?.tester?.adapter,
+      }),
     });
   }
 
-  /**
-   * Run a single stage
-   */
+  /** Run a single stage. */
   private async runStage(
     stage: PipelineStage,
     context: PipelineContext,
@@ -1065,14 +1061,17 @@ export class PairPipeline extends EventEmitter {
         // Skip tester if no code files changed (configurable, default true)
         const skipIfNoCode = this.config.skipTesterIfNoCodeChange ?? true;
         const changedFiles = context.workerResult?.filesChanged || [];
-        const hasCodeChange = changedFiles.some(isTesterCodeFile);
+        const hasCodeChange = changedFiles.some(file => this.config.verify?.enabled
+          ? isValidationRelevantFile(file)
+          : isTesterCodeFile(file));
         if (skipIfNoCode && !hasCodeChange) {
           console.log(`[${context.taskPrefix}] Skipping tester: no code files changed (${changedFiles.length} files: ${changedFiles.join(', ') || 'none'})`);
         } else {
         const testerResult = await this.runStage('tester', context);
         stages.push(testerResult);
 
-        if (!testerResult.success && !this.config.continueOnTestFail) {
+        const reviewerShouldJudgeFailure = context.testerResult?.deterministic === true;
+        if (!testerResult.success && !this.config.continueOnTestFail && !reviewerShouldJudgeFailure) {
           // Test failure is objective ground truth → record into the reflection
           // trail and drive a bounded self-repair retry (INT-1679).
           console.log(`[${context.taskPrefix}] Tester failed, retrying...`);
@@ -1351,6 +1350,7 @@ export function createPipelineFromConfig(
   draftAnalysis?: PipelineConfig['draftAnalysis'],
   maxReflections?: number,
   runMetadata?: PipelineRunMetadata,
+  verify?: PipelineConfig['verify'],
 ): PairPipeline {
   const stages: PipelineStage[] = [];
 
@@ -1360,7 +1360,7 @@ export function createPipelineFromConfig(
   if (roles?.reviewer?.enabled !== false) {
     stages.push('reviewer');
   }
-  if (roles?.tester?.enabled) {
+  if (roles?.tester?.enabled || verify?.enabled) {
     stages.push('tester');
   }
   if (roles?.documenter?.enabled) {
@@ -1382,6 +1382,7 @@ export function createPipelineFromConfig(
     jobProfiles,
     draftAnalysis,
     runMetadata,
+    verify,
   });
 }
 

--- a/src/agents/pairPipeline.verify.test.ts
+++ b/src/agents/pairPipeline.verify.test.ts
@@ -62,12 +62,18 @@ function task(): TaskItem {
   };
 }
 
-async function runPipeline(options: { continueOnTestFail?: boolean; verbose?: boolean } = {}) {
+async function runPipeline(options: {
+  continueOnTestFail?: boolean;
+  skipTesterIfNoCodeChange?: boolean;
+  verbose?: boolean;
+  verify?: { enabled: boolean; blockOnNewFailures: boolean; maxCommands: number };
+} = {}) {
   const { PairPipeline } = await import('./pairPipeline.js');
   const pipeline = new PairPipeline({
     stages: ['worker', 'tester', 'reviewer'],
     maxIterations: 1,
     skipTesterIfNoCodeChange: false,
+    verify: { enabled: true, blockOnNewFailures: true, maxCommands: 4 },
     ...options,
   });
   const logs: string[] = [];
@@ -133,7 +139,7 @@ describe('PairPipeline deterministic tester (INT-2662)', () => {
     }]);
     const { result } = await runPipeline();
     expect(result.success).toBe(true);
-    expect(result.testerResult).toMatchObject({ deterministic: true, testsPassed: 1, testsFailed: 0 });
+    expect(result.testerResult).toMatchObject({ deterministic: true, testsPassed: 0, testsFailed: 1 });
     expect(runTester).not.toHaveBeenCalled();
   });
 
@@ -144,7 +150,16 @@ describe('PairPipeline deterministic tester (INT-2662)', () => {
     expect(result.testerResult?.deterministic).toBeUndefined();
   });
 
-  it('propagates deterministic infrastructure failures as infra_error', async () => {
+  it('fails closed when the explicit verification manifest is invalid', async () => {
+    loadVerifyManifest.mockResolvedValue({ manifest: null, error: 'commands[0].run is required' });
+    const { result } = await runPipeline();
+    expect(result.success).toBe(false);
+    expect(result.stages.at(-1)).toMatchObject({ stage: 'tester', success: false });
+    expect(runTester).not.toHaveBeenCalled();
+    expect(runReviewer).not.toHaveBeenCalled();
+  });
+
+  it('downgrades deterministic infrastructure failures to the LLM fallback', async () => {
     discoverVerifyCommands.mockResolvedValue([verifyCommand]);
     runVerify.mockResolvedValue([{
       command: verifyCommand,
@@ -155,11 +170,38 @@ describe('PairPipeline deterministic tester (INT-2662)', () => {
       durationMs: 20,
     }]);
     const { result } = await runPipeline();
-    expect(result).toMatchObject({ success: false, finalStatus: 'infra_error' });
-    expect(result.stages.at(-1)).toMatchObject({ stage: 'tester', success: false });
+    expect(result).toMatchObject({ success: true, finalStatus: 'approved' });
+    expect(result.testerResult?.deterministic).toBeUndefined();
+    expect(runTester).toHaveBeenCalledOnce();
+    expect(runReviewer).toHaveBeenCalledOnce();
   });
 
-  it('keeps an approved task successful when continueOnTestFail is enabled', async () => {
+  it('downgrades an unavailable baseline comparison to the LLM fallback', async () => {
+    discoverVerifyCommands.mockResolvedValue([verifyCommand]);
+    runVerify.mockResolvedValue([{
+      command: verifyCommand, baseStatus: 'infra', headStatus: 'fail', newFailure: false,
+      rawOutputTail: 'unable to create baseline worktree', durationMs: 20,
+    }]);
+    const { result } = await runPipeline();
+    expect(result).toMatchObject({ success: true, finalStatus: 'approved' });
+    expect(result.testerResult?.deterministic).toBeUndefined();
+    expect(runTester).toHaveBeenCalledOnce();
+  });
+
+  it('preserves self-repair when an LLM fallback reports failure', async () => {
+    runTester.mockResolvedValue({
+      success: false, testsPassed: 0, testsFailed: 1, failedTests: ['LLM failure'], output: 'failed',
+    });
+    const { result } = await runPipeline();
+    expect(result.success).toBe(false);
+    expect(runTester).toHaveBeenCalledOnce();
+    expect(runReviewer).not.toHaveBeenCalled();
+  });
+
+  it('lets the reviewer judge a deterministic new failure', async () => {
+    runReviewer.mockResolvedValue({
+      decision: 'revise', feedback: 'unit tests introduced a new regression', issues: ['unit tests'],
+    });
     discoverVerifyCommands.mockResolvedValue([verifyCommand]);
     runVerify.mockResolvedValue([{
       command: verifyCommand,
@@ -169,9 +211,89 @@ describe('PairPipeline deterministic tester (INT-2662)', () => {
       rawOutputTail: 'new regression',
       durationMs: 5,
     }]);
-    const { result } = await runPipeline({ continueOnTestFail: true });
-    expect(result.success).toBe(true);
+    const { result } = await runPipeline();
+    expect(result.success).toBe(false);
     expect(result.testerResult).toMatchObject({ success: false, deterministic: true, failedTests: ['unit tests'] });
     expect(runReviewer).toHaveBeenCalledOnce();
+  });
+
+  it('runs verification for a validation-relevant manifest change', async () => {
+    runWorker.mockResolvedValue({
+      success: true, summary: 'updated manifest', filesChanged: ['.openswarm/verify.yaml'],
+      commands: ['npm test'], output: '', confidencePercent: 100,
+    });
+    loadVerifyManifest.mockResolvedValue({ manifest: { version: 1, commands: [verifyCommand] } });
+    runVerify.mockResolvedValue([{
+      command: verifyCommand, baseStatus: 'skipped', headStatus: 'pass',
+      newFailure: false, rawOutputTail: 'pass', durationMs: 1,
+    }]);
+    const { result } = await runPipeline({ skipTesterIfNoCodeChange: true });
+    expect(result.testerResult?.deterministic).toBe(true);
+    expect(runVerify).toHaveBeenCalledOnce();
+  });
+
+  it('limits manifest commands and executes deterministic verify only once', async () => {
+    const commands = Array.from({ length: 5 }, (_, index) => ({ ...verifyCommand, name: `command-${index}` }));
+    loadVerifyManifest.mockResolvedValue({ manifest: { version: 1, commands } });
+    runVerify.mockImplementation(async ({ commands: selected }) => selected.map((command: VerifyCommand) => ({
+      command,
+      baseStatus: 'skipped',
+      headStatus: 'pass',
+      newFailure: false,
+      rawOutputTail: 'pass',
+      durationMs: 1,
+    })));
+    await runPipeline({ verify: { enabled: true, blockOnNewFailures: true, maxCommands: 2 } });
+    expect(runVerify).toHaveBeenCalledOnce();
+    expect(runVerify.mock.calls[0][0].commands).toHaveLength(2);
+    expect(runReviewer).toHaveBeenCalledWith(expect.objectContaining({
+      verificationEvidence: expect.arrayContaining([expect.objectContaining({ command: expect.objectContaining({ name: 'command-0' }) })]),
+    }));
+  });
+
+  it('does not mark new failures failed when blockOnNewFailures is disabled', async () => {
+    discoverVerifyCommands.mockResolvedValue([verifyCommand]);
+    runVerify.mockResolvedValue([{
+      command: verifyCommand,
+      baseStatus: 'pass',
+      headStatus: 'fail',
+      newFailure: true,
+      rawOutputTail: 'new regression',
+      durationMs: 5,
+    }]);
+    const { result } = await runPipeline({ verify: { enabled: true, blockOnNewFailures: false, maxCommands: 4 } });
+    expect(result.testerResult).toMatchObject({ success: true, testsFailed: 1, deterministic: true });
+  });
+
+  it('auto-enables the tester stage from createPipelineFromConfig when verify is enabled', async () => {
+    loadVerifyManifest.mockResolvedValue({ manifest: { version: 1, commands: [verifyCommand] } });
+    runVerify.mockResolvedValue([{
+      command: verifyCommand,
+      baseStatus: 'skipped',
+      headStatus: 'pass',
+      newFailure: false,
+      rawOutputTail: 'pass',
+      durationMs: 1,
+    }]);
+    const { createPipelineFromConfig } = await import('./pairPipeline.js');
+    const roles = {
+      worker: { enabled: true, timeoutMs: 0 },
+      reviewer: { enabled: true, timeoutMs: 0 },
+      tester: { enabled: false, timeoutMs: 0 },
+    };
+    const pipeline = createPipelineFromConfig(
+      roles,
+      1,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { enabled: true, blockOnNewFailures: true, maxCommands: 4 },
+    );
+    const result = await pipeline.run(task(), process.cwd());
+    expect(result.success).toBe(true);
+    expect(result.testerResult?.deterministic).toBe(true);
+    expect(runVerify).toHaveBeenCalledOnce();
   });
 });

--- a/src/agents/pairPipelineTypes.ts
+++ b/src/agents/pairPipelineTypes.ts
@@ -1,5 +1,5 @@
 import type { TaskItem } from '../orchestration/decisionEngine.js';
-import type { PipelineStage, RoleConfig, PipelineGuardsConfig, JobProfile } from '../core/types.js';
+import type { PipelineStage, RoleConfig, PipelineGuardsConfig, JobProfile, VerifyConfig } from '../core/types.js';
 import type { CostInfo } from '../support/costTracker.js';
 import type { WorkerResult, ReviewResult, PairSession } from './agentPair.js';
 import type { TesterResult } from './tester.js';
@@ -34,6 +34,7 @@ export interface PipelineConfig {
     'skill-documenter'?: RoleConfig;
   };
   guards?: Partial<PipelineGuardsConfig>;
+  verify?: VerifyConfig;
   jobProfiles?: JobProfile[];
   runMetadata?: PipelineRunMetadata;
   skipTesterIfNoCodeChange?: boolean;

--- a/src/agents/pipelineGuards.test.ts
+++ b/src/agents/pipelineGuards.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { runGuards } from './pipelineGuards.js';
 import type { WorkerResult } from './agentPair.js';
 
@@ -30,6 +30,13 @@ describe('pipelineGuards — INT-2388 deterministic guards', () => {
 
   afterEach(() => {
     if (existsSync(repo)) rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('warns that the legacy quality gate is deprecated', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    await runGuards(mockWorker(), repo, { qualityGate: true });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('autonomous.verify'));
+    warn.mockRestore();
   });
 
   describe('dependencyAntiPatternCheck', () => {

--- a/src/agents/pipelineGuards.ts
+++ b/src/agents/pipelineGuards.ts
@@ -82,8 +82,8 @@ const VALID_BRANCH_PATTERNS = [
 // Guard Functions
 
 /**
- * Quality gate: run tsc --noEmit on TypeScript files or ruff check on Python files.
- * Blocking — failure causes a revise.
+ * @deprecated Prefer autonomous.verify baseline-diff evidence. This whole-tree
+ * gate is retained for compatibility and may block on pre-existing failures.
  */
 async function runQualityGate(
   workerResult: WorkerResult,
@@ -735,6 +735,7 @@ export async function runGuards(
   const results: GuardResult[] = [];
 
   if (config.qualityGate) {
+    console.warn('[Guard:qualityGate] Deprecated: use autonomous.verify baseline-diff verification instead.');
     results.push(await runQualityGate(workerResult, projectPath));
   }
 

--- a/src/agents/workerValidationEvidence.ts
+++ b/src/agents/workerValidationEvidence.ts
@@ -19,16 +19,18 @@ const INSPECTION_ONLY_COMMAND_RE = /^\s*(?:rg|grep|sed|cat|ls|find|pwd|git\s+(?:
 const SCRIPT_SMOKE_COMMAND_RE = /^\s*(?:python3?|node|tsx|ts-node|uv\s+run|npx|bunx|bash|sh)\b.*\b(?:scripts?\/|tests?\/|\.py|\.js|\.ts|\.sh|--help|--dry-run|smoke|verify|validate|check|test|build|compile)\b/i;
 const TESTER_CODE_FILE_RE = /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rs|go|java|rb|c|cpp|h|hpp)$/;
 
+export function isValidationRelevantFile(file: string): boolean {
+  if (/(^|\/)docs?\//i.test(file)) return false;
+  if (VALIDATION_RELEVANT_BASENAME_RE.test(file)) return true;
+  // Data/asset trees (locale, fixtures, snapshots, mocks) are exempt ONLY for
+  // non-code assets. A real source module under such a dir still needs a check.
+  if (DATA_ONLY_DIR_RE.test(file) && !TESTER_CODE_FILE_RE.test(file)) return false;
+  return VALIDATION_RELEVANT_FILE_RE.test(file) && !DOC_ONLY_FILE_RE.test(file);
+}
+
 function validationRelevantFiles(files: string[]): string[] {
   return files.filter(file => {
-    if (/(^|\/)docs?\//i.test(file)) return false;
-    if (VALIDATION_RELEVANT_BASENAME_RE.test(file)) return true;
-    // Data/asset trees (locale, fixtures, snapshots, mocks) are exempt ONLY for
-    // non-code assets. A real source module under such a dir (e.g.
-    // src/__mocks__/api.ts, test/fixtures/helper.ts) still needs a check —
-    // exempting the whole directory would be a gate bypass.
-    if (DATA_ONLY_DIR_RE.test(file) && !TESTER_CODE_FILE_RE.test(file)) return false;
-    return VALIDATION_RELEVANT_FILE_RE.test(file) && !DOC_ONLY_FILE_RE.test(file);
+    return isValidationRelevantFile(file);
   });
 }
 

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -1518,6 +1518,7 @@ export class AutonomousRunner {
       worktreeMode: this.config.worktreeMode ?? false,
       scheduleNextHeartbeat: () => this.scheduleNextHeartbeat(),
       guards: this.config.guards,
+      verify: this.config.verify,
       maxReflections: this.config.maxReflections,
     };
   }

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -170,6 +170,8 @@ export interface ExecutionContext {
   scheduleNextHeartbeat?: () => void;
   /** Pipeline guards configuration */
   guards?: Partial<import('../core/types.js').PipelineGuardsConfig>;
+  /** Deterministic baseline-diff verification. */
+  verify?: import('../core/types.js').VerifyConfig;
   /** Max objective self-repair attempts (lint/bs/test) before giving up (default: 3) */
   maxReflections?: number;
 }
@@ -810,6 +812,7 @@ export async function executePipeline(
       } : undefined,
       ctx.maxReflections,
       pipelineMetadata(task, actualPath, worktreeInfo),
+      ctx.verify,
     );
 
     const taskPrefix = buildTaskPrefix(task, actualPath);

--- a/src/automation/runnerTypes.ts
+++ b/src/automation/runnerTypes.ts
@@ -4,7 +4,7 @@
 
 import type { DecisionResult, TaskItem } from '../orchestration/decisionEngine.js';
 import type { ExecutorResult } from '../orchestration/workflow.js';
-import type { BacklogGroomingConfig, DefaultRolesConfig, ProjectAgentConfig, JobProfile } from '../core/types.js';
+import type { BacklogGroomingConfig, DefaultRolesConfig, ProjectAgentConfig, JobProfile, VerifyConfig } from '../core/types.js';
 
 export interface AutonomousConfig {
   defaultAdapter?: 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter' | 'claude';
@@ -39,6 +39,7 @@ export interface AutonomousConfig {
   /** Allow concurrent tasks on the same repo (requires worktreeMode). Default true. (INT-1975) */
   allowSameProjectConcurrent?: boolean;
   guards?: Partial<import('../core/types.js').PipelineGuardsConfig>;
+  verify?: VerifyConfig;
   /** Max objective self-repair attempts (lint/bs/test) before giving up (default: 3) */
   maxReflections?: number;
   /** Cooldown between task completions in ms (default: 1800000 = 30min) */

--- a/src/cli/reviewWorkflow.test.ts
+++ b/src/cli/reviewWorkflow.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+describe('OpenSwarm review workflow bootstrap (INT-2552)', () => {
+  const workflow = readFileSync(join(process.cwd(), '.github/workflows/review.yml'), 'utf8');
+  const document = parse(workflow) as { jobs: { review: { 'runs-on': string[]; steps: Array<Record<string, unknown>> } } };
+  const steps = document.jobs.review.steps;
+
+  it('prefers the GitHub App token but remains operational before secrets are installed', () => {
+    const token = steps.find((step) => step.uses === 'actions/create-github-app-token@v1');
+    const comment = steps.find((step) => step.name === 'Post review comment');
+    expect(document.jobs.review['runs-on']).toEqual(['self-hosted', 'openswarm-review']);
+    expect(token).toMatchObject({ id: 'app-token', 'continue-on-error': true });
+    expect(comment?.env).toMatchObject({ GH_TOKEN: '${{ steps.app-token.outputs.token || github.token }}' });
+  });
+
+  it('does not fail the comment step merely because review output is absent', () => {
+    const comment = steps.find((step) => step.name === 'Post review comment');
+    expect(comment?.run).toContain('if [ -f review-output.txt ]');
+  });
+});

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -141,6 +141,27 @@ agents:
 
       const config = loadConfig('/tmp/config.json');
       expect(config.autonomous?.maxReflections).toBe(3);
+      expect(config.autonomous?.verify).toEqual({
+        enabled: true,
+        blockOnNewFailures: true,
+        maxCommands: 4,
+      });
+    });
+
+    it('should preserve explicit autonomous.verify overrides', () => {
+      const jsonContent = JSON.stringify({
+        language: 'en',
+        linear: { apiKey: 'k', teamId: 't' },
+        agents: [{ name: 'main', projectPath: '/p', enabled: true, paused: false }],
+        autonomous: { enabled: true, verify: { enabled: false, blockOnNewFailures: false, maxCommands: 2 } },
+      });
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(jsonContent);
+      expect(loadConfig('/tmp/config.json').autonomous?.verify).toEqual({
+        enabled: false,
+        blockOnNewFailures: false,
+        maxCommands: 2,
+      });
     });
 
     it('should accept jobProfiles with partial role overrides', () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -257,6 +257,12 @@ const PipelineGuardsConfigSchema = z.object({
   reformatCheck: z.boolean().optional(),
 }).optional();
 
+const VerifyConfigSchema = z.object({
+  enabled: z.boolean().default(true),
+  blockOnNewFailures: z.boolean().default(true),
+  maxCommands: z.number().int().min(1).max(20).default(4),
+}).default({ enabled: true, blockOnNewFailures: true, maxCommands: 4 });
+
 const AutonomousConfigSchema = z.object({
   /** Auto-enable on service start */
   enabled: z.boolean().default(false),
@@ -298,6 +304,8 @@ const AutonomousConfigSchema = z.object({
   jobProfiles: z.array(JobProfileSchema).optional(),
   /** Pipeline quality guards (bad-edit lint gate, BS detector, etc.) */
   guards: PipelineGuardsConfigSchema,
+  /** Deterministic baseline-diff verification (default ON). */
+  verify: VerifyConfigSchema,
   /** Max objective self-repair attempts (lint/bs/test) before giving up */
   maxReflections: z.number().min(1).max(10).default(3),
   /** Cooldown between task completions in ms (default: 1800000 = 30min) */
@@ -607,6 +615,7 @@ function transformConfig(raw: RawConfig): SwarmConfig {
       worktreeMode: raw.autonomous.worktreeMode,
       allowSameProjectConcurrent: raw.autonomous.allowSameProjectConcurrent,
       guards: raw.autonomous.guards,
+      verify: raw.autonomous.verify,
       maxReflections: raw.autonomous.maxReflections,
       interTaskCooldownMs: raw.autonomous.interTaskCooldownMs,
       // jobProfiles was validated by the schema but dropped here, so per-task

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -253,6 +253,7 @@ export async function startService(config: SwarmConfig): Promise<void> {
       worktreeMode: config.autonomous.worktreeMode ?? false,
       // Pipeline guards
       guards: config.autonomous.guards,
+      verify: config.autonomous.verify,
       // Bad-edit / reflection self-repair budget
       maxReflections: config.autonomous.maxReflections,
       interTaskCooldownMs: config.autonomous.interTaskCooldownMs ?? 1_800_000,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -492,6 +492,12 @@ export interface PipelineGuardsConfig {
   autoFileFollowups?: boolean;
 }
 
+export type VerifyConfig = {
+  enabled: boolean;
+  blockOnNewFailures: boolean;
+  maxCommands: number;
+};
+
 export type AutonomousStartupConfig = {
   /** Auto-enable on service start */
   enabled: boolean;
@@ -534,6 +540,8 @@ export type AutonomousStartupConfig = {
   allowSameProjectConcurrent?: boolean;
   /** Pipeline guards configuration */
   guards?: Partial<PipelineGuardsConfig>;
+  /** Deterministic baseline-diff verification, enabled by default. */
+  verify?: VerifyConfig;
   /**
    * Max objective self-repair attempts (lint/bs/test failures) tolerated before
    * the bad-edit/reflection loop gives up. Independent of maxAttempts so it can


### PR DESCRIPTION
## Summary
- add `autonomous.verify` defaults (`enabled`, `blockOnNewFailures`, `maxCommands`) and wire them through service/runner/pipeline
- run deterministic verification once, share evidence with tester/reviewer, and preserve LLM fallback behavior
- fail closed on invalid manifests; downgrade true runner/base infrastructure failures to no deterministic evidence
- deprecate `qualityGate` with runtime guidance and document the new defaults

## Validation
- `npm test -- --run` — 155 files, 1840 passed, 1 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`
- `pairPipeline.ts` — 1500 lines

## OpenSwarm review
Decision: **REVISE** after four passes. Valid findings were addressed: LLM fallback self-repair, validation-relevant config changes, honest pass/fail counts, invalid-manifest fail-closed behavior, and baseline-infra downgrade. The remaining finding asks deterministic new failures to bypass the reviewer and hard-block; that conflicts with INT-2664’s explicit acceptance contract: “즉시 실패가 아니라 reviewer에게 증거와 함께 전달 … 하드 게이트가 아니라 evidence-informed review.” EN/KO reviewer prompts require a concrete `revise` reason when new failures exist, and the regression test models that verdict.

## Notes
- This is a stacked draft PR based on #283.
- A live `localhost:3847/api/events` smoke was not run because this repository process does not expose that endpoint in the current checkout/runtime; pipeline integration tests exercise the same evidence handoff without launching a mutating autonomous task.