### PR TITLE
Route worker models by tier and harden STUCK recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ adapter: codex   # one of: codex · codex-responses · gpt · openrouter · atla
 
 | Adapter | Backend | Models | Auth |
 |---------|---------|--------|------|
-| `codex-responses` | OpenAI Responses API (native loop, no CLI binary) | gpt-5-codex (default), o3, o4-mini | ChatGPT OAuth |
+| `codex-responses` | OpenAI Responses API (native loop, no CLI binary) | gpt-5.6-terra (default), gpt-5.6-sol, gpt-5.6-luna | ChatGPT OAuth |
 | `codex` | OpenAI Codex CLI (delegated) | gpt-5-codex (default), o3, o4-mini | ChatGPT OAuth / `codex` CLI auth |
 | `gpt` | OpenAI Chat API | gpt-4o (default), o3, … | OAuth PKCE |
 | `openrouter` | OpenRouter API (native agentic loop) | any OpenRouter model — gpt-5, gemini-2.5, deepseek, glm, qwen, … | `OPENROUTER_API_KEY` or OAuth PKCE |
@@ -211,7 +211,7 @@ autonomous:
   defaultRoles:
     worker:
       adapter: codex-responses
-      model: gpt-5-codex
+      model: gpt-5.6-terra
     reviewer:
       adapter: openrouter
       model: anthropic/claude-sonnet-4
@@ -229,7 +229,7 @@ autonomous:
     enabled: false
     cadenceHours: 24
     mode: comment
-    plannerModel: gpt-5.5
+    plannerModel: gpt-5.6-terra
     maxIssues: 80
 ```
 
@@ -239,20 +239,43 @@ autonomous:
 autonomous:
   defaultRoles:
     worker:
-      model: gpt-5-codex
-      escalateModel: openai/gpt-5     # escalate after repeated review failures
-      escalateAfterIteration: 3
+      model: gpt-5.6-terra            # balanced default implementation
+      escalateModel: gpt-5.6-sol      # frontier retry after a failed attempt
+      escalateAfterIteration: 2
       timeoutMs: 1800000
     reviewer:
-      model: gpt-5-codex
+      model: gpt-5.6-sol              # correctness gate
       timeoutMs: 600000
     tester:
       enabled: false
+      model: gpt-5.6-terra            # LLM fallback after deterministic verify
     documenter:
       enabled: false
+      model: gpt-5.6-luna
     auditor:
       enabled: false
+      model: gpt-5.6-sol
+    skill-documenter:
+      enabled: false
+      model: gpt-5.6-luna
+  jobProfiles:
+    - name: light
+      minMinutes: 1
+      maxMinutes: 29
+      effort: low
+      roles:
+        worker: gpt-5.6-luna
+        reviewer: gpt-5.6-terra
+    - name: heavy
+      minMinutes: 30
+      effort: high
+      roles:
+        worker: gpt-5.6-terra
+        reviewer: gpt-5.6-sol
 ```
+
+The native Codex adapter uses Terra when no model is pinned. Draft analysis uses
+Luna because it runs for every task; decomposition and hard review stay on Sol.
 
 ### Running the daemon
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,9 +3,9 @@
 # Copy this file to config.yaml to use
 
 # Default CLI adapter for worker/reviewer stages
-# Options: claude, codex, gpt, local, lmstudio, openrouter, atlascloud
-# For GPT: run `openswarm auth login --provider gpt`
-#   (uses the public Codex OAuth client by default — no extra config needed)
+# Options: codex-responses, codex, gpt, local, lmstudio, openrouter, atlascloud, claude
+# For ChatGPT OAuth: run `openswarm auth login --provider gpt`
+#   `codex-responses` runs OpenSwarm's native tool loop with the same login.
 # For OpenRouter: run `openswarm auth login --provider openrouter`
 #   (PKCE browser flow → stores a sk-or-* API key; falls back to manual paste)
 # For Atlas Cloud: set ATLASCLOUD_API_KEY
@@ -13,7 +13,7 @@
 # For lmstudio: start LM Studio Local Server (default http://localhost:1234)
 #   Optional env: LMSTUDIO_BASE_URL, LMSTUDIO_MODEL, LMSTUDIO_API_KEY
 #   If LMSTUDIO_MODEL is unset, the adapter auto-selects the first loaded model.
-adapter: claude
+adapter: codex-responses
 
 discord:
   token: ${DISCORD_TOKEN}
@@ -62,7 +62,7 @@ autonomous:
   decomposition:
     enabled: true                    # Enable decomposition
     thresholdMinutes: 30             # Decompose if estimated time exceeds this
-    plannerModel: claude-opus-4-7    # Planner model (Opus for deep decomposition)
+    plannerModel: gpt-5.6-sol         # High-leverage decomposition stays on Sol
 
   # Backlog grooming (Planner compares fetched open queue states against the repo).
   # Safe default: comment recommendations only. Set mode: apply to update
@@ -71,42 +71,36 @@ autonomous:
     enabled: false
     cadenceHours: 24
     mode: comment
-    plannerModel: claude-opus-4-7
+    plannerModel: gpt-5.6-terra       # Bulk queue analysis favors the balanced tier
     maxIssues: 80
 
   # Per-role settings
-  # Hybrid config: Claude for complex coding, local model for review/docs ($0)
+  # GPT-5.6: Luna=high-volume/light, Terra=balanced default, Sol=quality gate.
   defaultRoles:
     worker:
       enabled: true
-      adapter: claude
-      model: claude-sonnet-4-6         # Sonnet for coding tasks
-      escalateModel: claude-opus-4-7          # On failure: Opus
-      escalateAfterIteration: 3
+      model: gpt-5.6-terra             # Default implementation tier
+      escalateModel: gpt-5.6-sol       # Repeated failure earns the frontier tier
+      escalateAfterIteration: 2
       timeoutMs: 1800000  # 30 minutes
     reviewer:
       enabled: true
-      adapter: local                          # Local model — free, 7s response
-      model: gemma-4-e4b-it                   # Gemma 4 e4b via LMStudio
-      escalateModel: claude-sonnet-4-6 # Spot check: Sonnet reviews after N revisions
-      escalateAfterIteration: 3               # Escalate from 3rd iteration
-      timeoutMs: 60000    # 1 minute (local models are slower)
+      model: gpt-5.6-sol               # Correctness gate; light profile lowers this to Terra
+      timeoutMs: 600000
     tester:
       enabled: false
+      model: gpt-5.6-terra             # Used only if deterministic verify cannot run
     documenter:
       enabled: false
