### PR TITLE
Add Atlas Cloud adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,12 @@ OPENAI_CLIENT_ID=""
 OPENROUTER_API=""
 
 # -----------------------------------------------------------------------------
+# Atlas Cloud (required if adapter=atlascloud)
+# -----------------------------------------------------------------------------
+# Get a key from https://www.atlascloud.ai/console/api-keys
+ATLASCLOUD_API_KEY=""
+
+# -----------------------------------------------------------------------------
 # Task state (optional)
 # -----------------------------------------------------------------------------
 # Override location of the persisted task-state file

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,11 +3,12 @@
 # Copy this file to config.yaml to use
 
 # Default CLI adapter for worker/reviewer stages
-# Options: claude, codex, gpt, local, lmstudio, openrouter
+# Options: claude, codex, gpt, local, lmstudio, openrouter, atlascloud
 # For GPT: run `openswarm auth login --provider gpt`
 #   (uses the public Codex OAuth client by default — no extra config needed)
 # For OpenRouter: run `openswarm auth login --provider openrouter`
 #   (PKCE browser flow → stores a sk-or-* API key; falls back to manual paste)
+# For Atlas Cloud: set ATLASCLOUD_API_KEY
 # For local: start Ollama, LMStudio, or llama.cpp server
 # For lmstudio: start LM Studio Local Server (default http://localhost:1234)
 #   Optional env: LMSTUDIO_BASE_URL, LMSTUDIO_MODEL, LMSTUDIO_API_KEY

--- a/src/adapters/atlascloud.test.ts
+++ b/src/adapters/atlascloud.test.ts
@@ -1,0 +1,82 @@
+// ============================================
+// OpenSwarm - Atlas Cloud Adapter Tests
+// Purpose: Verify Atlas Cloud adapter wiring + API call shape
+// ============================================
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AtlasCloudCliAdapter, createApiCaller } from './atlascloud.js';
+import { RateLimitError } from './rateLimitError.js';
+import { getAdapter } from './index.js';
+
+describe('AtlasCloudCliAdapter', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  it('registers as a named adapter', () => {
+    const adapter = getAdapter('atlascloud');
+    expect(adapter.name).toBe('atlascloud');
+    expect(adapter.capabilities.supportsModelSelection).toBe(true);
+    expect(adapter.capabilities.supportsJsonOutput).toBe(true);
+  });
+
+  it('reports available when ATLASCLOUD_API_KEY is set', async () => {
+    process.env.ATLASCLOUD_API_KEY = 'test-key';
+    await expect(new AtlasCloudCliAdapter().isAvailable()).resolves.toBe(true);
+  });
+
+  it('calls Atlas Cloud /chat/completions with Bearer auth', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        'data: {"choices":[{"delta":{"role":"assistant","content":"hi"},"finish_reason":"stop"}]}\n\n' +
+          'data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n\n' +
+          'data: [DONE]\n',
+        { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const callApi = createApiCaller('atlas-test-key', 'deepseek-ai/deepseek-v4-pro');
+    const response = await callApi([{ role: 'user', content: 'ping' }], []);
+
+    expect(response.choices[0].message.content).toBe('hi');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.atlascloud.ai/v1/chat/completions');
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer atlas-test-key');
+
+    const body = JSON.parse(init.body as string);
+    expect(body.model).toBe('deepseek-ai/deepseek-v4-pro');
+    expect(body.messages).toEqual([{ role: 'user', content: 'ping' }]);
+    expect(body.tools).toBeUndefined();
+  });
+
+  it('includes tools when the agentic loop provides them', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ choices: [{ message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }] }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const callApi = createApiCaller('atlas-test-key', 'qwen/qwen3.5-flash');
+    await callApi(
+      [{ role: 'user', content: 'use tools' }],
+      [{ type: 'function', function: { name: 'read_file', description: 'read', parameters: { type: 'object' } } }],
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.tools).toHaveLength(1);
+    expect(body.tools[0].function.name).toBe('read_file');
+  });
+
+  it('throws a typed RateLimitError on 429', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('Rate limit exceeded', { status: 429 })));
+    const callApi = createApiCaller('atlas-test-key', 'deepseek-ai/deepseek-v4-pro');
+    await expect(callApi([{ role: 'user', content: 'x' }], [])).rejects.toBeInstanceOf(RateLimitError);
+  });
+});

