### PR TITLE
fix: durable project disable (INT-2799) + commit preserved partial work (INT-2729)

### DIFF
--- a/src/support/web.reposReload.test.ts
+++ b/src/support/web.reposReload.test.ts
@@ -52,6 +52,20 @@ describe('applyReposConfig — repos.json → runner reconciliation', () => {
     expect(runner._allowed()).not.toContain('/dev/WAVE');
   });
 
+  it('INT-2799: a denylisted config project is stripped from allowedProjects on restart', () => {
+    // Simulates a daemon restart after a dashboard soft-disable: config.yaml
+    // re-provides the project in allowedProjects (initialAllowed), but the
+    // disable recorded it in removedConfigPaths. Reconcile must strip it from
+    // both enabled and allowed so a config-defined project can't revive.
+    runner = makeRunner([], ['/dev/vega-agent']);
+    applyReposConfig(
+      runner as unknown as AutonomousRunner,
+      cfg({ enabled: ['/dev/vega-agent'], removedConfigPaths: ['/dev/vega-agent'] }),
+    );
+    expect(runner.getEnabledProjects()).not.toContain('/dev/vega-agent');
+    expect(runner._allowed()).not.toContain('/dev/vega-agent');
+  });
+
   it('pre-seeds the name→path cache for pinned and enabled repos', () => {
     applyReposConfig(
       runner as unknown as AutonomousRunner,

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -622,6 +622,14 @@ export async function startWebServer(port: number = 3847): Promise<void> {
               removedConfigPaths.delete(projectPath); // R6: explicit enable clears the denylist
               runnerRef?.enableProject(projectPath);
             } else {
+              // INT-2799: a soft-disable must survive a daemon restart. disableProject
+              // only clears the in-memory enabled set + project-selection file; on restart
+              // reconcileRepos re-enables from repos.json.enabled and config.yaml re-allows
+              // via allowedProjects, so a config-defined project (e.g. vega-agent) revives.
+              // Add it to removedConfigPaths — the hard R6 denylist reconcile filters on
+              // (applyReposConfig lines ~334/345) — so it stays disabled across restarts.
+              // enable (above) clears the denylist, keeping the two paths symmetric.
+              removedConfigPaths.add(projectPath);
               runnerRef?.disableProject(projectPath);
             }
             saveReposConfig();

--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -227,6 +227,27 @@ describe('preserveWorktree → createWorktree resume roundtrip (INT-2503)', () =
     expect(existsSync(join(resumed.worktreePath, '.openswarm-preserved'))).toBe(false);
   });
 
+  it('INT-2729: commits the dirty work to the branch so it survives dir removal', async () => {
+    const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+    writeFileSync(join(info.worktreePath, 'app.py'), 'base\npartial-impl\n');
+    writeFileSync(join(info.worktreePath, 'newmod.py'), 'wip\n');
+
+    expect(await preserveWorktree(info, 'session did not succeed')).toBe(true);
+
+    // The work is now a reachable commit on the swarm branch — verifiable from the
+    // main repo without the worktree dir. Simulate the manual cleanup that lost
+    // STO-1351 and confirm the commit (and its content) is still recoverable.
+    const log = git(repo, 'log', '--format=%s', 'swarm/INT-9-test').toString();
+    expect(log).toContain('wip: preserved partial work (auto, session did not succeed)');
+    execFileSync('git', ['-C', repo, 'worktree', 'remove', '--force', info.worktreePath], { stdio: 'pipe' });
+    expect(existsSync(info.worktreePath)).toBe(false);
+    expect(git(repo, 'show', 'swarm/INT-9-test:newmod.py').toString()).toBe('wip\n');
+    expect(git(repo, 'show', 'swarm/INT-9-test:app.py').toString()).toBe('base\npartial-impl\n');
+    // The internal preserve marker is control metadata, not user work — it must NOT
+    // be committed into the recovered branch (would pollute history / later PRs).
+    expect(() => git(repo, 'show', 'swarm/INT-9-test:.openswarm-preserved')).toThrow();
+  });
+
   it('removes a clean worktree instead of preserving it', async () => {
     const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
     expect(await preserveWorktree(info, 'test failure')).toBe(false);

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -272,6 +272,30 @@ export async function preserveWorktree(info: WorktreeInfo, reason: string): Prom
     return false;
   }
   const fileCount = dirty === null ? 0 : dirty.split('\n').filter(Boolean).length;
+  // INT-2729: the marker keeps the *directory* around for resume, but the partial
+  // work stays UNCOMMITTED — a manual cleanup of the worktree dir (e.g. a migration
+  // sweep) then loses it silently, even for a substantial, finished implementation
+  // (observed live: STO-1351, a 700+ line service preserved 7 days with zero commits,
+  // nearly lost). Capture the dirty work as a WIP commit on the swarm branch now, so
+  // it survives dir removal as a reachable git ref a human (or the retry) can recover.
+  // This runs BEFORE the marker is written so `git add -A` never stages the internal
+  // `.openswarm-preserved` control file into user history. Best-effort and silent: a
+  // commit failure just leaves the marker (written below) as the sole protection, as
+  // before. NEVER throw — same preserve path the INT-2521 ENOSPC guard exists for.
+  // Only meaningful when git status actually reported dirty files.
+  if (dirty !== null && fileCount > 0) {
+    try {
+      await git(worktreePath, 'add', '-A');
+      await git(
+        worktreePath,
+        '-c', 'user.email=swarm@openswarm.local', '-c', 'user.name=OpenSwarm',
+        'commit', '--no-verify', '-m', `wip: preserved partial work (auto, ${reason})`,
+      );
+      console.log(`[Worktree] WIP committed to ${info.branchName} before preserve: ${worktreePath}`);
+    } catch (err) {
+      console.warn(`[Worktree] WIP commit before preserve failed (marker still protects the tree): ${worktreePath}`, err instanceof Error ? err.message : err);
+    }
+  }
   // The resume marker is the ONLY thing that protects this tree from the next
   // createWorktree() recreate (which deletes the branch + worktree, ~L286/L299) and
   // the heartbeat orphan-sweep (pruneWorktrees drops marker-less trees). So if we


### PR DESCRIPTION
Two independent daemon-durability fixes surfaced from Todo triage.

## INT-2799 — dashboard project disable doesn't survive a restart
`/api/projects/toggle` disable only cleared the in-memory enabled set + the project-selection file. On restart `applyReposConfig` re-enables from `repos.json` and `config.yaml` re-allows via `allowedProjects`, so a **config-defined** project (e.g. vega-agent) revived and resumed work. Fix: toggle-disable now adds the path to `removedConfigPaths` — the hard R6 denylist reconcile filters on — symmetric with enable (which already clears it).

- `src/support/web.ts`: add to denylist on soft-disable
- `src/support/web.reposReload.test.ts`: regression — a denylisted config project stays out of enabled + allowedProjects across a reconcile

## INT-2729 — preserved partial work was never committed
`preserveWorktree` kept a failed session's worktree for resume but left the work **uncommitted**, so a manual dir cleanup lost it silently (STO-1351: a 700+ line finished service preserved 7 days with zero commits, nearly lost). Fix: best-effort WIP commit to the swarm branch **before** the marker is written (so `git add -A` never stages the internal `.openswarm-preserved` control file). `removeWorktree` keeps the branch, so the commit survives dir removal. Never throws (INT-2521 ENOSPC discipline). The Linear failure comment half of the ticket is already handled by `syncFailureState`, so no duplicate comment was added.

- `src/support/worktreeManager.ts`: commit-before-marker in `preserveWorktree`
- `src/support/worktreeManager.test.ts`: work recoverable from branch after dir removal; marker absent from the committed tree

## Validation
- `npx tsc --noEmit` — clean
- 124 tests across the 3 affected suites pass (web.reposReload, worktreeManager, runnerExecution.coverage)
- `openswarm review`: first pass flagged the marker-in-commit side effect → fixed (commit reordered before marker) + asserted in test; re-review hit the harness 15-turn agentic-loop timeout without a concrete follow-up finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)