### PR TITLE
fix(web): denylist both tilde+absolute path forms on disable (INT-2799 follow-up)

### DIFF
--- a/src/support/web.reposReload.test.ts
+++ b/src/support/web.reposReload.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { homedir } from 'node:os';
 import { applyReposConfig } from './web.js';
 import type { AutonomousRunner } from '../automation/autonomousRunner.js';
 
@@ -64,6 +65,25 @@ describe('applyReposConfig — repos.json → runner reconciliation', () => {
     );
     expect(runner.getEnabledProjects()).not.toContain('/dev/vega-agent');
     expect(runner._allowed()).not.toContain('/dev/vega-agent');
+  });
+
+  it('INT-2799: denylists the tilde form so config.yaml raw allowedProjects is caught', () => {
+    // config.ts loads allowedProjects WITHOUT expandPath, so config-defined repos
+    // land in the runner as the tilde form (`~/dev/vega-agent`) even though the
+    // dashboard toggle disables an absolute path. The disable must denylist BOTH
+    // forms (via pathDenylistVariants) or the raw tilde path slips the filter and
+    // the project revives. Here the persisted denylist holds only the tilde form
+    // (as the disable handler now records) and reconcile must still strip it.
+    const home = homedir();
+    const tilde = '~/dev/vega-agent';
+    const abs = `${home}/dev/vega-agent`;
+    runner = makeRunner([], [tilde]); // config.yaml raw (tilde) form in allowedProjects
+    applyReposConfig(
+      runner as unknown as AutonomousRunner,
+      cfg({ enabled: [abs], removedConfigPaths: [tilde, abs] }),
+    );
+    expect(runner._allowed()).not.toContain(tilde);
+    expect(runner.getEnabledProjects()).not.toContain(abs);
   });
 
   it('pre-seeds the name→path cache for pinned and enabled repos', () => {

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -313,6 +313,24 @@ function syncSet(set: Set<string>, values: string[]): void {
 }
 
 /**
+ * INT-2799: the removedConfigPaths denylist is matched by raw string equality in
+ * applyReposConfig, but the same repo reaches it in two forms — config.yaml's
+ * allowedProjects load raw (tilde `~/dev/x`; config.ts:expandPath is NOT applied
+ * there), while repos.json.enabled and dashboard toggle paths are absolute. A
+ * single-format entry misses the other form, so a config-defined project slips the
+ * filter and revives on restart. Return both variants so add (disable) and delete
+ * (enable/pin) cover every form — this also fixes the re-enable trap where only the
+ * absolute form was cleared and the lingering tilde form kept the repo denied.
+ */
+function pathDenylistVariants(p: string): string[] {
+  const home = homedir();
+  const variants = new Set<string>([p]);
+  if (p.startsWith('~')) variants.add(home + p.slice(1));
+  if (p.startsWith(home + '/')) variants.add('~' + p.slice(home.length));
+  return [...variants];
+}
+
+/**
  * Re-read ~/.claude/openswarm-repos.json and apply it to the in-memory registry
  * + runner. The file is the source of truth: the in-memory pinned/basePaths/
  * denylist Sets are refilled in place (endpoints close over those refs), and the
@@ -581,9 +599,9 @@ export async function startWebServer(port: number = 3847): Promise<void> {
           const { projectPath } = JSON.parse(body) as { projectPath: string };
           if (typeof projectPath === 'string' && projectPath) {
             pinnedProjects.add(projectPath);
-            // R6: an explicit pin is a deliberate re-enable — clear the denylist so it isn't
-            // skipped again by setWebRunner on the next restart.
-            removedConfigPaths.delete(projectPath);
+            // R6: an explicit pin is a deliberate re-enable — clear the denylist (both path
+            // forms — INT-2799) so it isn't skipped again by setWebRunner on the next restart.
+            for (const v of pathDenylistVariants(projectPath)) removedConfigPaths.delete(v);
             saveReposConfig();
             // Seed path cache so Linear project name matches immediately
             const name = projectPath.split('/').pop();
@@ -619,7 +637,8 @@ export async function startWebServer(port: number = 3847): Promise<void> {
           const { projectPath, enabled } = JSON.parse(body) as { projectPath: string; enabled: boolean };
           if (typeof projectPath === 'string' && typeof enabled === 'boolean') {
             if (enabled) {
-              removedConfigPaths.delete(projectPath); // R6: explicit enable clears the denylist
+              // R6: explicit enable clears the denylist (both path forms — INT-2799).
+              for (const v of pathDenylistVariants(projectPath)) removedConfigPaths.delete(v);
               runnerRef?.enableProject(projectPath);
             } else {
               // INT-2799: a soft-disable must survive a daemon restart. disableProject
@@ -627,9 +646,9 @@ export async function startWebServer(port: number = 3847): Promise<void> {
               // reconcileRepos re-enables from repos.json.enabled and config.yaml re-allows
               // via allowedProjects, so a config-defined project (e.g. vega-agent) revives.
               // Add it to removedConfigPaths — the hard R6 denylist reconcile filters on
-              // (applyReposConfig lines ~334/345) — so it stays disabled across restarts.
-              // enable (above) clears the denylist, keeping the two paths symmetric.
-              removedConfigPaths.add(projectPath);
+              // (applyReposConfig lines ~334/345) — in both tilde+absolute forms so the
+              // config.yaml raw path is caught too. enable (above) clears both, symmetric.
+              for (const v of pathDenylistVariants(projectPath)) removedConfigPaths.add(v);
               runnerRef?.disableProject(projectPath);
             }
             saveReposConfig();


### PR DESCRIPTION
Follow-up hardening on #301 (INT-2799).

The initial fix recorded only the dashboard toggle's path form in `removedConfigPaths`. But `config.ts` loads `allowedProjects` **without** `expandPath`, so a config-defined repo enters the runner as the **tilde** form (`~/dev/x`) while the dashboard toggle sends an **absolute** path — and the denylist filter in `applyReposConfig` is a raw string match. A single-format entry lets config.yaml's tilde path slip the filter, so the project still revives on restart.

Fix: add a `pathDenylistVariants` helper and record/clear **both** tilde + absolute forms on disable / enable / pin. Also closes the re-enable trap where only the absolute form was cleared and a lingering tilde entry kept the repo denied.

## Validation
- `npx tsc --noEmit` — clean
- `web.reposReload.test.ts`: 7 pass incl. new "denylists the tilde form so config.yaml raw allowedProjects is caught"
- pre-commit (oxlint + typecheck + size) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)