-      adapter: local
-      model: gemma-4-e4b-it
+      model: gpt-5.6-luna
       timeoutMs: 120000   # 2 minutes
     auditor:
       enabled: false
-      adapter: local
-      model: gemma-4-e4b-it
+      model: gpt-5.6-sol
       timeoutMs: 300000   # 5 minutes
     skill-documenter:
       enabled: false
-      adapter: local
-      model: gemma-4-e4b-it
+      model: gpt-5.6-luna
       timeoutMs: 120000   # 2 minutes
 
   # Deterministic baseline-diff verification (enabled by default).
@@ -137,17 +131,21 @@ autonomous:
   # (identical errors twice in a row). Default: 3.
   maxReflections: 3
 
-  # Job profiles for lightweight vs heavy work
+  # Job profiles override the default Worker/Reviewer pair by task estimate.
   jobProfiles:
-    - name: quick-analysis
-      maxMinutes: 15
+    - name: light
+      minMinutes: 1
+      maxMinutes: 29
+      effort: low
       roles:
-        worker: claude-haiku-4-5-20251001     # Haiku for simple tasks
-    - name: deep-engineering
-      minMinutes: 16
+        worker: gpt-5.6-luna
+        reviewer: gpt-5.6-terra
+    - name: heavy
+      minMinutes: 30
+      effort: high
       roles:
-        worker: claude-sonnet-4-6      # Sonnet for complex work
-        reviewer: claude-sonnet-4-6    # Sonnet reviews Sonnet
+        worker: gpt-5.6-terra
+        reviewer: gpt-5.6-sol
 
 # Long-running task monitoring (RunPod training, batch processing, etc.)
 #

