### PR TITLE
fix(cli): stop launchd-managed daemon via bootout (INT-2798)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -466,22 +466,38 @@ program
   .option('-t, --timeout <ms>', 'Max time to wait for graceful shutdown (default 10000)', '10000')
   .action(async (opts: { timeout: string }) => {
     const timeoutMs = parseInt(opts.timeout, 10);
-    const { stopDaemon, probeDaemonPort } = await import('./cli/daemon.js');
+    const effectiveTimeout = Number.isFinite(timeoutMs) ? timeoutMs : 10_000;
+    const { stopDaemon, probeDaemonPort, stopExternalDaemon, LAUNCHD_LABEL } = await import('./cli/daemon.js');
     try {
-      const stopped = await stopDaemon(Number.isFinite(timeoutMs) ? timeoutMs : 10_000);
-      if (!stopped) {
-        // No PID file — but an externally managed (launchd) daemon may still be
-        // serving. Point at the right lever instead of a misleading "not running".
-        if (await probeDaemonPort()) {
-          console.log('OpenSwarm is running but externally managed (no PID file — e.g. launchd).');
-          console.log('  stop: launchctl bootout gui/$UID/com.intrect.openswarm');
-          console.log('  restart: launchctl kickstart -k gui/$UID/com.intrect.openswarm');
-          return;
-        }
-        console.log('OpenSwarm is not running.');
+      const stopped = await stopDaemon(effectiveTimeout);
+      if (stopped) {
+        console.log('OpenSwarm stopped.');
         return;
       }
-      console.log('OpenSwarm stopped.');
+      // No PID file — an externally managed (launchd) daemon may still be serving.
+      // Drive `launchctl bootout` ourselves instead of leaving the user to do it.
+      if (await probeDaemonPort()) {
+        const result = await stopExternalDaemon(effectiveTimeout);
+        if (result.outcome === 'stopped') {
+          console.log('OpenSwarm stopped (launchd service booted out).');
+          console.log('  It will start again at next login; restart now with:');
+          console.log(`  launchctl kickstart -k gui/$UID/${LAUNCHD_LABEL}`);
+          return;
+        }
+        // Couldn't stop it automatically — fall back to actionable guidance.
+        console.log('OpenSwarm is running but externally managed (no PID file — e.g. launchd).');
+        if (result.outcome === 'failed') {
+          console.log(`  Automatic bootout failed (${result.detail}). Stop it manually:`);
+        } else if (result.outcome === 'not-managed') {
+          console.log(`  No launchd job under ${LAUNCHD_LABEL}; it was started another way. Stop it manually:`);
+        } else {
+          console.log('  Stop it manually:');
+        }
+        console.log(`  stop: launchctl bootout gui/$UID/${LAUNCHD_LABEL}`);
+        console.log(`  restart: launchctl kickstart -k gui/$UID/${LAUNCHD_LABEL}`);
+        return;
+      }
+      console.log('OpenSwarm is not running.');
     } catch (err) {
       console.error(`Failed to stop: ${(err as Error).message}`);
       process.exit(1);

--- a/src/cli/daemon.test.ts
+++ b/src/cli/daemon.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { execFile } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -10,6 +11,37 @@ vi.mock('node:os', async () => {
   const actual = await vi.importActual<typeof import('node:os')>('node:os');
   return { ...actual, homedir: () => TEST_HOME };
 });
+
+// Mock only execFile so stopExternalDaemon never spawns a real `launchctl`
+// (which could stop the developer's actual daemon). spawn stays real for the
+// startDaemon tests.
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return { ...actual, execFile: vi.fn() };
+});
+
+type ExecFileCb = (err: (Error & { code?: number }) | null, stdout: string, stderr: string) => void;
+
+/** Make the mocked execFile invoke its callback with the given launchctl result. */
+function stubExecFile(err: (Error & { code?: number }) | null, stderr = ''): void {
+  vi.mocked(execFile).mockImplementation(((..._args: unknown[]) => {
+    const cb = _args[_args.length - 1] as ExecFileCb;
+    cb(err, '', stderr);
+    return {} as ReturnType<typeof execFile>;
+  }) as unknown as typeof execFile);
+}
+
+const ORIG_PLATFORM = process.platform;
+const ORIG_GETUID = process.getuid;
+
+/** Force process.platform / getuid so the launchctl path is host-independent. */
+function setPlatform(platform: NodeJS.Platform, uid: number | undefined): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  Object.defineProperty(process, 'getuid', {
+    value: uid === undefined ? undefined : () => uid,
+    configurable: true,
+  });
+}
 
 // No real sockets: probeDaemonPort goes through global fetch, which each test
 // stubs. This keeps the suite runnable in sandboxes that forbid listen().
@@ -27,6 +59,9 @@ beforeAll(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.mocked(execFile).mockReset();
+  Object.defineProperty(process, 'platform', { value: ORIG_PLATFORM, configurable: true });
+  Object.defineProperty(process, 'getuid', { value: ORIG_GETUID, configurable: true });
   rmSync(PID_FILE, { force: true });
 });
 
