### PR TITLE
fix(review): require verified completion for max fixes

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -328,7 +328,7 @@ program
   }) => {
     try {
       if (opts.max) {
-        const { runReviewMaxCommand } = await import('./cli/reviewMaxCommand.js');
+        const { runReviewMaxCommand, reviewMaxResultFailed } = await import('./cli/reviewMaxCommand.js');
         const result = await runReviewMaxCommand({
           path: opts.path,
           concurrency: opts.concurrency,
@@ -348,7 +348,7 @@ program
           fixRounds: opts.fixRounds,
           learn: opts.learn,
         });
-        if (result && result.decision === 'reject') process.exitCode = 1;
+        if (reviewMaxResultFailed(result, !!opts.fix)) process.exitCode = 1;
         return;
       }
       const { runReviewCommand } = await import('./cli/reviewCommand.js');

--- a/src/cli/reviewAudit.test.ts
+++ b/src/cli/reviewAudit.test.ts
@@ -494,6 +494,38 @@ describe('runFixVerifyLoop (INT-2443)', () => {
     expect(result.stopReason).toBe('all-approved');
   });
 
+  it('does not complete on LLM approval until deterministic verification passes', async () => {
+    let verifies = 0;
+    let fixes = 0;
+    const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1, maxRounds: 3 }, {
+      fix: async (a) => {
+        fixes++;
+        return { success: true, filesChanged: a.files };
+      },
+      review: async () => ({ decision: 'approve', feedback: '' }),
+      verify: async () => ++verifies >= 2
+        ? { success: true }
+        : { success: false, failedTests: ['test'], output: 'new test failure' },
+    });
+    expect(fixes).toBe(2);
+    expect(verifies).toBe(2);
+    expect(result.rounds).toHaveLength(2);
+    expect(result.resolved).toBe(true);
+    expect(result.stopReason).toBe('all-approved');
+  });
+
+  it('fails closed when deterministic verification never passes', async () => {
+    const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1, maxRounds: 2 }, {
+      fix: async (a) => ({ success: true, filesChanged: a.files }),
+      review: async () => ({ decision: 'approve', feedback: '' }),
+      verify: async () => ({ success: false, failedTests: ['test'], output: 'still failing' }),
+    });
+    expect(result.rounds).toHaveLength(2);
+    expect(result.resolved).toBe(false);
+    expect(result.stopReason).toBe('max-rounds');
+    expect(result.finalRun.summary.issues.join('\n')).toContain('Deterministic verification failed');
+  });
+
   it('re-reviews the whole audit each round and fixes findings discovered in a previously approved area', async () => {
     const fixed: string[] = [];
     let confirmationFoundRegression = false;
@@ -564,16 +596,50 @@ describe('runFixVerifyLoop (INT-2443)', () => {
     expect(result.stopReason).toBe('all-approved');
   });
 
-  it('bails out with no-progress when a round edits nothing, and never re-reviews', async () => {
+  it('re-reviews after a no-edit fix and accepts a finding that is already cleared', async () => {
     let reviewed = 0;
     const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1, maxRounds: 3 }, {
       fix: async () => ({ success: true, filesChanged: [] }), // worker touched nothing
       review: async () => { reviewed++; return { decision: 'approve', feedback: '' }; },
     });
     expect(result.rounds).toHaveLength(1);
+    expect(result.stopReason).toBe('all-approved');
+    expect(result.resolved).toBe(true);
+    expect(reviewed).toBe(2); // whole surface: src/a + src/b
+  });
+
+  it('reports no-progress only after a no-edit whole review repeats identical findings', async () => {
+    const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1, maxRounds: 3 }, {
+      fix: async () => ({ success: true, filesChanged: [] }),
+      review: async (a) => a.label === 'src/b'
+        ? { decision: 'revise', feedback: '', issues: ['bug'] }
+        : { decision: 'approve', feedback: '' },
+    });
+    expect(result.rounds).toHaveLength(1);
     expect(result.stopReason).toBe('no-progress');
     expect(result.resolved).toBe(false);
-    expect(reviewed).toBe(0); // re-review skipped — no edits to verify
+  });
+
+  it('retries a no-edit worker when the whole review provides a changed diagnosis', async () => {
+    let fixes = 0;
+    const result = await runFixVerifyLoop(initial(), '/repo', { concurrency: 1, maxRounds: 3 }, {
+      fix: async (a) => {
+        fixes++;
+        return fixes === 1
+          ? { success: true, filesChanged: [] }
+          : { success: true, filesChanged: a.files };
+      },
+      review: async (a) => {
+        if (a.label === 'src/a') return { decision: 'approve', feedback: '' };
+        return fixes === 1
+          ? { decision: 'revise', feedback: '', issues: ['more actionable diagnosis'] }
+          : { decision: 'approve', feedback: '' };
+      },
+    });
+    expect(fixes).toBe(2);
+    expect(result.rounds).toHaveLength(2);
+    expect(result.stopReason).toBe('all-approved');
+    expect(result.resolved).toBe(true);
   });
 
   it('stops when a re-review hits a usage limit, and stays unresolved', async () => {

--- a/src/cli/reviewAudit.test.ts
+++ b/src/cli/reviewAudit.test.ts
@@ -510,6 +510,7 @@ describe('runFixVerifyLoop (INT-2443)', () => {
     expect(fixes).toBe(2);
     expect(verifies).toBe(2);
     expect(result.rounds).toHaveLength(2);
+    expect(result.rounds.map((round) => round.resolved)).toEqual([0, 1]);
     expect(result.resolved).toBe(true);
     expect(result.stopReason).toBe('all-approved');
   });

--- a/src/cli/reviewAudit.ts
+++ b/src/cli/reviewAudit.ts
@@ -843,13 +843,13 @@ export async function runFixVerifyLoop(
       run = mergeReReview(run, reReview);
       run = await applyVerificationGate(run, new Set(targets.map((target) => target.area.label)));
       const remaining = unresolved(run);
-      const freshByLabel = new Map(reReview.results.map((result) => [result.area.label, result]));
+      const gatedByLabel = new Map(run.results.map((result) => [result.area.label, result]));
       const rec: FixVerifyRound = {
         round,
         flagged: targets.length,
         edited: 0,
         filesChanged: [],
-        resolved: targets.filter((target) => freshByLabel.get(target.area.label)?.review?.decision === 'approve').length,
+        resolved: targets.filter((target) => gatedByLabel.get(target.area.label)?.review?.decision === 'approve').length,
         remaining,
       };
       rounds.push(rec);
@@ -878,14 +878,14 @@ export async function runFixVerifyLoop(
     run = await applyVerificationGate(run, new Set(edited.map((fix) => fix.label)));
 
     const remaining = unresolved(run);
-    const freshByLabel = new Map(reReview.results.map((result) => [result.area.label, result]));
+    const gatedByLabel = new Map(run.results.map((result) => [result.area.label, result]));
 
     const rec: FixVerifyRound = {
       round,
       flagged: targets.length,
       edited: edited.length,
       filesChanged: edited.flatMap((f) => f.filesChanged),
-      resolved: targets.filter((target) => freshByLabel.get(target.area.label)?.review?.decision === 'approve').length,
+      resolved: targets.filter((target) => gatedByLabel.get(target.area.label)?.review?.decision === 'approve').length,
       remaining,
     };
     rounds.push(rec);

--- a/src/cli/reviewAudit.ts
+++ b/src/cli/reviewAudit.ts
@@ -520,6 +520,7 @@ export interface RunAreaFixesOptions {
   concurrency: number;
   adapter?: AdapterName;
   timeoutMs?: number;
+  reasoningEffort?: 'low' | 'medium' | 'high';
   signal?: AbortSignal;
 }
 
@@ -573,6 +574,7 @@ async function defaultFixArea(
     projectPath: cwd,
     adapterName: opts.adapter,
     timeoutMs: opts.timeoutMs,
+    reasoningEffort: opts.reasoningEffort,
     nudgeMaxOnNoEdit: 1,
     signal: opts.signal,
     onLog,
@@ -675,6 +677,8 @@ export interface RunFixVerifyLoopDeps {
   onRoundEnd?: (r: FixVerifyRound) => void;
   /** Injectable clock for deterministic wall-clock budget tests. */
   now?: () => number;
+  /** Deterministic repository verification captured before workers edit files. */
+  verify?: () => Promise<{ success: boolean; output?: string; failedTests?: string[] } | null>;
 }
 
 class FixLoopTimeBudgetError extends Error {
@@ -743,7 +747,13 @@ export async function runFixVerifyLoop(
   const budgetSignal = AbortSignal.timeout(maxDurationMs);
   const phaseSignal = opts.signal ? AbortSignal.any([opts.signal, budgetSignal]) : budgetSignal;
   const reviewOpts: RunMaxReviewOptions = { concurrency: opts.concurrency, adapter: opts.adapter, signal: phaseSignal };
-  const fixOpts: RunAreaFixesOptions = { concurrency: opts.concurrency, adapter: opts.adapter, timeoutMs: opts.fixTimeoutMs, signal: phaseSignal };
+  const fixOpts: RunAreaFixesOptions = {
+    concurrency: opts.concurrency,
+    adapter: opts.adapter,
+    timeoutMs: opts.fixTimeoutMs,
+    reasoningEffort: 'high',
+    signal: phaseSignal,
+  };
   const reviewDeps: RunMaxReviewDeps = { review: deps.review, onProgress: deps.onReviewProgress };
   const fixDeps: RunAreaFixesDeps = { fix: deps.fix, onProgress: deps.onFixProgress };
   const allAreas = initial.results.map((result) => result.area);
@@ -756,6 +766,36 @@ export async function runFixVerifyLoop(
   // crashed is NOT resolved) — unlike fixTargets, which only counts non-approve
   // areas that still carry review findings worth another fix pass.
   const unresolved = (r: AuditRun): number => r.results.filter((x) => x.review?.decision !== 'approve').length;
+  const findingSignature = (r: AuditRun): string => JSON.stringify(r.results.map((result) => ({
+    label: result.area.label,
+    decision: result.review?.decision ?? 'error',
+    issues: result.review?.issues ?? [],
+    actions: result.review?.recommendedActions ?? [],
+  })));
+  const applyVerificationGate = async (current: AuditRun, targetLabels: Set<string>): Promise<AuditRun> => {
+    if (!deps.verify || unresolved(current) !== 0) return current;
+    const verification = await withinFixLoopBudget(deps.verify(), budgetSignal);
+    if (!verification || verification.success) return current;
+
+    const issue = [
+      `Deterministic verification failed: ${(verification.failedTests ?? []).join(', ') || 'repository checks'}`,
+      verification.output?.trim(),
+    ].filter(Boolean).join('\n');
+    const fallbackLabel = current.results[0]?.area.label;
+    const labels = targetLabels.size > 0 ? targetLabels : new Set(fallbackLabel ? [fallbackLabel] : []);
+    const results = current.results.map((result) => labels.has(result.area.label)
+      ? {
+          ...result,
+          review: {
+            decision: 'revise' as const,
+            feedback: 'LLM review approved, but deterministic verification still fails.',
+            issues: [issue],
+            recommendedActions: [{ type: 'fix', title: 'Make deterministic repository checks pass', location: result.area.dir }],
+          },
+        }
+      : result);
+    return { ...current, results, summary: aggregateAuditResults(results) };
+  };
 
   for (let round = 1; round <= maxRounds; round++) {
     const targets = fixTargets(run);
@@ -785,11 +825,40 @@ export async function runFixVerifyLoop(
     for (const f of edited) for (const p of f.filesChanged) allFiles.add(p);
 
     if (!edited.length) {
-      const rec: FixVerifyRound = { round, flagged: targets.length, edited: 0, filesChanged: [], resolved: 0, remaining: unresolved(run) };
+      // A no-edit worker report is not proof that the finding is unfixable. The
+      // finding may already have been resolved by another area's overlapping
+      // change, or a fresh reviewer may provide a more actionable diagnosis.
+      // Re-review the whole surface once before declaring no progress.
+      const before = findingSignature(run);
+      let reReview: AuditRun;
+      try {
+        reReview = await withinFixLoopBudget(runMaxReview(allAreas, cwd, reviewOpts, reviewDeps), budgetSignal);
+      } catch (error) {
+        if (error instanceof FixLoopTimeBudgetError) {
+          stopReason = 'time-budget';
+          break;
+        }
+        throw error;
+      }
+      run = mergeReReview(run, reReview);
+      run = await applyVerificationGate(run, new Set(targets.map((target) => target.area.label)));
+      const remaining = unresolved(run);
+      const freshByLabel = new Map(reReview.results.map((result) => [result.area.label, result]));
+      const rec: FixVerifyRound = {
+        round,
+        flagged: targets.length,
+        edited: 0,
+        filesChanged: [],
+        resolved: targets.filter((target) => freshByLabel.get(target.area.label)?.review?.decision === 'approve').length,
+        remaining,
+      };
       rounds.push(rec);
       deps.onRoundEnd?.(rec);
-      stopReason = 'no-progress';
-      break;
+      if (reReview.rateLimit) { stopReason = 'rate-limit'; break; }
+      if (!remaining) { stopReason = 'all-approved'; break; }
+      if (findingSignature(run) === before) { stopReason = 'no-progress'; break; }
+      if (round === maxRounds) { stopReason = 'max-rounds'; break; }
+      continue;
     }
 
     // Re-review the entire surface. Fixes are scoped by directory but can still
@@ -806,6 +875,7 @@ export async function runFixVerifyLoop(
       throw error;
     }
     run = mergeReReview(run, reReview);
+    run = await applyVerificationGate(run, new Set(edited.map((fix) => fix.label)));
 
     const remaining = unresolved(run);
     const freshByLabel = new Map(reReview.results.map((result) => [result.area.label, result]));

--- a/src/cli/reviewMaxCommand.test.ts
+++ b/src/cli/reviewMaxCommand.test.ts
@@ -22,7 +22,7 @@ vi.mock('../automation/runnerExecution.js', () => ({
   fileReviewerFollowups: (...args: unknown[]) => fileReviewerFollowupsMock(...args),
 }));
 
-const { filePerAreaFollowups, filePmSynthesizedIssues } = await import('./reviewMaxCommand.js');
+const { filePerAreaFollowups, filePmSynthesizedIssues, reviewMaxResultFailed } = await import('./reviewMaxCommand.js');
 
 function makeRun(actions: ReviewResult['recommendedActions']): AuditRun {
   const review: ReviewResult = { decision: 'revise', feedback: 'x', recommendedActions: actions };
@@ -36,6 +36,18 @@ beforeEach(() => {
   vi.clearAllMocks();
   ensureTaskSourceMock.mockResolvedValue({ createTask: vi.fn(), createSubIssue: vi.fn() });
   resolveIssueFromBranchMock.mockReturnValue(undefined);
+});
+
+describe('reviewMaxResultFailed', () => {
+  it('fails closed when --fix leaves a revise verdict unresolved', () => {
+    expect(reviewMaxResultFailed({ decision: 'revise', resolved: false }, true)).toBe(true);
+    expect(reviewMaxResultFailed({ decision: 'approve', resolved: true }, true)).toBe(false);
+  });
+
+  it('preserves report-only review semantics without --fix', () => {
+    expect(reviewMaxResultFailed({ decision: 'revise' }, false)).toBe(false);
+    expect(reviewMaxResultFailed({ decision: 'reject' }, false)).toBe(true);
+  });
 });
 
 describe('filePerAreaFollowups (INT-2599)', () => {

--- a/src/cli/reviewMaxCommand.tsx
+++ b/src/cli/reviewMaxCommand.tsx
@@ -33,6 +33,8 @@ import { resolveIssueFromBranch, ensureTaskSource, ensureProjectMapping } from '
 import { synthesizeAuditIssues } from './auditPM.js';
 import { c, status } from '../support/colors.js';
 import type { AdapterName } from '../adapters/types.js';
+import { loadConfig } from '../core/config.js';
+import { loadTrustedVerifyPlan, runDeterministicTester } from '../agents/deterministicTester.js';
 
 export interface ReviewMaxOptions {
   /** Project path (default cwd). */
@@ -65,6 +67,18 @@ export interface ReviewMaxOptions {
   fixRounds?: number;
   /** Record the audit findings into repo knowledge (default true; --no-learn opts out). (INT-2268) */
   learn?: boolean;
+}
+
+export interface ReviewMaxCommandResult {
+  decision: string;
+  /** For --fix, true only when every area has a fresh approve verdict. */
+  resolved?: boolean;
+}
+
+/** `--fix` must fail closed on revise/error, not only on an aggregate reject. */
+export function reviewMaxResultFailed(result: ReviewMaxCommandResult | null, fix: boolean): boolean {
+  if (!result) return false;
+  return result.decision === 'reject' || (fix && result.resolved !== true);
 }
 
 /**
@@ -160,7 +174,7 @@ export async function filePerAreaFollowups(cwd: string, fileIssue: string | bool
  * null when there's nothing to audit / the user declined). exit code is set to 1
  * by the caller on a reject verdict.
  */
-export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<{ decision: string } | null> {
+export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<ReviewMaxCommandResult | null> {
   const cwd = opts.path ?? process.cwd();
   const concurrency = positiveIntegerOption(opts.concurrency, 4, '--concurrency');
   const maxFilesPerArea = positiveIntegerOption(opts.maxFilesPerArea, 12, '--max-files-per-area');
@@ -190,6 +204,16 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
     console.log('Aborted.');
     return null;
   }
+
+  // Capture deterministic commands and npm script contents before any fix worker
+  // can edit them. LLM approval alone is not completion evidence: the fix must
+  // also leave the repository's real checks without new failures.
+  const verifyConfig = loadConfig().autonomous?.verify ?? {
+    enabled: true,
+    blockOnNewFailures: true,
+    maxCommands: 4,
+  };
+  const trustedVerifyPlan = opts.fix ? await loadTrustedVerifyPlan(cwd, verifyConfig) : undefined;
 
   // Live board → stderr so the final report on stdout stays pipe-clean.
   const events = new EventEmitter();
@@ -276,6 +300,21 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
           maxDurationMs: 2 * 60 * 60 * 1000,
         },
         {
+          verify: trustedVerifyPlan && trustedVerifyPlan.commands.length > 0
+            ? async () => {
+                const result = await runDeterministicTester(
+                  cwd,
+                  verifyConfig,
+                  trustedVerifyPlan.commands,
+                  trustedVerifyPlan.packageJsonByDirectory,
+                );
+                return result && {
+                  success: result.success,
+                  output: result.output,
+                  failedTests: result.failedTests,
+                };
+              }
+            : undefined,
           onRoundStart: (round, flagged) =>
             console.log(`\n${c.bold(`Round ${round}${maxRounds === undefined ? '' : `/${maxRounds}`}`)} — fixing ${flagged} area(s)...`),
           onFixProgress: (e) => {
@@ -353,7 +392,10 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
     }
   }
 
-  return { decision: run.summary.decision };
+  return {
+    decision: run.summary.decision,
+    resolved: opts.fix ? run.results.every((result) => result.review?.decision === 'approve') : undefined,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- make `review --max --fix` fail closed when any `revise` finding remains instead of exiting successfully unless the verdict was `reject`
- capture deterministic verification commands before workers edit files and require the real repository checks to pass before completion
- feed deterministic failures back into the next fix round as actionable findings
- re-review no-edit rounds before declaring no progress and retry when the diagnosis changes
- run fix workers with high reasoning effort
- report per-round resolved counts only after deterministic verification

## Live E2E evidence
A clean temporary Git repository with intentionally unsafe account operations was audited through the real `codex-responses` adapter.
- baseline `npm test` passed
- initial review found 4 defects and 3 follow-ups
- rounds 1, 2, and 3 remained `revise`
- the loop continued into round 4 rather than stopping at the former default of 3
- round 4 approved after changing both implementation and tests
- final `npm test` and `git diff --check` passed

## Validation
- `npm test` — 2,746 passed, 1 skipped
- focused completion-gate tests — 58 passed
- `npm run typecheck`
- `npm run lint`
- repeated local committed-diff reviews; all concrete findings were addressed