### PR TITLE
fix(memory): retry Lance writes on concurrency conflict — store path (INT-2817)

### DIFF
--- a/src/memory/memoryCore.ts
+++ b/src/memory/memoryCore.ts
@@ -193,6 +193,41 @@ export function getDb(): Connection | null { return db; }
 export function getTable(): Table | null { return table; }
 export function setTable(t: Table | null): void { table = t; }
 
+/**
+ * Retry a Lance write (add/update/delete) on optimistic-concurrency conflict.
+ *
+ * Lance commits are optimistic: concurrent writers race for the table version and
+ * the losers must re-commit. Its built-in retry budget is small (~2 attempts over
+ * 30s), so `openswarm review --max` — which fans out up to 16 reviewer subagents,
+ * each a SEPARATE process sharing this one on-disk table — blew straight past it
+ * ("Too many concurrent writers"). A single in-process mutex can't help across
+ * processes, so we retry at the application layer with exponential backoff + full
+ * jitter to desynchronize the competing writers. Appends and predicated
+ * update/delete are safe to re-run: Lance re-commits against the latest version on
+ * each attempt, so a retry is not a double-apply.
+ */
+export async function withMemoryWriteRetry<T>(op: () => Promise<T>, label = 'write'): Promise<T> {
+  const MAX_ATTEMPTS = 8;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await op();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // Keep this matcher tight to genuine optimistic-concurrency conflicts. "Too
+      // many concurrent writers" is already covered by "concurrent writers"; a bare
+      // "too many" would wrongly retry unrelated validation/cardinality errors.
+      const retryable = /concurrent writers|commit conflict|version conflict|retry_timeout/i.test(msg);
+      if (!retryable || attempt >= MAX_ATTEMPTS) throw err;
+      // Full jitter over an exponentially growing (capped) window so 16 racing
+      // writers don't back off in lockstep and immediately re-collide.
+      const cap = Math.min(2000, 50 * 2 ** attempt);
+      const delay = 25 + Math.floor(Math.random() * cap);
+      console.warn(`[Memory] ${label} contended (attempt ${attempt}/${MAX_ATTEMPTS}) — retrying in ${delay}ms`);
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+}
+
 async function hasLegacySchemaColumns(t: Table): Promise<boolean> {
   const schema = await t.schema();
   return schema.fields.some(field => LEGACY_SCHEMA_COLUMNS.has(field.name));
@@ -631,7 +666,7 @@ export async function saveMemory(
     expiresAt,
   };
 
-  await table.add([record]);
+  await withMemoryWriteRetry(() => table!.add([record]), `saveMemory(${type})`);
   console.log(`${status.ok(`[Memory] saved ${type}`)} ${c.yellow(`importance: ${importance.toFixed(2)}`)} ${c.dim('repo:')} ${c.cyan(repo)} ${c.dim('title:')} ${title}`);
   return id;
 }
@@ -687,7 +722,7 @@ export async function saveCognitiveMemory(
     expiresAt: PERMANENT_EXPIRY,
   };
 
-  await table.add([record]);
+  await withMemoryWriteRetry(() => table!.add([record]), `saveCognitiveMemory(${type})`);
   console.log(`${status.ok(`[Memory] saved cognitive ${type}`)} ${c.yellow(`importance: ${importance.toFixed(2)}`)} ${content.slice(0, 50)}...`);
   return id;
 }
@@ -707,7 +742,7 @@ export async function deleteMemoriesByDerivedFrom(derivedFrom: string): Promise<
   const ids = rows.filter((r) => r.derivedFrom === derivedFrom).map((r) => String(r.id));
   if (ids.length === 0) return 0;
   const list = ids.map((id) => `'${id.replace(/'/g, "''")}'`).join(', ');
-  await table.delete(`id IN (${list})`);
+  await withMemoryWriteRetry(() => table!.delete(`id IN (${list})`), 'deleteMemoriesByDerivedFrom');
   return ids.length;
 }
 

