### PR TITLE
fix(review): recover empty reviewer output

### DIFF
--- a/src/adapters/agenticLoop.test.ts
+++ b/src/adapters/agenticLoop.test.ts
@@ -220,6 +220,76 @@ describe('runAgenticLoop timeout contract', () => {
   });
 });
 
+describe('runAgenticLoop final-answer recovery (INT-2879)', () => {
+  it('routes a whitespace-only ordinary final response through recovery', async () => {
+    const logs: string[] = [];
+    let calls = 0;
+    const callApi = async () => {
+      calls++;
+      return calls === 1 ? finalResp(' \n ') : finalResp('Decision: approve\nNo findings.');
+    };
+
+    const result = await runAgenticLoop({
+      prompt: 'review the change',
+      cwd: process.cwd(),
+      model: 'test',
+      callApi,
+      webTools: false,
+      maxTurns: 1,
+      onLog: (line) => logs.push(line),
+    });
+
+    expect(calls).toBe(2);
+    expect(result.text).toContain('Decision: approve');
+    expect(logs).toContain('▸ Final answer turn (no tools) — loop ended without a final message');
+  });
+
+  it('retries once when the first no-tools final answer is empty', async () => {
+    const logs: string[] = [];
+    let calls = 0;
+    const callApi = async (_messages: ChatMessage[], tools: unknown[]) => {
+      calls++;
+      if (tools.length > 0) return toolCallResp('c1', 'read_file', { path: 'missing.ts' });
+      return calls === 2 ? finalResp('   ') : finalResp('Decision: revise\nFix the missing edge-case test.');
+    };
+
+    const result = await runAgenticLoop({
+      prompt: 'review the change',
+      cwd: process.cwd(),
+      model: 'test',
+      callApi: callApi as never,
+      webTools: false,
+      maxTurns: 0,
+      onLog: (line) => logs.push(line),
+    });
+
+    expect(calls).toBe(3);
+    expect(result.text).toContain('Fix the missing edge-case test.');
+    expect(logs).toContain('↻ Final answer was empty — retrying once (no tools)');
+  });
+
+  it('fails explicitly when the retry is also reasoning-only/empty', async () => {
+    let calls = 0;
+    const callApi = async (_messages: ChatMessage[], tools: unknown[]) => {
+      calls++;
+      if (tools.length > 0) return toolCallResp('c1', 'read_file', { path: 'missing.ts' });
+      return finalResp(calls === 2 ? '' : ' \n ');
+    };
+
+    await expect(
+      runAgenticLoop({
+        prompt: 'review the change',
+        cwd: process.cwd(),
+        model: 'test',
+        callApi: callApi as never,
+        webTools: false,
+        maxTurns: 0,
+      }),
+    ).rejects.toThrow('Agentic loop produced no final message after one retry');
+    expect(calls).toBe(3);
+  });
+});
+
 describe('runAgenticLoop tool exposure options', () => {
   it('hides search_memory when memoryTools=false without disabling file tools', async () => {
     let toolNames: string[] = [];

--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -441,7 +441,11 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
         });
         continue;
       }
-      finalText = assistantMsg.content ?? '';
+      // A whitespace-only no-tools response is not a user-visible final answer.
+      // Normalize it to empty so the final-answer recovery below retries instead
+      // of returning an effectively blank success. (INT-2879)
+      const content = assistantMsg.content;
+      finalText = typeof content === 'string' && content.trim() ? content : '';
       break;
     }
 
@@ -538,42 +542,63 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
   }
 
   // Final answer turn — maxTurns/타임아웃으로 끊겼는데 모델이 최종 텍스트를 못 낸 경우,
-  // 도구 없이 마지막 1회 호출로 결론을 강제한다. 이게 없으면 진단·분석형 작업이
+  // 도구 없이 호출해 결론을 강제한다. 이게 없으면 진단·분석형 작업이
   // 끝까지 도구만 호출하다 빈 결과("(no summary)")로 끝난다 — SWE 하이브리드 진단
   // 단계에서 발견된 결함.
