### PR TITLE
chore(release): v0.17.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.17.6 — 2026-07-13
+
+### Fixed
+
+- **Foreign project-local configs no longer hijack discovery or crash `review --max --fix`** — a repo's own `config.json` (any other app's settings) used to shadow `~/.config/openswarm/config.yaml` via the cwd search path and abort a max review right after the cost gate with `agents: expected array, received undefined`. Discovery now requires a top-level `agents` array before claiming a cwd `config.{yaml,yml,json}` (foreign or unparseable files are skipped with a notice), and the `review --max` verify-policy read falls back to built-in defaults with a warning instead of aborting. (INT-2762, #294)
+- **`review --max --fix` completion is verified** — fix runs keep iterating until the re-review fully approves, and completion requires verified evidence instead of a first-pass approve. (#292, #293)
+- **STUCK false-positive wave closed out (INT-2521)** — infra failures (adapter/CLI errors, git snapshot/diff failures, tester crashes, reviewer parse failures, worktree creation, ENOSPC full disk) are classified and retried as infrastructure instead of masquerading as quality rejects or fake passes; wall-clock timeouts now cover every stage, git op, and task; failed worktrees are preserved for resume with a 7-day sweep. (#256–#270, rolled up in #290)
+- **Daemon/worktree correctness** — single-instance guard + atomic state-file writes (INT-2570), the repo's real remote/default branch is resolved instead of hardcoded `origin/main` (INT-2545), duplicate Linear-issue PRs are drafted with a warning (INT-2544), and fan-out winner promotion copies files instead of `git apply` (a 79% production failure rate). (#234)
+
+### Added
+
+- **`review --base <ref>` committed-diff mode** — review the commits ahead of a base ref instead of the working tree (for CI on checked-out PR branches), plus a CI review workflow scaffold. (INT-2552)
+- **GPT-5.6 (sol/terra/luna) in the Codex OAuth model catalog.** (#274)
+- **Provider parity** — consolidated usage-limit detection across providers (INT-2520) and cost/token/duration parity for loop adapters with planner model pinning. (INT-2508, INT-2509)
+
 ## 0.17.5 — 2026-07-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -534,10 +534,11 @@ the CLI (fire-and-forget with a short timeout, and failures are silently ignored
 Full version history lives in **[CHANGELOG.md](CHANGELOG.md)** and the
 [GitHub Releases](https://github.com/unohee/OpenSwarm/releases) page.
 
-Latest — **v0.17.5**: a repeating reviewer now triggers a one-shot worker
-escalation (higher model and/or `high` effort) before the session gives up —
-on top of v0.17.4's cross-session feedback persistence and fan-out
-dirty-promotion fix, and v0.17.3's duplicate-daemon prevention. See
+Latest — **v0.17.6**: config discovery no longer lets a repo's own
+`config.json` shadow the real OpenSwarm config (which crashed
+`review --max --fix` in such repos), max-fix runs iterate until the
+re-review verifiably approves, and the INT-2521 stability wave stops
+infra errors from masquerading as STUCK/quality rejects. See
 CHANGELOG.md for the rest.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.17.5",
+      "version": "0.17.6",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
0.17.6 patch release. Headline: foreign project-local configs (a repo's own config.json) no longer hijack config discovery or crash `review --max --fix` (INT-2762, #294). Also ships the verified max-fix completion gates (#292/#293), the INT-2521 STUCK false-positive wave, and the GPT-5.6 Codex catalog. See CHANGELOG.md.