### PR TITLE
fix(config): ignore foreign project-local configs + guard review --max verify load (INT-2762)

### DIFF
--- a/src/cli/reviewMaxCommand.test.ts
+++ b/src/cli/reviewMaxCommand.test.ts
@@ -22,7 +22,14 @@ vi.mock('../automation/runnerExecution.js', () => ({
   fileReviewerFollowups: (...args: unknown[]) => fileReviewerFollowupsMock(...args),
 }));
 
-const { filePerAreaFollowups, filePmSynthesizedIssues, reviewMaxResultFailed } = await import('./reviewMaxCommand.js');
+const loadConfigMock = vi.fn();
+vi.mock('../core/config.js', async () => {
+  const actual = await vi.importActual<typeof import('../core/config.js')>('../core/config.js');
+  return { ...actual, loadConfig: (...args: unknown[]) => loadConfigMock(...args) };
+});
+
+const { filePerAreaFollowups, filePmSynthesizedIssues, reviewMaxResultFailed, loadVerifyConfigBestEffort } =
+  await import('./reviewMaxCommand.js');
 
 function makeRun(actions: ReviewResult['recommendedActions']): AuditRun {
   const review: ReviewResult = { decision: 'revise', feedback: 'x', recommendedActions: actions };
@@ -36,6 +43,34 @@ beforeEach(() => {
   vi.clearAllMocks();
   ensureTaskSourceMock.mockResolvedValue({ createTask: vi.fn(), createSubIssue: vi.fn() });
   resolveIssueFromBranchMock.mockReturnValue(undefined);
+});
+
+describe('loadVerifyConfigBestEffort (INT-2762)', () => {
+  const defaults = { enabled: true, blockOnNewFailures: true, maxCommands: 4 };
+
+  it('falls back to the built-in defaults when config discovery throws', () => {
+    // Regression: a repo whose own config.json shadows the OpenSwarm config used
+    // to abort `review --max --fix` right after the cost gate.
+    loadConfigMock.mockImplementation(() => {
+      throw new Error('Config validation failed:\n  - agents: Invalid input: expected array, received undefined');
+    });
+
+    expect(loadVerifyConfigBestEffort()).toEqual(defaults);
+  });
+
+  it('uses autonomous.verify when a valid config loads', () => {
+    loadConfigMock.mockReturnValue({
+      autonomous: { verify: { enabled: false, blockOnNewFailures: false, maxCommands: 2 } },
+    });
+
+    expect(loadVerifyConfigBestEffort()).toEqual({ enabled: false, blockOnNewFailures: false, maxCommands: 2 });
+  });
+
+  it('falls back to the defaults when the config has no verify block', () => {
+    loadConfigMock.mockReturnValue({ autonomous: {} });
+
+    expect(loadVerifyConfigBestEffort()).toEqual(defaults);
+  });
 });
 
 describe('reviewMaxResultFailed', () => {

--- a/src/cli/reviewMaxCommand.tsx
+++ b/src/cli/reviewMaxCommand.tsx
@@ -34,7 +34,25 @@ import { synthesizeAuditIssues } from './auditPM.js';
 import { c, status } from '../support/colors.js';
 import type { AdapterName } from '../adapters/types.js';
 import { loadConfig } from '../core/config.js';
+import type { VerifyConfig } from '../core/types.js';
 import { loadTrustedVerifyPlan, runDeterministicTester } from '../agents/deterministicTester.js';
+
+/**
+ * Best-effort verify config: `review --max` must still run in a repo with no —
+ * or an invalid — OpenSwarm config, so fall back to the built-in defaults
+ * instead of letting config discovery abort the audit. (INT-2762)
+ */
+export function loadVerifyConfigBestEffort(): VerifyConfig {
+  const defaults: VerifyConfig = { enabled: true, blockOnNewFailures: true, maxCommands: 4 };
+  try {
+    return loadConfig().autonomous?.verify ?? defaults;
+  } catch (err) {
+    // Warn so a configured verify policy never vanishes silently (reviewer gate).
+    const reason = err instanceof Error ? err.message.split('\n')[0] : String(err);
+    console.log(status.warn(`[Config] Verify policy using built-in defaults — ${reason}`));
+    return defaults;
+  }
+}
 
 export interface ReviewMaxOptions {
   /** Project path (default cwd). */
@@ -208,11 +226,7 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
   // Capture deterministic commands and npm script contents before any fix worker
   // can edit them. LLM approval alone is not completion evidence: the fix must
   // also leave the repository's real checks without new failures.
-  const verifyConfig = loadConfig().autonomous?.verify ?? {
-    enabled: true,
-    blockOnNewFailures: true,
-    maxCommands: 4,
-  };
+  const verifyConfig = loadVerifyConfigBestEffort();
   const trustedVerifyPlan = opts.fix ? await loadTrustedVerifyPlan(cwd, verifyConfig) : undefined;
 
   // Live board → stderr so the final report on stdout stays pipe-clean.

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
+import { join } from 'node:path';
 import {
+  findConfigFile,
   loadConfig,
   validateConfig,
   createAgentSession,
@@ -277,6 +279,59 @@ agents:
       } catch {
         // Might fail due to YAML parsing or validation
       }
+    });
+  });
+
+  // ============================================
+  // Config File Discovery
+  // ============================================
+
+  describe('findConfigFile project-local sniff (INT-2762)', () => {
+    const cwdYaml = join(process.cwd(), 'config.yaml');
+    const cwdJson = join(process.cwd(), 'config.json');
+    const xdgYaml = join(homedir(), '.config', 'openswarm', 'config.yaml');
+    const openswarmYaml = 'agents:\n  - name: main\n    projectPath: /tmp/project\n';
+    let savedEnvOverride: string | undefined;
+
+    beforeEach(() => {
+      savedEnvOverride = process.env.OPENSWARM_CONFIG;
+      delete process.env.OPENSWARM_CONFIG;
+    });
+
+    afterEach(() => {
+      if (savedEnvOverride !== undefined) process.env.OPENSWARM_CONFIG = savedEnvOverride;
+    });
+
+    it('skips a foreign cwd config.json and falls through to the user config', () => {
+      vi.mocked(existsSync).mockImplementation((p: fs.PathLike) => String(p) === cwdJson || String(p) === xdgYaml);
+      vi.mocked(readFileSync).mockImplementation((p: fs.PathOrFileDescriptor) =>
+        String(p) === cwdJson ? JSON.stringify({ kis_api: {}, discord: {} }) : openswarmYaml,
+      );
+
+      expect(findConfigFile()).toBe(xdgYaml);
+    });
+
+    it('keeps a cwd config that has a top-level agents array', () => {
+      vi.mocked(existsSync).mockImplementation((p: fs.PathLike) => String(p) === cwdYaml);
+      vi.mocked(readFileSync).mockReturnValue(openswarmYaml);
+
+      expect(findConfigFile()).toBe(cwdYaml);
+    });
+
+    it('returns null when only a foreign cwd config exists', () => {
+      vi.mocked(existsSync).mockImplementation((p: fs.PathLike) => String(p) === cwdJson);
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ some_app: true }));
+
+      expect(findConfigFile()).toBeNull();
+    });
+
+    it('treats an unparseable cwd config as foreign instead of crashing discovery', () => {
+      vi.mocked(existsSync).mockImplementation((p: fs.PathLike) => String(p) === cwdJson || String(p) === xdgYaml);
+      vi.mocked(readFileSync).mockImplementation((p: fs.PathOrFileDescriptor) =>
+        String(p) === cwdJson ? '{not json' : openswarmYaml,
+      );
+
+      expect(findConfigFile()).toBe(xdgYaml);
     });
   });
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -17,7 +17,9 @@ const CONFIG_FILENAMES = ['config.yaml', 'config.yml', 'config.json'] as const;
 
 // Directories searched for config, in priority order.
 // 1. $OPENSWARM_CONFIG — explicit file path (highest priority, handled separately).
