### PR TITLE
fix(memory): drop per-search lastAccessed write causing Lance concurrent-writer errors

### DIFF
--- a/src/memory/memoryCore.ts
+++ b/src/memory/memoryCore.ts
@@ -903,7 +903,16 @@ export async function searchMemorySafe(
       .sort((a, b) => b.hybridScore - a.hybridScore)
       .slice(0, limit);
 
-    updateAccessTime(scored.map(s => s.record.id)).catch((e) => console.warn('[Memory] Failed to update access time:', e));
+    // NOTE: we deliberately do NOT write a `lastAccessed` timestamp back here.
+    // Every search used to fire a Lance `table.update()` commit, but `lastAccessed`
+    // feeds nothing — retrieval recency uses `createdAt` (access-frequency/decay was
+    // removed, see calculateFreshness below), and no CLI reads the field. Under
+    // `openswarm review --max` (up to 16 concurrent reviewer subagents each searching
+    // memory) those per-search commits collided on Lance's optimistic-concurrency
+    // limit → "Too many concurrent writers … [Memory] Failed to update access time".
+    // Dropping a write with no read consumer removes the contention entirely. The
+    // schema field remains (set at record creation) so decay can be reintroduced with
+    // a batched/serialized writer if ever needed.
 
     const formatted: MemorySearchResult[] = scored.map(({ record: r, similarity, recency, importance, hybridScore }) => ({
       id: r.id,
@@ -952,16 +961,3 @@ export async function searchMemory(
   return result.memories;
 }
 
-/**
- * Update last_accessed timestamp for retrieved memories
- */
-async function updateAccessTime(ids: string[]): Promise<void> {
-  if (!table || ids.length === 0) return;
-
-  const uniqueIds = [...new Set(ids)];
-  const quotedIds = uniqueIds.map(id => `'${String(id).replace(/'/g, "''")}'`).join(', ');
-  await table.update({
-    where: `id IN (${quotedIds})`,
-    values: { lastAccessed: Date.now() },
-  });
-}


### PR DESCRIPTION
## Problem
Running `openswarm review --max --fix` with many parallel reviewer subagents (up to 16) spammed:
```
[Memory] Failed to update access time: lance error: Too many concurrent writers.
```

## Cause
`searchMemorySafe` (`src/memory/memoryCore.ts`) fired a Lance `table.update()` commit on **every** retrieval to stamp `lastAccessed`. With 16 concurrent reviewers each recalling memory, those commits collided on Lance's optimistic-concurrency retry limit.

## Fix
Remove the write. `lastAccessed` has **no read consumer** — retrieval recency uses `createdAt` (access-frequency/decay was already removed, per the `calculateFreshness` comment), and no CLI surfaces the field (verified by grep across `src/`). So the per-search commit was pure contention with zero benefit. Dropped the call and the now-unused `updateAccessTime` helper. The schema field remains (set at record creation) so a batched/serialized decay writer can be reintroduced later if wanted.

## Verification
- `npx tsc --noEmit` — clean
- `npx vitest run src/memory/` — 32 pass
- `openswarm review` — APPROVE (reviewer independently confirmed `lastAccessed` has no active read consumer, incl. `memoryOps.ts`)

## Residual note
Concurrent `table.add()` on the *store* path could in principle contend too, but that wasn't the reported failure (reviewers mostly recall). Left in scope-tight; can be hardened separately if it surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)