### PR TITLE
chore(release): v0.17.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.17.7 — 2026-07-16
+
+### Added
+
+- **Atlas Cloud provider adapter** — a new LLM adapter for Atlas Cloud, now featured as an official provider sponsor. (#297, #298)
+
+### Fixed
+
+- **`openswarm stop` actually stops a launchd-managed daemon** — when the daemon is externally managed (launchd, no PID file), stop used to only print a `launchctl bootout` hint and leave the daemon running. It now runs the bootout itself and waits for the port to close, falling back to the manual hint only if that fails. (INT-2798, #296)
+- **Dashboard project disable survives a daemon restart** — a soft-disable only cleared the in-memory enabled set, so on restart reconcile re-enabled config-defined projects and a repo (e.g. a `config.yaml` project) revived and resumed work. Disable now records the project in the hard `removedConfigPaths` denylist in **both** tilde and absolute path forms — `config.yaml` loads `allowedProjects` raw (tilde) while the dashboard sends an absolute path — and enable/pin clear both. (INT-2799, #301, #302)
+- **Failed-session partial work is committed before the worktree is preserved** — a preserved worktree kept its work uncommitted, so a manual directory cleanup lost it silently (a finished 700+ line implementation was nearly lost). It's now captured as a WIP commit on the swarm branch before the resume marker is written — surviving directory removal as a recoverable ref — without polluting history with the internal marker file. (INT-2729, #301)
+- **Lance memory writes no longer collide under `review --max`** — up to 16 reviewer subagents (separate processes sharing one on-disk table) overran Lance's optimistic-concurrency retry budget with `Too many concurrent writers`. The dead per-search `lastAccessed` write was removed, and every remaining memory write (add/update/delete) now retries genuine commit conflicts with jittered exponential backoff. (INT-2817, #303, #304)
+
 ## 0.17.6 — 2026-07-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -544,12 +544,11 @@ the CLI (fire-and-forget with a short timeout, and failures are silently ignored
 Full version history lives in **[CHANGELOG.md](CHANGELOG.md)** and the
 [GitHub Releases](https://github.com/unohee/OpenSwarm/releases) page.
 
-Latest — **v0.17.6**: config discovery no longer lets a repo's own
-`config.json` shadow the real OpenSwarm config (which crashed
-`review --max --fix` in such repos), max-fix runs iterate until the
-re-review verifiably approves, and the INT-2521 stability wave stops
-infra errors from masquerading as STUCK/quality rejects. See
-CHANGELOG.md for the rest.
+Latest — **v0.17.7**: `openswarm stop` now actually stops a launchd-managed
+daemon, a dashboard project disable survives a daemon restart, failed-session
+partial work is committed to its branch before the worktree is preserved, and
+Lance memory writes retry instead of colliding under `review --max`. Adds the
+Atlas Cloud provider adapter. See CHANGELOG.md for the rest.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.17.6",
+      "version": "0.17.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Release v0.17.7 (0.17.6 → 0.17.7, patch).

### Added
- Atlas Cloud provider adapter + sponsor (#297, #298)

### Fixed
- `openswarm stop` actually stops a launchd-managed daemon (INT-2798, #296)
- Dashboard project disable survives a daemon restart — tilde+absolute denylist (INT-2799, #301, #302)
- Failed-session partial work committed to branch before worktree preserve (INT-2729, #301)
- Lance memory writes no longer collide under `review --max` — dead `lastAccessed` write removed + jittered retry on all writes (INT-2817, #303, #304)

Bump: `package.json` + `package-lock.json` → 0.17.7. CHANGELOG + README "Latest" updated. `npm run ci` (lint+typecheck+build) green. npm publish follows on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)