-// 2. process.cwd() — project-local overrides (existing behavior).
+// 2. process.cwd() — project-local overrides. Generic filenames here (config.json/
+//    yaml) are commonly owned by the repo's own app, so cwd candidates must pass
+//    looksLikeOpenSwarmConfig before they shadow the user-level configs. (INT-2762)
 // 3. ~/.config/openswarm — XDG-style user config (preferred daemon location).
 // 4. ~/.openswarm — legacy home fallback.
 function getConfigSearchDirs(): string[] {
@@ -489,11 +491,26 @@ export function expandPath(path: string, resolveRelative = false): string {
 // Config Loading
 
 /**
+ * True when a project-local candidate looks like an OpenSwarm config.
+ * Requires the one top-level key the schema mandates — an `agents` array —
+ * so a repo's own config.json (any other app's settings) never shadows the
+ * real user-level config. Unparseable files are treated as foreign. (INT-2762)
+ */
+function looksLikeOpenSwarmConfig(path: string): boolean {
+  try {
+    const parsed = parseConfigFile(path);
+    return typeof parsed === 'object' && parsed !== null && Array.isArray((parsed as Record<string, unknown>).agents);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Find configuration file.
  *
  * Resolution order:
  *   1. $OPENSWARM_CONFIG env var (explicit file path override)
- *   2. ./config.{yaml,yml,json}           (project-local)
+ *   2. ./config.{yaml,yml,json}           (project-local; must look like an OpenSwarm config)
  *   3. ~/.config/openswarm/config.{…}     (XDG user config)
  *   4. ~/.openswarm/config.{…}            (legacy home fallback)
  */
@@ -507,8 +524,16 @@ export function findConfigFile(): string | null {
     throw new Error(`OPENSWARM_CONFIG points to a file that does not exist: ${envOverride}`);
   }
 
-  for (const path of getConfigSearchPaths()) {
-    if (existsSync(path)) {
+  const dirs = getConfigSearchDirs();
+  for (let i = 0; i < dirs.length; i++) {
+    const projectLocal = i === 0; // getConfigSearchDirs() lists process.cwd() first
+    for (const name of CONFIG_FILENAMES) {
+      const path = join(dirs[i], name);
+      if (!existsSync(path)) continue;
+      if (projectLocal && !looksLikeOpenSwarmConfig(path)) {
+        console.log(status.warn(`[Config] Ignoring ${path} — not an OpenSwarm config (no top-level "agents" list)`));
+        continue;
+      }
       return path;
     }
   }


### PR DESCRIPTION
## 문제

자체 `config.json`을 가진 레포(실측: STONKS)에서 `openswarm review --max --fix` 실행 시 비용 확인 직후 크래시:

```
Config validation failed:
  - agents: Invalid input: expected array, received undefined
```

## 원인 (두 층위)

1. **root** — `findConfigFile`의 cwd 탐색이 범용 이름 `config.{yaml,yml,json}`을 무조건 OpenSwarm 설정으로 간주. 외부 앱의 `config.json`이 `~/.config/openswarm/config.yaml`을 가림.
2. **direct** — `reviewMaxCommand.tsx`의 `loadConfig().autonomous?.verify`(#293에서 추가)가 CLI 경로에서 유일하게 try/catch 가드 없이 호출됨. 앞선 로드들은 best-effort로 삼켜져 확인 프롬프트 뒤에서야 터짐.

## 해결

- `findConfigFile`: cwd 후보는 top-level `agents` 배열(스키마 필수 키)을 가진 경우에만 채택. 외부/파싱 불가 파일은 안내 후 skip → 사용자 설정으로 폴스루. `$OPENSWARM_CONFIG`·home 경로는 기존 동작 유지.
- `loadVerifyConfigBestEffort()` 추출: 실패 시 내장 기본값 폴백 + 경고 출력(verify 정책이 조용히 무시되지 않도록).

## 검증

- 신규 테스트 7개(sniff 4 + fallback 3), 전체 vitest 197 파일 2753개 green, typecheck/lint/build 통과
- STONKS 실측: `config.json` skip 안내 → `~/.config/openswarm/config.yaml` 로드 → dry-run 플랜 정상 출력
- `openswarm review` 셀프 게이트: REVISE finding 중 "fallback 침묵" 지적을 경고 출력으로 반영, "sniff 미래 취약성"은 주석 명시로 수용

Closes INT-2762