@@ -111,5 +146,66 @@ describe('startDaemon duplicate prevention (INT-2473)', () => {
     const fetchFn = stubFetch(async () => new Response('{}', { status: 200 }));
     await expect(startDaemon()).rejects.toThrow(/already running \(pid/);
     expect(fetchFn).not.toHaveBeenCalled();
+  });
+});
+
+describe('stopExternalDaemon (launchd bootout)', () => {
+  it('boots out the launchd job and reports stopped once the port goes quiet', async () => {
+    const { stopExternalDaemon } = await import('./daemon.js');
+    setPlatform('darwin', 501);
+    stubExecFile(null); // bootout succeeds
+    stubFetch(async () => {
+      throw new TypeError('fetch failed: ECONNREFUSED'); // port is dead now
+    });
+    const res = await stopExternalDaemon(1000);
+    expect(res.outcome).toBe('stopped');
+    expect(vi.mocked(execFile)).toHaveBeenCalledWith(
+      'launchctl',
+      ['bootout', 'gui/501/com.intrect.openswarm'],
+      expect.anything(),
+      expect.any(Function),
+    );
+  });
+
+  it('reports not-managed when launchctl has no job under our label', async () => {
+    const { stopExternalDaemon } = await import('./daemon.js');
+    setPlatform('darwin', 501);
+    stubExecFile(Object.assign(new Error('bootout'), { code: 3 }), 'Boot-out failed: 3: No such process');
+    const res = await stopExternalDaemon(1000);
+    expect(res.outcome).toBe('not-managed');
+  });
+
+  it('reports failed on an unexpected launchctl error', async () => {
+    const { stopExternalDaemon } = await import('./daemon.js');
+    setPlatform('darwin', 501);
+    stubExecFile(Object.assign(new Error('bootout'), { code: 1 }), 'Operation not permitted');
+    const res = await stopExternalDaemon(1000);
+    expect(res.outcome).toBe('failed');
+    expect(res.detail).toContain('Operation not permitted');
+  });
+
+  it('reports failed when the port keeps answering after bootout', async () => {
+    const { stopExternalDaemon } = await import('./daemon.js');
+    setPlatform('darwin', 501);
+    stubExecFile(null); // bootout "succeeds" but the process never dies
+    stubFetch(async () => new Response('{}', { status: 200 }));
+    const res = await stopExternalDaemon(300);
+    expect(res.outcome).toBe('failed');
+  });
+
+  it('reports unsupported off macOS without touching launchctl', async () => {
+    const { stopExternalDaemon } = await import('./daemon.js');
+    setPlatform('win32', 501);
+    const res = await stopExternalDaemon(1000);
+    expect(res.outcome).toBe('unsupported');
+    expect(vi.mocked(execFile)).not.toHaveBeenCalled();
+  });
+
+  it('reports unsupported when the platform has no getuid', async () => {
+    const { stopExternalDaemon } = await import('./daemon.js');
+    setPlatform('darwin', undefined);
+    const res = await stopExternalDaemon(1000);
+    expect(res.outcome).toBe('unsupported');
+    expect(vi.mocked(execFile)).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -7,7 +7,7 @@
 // and exits the parent. `openswarm stop` reads the PID file and sends SIGTERM.
 // `openswarm status` reports running/stopped plus port 3847 health.
 
-import { spawn } from 'node:child_process';
+import { spawn, execFile } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
@@ -19,6 +19,8 @@ const LOG_DIR = join(STATE_DIR, 'logs');
 const PID_FILE = join(STATE_DIR, 'openswarm.pid');
 const LOG_FILE = join(LOG_DIR, 'openswarm.log');
 const DAEMON_PORT = 3847;
+/** launchd service label the install script (scripts/install-service.sh) bootstraps. */
+const LAUNCHD_LABEL = 'com.intrect.openswarm';
 
 export interface DaemonStatus {
   running: boolean;
@@ -187,6 +189,79 @@ export async function stopDaemon(timeoutMs = 10_000): Promise<boolean> {
   );
 }
 
+/** Outcome of trying to stop a launchd-managed daemon via `launchctl bootout`. */
+export interface ExternalStopResult {
+  /**
+   * - 'stopped'      — booted out and the API port went quiet.
+   * - 'not-managed'  — launchctl has no job under our label; the running daemon
+   *                    was started some other way (e.g. `node dist/index.js`).
+   * - 'unsupported'  — not macOS, so launchctl can't be driven.
+   * - 'failed'       — bootout errored, or the port kept answering past the timeout.
+   */
+  outcome: 'stopped' | 'not-managed' | 'unsupported' | 'failed';
+  detail?: string;
+}
+
+/** Run `launchctl <args>`, resolving the exit code and stderr instead of throwing. */
+function runLaunchctl(args: string[], timeoutMs = 5000): Promise<{ ok: boolean; code: number | null; stderr: string }> {
+  return new Promise((resolve) => {
+    execFile('launchctl', args, { timeout: timeoutMs }, (err, _stdout, stderr) => {
+      const errCode = (err as { code?: unknown } | null)?.code;
+      resolve({
+        ok: !err,
+        code: typeof errCode === 'number' ? errCode : null,
+        stderr: (stderr ?? '').toString().trim(),
+      });
+    });
+  });
+}
+
+/**
+ * Stop a launchd-managed daemon (no PID file) by booting its job out of the
+ * user's GUI domain. This is the counterpart of the `launchctl bootstrap` the
+ * install script runs.
+ *
+ * `bootout` (not `stop`/`kill`) because the plist's KeepAlive is `Crashed: true`:
+ * a `launchctl stop` that ends in a non-zero exit would be respawned, whereas
+ * booting the job out unloads it so it can't come back until the plist is
+ * re-bootstrapped (at next login, since it lives in ~/Library/LaunchAgents).
+ * The daemon handles SIGTERM with a graceful shutdown (src/index.ts), which is
+ * exactly the signal bootout delivers.
+ *
+ * Callers should only reach here after `stopDaemon()` returned false AND
+ * `probeDaemonPort()` confirmed a daemon is actually serving.
+ */
+export async function stopExternalDaemon(timeoutMs = 10_000): Promise<ExternalStopResult> {
+  if (process.platform !== 'darwin') {
+    return { outcome: 'unsupported', detail: `launchctl is macOS-only (platform: ${process.platform})` };
+  }
+  const uid = typeof process.getuid === 'function' ? process.getuid() : undefined;
+  if (uid === undefined) {
+    return { outcome: 'unsupported', detail: 'could not resolve current uid' };
+  }
+
+  const target = `gui/${uid}/${LAUNCHD_LABEL}`;
+  const res = await runLaunchctl(['bootout', target]);
+
+  if (!res.ok) {
+    // bootout exits 3 / "No such process" when our label isn't loaded — the
+    // running daemon isn't this launchd job, so there's nothing for us to unload.
+    if (res.code === 3 || /no such process|could not find/i.test(res.stderr)) {
+      return { outcome: 'not-managed', detail: res.stderr || 'launchctl reported no such service' };
+    }
+    return { outcome: 'failed', detail: res.stderr || `launchctl bootout exited ${res.code}` };
+  }
+
+  // launchctl returns before the process has fully exited, so wait for the API
+  // port to stop answering before declaring the daemon dead.
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!(await probeDaemonPort())) return { outcome: 'stopped' };
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return { outcome: 'failed', detail: `daemon still answering port ${DAEMON_PORT} after ${timeoutMs}ms` };
+}
+
 /**
  * Read the last `lines` lines of the daemon log. Used by `openswarm start` to
  * show why the daemon exited when it dies during startup.
@@ -230,3 +305,4 @@ export async function getDaemonStatusFull(): Promise<DaemonStatus> {
 }
 
 export const DAEMON_PATHS = { STATE_DIR, LOG_DIR, PID_FILE, LOG_FILE } as const;
+export { LAUNCHD_LABEL };


### PR DESCRIPTION
## 문제

`openswarm stop`이 launchd로 관리되는 데몬(`com.intrect.openswarm`)을 실제로 종료하지 못했다. launchd 데몬은 PID 파일을 쓰지 않으므로 `stopDaemon()`이 `false`를 반환하고, stop 액션은 `launchctl bootout ...`을 **사용자가 직접 치라는 안내 메시지만** 출력했다 — 데몬은 계속 실행됨.

```
$ openswarm stop
OpenSwarm is running but externally managed (no PID file — e.g. launchd).
  stop: launchctl bootout gui/$UID/com.intrect.openswarm
  ...
```

## 해결

PID-file 경로가 실패하고 API 포트가 살아있으면, CLI가 직접 `launchctl bootout gui/<uid>/com.intrect.openswarm`을 실행한다.

- **`bootout`을 쓴 이유**: plist의 KeepAlive가 `Crashed`-only라 `launchctl stop`/`kill`은 비정상 종료 시 재스폰될 수 있다. `bootout`은 job을 언로드해 재스폰을 막고, plist가 `~/Library/LaunchAgents`에 있어 **다음 로그인 시 재로드**된다(=현 세션 stop 의미에 부합). 데몬은 SIGTERM→graceful shutdown→exit 0을 처리하며, 이는 bootout이 보내는 신호와 동일하다.
- launchctl을 구동할 수 없을 때(non-macOS, `getuid` 없음, 우리 레이블의 launchd job 없음, bootout 에러)만 기존 수동 안내로 폴백한다.

## 변경

- `src/cli/daemon.ts`: `stopExternalDaemon()` + `runLaunchctl()` 헬퍼 + `LAUNCHD_LABEL` export
- `src/cli.ts`: stop 액션에서 `stopExternalDaemon()` 호출, 성공/폴백 메시지 분기
- `src/cli/daemon.test.ts`: 6 케이스(stopped/not-managed/failed/timeout/unsupported×2)

## 검증

- `tsc --noEmit` clean, 전체 vitest **2759 passed / 1 skipped** (197 files)
- **실 데몬 E2E**: 실행 중이던 launchd 데몬(PID 2072) 대상 `node dist/cli.js stop` → job 언로드·포트 3847 death·PID 소멸 확인 → `launchctl bootstrap`으로 원상 복구

```
$ node dist/cli.js stop
OpenSwarm stopped (launchd service booted out).
  It will start again at next login; restart now with:
  launchctl kickstart -k gui/$UID/com.intrect.openswarm
```

Closes INT-2798