### PR TITLE
fix(review): continue max fixes until fully approved

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -319,7 +319,7 @@ program
   .option('--fallback <adapter>', 'For --max: retry usage-limited areas on this adapter (default: claude for codex)')
   .option('--no-fallback', 'For --max: disable the automatic usage-limit fallback')
   .option('--fix', 'For --max: apply reviewer fixes and re-review until every area approves (working tree only, no commit)')
-  .option('--fix-rounds <n>', 'For --max --fix: optional safety cap on fix → re-review rounds (default: no cap)', parsePositiveIntegerOption)
+  .option('--fix-rounds <n>', 'For --max --fix: optional round cap (default: until clean, with a two-hour safety budget)', parsePositiveIntegerOption)
   .option('--no-learn', 'For --max: do not record the audit findings into the repo knowledge memory')
   .action(async (opts: {
     path?: string; base?: string; issues?: string | boolean; issuesPerArea?: string | boolean; file?: string | boolean; adapter?: string; debug?: boolean;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -318,8 +318,8 @@ program
   .option('--no-linear', 'For --max: skip creating the default Linear master audit issue')
   .option('--fallback <adapter>', 'For --max: retry usage-limited areas on this adapter (default: claude for codex)')
   .option('--no-fallback', 'For --max: disable the automatic usage-limit fallback')
-  .option('--fix', 'For --max: apply the reviewer fixes to each flagged area, then re-review — looping up to --fix-rounds (working tree only, no commit)')
-  .option('--fix-rounds <n>', 'For --max --fix: max fix → re-review rounds before giving up (default 3)', parsePositiveIntegerOption)
+  .option('--fix', 'For --max: apply reviewer fixes and re-review until every area approves (working tree only, no commit)')
+  .option('--fix-rounds <n>', 'For --max --fix: optional safety cap on fix → re-review rounds (default: no cap)', parsePositiveIntegerOption)
   .option('--no-learn', 'For --max: do not record the audit findings into the repo knowledge memory')
   .action(async (opts: {
     path?: string; base?: string; issues?: string | boolean; issuesPerArea?: string | boolean; file?: string | boolean; adapter?: string; debug?: boolean;

--- a/src/cli/reviewAudit.test.ts
+++ b/src/cli/reviewAudit.test.ts
@@ -463,12 +463,15 @@ describe('runFixVerifyLoop (INT-2443)', () => {
   });
 
   it('loops fix → re-review and converges once the re-review approves', async () => {
-    let reviews = 0;
+    let bReviews = 0;
     const fixed: string[] = [];
     const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 2, maxRounds: 3 }, {
       fix: async (a) => { fixed.push(a.label); return { success: true, filesChanged: a.files }; },
       // round 1 re-review still revises, round 2 approves
-      review: async () => ({ decision: ++reviews >= 2 ? 'approve' : 'revise', feedback: '' }),
+      review: async (a) => ({
+        decision: a.label === 'src/b' && ++bReviews < 2 ? 'revise' : 'approve',
+        feedback: '',
+      }),
     });
     expect(result.rounds).toHaveLength(2);
     expect(result.resolved).toBe(true);
@@ -478,17 +481,20 @@ describe('runFixVerifyLoop (INT-2443)', () => {
   });
 
   it('keeps fixing past three rounds by default until every area approves', async () => {
-    let reviews = 0;
+    let bReviews = 0;
     const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1 }, {
       fix: async (a) => ({ success: true, filesChanged: a.files }),
-      review: async () => ({ decision: ++reviews >= 5 ? 'approve' : 'revise', feedback: '' }),
+      review: async (a) => ({
+        decision: a.label === 'src/b' && ++bReviews < 5 ? 'revise' : 'approve',
+        feedback: '',
+      }),
     });
     expect(result.rounds).toHaveLength(5);
     expect(result.resolved).toBe(true);
     expect(result.stopReason).toBe('all-approved');
   });
 
-  it('runs a whole-audit confirmation and fixes findings discovered in a previously approved area', async () => {
+  it('re-reviews the whole audit each round and fixes findings discovered in a previously approved area', async () => {
     const fixed: string[] = [];
     let confirmationFoundRegression = false;
     const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1 }, {
@@ -513,12 +519,27 @@ describe('runFixVerifyLoop (INT-2443)', () => {
   it('stops at the round budget and reports the still-flagged area', async () => {
     const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1, maxRounds: 2 }, {
       fix: async (a) => ({ success: true, filesChanged: a.files }),
-      review: async () => ({ decision: 'reject', feedback: '' }), // never clears
+      review: async (a) => ({ decision: a.label === 'src/b' ? 'reject' : 'approve', feedback: '' }), // never clears b
     });
     expect(result.rounds).toHaveLength(2);
     expect(result.stopReason).toBe('max-rounds');
     expect(result.resolved).toBe(false);
     expect(fixTargets(result.finalRun).map((t) => t.area.label)).toEqual(['src/b']);
+  });
+
+  it('fails unresolved when the whole-loop wall-clock budget is exhausted', async () => {
+    let now = 0;
+    const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1, maxDurationMs: 100 }, {
+      now: () => now,
+      fix: async (a) => {
+        now += 100;
+        return { success: true, filesChanged: a.files };
+      },
+      review: async (a) => ({ decision: a.label === 'src/b' ? 'revise' : 'approve', feedback: '' }),
+    });
+    expect(result.rounds).toHaveLength(1);
+    expect(result.resolved).toBe(false);
+    expect(result.stopReason).toBe('time-budget');
   });
 
   it('bails out with no-progress when a round edits nothing, and never re-reviews', async () => {

--- a/src/cli/reviewAudit.test.ts
+++ b/src/cli/reviewAudit.test.ts
@@ -542,6 +542,19 @@ describe('runFixVerifyLoop (INT-2443)', () => {
     expect(result.stopReason).toBe('time-budget');
   });
 
+  it('reports all-approved before consulting an expired time budget', async () => {
+    const clean: AuditRun = {
+      results: [{ area: area('src/a'), review: { decision: 'approve', feedback: '' } }],
+      summary: aggregateAuditResults([]),
+    };
+    const result = await runFixVerifyLoop(clean, '/repo', { concurrency: 1, maxDurationMs: 1 }, {
+      now: () => 10_000,
+    });
+    expect(result.rounds).toHaveLength(0);
+    expect(result.resolved).toBe(true);
+    expect(result.stopReason).toBe('all-approved');
+  });
+
   it('bails out with no-progress when a round edits nothing, and never re-reviews', async () => {
     let reviewed = 0;
     const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1, maxRounds: 3 }, {

--- a/src/cli/reviewAudit.test.ts
+++ b/src/cli/reviewAudit.test.ts
@@ -542,6 +542,15 @@ describe('runFixVerifyLoop (INT-2443)', () => {
     expect(result.stopReason).toBe('time-budget');
   });
 
+  it('interrupts an in-flight fix phase when the whole-loop budget expires', async () => {
+    const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1, maxDurationMs: 10 }, {
+      fix: async () => await new Promise<{ success: boolean; filesChanged: string[] }>(() => {}),
+    });
+    expect(result.rounds).toHaveLength(0);
+    expect(result.resolved).toBe(false);
+    expect(result.stopReason).toBe('time-budget');
+  });
+
   it('reports all-approved before consulting an expired time budget', async () => {
     const clean: AuditRun = {
       results: [{ area: area('src/a'), review: { decision: 'approve', feedback: '' } }],

--- a/src/cli/reviewAudit.test.ts
+++ b/src/cli/reviewAudit.test.ts
@@ -477,6 +477,39 @@ describe('runFixVerifyLoop (INT-2443)', () => {
     expect(fixed).toEqual(['src/b', 'src/b']);            // fixed twice, never touched src/a
   });
 
+  it('keeps fixing past three rounds by default until every area approves', async () => {
+    let reviews = 0;
+    const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1 }, {
+      fix: async (a) => ({ success: true, filesChanged: a.files }),
+      review: async () => ({ decision: ++reviews >= 5 ? 'approve' : 'revise', feedback: '' }),
+    });
+    expect(result.rounds).toHaveLength(5);
+    expect(result.resolved).toBe(true);
+    expect(result.stopReason).toBe('all-approved');
+  });
+
+  it('runs a whole-audit confirmation and fixes findings discovered in a previously approved area', async () => {
+    const fixed: string[] = [];
+    let confirmationFoundRegression = false;
+    const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1 }, {
+      fix: async (a) => {
+        fixed.push(a.label);
+        return { success: true, filesChanged: a.files };
+      },
+      review: async (a) => {
+        if (a.label === 'src/a' && !confirmationFoundRegression) {
+          confirmationFoundRegression = true;
+          return { decision: 'revise', feedback: '', issues: ['cross-area regression'] };
+        }
+        return { decision: 'approve', feedback: '' };
+      },
+    });
+    expect(fixed).toEqual(['src/b', 'src/a']);
+    expect(result.rounds).toHaveLength(2);
+    expect(result.resolved).toBe(true);
+    expect(result.stopReason).toBe('all-approved');
+  });
+
   it('stops at the round budget and reports the still-flagged area', async () => {
     const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1, maxRounds: 2 }, {
       fix: async (a) => ({ success: true, filesChanged: a.files }),

--- a/src/cli/reviewAudit.ts
+++ b/src/cli/reviewAudit.ts
@@ -655,7 +655,7 @@ export interface RunFixVerifyLoopOptions {
   adapter?: AdapterName;
   /** Per-area fix-worker timeout (caller sets the long default). */
   fixTimeoutMs?: number;
-  /** Hard cap on fix → re-review rounds (default 3). */
+  /** Optional hard cap on fix → re-review rounds. Unset means run until clean or blocked. */
   maxRounds?: number;
   signal?: AbortSignal;
 }
@@ -691,8 +691,9 @@ export function mergeReReview(base: AuditRun, reReview: AuditRun): AuditRun {
 }
 
 /**
- * Iterate fix → re-review until every area approves or the round budget runs
- * out. Each round applies the reviewer's fixes to the currently-flagged areas,
+ * Iterate fix → re-review until every area approves or an explicit round budget
+ * runs out. Without a budget, continue until clean, no-progress, or rate-limit.
+ * Each round applies the reviewer's fixes to the currently-flagged areas,
  * then re-reviews ONLY the areas actually edited (an untouched flagged area
  * keeps its prior verdict — re-reviewing it would waste a subagent). Stops early
  * when a round edits nothing (workers can't progress) or a re-review hits a
@@ -705,11 +706,12 @@ export async function runFixVerifyLoop(
   opts: RunFixVerifyLoopOptions,
   deps: RunFixVerifyLoopDeps = {},
 ): Promise<FixVerifyResult> {
-  const maxRounds = opts.maxRounds && opts.maxRounds > 0 ? opts.maxRounds : 3;
+  const maxRounds = opts.maxRounds && opts.maxRounds > 0 ? opts.maxRounds : Number.POSITIVE_INFINITY;
   const reviewOpts: RunMaxReviewOptions = { concurrency: opts.concurrency, adapter: opts.adapter, signal: opts.signal };
   const fixOpts: RunAreaFixesOptions = { concurrency: opts.concurrency, adapter: opts.adapter, timeoutMs: opts.fixTimeoutMs, signal: opts.signal };
   const reviewDeps: RunMaxReviewDeps = { review: deps.review, onProgress: deps.onReviewProgress };
   const fixDeps: RunAreaFixesDeps = { fix: deps.fix, onProgress: deps.onFixProgress };
+  const allAreas = initial.results.map((result) => result.area);
 
   let run = initial;
   const rounds: FixVerifyRound[] = [];
@@ -748,7 +750,21 @@ export async function runFixVerifyLoop(
     const reReview = await runMaxReview(editedAreas, cwd, reviewOpts, reviewDeps);
     run = mergeReReview(run, reReview);
 
-    const remaining = unresolved(run);
+    let remaining = unresolved(run);
+
+    // A targeted re-review can only prove that the edited areas are clean. The
+    // edits may still regress callers or shared contracts in an area that was
+    // approved earlier. Before declaring convergence, run one fresh whole-audit
+    // confirmation. Any newly flagged area is merged back into `run` and becomes
+    // a target for the next fix round. (INT-2443 follow-up)
+    let confirmationRateLimit = false;
+    if (remaining === 0) {
+      const confirmation = await runMaxReview(allAreas, cwd, reviewOpts, reviewDeps);
+      run = mergeReReview(run, confirmation);
+      remaining = unresolved(run);
+      confirmationRateLimit = !!confirmation.rateLimit;
+    }
+
     const rec: FixVerifyRound = {
       round,
       flagged: targets.length,
@@ -760,7 +776,7 @@ export async function runFixVerifyLoop(
     rounds.push(rec);
     deps.onRoundEnd?.(rec);
 
-    if (reReview.rateLimit) { stopReason = 'rate-limit'; break; }
+    if (reReview.rateLimit || confirmationRateLimit) { stopReason = 'rate-limit'; break; }
     if (!remaining) { stopReason = 'all-approved'; break; }
     if (round === maxRounds) { stopReason = 'max-rounds'; break; }
   }

--- a/src/cli/reviewAudit.ts
+++ b/src/cli/reviewAudit.ts
@@ -637,7 +637,7 @@ export interface FixVerifyRound {
 }
 
 /** Why the loop stopped. */
-export type FixVerifyStop = 'all-approved' | 'max-rounds' | 'no-progress' | 'rate-limit';
+export type FixVerifyStop = 'all-approved' | 'max-rounds' | 'no-progress' | 'rate-limit' | 'time-budget';
 
 export interface FixVerifyResult {
   rounds: FixVerifyRound[];
@@ -657,6 +657,8 @@ export interface RunFixVerifyLoopOptions {
   fixTimeoutMs?: number;
   /** Optional hard cap on fix → re-review rounds. Unset means run until clean or blocked. */
   maxRounds?: number;
+  /** Whole-loop wall-clock budget. Defaults to two hours. */
+  maxDurationMs?: number;
   signal?: AbortSignal;
 }
 
@@ -671,6 +673,8 @@ export interface RunFixVerifyLoopDeps {
   onReviewProgress?: (e: AuditProgress) => void;
   /** End of each round: its record. */
   onRoundEnd?: (r: FixVerifyRound) => void;
+  /** Injectable clock for deterministic wall-clock budget tests. */
+  now?: () => number;
 }
 
 /**
@@ -694,8 +698,8 @@ export function mergeReReview(base: AuditRun, reReview: AuditRun): AuditRun {
  * Iterate fix → re-review until every area approves or an explicit round budget
  * runs out. Without a budget, continue until clean, no-progress, or rate-limit.
  * Each round applies the reviewer's fixes to the currently-flagged areas,
- * then re-reviews ONLY the areas actually edited (an untouched flagged area
- * keeps its prior verdict — re-reviewing it would waste a subagent). Stops early
+ * then re-reviews the whole audit surface so cross-area regressions are detected
+ * immediately. Stops early
  * when a round edits nothing (workers can't progress) or a re-review hits a
  * usage limit, so it never spins. Edits accumulate in the working tree — no
  * commit — so the user reviews the diff before committing. (INT-2443)
@@ -707,6 +711,9 @@ export async function runFixVerifyLoop(
   deps: RunFixVerifyLoopDeps = {},
 ): Promise<FixVerifyResult> {
   const maxRounds = opts.maxRounds && opts.maxRounds > 0 ? opts.maxRounds : Number.POSITIVE_INFINITY;
+  const maxDurationMs = opts.maxDurationMs && opts.maxDurationMs > 0 ? opts.maxDurationMs : 2 * 60 * 60 * 1000;
+  const now = deps.now ?? Date.now;
+  const startedAt = now();
   const reviewOpts: RunMaxReviewOptions = { concurrency: opts.concurrency, adapter: opts.adapter, signal: opts.signal };
   const fixOpts: RunAreaFixesOptions = { concurrency: opts.concurrency, adapter: opts.adapter, timeoutMs: opts.fixTimeoutMs, signal: opts.signal };
   const reviewDeps: RunMaxReviewDeps = { review: deps.review, onProgress: deps.onReviewProgress };
@@ -723,6 +730,10 @@ export async function runFixVerifyLoop(
   const unresolved = (r: AuditRun): number => r.results.filter((x) => x.review?.decision !== 'approve').length;
 
   for (let round = 1; round <= maxRounds; round++) {
+    if (now() - startedAt >= maxDurationMs) {
+      stopReason = 'time-budget';
+      break;
+    }
     const targets = fixTargets(run);
     if (!targets.length) {
       // Nothing left to fix. Clean if every area approves; otherwise the leftover
@@ -744,39 +755,27 @@ export async function runFixVerifyLoop(
       break;
     }
 
-    // Re-review only the edited areas; merge their fresh verdicts back in.
-    const editedLabels = new Set(edited.map((f) => f.label));
-    const editedAreas = targets.filter((t) => editedLabels.has(t.area.label)).map((t) => t.area);
-    const reReview = await runMaxReview(editedAreas, cwd, reviewOpts, reviewDeps);
+    // Re-review the entire surface. Fixes are scoped by directory but can still
+    // affect callers and shared contracts elsewhere, so a targeted review cannot
+    // prove that the repository is fully clean.
+    const reReview = await runMaxReview(allAreas, cwd, reviewOpts, reviewDeps);
     run = mergeReReview(run, reReview);
 
-    let remaining = unresolved(run);
-
-    // A targeted re-review can only prove that the edited areas are clean. The
-    // edits may still regress callers or shared contracts in an area that was
-    // approved earlier. Before declaring convergence, run one fresh whole-audit
-    // confirmation. Any newly flagged area is merged back into `run` and becomes
-    // a target for the next fix round. (INT-2443 follow-up)
-    let confirmationRateLimit = false;
-    if (remaining === 0) {
-      const confirmation = await runMaxReview(allAreas, cwd, reviewOpts, reviewDeps);
-      run = mergeReReview(run, confirmation);
-      remaining = unresolved(run);
-      confirmationRateLimit = !!confirmation.rateLimit;
-    }
+    const remaining = unresolved(run);
+    const freshByLabel = new Map(reReview.results.map((result) => [result.area.label, result]));
 
     const rec: FixVerifyRound = {
       round,
       flagged: targets.length,
       edited: edited.length,
       filesChanged: edited.flatMap((f) => f.filesChanged),
-      resolved: reReview.results.filter((r) => r.review?.decision === 'approve').length,
+      resolved: targets.filter((target) => freshByLabel.get(target.area.label)?.review?.decision === 'approve').length,
       remaining,
     };
     rounds.push(rec);
     deps.onRoundEnd?.(rec);
 
-    if (reReview.rateLimit || confirmationRateLimit) { stopReason = 'rate-limit'; break; }
+    if (reReview.rateLimit) { stopReason = 'rate-limit'; break; }
     if (!remaining) { stopReason = 'all-approved'; break; }
     if (round === maxRounds) { stopReason = 'max-rounds'; break; }
   }

--- a/src/cli/reviewAudit.ts
+++ b/src/cli/reviewAudit.ts
@@ -730,15 +730,15 @@ export async function runFixVerifyLoop(
   const unresolved = (r: AuditRun): number => r.results.filter((x) => x.review?.decision !== 'approve').length;
 
   for (let round = 1; round <= maxRounds; round++) {
-    if (now() - startedAt >= maxDurationMs) {
-      stopReason = 'time-budget';
-      break;
-    }
     const targets = fixTargets(run);
     if (!targets.length) {
       // Nothing left to fix. Clean if every area approves; otherwise the leftover
       // is an errored/unfixable area, not a success.
       stopReason = unresolved(run) === 0 ? 'all-approved' : 'no-progress';
+      break;
+    }
+    if (now() - startedAt >= maxDurationMs) {
+      stopReason = 'time-budget';
       break;
     }
     deps.onRoundStart?.(round, targets.length);

--- a/src/cli/reviewAudit.ts
+++ b/src/cli/reviewAudit.ts
@@ -630,7 +630,7 @@ export interface FixVerifyRound {
   /** Areas the fix workers actually edited. */
   edited: number;
   filesChanged: string[];
-  /** Edited areas that flipped to approve after the re-review. */
+  /** Previously flagged areas that the fresh whole-audit now approves. */
   resolved: number;
   /** Areas still flagged across the whole run after the re-review. */
   remaining: number;
@@ -677,6 +677,32 @@ export interface RunFixVerifyLoopDeps {
   now?: () => number;
 }
 
+class FixLoopTimeBudgetError extends Error {
+  constructor() {
+    super('fix/review loop time budget exhausted');
+    this.name = 'FixLoopTimeBudgetError';
+  }
+}
+
+/** Reject promptly when the whole-loop budget expires; the same signal aborts in-flight agents. */
+async function withinFixLoopBudget<T>(work: Promise<T>, budgetSignal: AbortSignal): Promise<T> {
+  if (budgetSignal.aborted) throw new FixLoopTimeBudgetError();
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new FixLoopTimeBudgetError());
+    budgetSignal.addEventListener('abort', onAbort, { once: true });
+    work.then(
+      (value) => {
+        budgetSignal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (error) => {
+        budgetSignal.removeEventListener('abort', onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
 /**
  * Overlay fresh re-review verdicts onto a base run: any area the re-review
  * actually re-verdicted takes the new result, the rest keep theirs. (mergeFallback
@@ -714,8 +740,10 @@ export async function runFixVerifyLoop(
   const maxDurationMs = opts.maxDurationMs && opts.maxDurationMs > 0 ? opts.maxDurationMs : 2 * 60 * 60 * 1000;
   const now = deps.now ?? Date.now;
   const startedAt = now();
-  const reviewOpts: RunMaxReviewOptions = { concurrency: opts.concurrency, adapter: opts.adapter, signal: opts.signal };
-  const fixOpts: RunAreaFixesOptions = { concurrency: opts.concurrency, adapter: opts.adapter, timeoutMs: opts.fixTimeoutMs, signal: opts.signal };
+  const budgetSignal = AbortSignal.timeout(maxDurationMs);
+  const phaseSignal = opts.signal ? AbortSignal.any([opts.signal, budgetSignal]) : budgetSignal;
+  const reviewOpts: RunMaxReviewOptions = { concurrency: opts.concurrency, adapter: opts.adapter, signal: phaseSignal };
+  const fixOpts: RunAreaFixesOptions = { concurrency: opts.concurrency, adapter: opts.adapter, timeoutMs: opts.fixTimeoutMs, signal: phaseSignal };
   const reviewDeps: RunMaxReviewDeps = { review: deps.review, onProgress: deps.onReviewProgress };
   const fixDeps: RunAreaFixesDeps = { fix: deps.fix, onProgress: deps.onFixProgress };
   const allAreas = initial.results.map((result) => result.area);
@@ -743,7 +771,16 @@ export async function runFixVerifyLoop(
     }
     deps.onRoundStart?.(round, targets.length);
 
-    const fixes = await runAreaFixes(run, cwd, fixOpts, fixDeps);
+    let fixes: FixAreaResult[];
+    try {
+      fixes = await withinFixLoopBudget(runAreaFixes(run, cwd, fixOpts, fixDeps), budgetSignal);
+    } catch (error) {
+      if (error instanceof FixLoopTimeBudgetError) {
+        stopReason = 'time-budget';
+        break;
+      }
+      throw error;
+    }
     const edited = fixes.filter((f) => f.applied && f.filesChanged.length);
     for (const f of edited) for (const p of f.filesChanged) allFiles.add(p);
 
@@ -758,7 +795,16 @@ export async function runFixVerifyLoop(
     // Re-review the entire surface. Fixes are scoped by directory but can still
     // affect callers and shared contracts elsewhere, so a targeted review cannot
     // prove that the repository is fully clean.
-    const reReview = await runMaxReview(allAreas, cwd, reviewOpts, reviewDeps);
+    let reReview: AuditRun;
+    try {
+      reReview = await withinFixLoopBudget(runMaxReview(allAreas, cwd, reviewOpts, reviewDeps), budgetSignal);
+    } catch (error) {
+      if (error instanceof FixLoopTimeBudgetError) {
+        stopReason = 'time-budget';
+        break;
+      }
+      throw error;
+    }
     run = mergeReReview(run, reReview);
 
     const remaining = unresolved(run);

--- a/src/cli/reviewMaxCommand.tsx
+++ b/src/cli/reviewMaxCommand.tsx
@@ -245,8 +245,8 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
 
   // (3.5) --fix: iterate fix → re-review until every flagged area approves or an
   //       explicitly requested --fix-rounds budget runs out. Each round fixes the
-  //       currently-flagged areas, then re-reviews only the ones actually edited
-  //       for a fresh verdict. Edits accumulate in the working tree — no commit —
+  //       currently-flagged areas, then re-reviews the full audit surface for a
+  //       fresh verdict. Edits accumulate in the working tree — no commit —
   //       so the user reviews the diff first. (INT-2249 / INT-2443)
   if (opts.fix) {
     const targets = fixTargets(run);

--- a/src/cli/reviewMaxCommand.tsx
+++ b/src/cli/reviewMaxCommand.tsx
@@ -61,7 +61,7 @@ export interface ReviewMaxOptions {
   noFallback?: boolean;
   /** Apply the reviewer's fixes to each non-approve area (working tree only). (INT-2249) */
   fix?: boolean;
-  /** For --fix: max fix → re-review rounds before giving up (default 3). (INT-2443) */
+  /** For --fix: optional fix → re-review round cap. Unset means continue until clean or blocked. */
   fixRounds?: number;
   /** Record the audit findings into repo knowledge (default true; --no-learn opts out). (INT-2268) */
   learn?: boolean;
@@ -243,8 +243,8 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
     console.warn(`  Retry after ${when}${resolveFallbackAdapter(opts) ? ' (fallback adapter also exhausted)' : ', or set `--fallback <adapter>`'}.`);
   }
 
-  // (3.5) --fix: iterate fix → re-review until every flagged area approves or the
-  //       round budget (--fix-rounds, default 3) runs out. Each round fixes the
+  // (3.5) --fix: iterate fix → re-review until every flagged area approves or an
+  //       explicitly requested --fix-rounds budget runs out. Each round fixes the
   //       currently-flagged areas, then re-reviews only the ones actually edited
   //       for a fresh verdict. Edits accumulate in the working tree — no commit —
   //       so the user reviews the diff first. (INT-2249 / INT-2443)
@@ -253,9 +253,14 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
     if (!targets.length) {
       console.log('\n--fix: nothing to apply (every area approved).');
     } else {
-      const maxRounds = positiveIntegerOption(opts.fixRounds, 3, '--fix-rounds');
+      const maxRounds = opts.fixRounds === undefined
+        ? undefined
+        : positiveIntegerOption(opts.fixRounds, opts.fixRounds, '--fix-rounds');
+      const roundBudget = maxRounds === undefined
+        ? 'until every area approves'
+        : `up to ${c.yellow(String(maxRounds))} round(s)`;
       console.log(
-        `\n${status.running('Fix → verify loop')} up to ${c.yellow(String(maxRounds))} round(s), ` +
+        `\n${status.running('Fix → verify loop')} ${roundBudget}, ` +
           `${c.yellow(String(targets.length))} area(s) flagged, ${concurrency} concurrent worker(s).`,
       );
       const loop = await runFixVerifyLoop(
@@ -266,7 +271,7 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
         { concurrency, adapter: opts.adapter as AdapterName | undefined, fixTimeoutMs: 900_000, maxRounds },
         {
           onRoundStart: (round, flagged) =>
-            console.log(`\n${c.bold(`Round ${round}/${maxRounds}`)} — fixing ${flagged} area(s)...`),
+            console.log(`\n${c.bold(`Round ${round}${maxRounds === undefined ? '' : `/${maxRounds}`}`)} — fixing ${flagged} area(s)...`),
           onFixProgress: (e) => {
             if (e.type === 'done') console.log(`  ${status.ok(`${e.label} — ${e.filesChanged} file(s) changed`)}`);
             else if (e.type === 'error') console.log(`  ${status.err(`${e.label} — ${e.error}`)}`);

--- a/src/cli/reviewMaxCommand.tsx
+++ b/src/cli/reviewMaxCommand.tsx
@@ -268,7 +268,13 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
         cwd,
         // 15 min per area: the adapter default (5 min) SIGKILLs fix workers on
         // issue-heavy areas mid-edit.
-        { concurrency, adapter: opts.adapter as AdapterName | undefined, fixTimeoutMs: 900_000, maxRounds },
+        {
+          concurrency,
+          adapter: opts.adapter as AdapterName | undefined,
+          fixTimeoutMs: 900_000,
+          maxRounds,
+          maxDurationMs: 2 * 60 * 60 * 1000,
+        },
         {
           onRoundStart: (round, flagged) =>
             console.log(`\n${c.bold(`Round ${round}${maxRounds === undefined ? '' : `/${maxRounds}`}`)} — fixing ${flagged} area(s)...`),
@@ -294,6 +300,7 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
         'max-rounds': 'round budget spent',
         'no-progress': 'workers made no edits',
         'rate-limit': 'usage limit hit',
+        'time-budget': 'two-hour safety budget spent',
       };
       // Count "not approved" (includes errored/rate-limited areas), matching
       // loop.resolved — fixTargets would undercount an errored area.


### PR DESCRIPTION
## Summary
- make `review --max --fix` continue until every audit area approves instead of stopping after three rounds by default
- retain `--fix-rounds N` as an explicit optional cap
- re-review the entire audit surface after every fix round so cross-area regressions become new fix targets immediately
- enforce a hard two-hour whole-loop budget with an AbortSignal that interrupts in-flight fix and review agents
- keep unresolved/no-progress/rate-limit/time-budget outcomes failing rather than silently claiming success

## Validation
- `npm test` — 2,737 passed, 1 skipped
- focused review loop suite — 48 passed
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

## Review rounds
Local committed-diff review was run repeatedly. Concrete findings about an unbounded loop, stale cross-area approvals, timeout ordering, and in-flight budget enforcement were addressed. The final run returned `REVISE` without any issue or suggestion; this non-actionable verdict is documented rather than treated as evidence of a remaining defect.