--- a/src/memory/memoryOps.ts
+++ b/src/memory/memoryOps.ts
@@ -15,6 +15,7 @@ import {
   calculateFreshness,
   safeParseMetadata,
   logWork,
+  withMemoryWriteRetry,
   type MemoryType,
   type MemorySearchResult,
   type CognitiveMemoryRecord,
@@ -42,12 +43,15 @@ async function loadMemoryById(table: MemoryTable, id: string): Promise<any | nul
 async function updateMemoryRecord(table: MemoryTable, record: any): Promise<void> {
   const normalized = normalizeRecords([record])[0];
   const { id, ...values } = normalized;
-  await table.update({ where: idPredicate(id), values: values as Record<string, any> });
+  await withMemoryWriteRetry(
+    () => table.update({ where: idPredicate(id), values: values as Record<string, any> }),
+    'updateMemoryRecord',
+  );
 }
 
 async function deleteMemoryIds(table: MemoryTable, ids: string[]): Promise<void> {
   if (ids.length === 0) return;
-  await table.delete(idsPredicate(ids));
+  await withMemoryWriteRetry(() => table.delete(idsPredicate(ids)), 'deleteMemoryIds');
 }
 
 /**

--- a/src/memory/memoryWriteRetry.test.ts
+++ b/src/memory/memoryWriteRetry.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { withMemoryWriteRetry } from './memoryCore.js';
+
+// withMemoryWriteRetry wraps Lance writes so `openswarm review --max` (up to 16
+// concurrent reviewer processes sharing one on-disk table) survives Lance's
+// optimistic-concurrency conflicts instead of surfacing "Too many concurrent
+// writers". Fake timers skip the real backoff sleeps.
+describe('withMemoryWriteRetry (INT-2817 store-path concurrency)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('returns the result without retrying when the write succeeds', async () => {
+    const op = vi.fn().mockResolvedValue('ok');
+    await expect(withMemoryWriteRetry(op, 'test')).resolves.toBe('ok');
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on a concurrent-writer conflict and then succeeds', async () => {
+    vi.useFakeTimers();
+    const op = vi.fn()
+      .mockRejectedValueOnce(new Error('lance error: Too many concurrent writers.'))
+      .mockRejectedValueOnce(new Error('Commit conflict: version conflict detected'))
+      .mockResolvedValue('stored');
+    const p = withMemoryWriteRetry(op, 'test');
+    await vi.runAllTimersAsync();
+    await expect(p).resolves.toBe('stored');
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  it('rethrows a non-retryable error immediately (no retry)', async () => {
+    const op = vi.fn().mockRejectedValue(new Error('schema mismatch: column not found'));
+    await expect(withMemoryWriteRetry(op, 'test')).rejects.toThrow('schema mismatch');
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after the attempt cap when the conflict never clears', async () => {
+    vi.useFakeTimers();
+    const op = vi.fn().mockRejectedValue(new Error('Too many concurrent writers.'));
+    const p = withMemoryWriteRetry(op, 'test');
+    const assertion = expect(p).rejects.toThrow('concurrent writers');
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(op).toHaveBeenCalledTimes(8); // MAX_ATTEMPTS
+  });
+});


### PR DESCRIPTION
Follow-up to #303. That PR removed the per-search `lastAccessed` write; this hardens the remaining **store path** the residual note called out.

## Problem
Under `openswarm review --max`, up to 16 reviewer subagents run as **separate processes** sharing one on-disk Lance table. `table.add` (and predicated `update`/`delete`) commit optimistically, and Lance's built-in retry budget (~2 attempts / 30s) is too small for that fan-out → `Too many concurrent writers`. An in-process mutex can't serialize across processes.

## Fix
`withMemoryWriteRetry(op, label)` — retry on optimistic-concurrency conflicts with exponential backoff + **full jitter** (max 8 attempts) so racing writers desynchronize and re-commit against the latest table version. Appends and predicated update/delete are safe to re-run (Lance re-commits against latest each attempt, so no double-apply). Non-retryable errors rethrow immediately; the matcher is kept tight to genuine conflict signals (`concurrent writers` / `commit conflict` / `version conflict` / `retry_timeout`).

Applied to **all 5 memory write sites**:
- `memoryCore.ts`: `saveMemory` add, `saveCognitiveMemory` add, `deleteMemoriesByDerivedFrom` delete
- `memoryOps.ts`: `updateMemoryRecord` update, `deleteMemoryIds` delete

## Verification
- `npx tsc --noEmit` — clean
- `src/memory/` — 36 pass, incl. new `memoryWriteRetry.test.ts` (success / retry-then-succeed / non-retryable rethrow / give-up-after-cap, via fake timers)
- `openswarm review` — APPROVE (suggested tightening the retryable matcher → applied; `too many` dropped as redundant/over-broad)

## Deferred
Reviewer suggested a cross-process concurrent-write stress harness — genuinely useful but heavier/flakier than this fix warrants; left as a future item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)