-  // Note: an empty-string finalText ('') intentionally triggers this too — an
-  // empty final answer is worthless, so the one extra call to salvage a real
-  // conclusion is the whole point, not an accidental cost (INT-1442 part 3).
+  // 첫 salvage가 reasoning-only 응답처럼 사용자에게 보이는 content를 하나도 내지
+  // 않으면 딱 한 번 재시도한다. 두 번 모두 비면 성공/REVISE로 위장하지 않고 실패로
+  // 올려 보내 reviewer/worker 호출자가 명시적으로 처리하게 한다. (INT-1442, INT-2879)
   if (!finalText && apiCallCount > 0) {
-    onLog?.('▸ Final answer turn (no tools) — loop ended without a final message');
+    const maxFinalAnswerAttempts = 2;
     messages.push({
       role: 'user',
       content:
         "You've reached this turn's step limit, so stop calling tools now. Using everything " +
-        'above, write your final answer as plain text — what you accomplished, the key result, ' +
-        'and anything still left to do. Do not mention step/tool limits or "budget" to the user.',
+        'above, write a non-empty final answer now. Follow the output format requested in the ' +
+        'original task exactly. Do not mention step/tool limits or "budget" to the user.',
     });
-    try {
-      const response = await callApi(messages, []);
-      if (response.usage) {
-        totalTokens += response.usage.prompt_tokens + response.usage.completion_tokens;
-        inputTokens += response.usage.prompt_tokens;
-        outputTokens += response.usage.completion_tokens;
-        cachedTokens += response.usage.cached_tokens ?? 0;
+
+    for (let attempt = 1; attempt <= maxFinalAnswerAttempts && !finalText; attempt++) {
+      if (attempt === 1) {
+        onLog?.('▸ Final answer turn (no tools) — loop ended without a final message');
+      } else {
+        onLog?.('↻ Final answer was empty — retrying once (no tools)');
+        messages.push({
+          role: 'user',
+          content:
+            'Your previous final-answer attempt returned no user-visible text. Respond now with ' +
+            'the complete, non-empty final answer in the exact format requested by the original task.',
+        });
       }
-      apiCallCount++;
-      finalText = response.choices?.[0]?.message?.content ?? '';
-    } catch (err) {
-      // A rate limit on the salvage call must still propagate — swallowing it
-      // here would return an empty result the scheduler reads as a plain failure
-      // instead of pausing. Mirror the main call path: preserve a typed
-      // RateLimitError, then re-detect an untyped one from the message. (INT-2519)
-      if (err instanceof RateLimitError) throw err;
-      const msg = err instanceof Error ? err.message : String(err);
-      const rl = detectRateLimit('', msg);
-      if (rl) throw rl;
-      if (isInfraError(err)) throw err; // infra on the salvage call → infra_error, not fake result (INT-2520)
-      onLog?.(`✖ Final answer turn failed: ${msg}`);
+
+      try {
+        const response = await callApi(messages, []);
+        if (response.usage) {
+          totalTokens += response.usage.prompt_tokens + response.usage.completion_tokens;
+          inputTokens += response.usage.prompt_tokens;
+          outputTokens += response.usage.completion_tokens;
+          cachedTokens += response.usage.cached_tokens ?? 0;
+        }
+        apiCallCount++;
+        const content = response.choices?.[0]?.message?.content;
+        finalText = typeof content === 'string' && content.trim() ? content : '';
+      } catch (err) {
+        // A rate limit on a salvage call must still propagate — swallowing it
+        // here would return an empty result the scheduler reads as a plain failure
+        // instead of pausing. Mirror the main call path: preserve a typed
+        // RateLimitError, then re-detect an untyped one from the message. (INT-2519)
+        if (err instanceof RateLimitError) throw err;
+        const msg = err instanceof Error ? err.message : String(err);
+        const rl = detectRateLimit('', msg);
+        if (rl) throw rl;
+        if (isInfraError(err)) throw err; // infra on salvage → infra_error, not fake result (INT-2520)
+        onLog?.(`✖ Final answer turn failed (${attempt}/${maxFinalAnswerAttempts}): ${msg}`);
+      }
+    }
+
+    if (!finalText) {
+      onLog?.('✖ Final answer remained empty after one retry');
+      throw new Error('Agentic loop produced no final message after one retry');
     }
   }
 

--- a/src/adapters/codex.test.ts
+++ b/src/adapters/codex.test.ts
@@ -126,6 +126,21 @@ describe('CodexCliAdapter', () => {
     expect(result.suggestions).toEqual(['Add unit test']);
   });
 
+  it('rejects reasoning-only reviewer output instead of fabricating REVISE', () => {
+    const raw = {
+      exitCode: 0,
+      stdout: [
+        '{"type":"turn.started"}',
+        '{"type":"item.completed","item":{"type":"reasoning","text":"Summarizing findings"}}',
+        '{"type":"turn.completed"}',
+      ].join('\n'),
+      stderr: '',
+      durationMs: 1,
+    };
+
+    expect(() => adapter.parseReviewerOutput(raw)).toThrow('Reviewer output was empty');
+  });
+
   it('streams agent messages into live log lines', () => {
     const logs: string[] = [];
     const remainder = adapter.parseStreamingChunk?.([

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -17,6 +17,7 @@ import { t } from '../locale/index.js';
 import { AuthProfileStore, ensureValidToken } from '../auth/index.js';
 import { getCodexModelIds } from './codexModels.js';
 import { codexMcpConfigFlags } from './memoryMcp.js';
+import { parseReviewerResult } from './resultParsing.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -117,7 +118,9 @@ export class CodexCliAdapter implements CliAdapter {
 
   parseReviewerOutput(raw: CliRunResult): ReviewResult {
     const resultText = extractCodexMessageText(raw.stdout);
-    return extractReviewerResultJson(resultText) || extractReviewerFromText(resultText);
+    // Event extraction is Codex-specific; reviewer parsing and the empty-output
+    // contract belong to the shared parser used by every in-process adapter.
+    return parseReviewerResult(resultText);
   }
 }
 
@@ -187,6 +190,7 @@ function extractCodexExecutedCommands(output: string): string[] {
 
 function extractCodexMessageText(output: string): string {
   let lastMessage = '';
+  let sawStructuredEvent = false;
 
   for (const line of output.split('\n')) {
     const trimmed = line.trim();
@@ -194,6 +198,7 @@ function extractCodexMessageText(output: string): string {
 
     try {
       const event = JSON.parse(trimmed);
+      if (typeof event?.type === 'string') sawStructuredEvent = true;
       if (
         event.type === 'item.completed' &&
         event.item?.type === 'agent_message' &&
@@ -206,7 +211,10 @@ function extractCodexMessageText(output: string): string {
     }
   }
 
-  return lastMessage || output;
+  // Keep the legacy plain-text fallback only when stdout was not a Codex event
+  // stream. Returning reasoning/tool NDJSON as if it were the final message makes
+  // a reasoning-only run look non-empty and fabricates a reviewer verdict. (INT-2879)
+  return lastMessage || (sawStructuredEvent ? '' : output);
 }
 
 function emitCodexStreamEvent(line: string, onLog: (line: string) => void): void {
@@ -443,110 +451,6 @@ function extractErrorMessage(text: string): string {
     return lines[0].slice(0, 200);
   }
   return 'Unknown error';
-}
-
-function extractReviewerResultJson(text: string): ReviewResult | null {
-  const jsonMatch = text.match(/```json\s*([\s\S]*?)\s*```/);
-  if (!jsonMatch) {
-    const objMatch = text.match(/\{\s*"decision"\s*:/);
-    if (!objMatch) return null;
-
-    const startIdx = objMatch.index!;
-    let depth = 0;
-    let endIdx = startIdx;
-
-    for (let i = startIdx; i < text.length; i++) {
-      if (text[i] === '{') depth++;
-      if (text[i] === '}') {
-        depth--;
-        if (depth === 0) {
-          endIdx = i + 1;
-          break;
-        }
-      }
-    }
-
-    try {
-      return normalizeReviewResult(JSON.parse(text.slice(startIdx, endIdx)));
-    } catch {
-      return null;
-    }
-  }
-
-  try {
-    return normalizeReviewResult(JSON.parse(jsonMatch[1]));
-  } catch {
-    return null;
-  }
-}
-
-function extractReviewerFromText(text: string): ReviewResult {
-  // Prefer the reviewer's EXPLICIT verdict over scattered keyword matching — a
-  // task about "reject"/"approve" makes prose matching misclassify a revise as a
-  // reject and kill it. Default to the safe, retryable 'revise'. (INT-2485)
-  const explicit = text.match(
-    /\bdecision\b\s*[:=-]?\s*["'`]?\s*(approve[d]?|reject(?:ed)?|revis(?:e|ion)|request[- ]?changes)/i,
-  );
-  let decision: ReviewResult['decision'] = 'revise';
-  if (explicit) {
-    const verdict = explicit[1].toLowerCase();
-    decision = verdict.startsWith('approv') ? 'approve' : verdict.startsWith('reject') ? 'reject' : 'revise';
-  }
-
-  return {
-    decision,
-    feedback: extractSummary(text),
-    issues: extractBulletsAfter(text, /issues?:/i),
-    suggestions: extractBulletsAfter(text, /suggestions?:/i),
-  };
-}
-
-function normalizeReviewResult(parsed: Record<string, unknown>): ReviewResult {
-  const decision = parsed.decision === 'approve' || parsed.decision === 'reject'
-    ? parsed.decision
-    : 'revise';
-
-  return {
-    decision,
-    feedback: typeof parsed.feedback === 'string' ? parsed.feedback : t('common.fallback.noSummary'),
-    issues: Array.isArray(parsed.issues)
-      ? parsed.issues.filter((v): v is string => typeof v === 'string')
-      : [],
-    suggestions: Array.isArray(parsed.suggestions)
-      ? parsed.suggestions.filter((v): v is string => typeof v === 'string')
-      : [],
-    recommendedActions: Array.isArray(parsed.recommendedActions)
-      ? parsed.recommendedActions
-          .filter((a): a is Record<string, unknown> => !!a && typeof a === 'object')
-          .map((a) => ({
-            type: typeof a.type === 'string' && a.type ? a.type : 'follow-up',
-            title: typeof a.title === 'string' ? a.title.trim() : '',
-            location: typeof a.location === 'string' ? a.location : undefined,
-          }))
-          .filter((a) => a.title.length > 0)
-      : undefined,
-  };
-}
-
-function extractBulletsAfter(text: string, heading: RegExp): string[] {
-  const lines = text.split('\n');
-  const start = lines.findIndex((line) => heading.test(line));
-  if (start < 0) return [];
-
-  const items: string[] = [];
-  for (const line of lines.slice(start + 1)) {
-    const trimmed = line.trim();
-    if (!trimmed) {
-      if (items.length > 0) break;
-      continue;
-    }
-    if (!trimmed.startsWith('-') && !trimmed.startsWith('*')) {
-      if (items.length > 0) break;
-      continue;
-    }
-    items.push(trimmed.replace(/^[-*]\s*/, ''));
-  }
-  return items;
 }
 
 function truncate(s: string, max: number): string {

--- a/src/adapters/resultParsing.test.ts
+++ b/src/adapters/resultParsing.test.ts
@@ -23,6 +23,18 @@ describe('parseReviewerResult text-fallback decision (INT-2485 false-reject)', (
   it('defaults to the safe revise when no explicit verdict is present', () => {
     expect(parseReviewerResult('The code rejects invalid input and approves valid tokens.').decision).toBe('revise');
   });
+
+  it('rejects an empty result instead of fabricating a finding-less REVISE', () => {
+    expect(() => parseReviewerResult('  \n ')).toThrow('Reviewer output was empty');
+  });
+
+  it('preserves issues and suggestions from plain-text fallback output', () => {
+    const result = parseReviewerResult(
+      'Decision: revise\nNeeds work.\nIssues:\n- Missing retry test\nSuggestions:\n- Add boundary coverage',
+    );
+    expect(result.issues).toEqual(['Missing retry test']);
+    expect(result.suggestions).toEqual(['Add boundary coverage']);
+  });
 });
 
 describe('parseReviewerResult recommendedActions (INT-1954)', () => {

--- a/src/adapters/resultParsing.ts
+++ b/src/adapters/resultParsing.ts
@@ -119,9 +119,31 @@ function extractReviewerFromText(text: string): ReviewResult {
   return {
     decision,
     feedback: extractSummary(text),
-    issues: [],
-    suggestions: [],
+    issues: extractBulletsAfter(text, /issues?:/i),
+    suggestions: extractBulletsAfter(text, /suggestions?:/i),
   };
+}
+
+/** Preserve structured findings from plain-text reviewer fallbacks. */
+function extractBulletsAfter(text: string, heading: RegExp): string[] {
+  const lines = text.split('\n');
+  const start = lines.findIndex((line) => heading.test(line));
+  if (start < 0) return [];
+
+  const items: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      if (items.length > 0) break;
+      continue;
+    }
+    if (!trimmed.startsWith('-') && !trimmed.startsWith('*')) {
+      if (items.length > 0) break;
+      continue;
+    }
+    items.push(trimmed.replace(/^[-*]\s*/, ''));
+  }
+  return items;
 }
 
 /** Brace-balanced scan for the JSON object containing `marker`. */
@@ -172,5 +194,11 @@ export function parseWorkerResult(text: string): WorkerResult {
 
 /** JSON-first with text fallback — the canonical reviewer-output parse. */
 export function parseReviewerResult(text: string): ReviewResult {
+  // An empty reviewer result is a harness failure, not a quality verdict. Falling
+  // through to the safe text default would fabricate REVISE with no findings and
+  // leave the user with an unactionable gate result. (INT-2879)
+  if (!text.trim()) {
+    throw new Error('Reviewer output was empty: no final message or verdict');
+  }
   return extractReviewerResultJson(text) ?? extractReviewerFromText(text);
 }


### PR DESCRIPTION
## Summary

- retry a reasoning-only or empty final-answer response once, then fail explicitly if the retry is also empty
- normalize whitespace-only ordinary final responses so they enter the same recovery path
- reject empty reviewer output instead of fabricating a finding-less `REVISE`
- route Codex CLI reviewer parsing through the shared parser while preserving plain-text issue/suggestion bullets

## Root cause

The final-answer salvage path accepted an empty response, and reviewer text parsing defaulted any unparseable output to `REVISE`. A reasoning-only completion therefore became a successful-looking review verdict with no actionable findings.

## User impact

`openswarm review` now either recovers a real final report or exits as a harness failure. It no longer reports an evidence-free `REVISE` when the reviewer produced no user-visible message.

## Validation

- `npm test` — 200 files passed; 2,804 tests passed, 1 skipped
- `npm run ci` — full oxlint, TypeScript typecheck, and build passed
- focused adapter/reviewer regression suite — 118 tests passed
- OpenSwarm review gate: first `REVISE` found the whitespace-only ordinary-final gap; second `REVISE` found duplicate Codex parsing. Both findings were addressed. The final re-review stalled inside one `codex-responses` stream for over 230 seconds and was stopped without a verdict; no additional finding was emitted.

## Tracking

Linear: INT-2879