--- a/src/adapters/atlascloud.ts
+++ b/src/adapters/atlascloud.ts
@@ -1,0 +1,167 @@
+// ============================================
+// OpenSwarm - Atlas Cloud CLI Adapter
+// Calls the Atlas Cloud OpenAI-compatible Chat Completions API.
+// ============================================
+
+import type {
+  CliAdapter,
+  CliRunOptions,
+  CliRunResult,
+  AdapterCapabilities,
+  WorkerResult,
+  ReviewResult,
+} from './types.js';
+import {
+  runAgenticLoop,
+  loopResultToCliResult,
+  type ChatMessage,
+  type AgenticLoopOptions,
+} from './agenticLoop.js';
+import { resolveMcpTools } from '../mcp/mcpClient.js';
+import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
+import { RateLimitError, rateLimitFromHttpResponse } from './rateLimitError.js';
+import { isInfraError } from './errorClassification.js';
+import { consumeChatCompletionsStream } from './chatStream.js';
+import type { ToolDefinition } from './tools.js';
+
+export const ATLASCLOUD_API_BASE = 'https://api.atlascloud.ai/v1';
+export const ATLASCLOUD_DEFAULT_MODEL = 'deepseek-ai/deepseek-v4-pro';
+
+function getEnvApiKey(): string | undefined {
+  return process.env.ATLASCLOUD_API_KEY?.trim() || process.env.ATLAS_CLOUD_API_KEY?.trim() || undefined;
+}
+
+export class AtlasCloudCliAdapter implements CliAdapter {
+  readonly name = 'atlascloud';
+
+  readonly capabilities: AdapterCapabilities = {
+    supportsStreaming: false,
+    supportsJsonOutput: true,
+    supportsModelSelection: true,
+    managedGit: false,
+    supportedSkills: [],
+  };
+
+  async isAvailable(): Promise<boolean> {
+    return Boolean(getEnvApiKey());
+  }
+
+  buildCommand(_options: CliRunOptions): { command: string; args: string[] } {
+    return { command: 'echo', args: ['"Atlas Cloud adapter uses run() — not shell spawn"'] };
+  }
+
+  async getDefaultModel(): Promise<string> {
+    return ATLASCLOUD_DEFAULT_MODEL;
+  }
+
+  async run(options: CliRunOptions): Promise<CliRunResult> {
+    const startTime = Date.now();
+    const apiKey = getEnvApiKey();
+
+    if (!apiKey) {
+      return {
+        exitCode: 1,
+        stdout: '',
+        stderr: 'Auth error: Set ATLASCLOUD_API_KEY to use the Atlas Cloud adapter.',
+        durationMs: Date.now() - startTime,
+      };
+    }
+
+    const model = options.model ?? await this.getDefaultModel();
+    const callApi = createApiCaller(apiKey, model, {
+      onToken: options.onToken,
+      signal: options.signal,
+    });
+
+    const mcpTools = await resolveMcpTools(options.mcpTools);
+
+    const loopOptions: AgenticLoopOptions = {
+      systemPrompt: options.systemPrompt,
+      prompt: options.prompt,
+      cwd: options.cwd ?? process.cwd(),
+      model,
+      callApi,
+      maxTurns: options.maxTurns ?? 20,
+      timeoutMs: options.timeoutMs ?? 300000,
+      onLog: options.onLog,
+      enableTools: options.enableTools ?? true,
+      nudgeMaxOnNoEdit: options.nudgeMaxOnNoEdit,
+      protectedFiles: options.protectedFiles,
+      bashTimeoutMs: options.bashTimeoutMs,
+      webTools: options.webTools,
+      memoryTools: options.memoryTools,
+      readOnly: options.readOnly,
+      mcpTools,
+      signal: options.signal,
+      editFormat: options.editFormat,
+    };
+
+    try {
+      const result = await runAgenticLoop(loopOptions);
+      options.onLog?.(
+        `[Atlas Cloud] ${result.apiCallCount} API calls, ${result.toolCallCount} tool uses, ${result.totalTokens} tokens`,
+      );
+      return loopResultToCliResult(result);
+    } catch (err) {
+      if (err instanceof RateLimitError) throw err;
+      if (isInfraError(err)) throw err;
+      return {
+        exitCode: 1,
+        stdout: '',
+        stderr: `Atlas Cloud agentic loop failed: ${err instanceof Error ? err.message : String(err)}`,
+        durationMs: Date.now() - startTime,
+      };
+    }
+  }
+
+  parseWorkerOutput(raw: CliRunResult): WorkerResult {
+    return parseWorkerResult(raw.stdout);
+  }
+
+  parseReviewerOutput(raw: CliRunResult): ReviewResult {
+    return parseReviewerResult(raw.stdout);
+  }
+}
+
+export interface AtlasCloudApiCallerOptions {
+  onToken?: (delta: string) => void;
+  signal?: AbortSignal;
+}
+
+export function createApiCaller(apiKey: string, model: string, opts: AtlasCloudApiCallerOptions = {}) {
+  return async (messages: ChatMessage[], tools: ToolDefinition[]) => {
+    const body: Record<string, unknown> = {
+      model,
+      messages,
+      temperature: 0.2,
+      max_tokens: 16384,
+      stream: true,
+      stream_options: { include_usage: true },
+    };
+    if (tools.length > 0) {
+      body.tools = tools;
+    }
+
+    const res = await fetch(`${ATLASCLOUD_API_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      signal: opts.signal,
+    });
+
+    if (!res.ok) {
+      const errText = await res.text().catch(() => '');
+      const rl = rateLimitFromHttpResponse(res.status, res.headers, errText);
+      if (rl) throw rl;
+      throw new Error(`Atlas Cloud API error (${res.status}): ${errText.slice(0, 500)}`);
+    }
+
+    return consumeChatCompletionsStream(res, opts.onToken);
+  };
+}
+
+// Worker/Reviewer output parsing lives in ./resultParsing.ts (shared with the
+// gpt, local, and openrouter adapters).

--- a/src/adapters/index.test.ts
+++ b/src/adapters/index.test.ts
@@ -3,7 +3,7 @@ import { isKnownAdapter, listAdapterNames } from './index.js';
 
 describe('isKnownAdapter', () => {
   it('accepts currently-registered adapters (incl. claude, the opt-in claude -p delegate)', () => {
-    for (const name of ['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter', 'claude']) {
+    for (const name of ['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter', 'atlascloud', 'claude']) {
       expect(isKnownAdapter(name)).toBe(true);
     }
   });
@@ -19,7 +19,7 @@ describe('isKnownAdapter', () => {
 
   it('listAdapterNames returns every registered adapter', () => {
     expect([...listAdapterNames()].sort()).toEqual(
-      ['claude', 'codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter'].sort(),
+      ['atlascloud', 'claude', 'codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter'].sort(),
     );
   });
 });

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -21,6 +21,7 @@ export { GptCliAdapter } from './gpt.js';
 export { LocalModelAdapter } from './local.js';
 export { LmStudioAdapter } from './lmstudio.js';
 export { OpenRouterCliAdapter } from './openrouter.js';
+export { AtlasCloudCliAdapter } from './atlascloud.js';
 export { ClaudeCliAdapter } from './claude.js';
 export { registerProcess, getProcess, getAllProcesses, killProcess, startHealthChecker, stopHealthChecker } from './processRegistry.js';
 
@@ -30,6 +31,7 @@ import { GptCliAdapter } from './gpt.js';
 import { LocalModelAdapter } from './local.js';
 import { LmStudioAdapter } from './lmstudio.js';
 import { OpenRouterCliAdapter } from './openrouter.js';
+import { AtlasCloudCliAdapter } from './atlascloud.js';
 import { ClaudeCliAdapter } from './claude.js';
 import type { AdapterName, CliAdapter } from './types.js';
 
@@ -40,6 +42,7 @@ const adapters: Record<string, CliAdapter> = {
   local: new LocalModelAdapter(),
   lmstudio: new LmStudioAdapter(),
   openrouter: new OpenRouterCliAdapter(),
+  atlascloud: new AtlasCloudCliAdapter(),
   // claude -p CLI delegate — opt-in fallback (Anthropic hasn't blocked it). Offered
   // by `openswarm init` and the dashboard provider switch, so it must be registered.
   claude: new ClaudeCliAdapter(),

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -10,7 +10,7 @@ import type { CostInfo } from '../support/costTracker.js';
 // Re-export for convenience
 export type { WorkerResult, ReviewResult };
 
-export type AdapterName = 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter' | 'claude';
+export type AdapterName = 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter' | 'atlascloud' | 'claude';
 
 /**
  * Raw result from a CLI process execution

--- a/src/automation/runnerTypes.ts
+++ b/src/automation/runnerTypes.ts
@@ -7,7 +7,7 @@ import type { ExecutorResult } from '../orchestration/workflow.js';
 import type { BacklogGroomingConfig, DefaultRolesConfig, ProjectAgentConfig, JobProfile, VerifyConfig } from '../core/types.js';
 
 export interface AutonomousConfig {
-  defaultAdapter?: 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter' | 'claude';
+  defaultAdapter?: 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter' | 'atlascloud' | 'claude';
   linearTeamId: string;
   allowedProjects: string[];
   heartbeatSchedule: string;

--- a/src/cli/initWizard.test.ts
+++ b/src/cli/initWizard.test.ts
@@ -53,8 +53,8 @@ describe('buildWizardConfig', () => {
 });
 
 // AdapterNameSchema (src/core/config.ts) accepts exactly these.
-const VALID_ADAPTERS = ['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter', 'claude'];
-const PROVIDERS = ['codex-responses', 'openrouter', 'gpt', 'lmstudio', 'local', 'codex', 'claude'] as const;
+const VALID_ADAPTERS = ['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter', 'atlascloud', 'claude'];
+const PROVIDERS = ['codex-responses', 'openrouter', 'atlascloud', 'gpt', 'lmstudio', 'local', 'codex', 'claude'] as const;
 const adapterOf = (cfg: string) =>
   cfg.split('\n').find((l) => l.startsWith('adapter:'))?.replace('adapter:', '').trim();
 

--- a/src/cli/initWizard.ts
+++ b/src/cli/initWizard.ts
@@ -21,7 +21,7 @@ import { type LinearCredential } from '../linear/index.js';
 import { pickAndSaveLinearMapping } from './linearMapping.js';
 import { banner } from '../support/banner.js';
 
-type ProviderId = 'codex-responses' | 'openrouter' | 'gpt' | 'lmstudio' | 'local' | 'codex' | 'claude';
+type ProviderId = 'codex-responses' | 'openrouter' | 'atlascloud' | 'gpt' | 'lmstudio' | 'local' | 'codex' | 'claude';
 type TaskBackend = 'linear' | 'local';
 type NotifyChannel = 'none' | 'discord' | 'slack' | 'telegram' | 'webhook';
 
@@ -29,6 +29,7 @@ const PROVIDER_CHOICES: { name: string; value: ProviderId; description: string }
   { name: 'codex-responses', value: 'codex-responses', description: 'ChatGPT subscription (OAuth) — Codex models, native loop' },
   { name: 'codex', value: 'codex', description: 'External codex CLI (delegated)' },
   { name: 'openrouter', value: 'openrouter', description: 'OpenRouter API key or OAuth (any model)' },
+  { name: 'atlascloud', value: 'atlascloud', description: 'Atlas Cloud API key (OpenAI-compatible models)' },
   { name: 'gpt', value: 'gpt', description: 'OpenAI ChatGPT OAuth (chat/completions)' },
   { name: 'claude', value: 'claude', description: 'Claude Code CLI (claude -p) — opt-in fallback' },
   { name: 'lmstudio', value: 'lmstudio', description: 'Local LM Studio server (no account)' },

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -43,7 +43,7 @@ function getConfigSearchPaths(): string[] {
 
 const DEFAULT_HEARTBEAT_INTERVAL = 30 * 60 * 1000; // 30 minutes
 const DEFAULT_GITHUB_CHECK_INTERVAL = 5 * 60 * 1000; // 5 minutes
-const AdapterNameSchema = z.enum(['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter', 'claude']);
+const AdapterNameSchema = z.enum(['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter', 'atlascloud', 'claude']);
 
 // Zod Schemas
 
@@ -793,9 +793,10 @@ export function generateSampleConfig(): string {
 # Environment variables use \${VAR_NAME} or \${VAR_NAME:-default} format
 
 # Default CLI adapter for worker/reviewer stages
-# Options: codex, openrouter, lmstudio, local, gpt
+# Options: codex, openrouter, atlascloud, lmstudio, local, gpt
 # - codex:      OpenAI Codex via PKCE login (openswarm auth login --provider codex)
 # - openrouter: OpenRouter API key (OPENROUTER_API_KEY env var or openswarm auth login --provider openrouter)
+# - atlascloud: Atlas Cloud API key (ATLASCLOUD_API_KEY env var)
 # - lmstudio:   LM Studio local server (set LMSTUDIO_BASE_URL / LMSTUDIO_MODEL)
 # - local:      Ollama local models (ollama pull <model>)
 # - gpt:        OpenAI Chat API via OAuth (openswarm auth login --provider gpt)

--- a/src/core/providerOverride.ts
+++ b/src/core/providerOverride.ts
@@ -16,7 +16,7 @@ const OVERRIDE_PATH = join(OVERRIDE_DIR, 'provider-override.json');
 // zero feedback (observed 2026-07-05: override={"provider":"claude"} → no switch, no log). Honor
 // the operator's choice; the startup mismatch warning still prints loudly, and a credit-less pin
 // surfaces as visible worker failures rather than a silent revert.
-const VALID: readonly AdapterName[] = ['claude', 'codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter'];
+const VALID: readonly AdapterName[] = ['claude', 'codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter', 'atlascloud'];
 const VALID_SET = new Set<AdapterName>(VALID);
 
 /** The provider the user last selected via the dashboard, or undefined if never toggled. */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -116,7 +116,7 @@ export type McpConfig = {
  */
 export type SwarmConfig = {
   /** Default CLI adapter */
-  adapter?: 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter' | 'claude';
+  adapter?: 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter' | 'atlascloud' | 'claude';
   /** UI language: 'en' | 'ko' (default: 'en') */
   language: 'en' | 'ko';
   /** Discord bot token */
@@ -282,7 +282,7 @@ export type ModelConfig = {
 /**
  * Per-role configuration
  */
-export type AgentAdapterName = 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter' | 'claude';
+export type AgentAdapterName = 'codex' | 'codex-responses' | 'gpt' | 'local' | 'lmstudio' | 'openrouter' | 'atlascloud' | 'claude';
 
 export type WorkerFanoutCandidateConfig = {
   /** Stable display/id for logs and scoring. */

--- a/src/support/chatBackend.test.ts
+++ b/src/support/chatBackend.test.ts
@@ -14,7 +14,7 @@ describe('curatedModels (INT-1961)', () => {
   });
 
   it('always yields at least the default for every provider', () => {
-    for (const p of ['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter'] as const) {
+    for (const p of ['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter', 'atlascloud'] as const) {
       const m = curatedModels(p);
       expect(m).toContain(getDefaultChatModel(p));
     }

--- a/src/support/chatBackend.ts
+++ b/src/support/chatBackend.ts
@@ -79,6 +79,12 @@ export const CHAT_MODEL_ALIASES: Record<AdapterName, Record<string, string>> = {
     kimi: 'moonshotai/kimi-k2',
     glm: 'z-ai/glm-4.6',
   },
+  atlascloud: {
+    deepseek: 'deepseek-ai/deepseek-v4-pro',
+    'deepseek-v4': 'deepseek-ai/deepseek-v4-pro',
+    qwen: 'qwen/qwen3.5-flash',
+    'qwen-flash': 'qwen/qwen3.5-flash',
+  },
   claude: {
     // `claude -p --model <alias>` takes version-robust aliases directly.
     sonnet: 'sonnet',
@@ -104,6 +110,7 @@ export function getDefaultChatModel(provider: AdapterName): string {
   if (provider === 'local') return 'gemma3:4b';
   if (provider === 'lmstudio') return process.env.LMSTUDIO_MODEL ?? 'local-model';
   if (provider === 'openrouter') return 'openai/gpt-5';
+  if (provider === 'atlascloud') return 'deepseek-ai/deepseek-v4-pro';
   return 'gpt-5-codex';
 }
 
@@ -406,4 +413,3 @@ function extractCodexChatResponse(stdout: string): string {
   }
   return lastMessage;
 }
-


### PR DESCRIPTION
## Summary
- add an `atlascloud` adapter that uses Atlas Cloud's OpenAI-compatible chat completions endpoint with `ATLASCLOUD_API_KEY`
- register the adapter across the adapter registry, config schema, provider override handling, init wizard, and chat model aliases
- document the required env var in config samples and add focused adapter/registration tests

## Validation
- `npm test -- src/adapters/atlascloud.test.ts src/adapters/index.test.ts src/cli/initWizard.test.ts src/support/chatBackend.test.ts` (34 passed)
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- confirmed Atlas model IDs `deepseek-ai/deepseek-v4-pro` and `qwen/qwen3.5-flash` are present in the live Atlas Cloud model list

No README changes.