--- a/src/adapters/codexResponses.test.ts
+++ b/src/adapters/codexResponses.test.ts
@@ -78,7 +78,12 @@ describe('parseWorkerOutput command backfill', () => {
 
 describe('selectDefaultCodexResponseModel', () => {
   it('prefers the stable default when the live catalog includes it', () => {
-    expect(selectDefaultCodexResponseModel(['gpt-5.3-codex-spark', 'gpt-5.4-mini', 'gpt-5.5'])).toBe('gpt-5.5');
+    expect(selectDefaultCodexResponseModel([
+      'gpt-5.3-codex-spark',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+    ])).toBe('gpt-5.6-terra');
   });
 
   it('does not pick Spark implicitly when another model is available', () => {
@@ -86,7 +91,7 @@ describe('selectDefaultCodexResponseModel', () => {
   });
 
   it('does not choose Spark implicitly even if it is the only discovered model', () => {
-    expect(selectDefaultCodexResponseModel(['gpt-5.3-codex-spark'])).toBe('gpt-5.5');
+    expect(selectDefaultCodexResponseModel(['gpt-5.3-codex-spark'])).toBe('gpt-5.6-terra');
   });
 });
 
@@ -96,7 +101,7 @@ describe('unsupported-model fallback', () => {
     const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
       const target = String(url);
       if (target.includes('/backend-api/codex/models')) {
-        return new Response(JSON.stringify({ models: [{ slug: 'gpt-5.5', priority: 1 }] }), { status: 200 });
+        return new Response(JSON.stringify({ models: [{ slug: 'gpt-5.6-terra', priority: 1 }] }), { status: 200 });
       }
 
       const body = JSON.parse(String(init?.body ?? '{}')) as { model?: string };
@@ -129,7 +134,7 @@ describe('unsupported-model fallback', () => {
     await callApi([{ role: 'user', content: 'first' }], []);
     await callApi([{ role: 'user', content: 'second' }], []);
 
-    expect(requestedModels).toEqual(['unsupported-model', 'gpt-5.5', 'gpt-5.5']);
+    expect(requestedModels).toEqual(['unsupported-model', 'gpt-5.6-terra', 'gpt-5.6-terra']);
   });
 });
 

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -25,7 +25,9 @@ import { isInfraError } from './errorClassification.js';
 import { getCodexModelIds } from './codexModels.js';
 
 const CODEX_RESPONSES_URL = 'https://chatgpt.com/backend-api/codex/responses';
-const DEFAULT_MODEL = 'gpt-5.5';
+// Balanced default for unpinned work. Role configs can select Sol for
+// quality-first work and Luna for high-volume/light work.
+const DEFAULT_MODEL = 'gpt-5.6-terra';
 const PROFILE_KEY = 'openai-gpt:default';
 const SPARK_MODEL = 'gpt-5.3-codex-spark';
 

--- a/src/agents/draftAnalyzer.test.ts
+++ b/src/agents/draftAnalyzer.test.ts
@@ -84,6 +84,10 @@ describe('runDraftAnalysis fallback', () => {
     expect(adapterModule.getAdapter).not.toHaveBeenCalledWith('claude');
     // Single adapter attempt only — quota error breaks out to best-effort, no fallback.
     expect(adapterModule.spawnCli).toHaveBeenCalledTimes(1);
+    expect(adapterModule.spawnCli).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ model: 'gpt-5.6-luna' }),
+    );
     // Pipeline continues with a best-effort (insufficient) draft.
     expect(result.sufficient).toBe(false);
   });

--- a/src/agents/draftAnalyzer.ts
+++ b/src/agents/draftAnalyzer.ts
@@ -28,6 +28,11 @@ import type { AdapterName } from '../adapters/types.js';
  * updates) — it is one constant per provider, easy to bump.
  */
 const DRAFT_MODELS: Partial<Record<AdapterName, string>> = {
+  // Drafting is a high-volume classification/routing pass, so the efficient
+  // GPT-5.6 tier is the right default. Downstream implementation/review still
+  // use their independently configured Terra/Sol tiers.
+  codex: 'gpt-5.6-luna',
+  'codex-responses': 'gpt-5.6-luna',
   // Capable but cost-aware model for the brief (INT-1915): the drafter runs on
   // EVERY task, and claude -p loads the full personal env (~39k tokens/call), so
   // opus on every brief was too costly. sonnet keeps the brief faithful at a

--- a/src/agents/pairPipeline.coverage.test.ts
+++ b/src/agents/pairPipeline.coverage.test.ts
@@ -378,7 +378,11 @@ describe('PairPipeline coverage extension', () => {
 
     const result = await pipeline.run(task(), process.cwd());
 
-    expect(result.success).toBe(false);
+    expect(result).toMatchObject({
+      success: false,
+      failureSignal: 'stuck',
+      stuckReason: expect.stringContaining('Same error repeated'),
+    });
     // Stuck detection fires before a 4th worker call would happen.
     expect(runWorker).toHaveBeenCalledTimes(3);
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('STUCK DETECTED'));

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -840,6 +840,7 @@ export class PairPipeline extends EventEmitter {
       // Stuck detection check (before iteration starts)
       const stuckCheck = this.stuckDetector.check();
       if (stuckCheck.isStuck) {
+        context.stuckReason = stuckCheck.reason;
         console.error(`[${context.taskPrefix}] STUCK DETECTED: ${stuckCheck.reason}`);
         console.error(`[${context.taskPrefix}] Suggestion: ${stuckCheck.suggestion}`);
         this.emit('stuck', {
@@ -1262,7 +1263,6 @@ export class PairPipeline extends EventEmitter {
     const session = context.session;
     const finalStatus = session.status as PipelineResult['finalStatus'] || 'failed';
     const success = finalStatus === 'approved';
-
     // Aggregate costs from all stages
     const stageCosts: (CostInfo | undefined)[] = [];
     if (context.workerResult?.costInfo) stageCosts.push(context.workerResult.costInfo);
@@ -1272,18 +1272,18 @@ export class PairPipeline extends EventEmitter {
     if (context.auditorResult?.costInfo) stageCosts.push(context.auditorResult.costInfo);
     if (context.skillDocumenterResult?.costInfo) stageCosts.push(context.skillDocumenterResult.costInfo);
     const totalCost = stageCosts.length > 0 ? aggregateCosts(stageCosts) : undefined;
-
     if (totalCost) {
       console.log(`[${context.taskPrefix}] Total cost: ${formatCost(totalCost)}`);
       broadcastEvent({ type: 'task:cost', data: { taskId: context.task.id, cost: totalCost } });
     }
-
     const result: PipelineResult = {
       success,
       sessionId: context.session.id,
       stages,
       finalStatus,
-      failureSignal: context.guardsResult?.results.some(r => r.blocking && !r.passed) || context.testerResult?.success === false ? 'gate-fail' : undefined,
+      failureSignal: context.stuckReason ? 'stuck'
+        : context.guardsResult?.results.some(r => r.blocking && !r.passed) || context.testerResult?.success === false ? 'gate-fail' : undefined,
+      stuckReason: context.stuckReason,
       totalDuration: Date.now() - startTime,
       iterations: context.currentIteration,
       workerResult: context.workerResult,

--- a/src/agents/pairPipelineTypes.ts
+++ b/src/agents/pairPipelineTypes.ts
@@ -68,7 +68,8 @@ export interface PipelineResult {
   sessionId: string;
   stages: StageResult[];
   finalStatus: 'approved' | 'rejected' | 'failed' | 'cancelled' | 'decomposed' | 'superseded' | 'rate_limited' | 'infra_error';
-  failureSignal?: 'gate-fail' | 'timeout';
+  failureSignal?: 'gate-fail' | 'timeout' | 'stuck';
+  stuckReason?: string;
   rateLimitResetsAt?: number;
   totalDuration: number;
   iterations: number;
@@ -121,6 +122,8 @@ export interface PipelineContext {
   trustedVerifyInputFingerprint?: string;
   /** Deferred capture error so invalid manifests retain tester-stage failure semantics. */
   trustedVerifyError?: unknown;
+  /** Pair-level stagnation detector reason, preserved so the scheduler does not rerun the same loop. */
+  stuckReason?: string;
 }
 
 export type PipelineEventType = 'stage:start' | 'stage:complete' | 'stage:fail' | 'iteration:start' | 'iteration:complete' | 'iteration:fail' | 'pipeline:complete' | 'pipeline:fail' | 'fanout:gate' | 'halt';

--- a/src/automation/autonomousRunner.durable.test.ts
+++ b/src/automation/autonomousRunner.durable.test.ts
@@ -290,6 +290,42 @@ describe('AutonomousRunner durable completion race', () => {
     internal.durableRuns.close();
   });
 
+  it('resumes durable NEEDS_HUMAN when an operator moves a stuck issue to Todo', async () => {
+    const [{ AutonomousRunner }, execution] = await Promise.all([
+      import('./autonomousRunner.js'),
+      import('./runnerExecution.js'),
+    ]);
+    const unstick = vi.fn(async () => {});
+    execution.setTaskSource({
+      kind: 'linear', fetchTasks: vi.fn(async () => []), getExecutionComments: vi.fn(async () => []),
+      updateState: vi.fn(async () => true), addComment: vi.fn(async () => {}),
+      createTask: vi.fn(), createSubIssue: vi.fn(), logPairStart: vi.fn(),
+      logPairComplete: vi.fn(), logBlocked: vi.fn(), logStuck: vi.fn(), unstick,
+      logHalt: vi.fn(), markAsDecomposed: vi.fn(),
+    } as unknown as ITaskSource);
+    const runner = new AutonomousRunner({
+      linearTeamId: 'team', allowedProjects: ['/repo'], heartbeatSchedule: '0 * * * *',
+      autoExecute: true, maxConsecutiveTasks: 1, cooldownSeconds: 0, dryRun: true,
+      automationLedgerMode: 'primary', automationDbPath: join(root, 'stuck-recovery.db'),
+    });
+    const internal = runner as unknown as InternalRunner;
+    internal.durableRuns.importLegacyRun({
+      issueId: 'stuck-issue', source: 'linear', identifier: 'INT-STUCK', title: 'retry me',
+      projectPath: '/repo', state: 'NEEDS_HUMAN',
+    });
+    const task: TaskItem = {
+      id: 'stuck-issue', issueId: 'stuck-issue', issueIdentifier: 'INT-STUCK', source: 'linear',
+      title: 'retry me', priority: 2, createdAt: Date.now(), linearState: 'Todo',
+      labels: ['swarm:stuck'], linearProject: { id: 'project', name: 'Repo' },
+    };
+
+    expect(internal.filterAlreadyProcessed([task])).toEqual([task]);
+    expect(internal.durableRuns.getRun('stuck-issue')).toMatchObject({ state: 'READY' });
+    await Promise.resolve();
+    expect(unstick).toHaveBeenCalledWith('stuck-issue');
+    internal.durableRuns.close();
+  });
+
   it('recovers a PR published before process death without rerunning the pipeline', async () => {
     const [{ AutonomousRunner }, execution] = await Promise.all([
       import('./autonomousRunner.js'),

--- a/src/automation/autonomousRunner.infraError.test.ts
+++ b/src/automation/autonomousRunner.infraError.test.ts
@@ -105,6 +105,29 @@ describe('AutonomousRunner infra_error handling (INT-2010)', () => {
     expect(history.every((entry: { failureCause?: string }) => entry.failureCause === 'infra')).toBe(true);
   });
 
+  it('parks a pair-level stuck result once without replaying the outer retry budget', async () => {
+    const source = mockTaskSource();
+    runnerExecution.setTaskSource(source);
+    const runner = new AutonomousRunner(cfg());
+    const scheduler = (runner as unknown as { scheduler: TaskScheduler }).scheduler;
+    const stuck: PipelineResult = {
+      ...result('failed'),
+      failureSignal: 'stuck',
+      stuckReason: 'Same error repeated 3 times: schema validation failed',
+      taskContext: { issueIdentifier: 'INT-1', projectPath: '/repo', taskTitle: 'Edit some files' },
+    };
+
+    scheduler.startTask(task(), '/repo', async () => stuck);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(source.logStuck).toHaveBeenCalledTimes(1);
+    expect(source.logStuck).toHaveBeenCalledWith(
+      'ISSUE-1', 'autonomous-runner', expect.stringContaining('Same error repeated 3 times'),
+    );
+    const state = JSON.parse(readFileSync(join(tempDir, 'runner-task-state.json'), 'utf8'));
+    expect(state.failed['ISSUE-1']).toBe(4);
+  });
+
   it('does not persist a superseded open issue as completed (INT-2568)', async () => {
     const source = mockTaskSource();
     runnerExecution.setTaskSource(source);

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -542,6 +542,39 @@ export class AutonomousRunner {
         return;
       }
 
+      // The bounded pair loop already proved stagnation (same error/output or
+      // repeated REVISE). Retrying the whole pipeline would only replay the same
+      // loop up to MAX_RETRY_COUNT times, multiplying cost and STUCK log noise.
+      if (result.failureSignal === 'stuck' && task.issueId) {
+        const failureDetail = result.stuckReason
+          ?? pickFailureDetail([result.lastReviewFeedback, result.reviewResult?.feedback, result.workerResult?.error])
+          ?? 'Pair pipeline detected repeated non-progress.';
+        this.completedTaskIds.add(task.issueId);
+        this.failedTaskCounts.set(task.issueId, AutonomousRunner.MAX_RETRY_COUNT);
+        clearRetryTime(task.issueId, this.failedTaskRetryTimes);
+        recordLastFailureDetail(this.taskStateRef, task.issueId, failureDetail);
+        if (this.durableRuns.isPrimary) {
+          this.durableRuns.markNeedsHuman(task.issueId, `Pair pipeline stuck: ${failureDetail}`);
+        }
+        this.saveTaskState();
+        if (result.taskContext?.projectPath) {
+          await removePreservedWorktreeAt(result.taskContext.projectPath)
+            .catch((err) => console.warn('[Worktree] STUCK cleanup failed:', err));
+        }
+        try {
+          await execution.syncFailureState(task, `Pair pipeline stuck: ${failureDetail}`);
+          await getTaskSource()?.logStuck(
+            task.issueId,
+            'autonomous-runner',
+            `Pair pipeline detected repeated non-progress; another full retry would repeat the same loop.\n\n**Reason:**\n${failureDetail}`,
+          );
+          console.log(`[Scheduler] Issue ${task.issueId} marked STUCK from pair-level stagnation (no outer retry)`);
+        } catch (err) {
+          console.error('[Scheduler] Failed to update pair-level STUCK issue state:', err);
+        }
+        return;
+      }
+
       console.log(`[Scheduler] Task failed: ${taskCtx} ${task.title}`);
       broadcastEvent({ type: 'task:completed', data: { taskId: task.id, success: false, duration: result.totalDuration } });
       await reportToDiscord(formatPipelineResultEmbed(result));
@@ -798,8 +831,7 @@ export class AutonomousRunner {
       if (
         this.durableRuns.isPrimary
         && durableRun?.state === 'NEEDS_HUMAN'
-        && !isStuck
-        && task.linearState === 'Todo'
+        && ['Todo', 'In Progress', 'In Review'].includes(task.linearState ?? '')
       ) {
         const resumed = this.durableRuns.resumeNeedsHuman(id);
         if (resumed) {
@@ -900,7 +932,7 @@ export class AutonomousRunner {
         console.warn(`[AutonomousRunner] Failed to clear stuck label for ${id}:`, err));
     }
     if (stuckSkipped > 0) {
-      this.syslog(`🛑 Skipped ${stuckSkipped} stuck issue(s) (retries exhausted — remove the \`${STUCK_LABEL}\` label or move to Todo to retry)`);
+      this.syslog(`🛑 Skipped ${stuckSkipped} stuck issue(s) (retries exhausted — remove the \`${STUCK_LABEL}\` label or move to Todo / In Progress to retry)`);
     }
     if (recovered > 0) {
       this.saveTaskState();

--- a/src/automation/runnerFailureCause.test.ts
+++ b/src/automation/runnerFailureCause.test.ts
@@ -9,6 +9,7 @@ describe('pipeline history failure causes (INT-2659)', () => {
     ['no-changes', { success: false, finalStatus: 'failed', workerFilesChanged: 0 }],
     ['gate-fail', { success: false, finalStatus: 'failed', workerFilesChanged: 1, failureSignal: 'gate-fail' }],
     ['timeout', { success: false, finalStatus: 'infra_error', failureSignal: 'timeout' }],
+    ['stuck', { success: false, finalStatus: 'failed', failureSignal: 'stuck' }],
     ['cancelled', { success: false, finalStatus: 'cancelled' }],
   ] as const)('classifies %s from structural fields', (expected, signals) => {
     expect(classifyFailureCause(signals)).toBe(expected);

--- a/src/automation/runnerState.ts
+++ b/src/automation/runnerState.ts
@@ -301,12 +301,12 @@ export interface PipelineHistoryEntry {
   completedAt: string; // ISO-8601
 }
 
-export type FailureCause = 'reviewer-reject' | 'infra' | 'rate-limit' | 'no-changes' | 'gate-fail' | 'timeout' | 'cancelled';
+export type FailureCause = 'reviewer-reject' | 'infra' | 'rate-limit' | 'no-changes' | 'gate-fail' | 'timeout' | 'stuck' | 'cancelled';
 
 export interface FailureCauseSignals {
   success: boolean;
   finalStatus: string;
-  failureSignal?: 'gate-fail' | 'timeout';
+  failureSignal?: 'gate-fail' | 'timeout' | 'stuck';
   workerFilesChanged?: number;
   reviewerDecision?: string;
 }
@@ -318,6 +318,7 @@ export function classifyFailureCause(signals: FailureCauseSignals): FailureCause
   if (signals.finalStatus === 'rate_limited') return 'rate-limit';
   if (signals.failureSignal === 'timeout') return 'timeout';
   if (signals.finalStatus === 'infra_error') return 'infra';
+  if (signals.failureSignal === 'stuck') return 'stuck';
   if (signals.workerFilesChanged === 0) return 'no-changes';
   if (signals.failureSignal === 'gate-fail') return 'gate-fail';
   if (signals.finalStatus === 'rejected' || signals.reviewerDecision === 'reject' || signals.reviewerDecision === 'revise') return 'reviewer-reject';
@@ -327,7 +328,7 @@ export function classifyFailureCause(signals: FailureCauseSignals): FailureCause
 export function aggregateFailureCauses(entries: PipelineHistoryEntry[]): Record<FailureCause, number> {
   const counts: Record<FailureCause, number> = {
     'reviewer-reject': 0, infra: 0, 'rate-limit': 0, 'no-changes': 0,
-    'gate-fail': 0, timeout: 0, cancelled: 0,
+    'gate-fail': 0, timeout: 0, stuck: 0, cancelled: 0,
   };
   for (const entry of entries) if (entry.failureCause) counts[entry.failureCause]++;
   return counts;

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -1543,6 +1543,8 @@ export async function getStuckIssues(): Promise<{
       reason = 'Blocked by dependencies';
     } else if (labelNames.includes('needs-help')) {
       reason = 'Needs manual intervention';
+    } else if (labelNames.includes(STUCK_LABEL)) {
+      reason = 'Automatic retries exhausted';
     }
 
     failedIssues.push({

--- a/src/support/chatBackend.execution.test.ts
+++ b/src/support/chatBackend.execution.test.ts
@@ -1,0 +1,86 @@
+import { dirname } from 'node:path';
+import { existsSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CliAdapter } from '../adapters/types.js';
+
+const getAdapter = vi.hoisted(() => vi.fn());
+
+vi.mock('../adapters/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../adapters/index.js')>();
+  return { ...actual, getAdapter };
+});
+
+import { runChatCompletion } from './chatBackend.js';
+
+function cliAdapter(buildCommand: CliAdapter['buildCommand']): CliAdapter {
+  return {
+    name: 'codex',
+    capabilities: {
+      supportsStreaming: true,
+      supportsJsonOutput: true,
+      supportsModelSelection: true,
+      managedGit: false,
+      supportedSkills: [],
+    },
+    isAvailable: async () => true,
+    getDefaultModel: async () => 'gpt-5-codex',
+    buildCommand,
+    parseWorkerOutput: () => ({ success: true, summary: '', filesChanged: [], commands: [], output: '' }),
+    parseReviewerOutput: () => ({ decision: 'approve', feedback: '', issues: [], suggestions: [] }),
+  };
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe('runChatCompletion CLI fallback', () => {
+  it('stores prompts in an unpredictable owner-only temp path and removes it', async () => {
+    let promptPath = '';
+    getAdapter.mockReturnValue(cliAdapter((options) => {
+      promptPath = options.prompt;
+      const script = [
+        "const fs = require('node:fs')",
+        'const p = process.argv[1]',
+        'const payload = JSON.stringify({ path: p, mode: fs.statSync(p).mode & 0o777, content: fs.readFileSync(p, \'utf8\') })',
+        "console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: payload } }))",
+      ].join(';');
+      return { command: process.execPath, args: ['-e', script, options.prompt] };
+    }));
+
+    const result = await runChatCompletion({
+      prompt: 'sensitive prompt',
+      provider: 'codex',
+      timeoutMs: 5000,
+    });
+    const payload = JSON.parse(result.response) as { path: string; mode: number; content: string };
+
+    expect(payload.path).toBe(promptPath);
+    expect(payload.mode).toBe(0o600);
+    expect(payload.content).toBe('sensitive prompt');
+    expect(promptPath).toMatch(/openswarm-chat-[^/]+\/prompt\.txt$/);
+    expect(existsSync(promptPath)).toBe(false);
+    expect(existsSync(dirname(promptPath))).toBe(false);
+  });
+
+  it('terminates the spawned CLI process when the caller aborts', async () => {
+    let promptPath = '';
+    getAdapter.mockReturnValue(cliAdapter((options) => {
+      promptPath = options.prompt;
+      return { command: process.execPath, args: ['-e', 'setInterval(() => {}, 1000)'] };
+    }));
+    const controller = new AbortController();
+    const startedAt = Date.now();
+    const pending = runChatCompletion({
+      prompt: 'cancel me',
+      provider: 'codex',
+      timeoutMs: 5000,
+      signal: controller.signal,
+    });
+
+    setTimeout(() => controller.abort(), 50);
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(Date.now() - startedAt).toBeLessThan(2000);
+    expect(existsSync(promptPath)).toBe(false);
+    expect(existsSync(dirname(promptPath))).toBe(false);
+  });
+});

--- a/src/support/chatBackend.test.ts
+++ b/src/support/chatBackend.test.ts
@@ -3,7 +3,13 @@ import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { curatedModels, getDefaultChatModel, buildRepoContext } from './chatBackend.js';
+import {
+  CHAT_MODEL_ALIASES,
+  buildRepoContext,
+  curatedModels,
+  getDefaultChatModel,
+  inferProviderFromModel,
+} from './chatBackend.js';
 
 describe('curatedModels (INT-1961)', () => {
   it('includes the provider default first and dedupes', () => {
@@ -17,6 +23,21 @@ describe('curatedModels (INT-1961)', () => {
     for (const p of ['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter', 'atlascloud'] as const) {
       const m = curatedModels(p);
       expect(m).toContain(getDefaultChatModel(p));
+    }
+  });
+
+  it('maps Codex Responses aliases to the GPT-5.6 capability tiers', () => {
+    expect(getDefaultChatModel('codex-responses')).toBe('gpt-5.6-terra');
+    expect(CHAT_MODEL_ALIASES['codex-responses']).toEqual(expect.objectContaining({
+      big: 'gpt-5.6-sol',
+      medium: 'gpt-5.6-terra',
+      small: 'gpt-5.6-luna',
+    }));
+  });
+
+  it('infers codex-responses for bare GPT-5.6 tier slugs', () => {
+    for (const tier of ['sol', 'terra', 'luna']) {
+      expect(inferProviderFromModel(`gpt-5.6-${tier}`)).toBe('codex-responses');
     }
   });
 });

--- a/src/support/chatBackend.ts
+++ b/src/support/chatBackend.ts
@@ -1,6 +1,7 @@
 import { spawn, execFileSync } from 'node:child_process';
-import { writeFile, unlink } from 'node:fs/promises';
+import { mkdtemp, rmdir, unlink, writeFile } from 'node:fs/promises';
 import { existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 import type { AdapterName } from '../adapters/index.js';
 import { getAdapter, getDefaultAdapterName } from '../adapters/index.js';
@@ -38,9 +39,9 @@ export const CHAT_MODEL_ALIASES: Record<AdapterName, Record<string, string>> = {
   },
   'codex-responses': {
     // Codex backend tiers (see `openswarm auth models` for the live list).
-    big: 'gpt-5.5',
-    medium: 'gpt-5.4',
-    small: 'gpt-5.4-mini',
+    big: 'gpt-5.6-sol',
+    medium: 'gpt-5.6-terra',
+    small: 'gpt-5.6-luna',
     codex: 'gpt-5.3-codex',
   },
   gpt: {
@@ -95,6 +96,10 @@ export const CHAT_MODEL_ALIASES: Record<AdapterName, Record<string, string>> = {
 
 export function inferProviderFromModel(model?: string): AdapterName {
   if (!model) return getDefaultAdapterName();
+  // The GPT-5.6 capability-tier slugs are served by the ChatGPT Codex backend
+  // in this app. Keep an explicit --provider gpt escape hatch for public-API
+  // callers, but do not silently route a bare tier slug to /v1/chat/completions.
+  if (/^gpt-5\.6-(?:sol|terra|luna)$/i.test(model)) return 'codex-responses';
   if (model.includes('codex')) return 'codex';
   if (model.startsWith('gpt-') || model.startsWith('o3') || model.startsWith('o4')) return 'gpt';
   if (model.includes('/')) return 'openrouter';
@@ -105,7 +110,7 @@ export function inferProviderFromModel(model?: string): AdapterName {
 
 export function getDefaultChatModel(provider: AdapterName): string {
   if (provider === 'codex') return 'gpt-5-codex';
-  if (provider === 'codex-responses') return 'gpt-5.5';
+  if (provider === 'codex-responses') return 'gpt-5.6-terra';
   if (provider === 'gpt') return 'gpt-4o';
   if (provider === 'local') return 'gemma3:4b';
   if (provider === 'lmstudio') return process.env.LMSTUDIO_MODEL ?? 'local-model';
@@ -149,6 +154,13 @@ export function shortenChatModel(model: string): string {
   // OpenRouter: "anthropic/claude-sonnet-4" → "claude-sonnet-4"
   if (model.includes('/')) return model.split('/').pop() ?? model;
   return model;
+}
+
+function chatAbortError(signal?: AbortSignal): Error {
+  if (signal?.reason instanceof Error) return signal.reason;
+  const error = new Error('Chat response cancelled');
+  error.name = 'AbortError';
+  return error;
 }
 
 /**
@@ -275,6 +287,8 @@ async function runChatViaAdapter(
 }
 
 export async function runChatCompletion(options: ChatCompletionOptions): Promise<ChatCompletionResult> {
+  if (options.signal?.aborted) throw chatAbortError(options.signal);
+
   const provider = options.provider ?? inferProviderFromModel(options.model);
   const model = resolveChatModel(options.model, provider);
   const adapter = getAdapter(provider);
@@ -284,10 +298,14 @@ export async function runChatCompletion(options: ChatCompletionOptions): Promise
     return runChatViaAdapter(adapter, provider, model, cwd, options);
   }
 
-  const promptFile = `/tmp/openswarm-chat-${Date.now()}.txt`;
-  await writeFile(promptFile, options.prompt);
+  // CLI adapters consume a prompt path. Use a private, unpredictable directory
+  // and owner-only file instead of exposing prompt contents in a predictable
+  // world-readable /tmp filename.
+  const promptDir = await mkdtemp(join(tmpdir(), 'openswarm-chat-'));
+  const promptFile = join(promptDir, 'prompt.txt');
 
   try {
+    await writeFile(promptFile, options.prompt, { mode: 0o600 });
     const { command, args } = adapter.buildCommand({
       prompt: promptFile,
       cwd,
@@ -309,6 +327,35 @@ export async function runChatCompletion(options: ChatCompletionOptions): Promise
       let startedStreaming = false;
       let thinkingTimer: NodeJS.Timeout | null = null;
       let timeout: NodeJS.Timeout | null = null;
+      let abortKillTimer: NodeJS.Timeout | null = null;
+      let settled = false;
+
+      const cleanupProcessHooks = () => {
+        if (timeout) clearTimeout(timeout);
+        if (thinkingTimer) clearTimeout(thinkingTimer);
+        if (abortKillTimer) clearTimeout(abortKillTimer);
+        options.signal?.removeEventListener('abort', onAbort);
+      };
+
+      const settle = (action: () => void) => {
+        if (settled) return;
+        settled = true;
+        cleanupProcessHooks();
+        action();
+      };
+
+      const onAbort = () => {
+        proc.kill('SIGTERM');
+        // A child can trap/ignore SIGTERM. Do not let cancellation leave an
+        // orphaned model process behind indefinitely.
+        abortKillTimer = setTimeout(() => {
+          if (proc.exitCode === null) proc.kill('SIGKILL');
+        }, 1000);
+        abortKillTimer.unref();
+      };
+
+      if (options.signal?.aborted) onAbort();
+      else options.signal?.addEventListener('abort', onAbort, { once: true });
 
       const resetThinkingTimer = () => {
         if (!options.onText) return;
@@ -354,17 +401,20 @@ export async function runChatCompletion(options: ChatCompletionOptions): Promise
       if ((options.timeoutMs ?? 180000) > 0) {
         timeout = setTimeout(() => {
           proc.kill('SIGKILL');
-          reject(new Error('Chat response timeout'));
+          settle(() => reject(new Error('Chat response timeout')));
         }, options.timeoutMs ?? 180000);
       }
 
       proc.on('close', (code) => {
-        if (timeout) clearTimeout(timeout);
-        if (thinkingTimer) clearTimeout(thinkingTimer);
         flushLines(true);
 
+        if (options.signal?.aborted) {
+          settle(() => reject(chatAbortError(options.signal)));
+          return;
+        }
+
         if (code !== 0 && !stdout.trim()) {
-          reject(new Error(stderr.trim() || `${provider} exited with code ${code}`));
+          settle(() => reject(new Error(stderr.trim() || `${provider} exited with code ${code}`)));
           return;
         }
 
@@ -372,25 +422,28 @@ export async function runChatCompletion(options: ChatCompletionOptions): Promise
         const cost = undefined;
         const tokens = undefined;
 
-        resolve({
+        settle(() => resolve({
           response: response || '[No response]',
           provider,
           model,
           sessionId: capturedSessionId || undefined,
           cost,
           tokens,
-        });
+        }));
       });
 
       proc.on('error', (error) => {
-        if (timeout) clearTimeout(timeout);
-        if (thinkingTimer) clearTimeout(thinkingTimer);
-        reject(error);
+        settle(() => reject(options.signal?.aborted ? chatAbortError(options.signal) : error));
       });
     });
   } finally {
     try {
       await unlink(promptFile);
+    } catch {
+      // Ignore temp cleanup errors.
+    }
+    try {
+      await rmdir(promptDir);
     } catch {
       // Ignore temp cleanup errors.
     }

--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -95,11 +95,12 @@ describe('resolveSharedPaths (INT-2415)', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('auto-detects node_modules/.venv/venv that exist at the repo root', () => {
+  it('auto-detects node_modules and verification virtualenvs that exist at the repo root', () => {
     mkdirSync(join(repo, 'node_modules'), { recursive: true });
+    mkdirSync(join(repo, '.venv-verify'), { recursive: true });
     mkdirSync(join(repo, '.venv'), { recursive: true });
     // venv is absent → excluded; only existing candidates are returned.
-    expect(resolveSharedPaths(repo, null).sort()).toEqual(['.venv', 'node_modules']);
+    expect(resolveSharedPaths(repo, null).sort()).toEqual(['.venv', '.venv-verify', 'node_modules']);
   });
 
   it('returns [] when no auto-detect candidates exist', () => {

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -138,7 +138,7 @@ function assertManagedWorktreePath(repoPath: string, worktreePath: string): stri
 // deps/DBs are read-mostly, so parallel workers sharing them is safe.
 
 /** Always-gitignored dependency dirs safe to auto-link without a config. */
-const AUTO_SHARED_CANDIDATES = ['node_modules', '.venv', 'venv'];
+const AUTO_SHARED_CANDIDATES = ['node_modules', '.venv-verify', '.venv', 'venv'];
 
 interface SandboxConfig {
   sandbox?: { sharedPaths?: string[] } | null;

--- a/src/verify/discover.test.ts
+++ b/src/verify/discover.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -10,7 +10,10 @@ const roots: string[] = [];
 async function fixture(files: Record<string, string>): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'openswarm-verify-discover-'));
   roots.push(root);
-  await Promise.all(Object.entries(files).map(([name, content]) => writeFile(join(root, name), content, 'utf8')));
+  await Promise.all(Object.entries(files).map(async ([name, content]) => {
+    await mkdir(dirname(join(root, name)), { recursive: true });
+    await writeFile(join(root, name), content, 'utf8');
+  }));
   return root;
 }
 
@@ -45,6 +48,16 @@ describe('discoverVerifyCommands', () => {
     const root = await fixture({ [name]: content });
     expect(await discoverVerifyCommands(root)).toEqual([
       { name: 'pytest', run: 'python -m pytest -x -q', kind: 'test', timeoutMs: 300_000 },
+    ]);
+  });
+
+  it('prefers the repository verification virtualenv for pytest', async () => {
+    const root = await fixture({
+      'pytest.ini': '[pytest]\n',
+      '.venv-verify/bin/python': '#!/bin/sh\n',
+    });
+    expect(await discoverVerifyCommands(root)).toEqual([
+      { name: 'pytest', run: './.venv-verify/bin/python -m pytest -x -q', kind: 'test', timeoutMs: 300_000 },
     ]);
   });
 

--- a/src/verify/discover.ts
+++ b/src/verify/discover.ts
@@ -12,6 +12,16 @@ async function readText(path: string): Promise<string | null> {
   return readFile(path, 'utf8').catch(() => null);
 }
 
+async function pythonCommand(projectPath: string): Promise<string> {
+  const candidates = process.platform === 'win32'
+    ? ['.venv-verify/Scripts/python.exe', '.venv/Scripts/python.exe', 'venv/Scripts/python.exe']
+    : ['.venv-verify/bin/python', '.venv/bin/python', 'venv/bin/python'];
+  for (const candidate of candidates) {
+    if (await exists(join(projectPath, candidate))) return `./${candidate}`;
+  }
+  return 'python';
+}
+
 function command(name: string, run: string, kind: VerifyCommand['kind']): VerifyCommand {
   return { name, run, kind, timeoutMs: DEFAULT_TIMEOUT_MS };
 }
@@ -50,7 +60,7 @@ export async function discoverVerifyCommands(projectPath: string): Promise<Verif
   const pyproject = await readText(join(projectPath, 'pyproject.toml'));
   const setupCfg = await readText(join(projectPath, 'setup.cfg'));
   if (pytestIni || pyproject?.includes('[tool.pytest.ini_options]') || setupCfg?.includes('[tool:pytest]')) {
-    commands.push(command('pytest', 'python -m pytest -x -q', 'test'));
+    commands.push(command('pytest', `${await pythonCommand(projectPath)} -m pytest -x -q`, 'test'));
   }
 
   // Rust repositories use Cargo's native test runner.

--- a/src/verify/runner.test.ts
+++ b/src/verify/runner.test.ts
@@ -273,6 +273,15 @@ describe('runVerify', () => {
     expect(evidence).toMatchObject({ headStatus: 'fail', baseStatus: 'fail', newFailure: false });
   });
 
+  it('normalizes isolated worktree paths when comparing the same failure', async () => {
+    const [evidence] = await runVerify({
+      projectPath: repo,
+      commands: [verify('printf "%s\\npre-existing failure\\n" "$PWD"; exit 1')],
+      baseRef: 'HEAD',
+    });
+    expect(evidence).toMatchObject({ headStatus: 'fail', baseStatus: 'fail', newFailure: false });
+  });
+
   it('marks an additional head failure as new when base already fails', async () => {
     await writeFile(join(repo, 'existing-failure'), 'yes\n', 'utf8');
     git('add', 'existing-failure');
@@ -317,6 +326,20 @@ describe('runVerify', () => {
     });
 
     expect(evidence).toMatchObject({ headStatus: 'fail', baseStatus: 'fail', newFailure: true });
+  });
+
+  it('waives the same pre-existing missing environment dependency after a manifest change', async () => {
+    await writeFile(join(repo, 'pyproject.toml'), '[project]\nname = "fixture"\n', 'utf8');
+    git('add', 'pyproject.toml');
+    git('commit', '-m', 'base python manifest');
+    await writeFile(join(repo, 'pyproject.toml'), '[project]\nname = "fixture"\nversion = "1"\n', 'utf8');
+
+    const [evidence] = await runVerify({
+      projectPath: repo,
+      commands: [verify("printf '%s\\nModuleNotFoundError: No module named '\"'\"'slack_bolt'\"'\"'\\n' \"$PWD\"; exit 1")],
+      baseRef: 'HEAD',
+    });
+    expect(evidence).toMatchObject({ headStatus: 'fail', baseStatus: 'fail', newFailure: false });
   });
 
   it.each(['Cargo.toml', 'go.mod'])('invalidates baseline failures when %s changes', async (name) => {

--- a/src/verify/runner.ts
+++ b/src/verify/runner.ts
@@ -36,6 +36,7 @@ interface CommandResult {
   status: 'pass' | 'fail' | 'infra';
   output: string;
   outputFingerprint?: string;
+  environmentFailure?: boolean;
   baselineEnvironmentChanged?: boolean;
 }
 
@@ -68,6 +69,27 @@ function hasSameFailure(base: CommandResult, head: CommandResult): boolean {
   return base.outputFingerprint !== undefined && base.outputFingerprint === head.outputFingerprint;
 }
 
+function normalizeFailureOutput(output: string, projectRoot: string): string {
+  const escapedRoot = projectRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return output
+    .replace(new RegExp(escapedRoot, 'g'), '<PROJECT>')
+    .replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'), '')
+    .replace(/(=+ .*? in )\d+(?:\.\d+)?s( =+)/g, '$1<DURATION>$2')
+    .replace(/(Ran \d+ tests? in )\d+(?:\.\d+)?s/g, '$1<DURATION>')
+    .replace(/(finished in )\d+(?:\.\d+)?s/gi, '$1<DURATION>');
+}
+
+function isEnvironmentFailure(output: string): boolean {
+  return [
+    /ModuleNotFoundError:\s*No module named\b/i,
+    /ImportError:\s*No module named\b/i,
+    /Cannot find module ['"]/i,
+    /could not find [`']?Cargo\.toml/i,
+    /failed to (?:load|read) manifest for workspace member/i,
+    /Cargo\.toml.*(?:No such file or directory|os error 2)/i,
+  ].some((pattern) => pattern.test(output));
+}
+
 function appendTail(current: Buffer, chunk: Buffer): Buffer {
   const combined = Buffer.concat([current, chunk]);
   return combined.length <= OUTPUT_TAIL_BYTES ? combined : combined.subarray(combined.length - OUTPUT_TAIL_BYTES);
@@ -98,15 +120,28 @@ async function runCommand(command: VerifyCommand, root: string, env: NodeJS.Proc
       detached,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-    child.stdout.on('data', (chunk: Buffer) => { outputHash.update(chunk); output = appendTail(output, chunk); });
-    child.stderr.on('data', (chunk: Buffer) => { outputHash.update(chunk); output = appendTail(output, chunk); });
+    const record = (chunk: Buffer) => {
+      outputHash.update(normalizeFailureOutput(chunk.toString('utf8'), cwd));
+      output = appendTail(output, chunk);
+    };
+    child.stdout.on('data', record);
+    child.stderr.on('data', record);
 
     const finish = (status: CommandResult['status'], extra = '') => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      if (extra) { outputHash.update(extra); output = appendTail(output, Buffer.from(extra)); }
-      resolveResult({ status, output: output.toString('utf8'), outputFingerprint: outputHash.digest('hex') });
+      if (extra) {
+        outputHash.update(normalizeFailureOutput(extra, cwd));
+        output = appendTail(output, Buffer.from(extra));
+      }
+      const outputText = output.toString('utf8');
+      resolveResult({
+        status,
+        output: outputText,
+        outputFingerprint: outputHash.digest('hex'),
+        environmentFailure: status === 'fail' && isEnvironmentFailure(outputText),
+      });
     };
     const timer = setTimeout(() => {
       timedOut = true;
@@ -327,12 +362,14 @@ export async function runVerify(options: RunVerifyOptions): Promise<VerifyEviden
     const rawOutputTail = Buffer.from(`[base]\n${base.output}\n[head]\n${head.output}`, 'utf8')
       .subarray(-OUTPUT_TAIL_BYTES)
       .toString('utf8');
+    const sameFailure = base.status === 'fail' && hasSameFailure(base, head);
+    const sameEnvironmentFailure = !!(sameFailure && base.environmentFailure && head.environmentFailure);
     evidence.push({
       command,
       baseStatus: base.status,
       headStatus: 'fail',
       newFailure: base.status === 'pass'
-        || (base.status === 'fail' && (base.baselineEnvironmentChanged || !hasSameFailure(base, head))),
+        || (base.status === 'fail' && (!sameFailure || (!!base.baselineEnvironmentChanged && !sameEnvironmentFailure))),
       rawOutputTail,
       durationMs: Date.now() - started,
     });


### PR DESCRIPTION
## What changed

- route worker stages to GPT-5.6 models by workload tier instead of using the most expensive model everywhere
- normalize deterministic verification failure output across isolated base/head worktrees
- reuse repository Python virtualenvs, including `.venv-verify`
- treat identical pre-existing missing-environment failures as baseline failures even when dependency manifests changed
- propagate pair-level stagnation so the scheduler parks it once instead of replaying the full outer retry budget
- resume durable `NEEDS_HUMAN` runs when an operator moves a stuck issue to Todo/In Progress, even while the label is still present
- show a meaningful reason for `swarm:stuck` issues in the dashboard

## Root cause

STUCK issues accumulated through three interacting paths: temporary worktree paths made identical verifier failures hash differently, repository-specific Python environments were ignored, and durable `NEEDS_HUMAN` filtering ran before the active-state recovery branch. Pair-level STUCK decisions were also retried as ordinary failures, multiplying logs and model usage.

## Impact

Pre-existing environment defects no longer look like regressions, explicit operator recovery works again, and confirmed stagnation is recorded once. After deploying this branch, the live heartbeat resumed 17 previously stranded runs from `NEEDS_HUMAN`.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test -- --run`: 212 files, 2,980 passed, 1 skipped
- `openswarm review --path .`: APPROVE
- live service restarted successfully as PID 62341
- durable ledger: 17 `operator_resumed` transitions observed after restart
