### PR TITLE
Harden Sprint 1 runtime safety boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ adapter: codex   # one of: codex · codex-responses · gpt · openrouter · atla
 
 | Adapter | Backend | Models | Auth |
 |---------|---------|--------|------|
-| `codex-responses` | OpenAI Responses API (native loop, no CLI binary) | gpt-5-codex (default), o3, o4-mini | ChatGPT OAuth |
+| `codex-responses` | OpenAI Responses API (native loop, no CLI binary) | gpt-5.6-terra (default), gpt-5.6-sol, gpt-5.6-luna | ChatGPT OAuth |
 | `codex` | OpenAI Codex CLI (delegated) | gpt-5-codex (default), o3, o4-mini | ChatGPT OAuth / `codex` CLI auth |
 | `gpt` | OpenAI Chat API | gpt-4o (default), o3, … | OAuth PKCE |
 | `openrouter` | OpenRouter API (native agentic loop) | any OpenRouter model — gpt-5, gemini-2.5, deepseek, glm, qwen, … | `OPENROUTER_API_KEY` or OAuth PKCE |
@@ -211,7 +211,7 @@ autonomous:
   defaultRoles:
     worker:
       adapter: codex-responses
-      model: gpt-5-codex
+      model: gpt-5.6-terra
     reviewer:
       adapter: openrouter
       model: anthropic/claude-sonnet-4
@@ -229,7 +229,7 @@ autonomous:
     enabled: false
     cadenceHours: 24
     mode: comment
-    plannerModel: gpt-5.5
+    plannerModel: gpt-5.6-terra
     maxIssues: 80
 ```
 
@@ -239,20 +239,43 @@ autonomous:
 autonomous:
   defaultRoles:
     worker:
-      model: gpt-5-codex
-      escalateModel: openai/gpt-5     # escalate after repeated review failures
-      escalateAfterIteration: 3
+      model: gpt-5.6-terra            # balanced default implementation
+      escalateModel: gpt-5.6-sol      # frontier retry after a failed attempt
+      escalateAfterIteration: 2
       timeoutMs: 1800000
     reviewer:
-      model: gpt-5-codex
+      model: gpt-5.6-sol              # correctness gate
       timeoutMs: 600000
     tester:
       enabled: false
+      model: gpt-5.6-terra            # LLM fallback after deterministic verify
     documenter:
       enabled: false
+      model: gpt-5.6-luna
     auditor:
       enabled: false
+      model: gpt-5.6-sol
+    skill-documenter:
+      enabled: false
+      model: gpt-5.6-luna
+  jobProfiles:
+    - name: light
+      minMinutes: 1
+      maxMinutes: 29
+      effort: low
+      roles:
+        worker: gpt-5.6-luna
+        reviewer: gpt-5.6-terra
+    - name: heavy
+      minMinutes: 30
+      effort: high
+      roles:
+        worker: gpt-5.6-terra
+        reviewer: gpt-5.6-sol
 ```
+
+The native Codex adapter uses Terra when no model is pinned. Draft analysis uses
+Luna because it runs for every task; decomposition and hard review stay on Sol.
 
 ### Running the daemon
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,9 +3,9 @@
 # Copy this file to config.yaml to use
 
 # Default CLI adapter for worker/reviewer stages
-# Options: claude, codex, gpt, local, lmstudio, openrouter, atlascloud
-# For GPT: run `openswarm auth login --provider gpt`
-#   (uses the public Codex OAuth client by default — no extra config needed)
+# Options: codex-responses, codex, gpt, local, lmstudio, openrouter, atlascloud, claude
+# For ChatGPT OAuth: run `openswarm auth login --provider gpt`
+#   `codex-responses` runs OpenSwarm's native tool loop with the same login.
 # For OpenRouter: run `openswarm auth login --provider openrouter`
 #   (PKCE browser flow → stores a sk-or-* API key; falls back to manual paste)
 # For Atlas Cloud: set ATLASCLOUD_API_KEY
@@ -13,7 +13,7 @@
 # For lmstudio: start LM Studio Local Server (default http://localhost:1234)
 #   Optional env: LMSTUDIO_BASE_URL, LMSTUDIO_MODEL, LMSTUDIO_API_KEY
 #   If LMSTUDIO_MODEL is unset, the adapter auto-selects the first loaded model.
-adapter: claude
+adapter: codex-responses
 
 discord:
   token: ${DISCORD_TOKEN}
@@ -62,7 +62,7 @@ autonomous:
   decomposition:
     enabled: true                    # Enable decomposition
     thresholdMinutes: 30             # Decompose if estimated time exceeds this
-    plannerModel: claude-opus-4-7    # Planner model (Opus for deep decomposition)
+    plannerModel: gpt-5.6-sol         # High-leverage decomposition stays on Sol
 
   # Backlog grooming (Planner compares fetched open queue states against the repo).
   # Safe default: comment recommendations only. Set mode: apply to update
@@ -71,42 +71,36 @@ autonomous:
     enabled: false
     cadenceHours: 24
     mode: comment
-    plannerModel: claude-opus-4-7
+    plannerModel: gpt-5.6-terra       # Bulk queue analysis favors the balanced tier
     maxIssues: 80
 
   # Per-role settings
-  # Hybrid config: Claude for complex coding, local model for review/docs ($0)
+  # GPT-5.6: Luna=high-volume/light, Terra=balanced default, Sol=quality gate.
   defaultRoles:
     worker:
       enabled: true
-      adapter: claude
-      model: claude-sonnet-4-6         # Sonnet for coding tasks
-      escalateModel: claude-opus-4-7          # On failure: Opus
-      escalateAfterIteration: 3
+      model: gpt-5.6-terra             # Default implementation tier
+      escalateModel: gpt-5.6-sol       # Repeated failure earns the frontier tier
+      escalateAfterIteration: 2
       timeoutMs: 1800000  # 30 minutes
     reviewer:
       enabled: true
-      adapter: local                          # Local model — free, 7s response
-      model: gemma-4-e4b-it                   # Gemma 4 e4b via LMStudio
-      escalateModel: claude-sonnet-4-6 # Spot check: Sonnet reviews after N revisions
-      escalateAfterIteration: 3               # Escalate from 3rd iteration
-      timeoutMs: 60000    # 1 minute (local models are slower)
+      model: gpt-5.6-sol               # Correctness gate; light profile lowers this to Terra
+      timeoutMs: 600000
     tester:
       enabled: false
+      model: gpt-5.6-terra             # Used only if deterministic verify cannot run
     documenter:
       enabled: false
-      adapter: local
-      model: gemma-4-e4b-it
+      model: gpt-5.6-luna
       timeoutMs: 120000   # 2 minutes
     auditor:
       enabled: false
-      adapter: local
-      model: gemma-4-e4b-it
+      model: gpt-5.6-sol
       timeoutMs: 300000   # 5 minutes
     skill-documenter:
       enabled: false
-      adapter: local
-      model: gemma-4-e4b-it
+      model: gpt-5.6-luna
       timeoutMs: 120000   # 2 minutes
 
   # Deterministic baseline-diff verification (enabled by default).
@@ -137,17 +131,21 @@ autonomous:
   # (identical errors twice in a row). Default: 3.
   maxReflections: 3
 
-  # Job profiles for lightweight vs heavy work
+  # Job profiles override the default Worker/Reviewer pair by task estimate.
   jobProfiles:
-    - name: quick-analysis
-      maxMinutes: 15
+    - name: light
+      minMinutes: 1
+      maxMinutes: 29
+      effort: low
       roles:
-        worker: claude-haiku-4-5-20251001     # Haiku for simple tasks
-    - name: deep-engineering
-      minMinutes: 16
+        worker: gpt-5.6-luna
+        reviewer: gpt-5.6-terra
+    - name: heavy
+      minMinutes: 30
+      effort: high
       roles:
-        worker: claude-sonnet-4-6      # Sonnet for complex work
-        reviewer: claude-sonnet-4-6    # Sonnet reviews Sonnet
+        worker: gpt-5.6-terra
+        reviewer: gpt-5.6-sol
 
 # Long-running task monitoring (RunPod training, batch processing, etc.)
 #

--- a/src/adapters/applyPatch.test.ts
+++ b/src/adapters/applyPatch.test.ts
@@ -22,6 +22,10 @@ describe('parseV4A', () => {
     expect(() => parseV4A('no envelope here')).toThrow(/Begin Patch/);
   });
 
+  it('throws on a truncated patch missing the explicit End marker', () => {
+    expect(() => parseV4A('*** Begin Patch\n*** Add File: partial.txt\n+unsafe')).toThrow(/End Patch/);
+  });
+
   it('parses update / add / delete / move ops', () => {
     const ops = parseV4A(wrap(
       '*** Update File: a.ts\n@@\n-old\n+new\n' +

--- a/src/adapters/applyPatch.ts
+++ b/src/adapters/applyPatch.ts
@@ -82,9 +82,7 @@ export function parseV4A(patchText: string): FileOp[] {
       }
     }
   }
-  // No explicit End marker — finalize what we have.
-  pushOp();
-  return ops;
+  throw new Error('missing "*** End Patch"');
 }
 
 /** Locate `block` in `content` lines; return start index, or -1. Tries exact, then trimEnd-fuzzy. */

--- a/src/adapters/base.spawn.test.ts
+++ b/src/adapters/base.spawn.test.ts
@@ -1,4 +1,7 @@
 import { EventEmitter } from 'node:events';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
 import type { CliAdapter } from './types.js';
@@ -44,5 +47,34 @@ describe('argv-safe adapter spawning', () => {
       ['--model', injected],
       expect.objectContaining({ shell: false }),
     );
+  });
+
+  it('removes adapter-owned temporary paths after the child settles', async () => {
+    const proc = Object.assign(new EventEmitter(), {
+      pid: 124,
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      stdin: { end: vi.fn() },
+      kill: vi.fn(),
+    });
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => proc.emit('close', 0));
+      return proc;
+    });
+    const temporaryDir = mkdtempSync(join(tmpdir(), 'openswarm-adapter-cleanup-'));
+    writeFileSync(join(temporaryDir, 'mcp.json'), '{}');
+    const adapter = {
+      name: 'fixture',
+      capabilities: { supportsStreaming: false, supportsJsonOutput: false, supportsModelSelection: false, managedGit: false, supportedSkills: [] },
+      isAvailable: async () => true,
+      getDefaultModel: async () => 'fixture',
+      buildCommand: () => ({ command: 'fixture-cli', args: [], cleanupPaths: [temporaryDir] }),
+      parseWorkerOutput: () => ({ success: true, summary: '', filesChanged: [], commands: [], output: '' }),
+      parseReviewerOutput: () => ({ decision: 'approve' as const, feedback: '', issues: [], suggestions: [] }),
+    } satisfies CliAdapter;
+
+    await spawnCli(adapter, { prompt: 'hello', cwd: process.cwd() });
+
+    expect(existsSync(temporaryDir)).toBe(false);
   });
 });

--- a/src/adapters/base.spawn.test.ts
+++ b/src/adapters/base.spawn.test.ts
@@ -1,0 +1,48 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import type { CliAdapter } from './types.js';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ spawn: spawnMock }));
+
+import { spawnCli } from './base.js';
+
+describe('argv-safe adapter spawning', () => {
+  it('passes metacharacters as one argv value with shell disabled', async () => {
+    const proc = Object.assign(new EventEmitter(), {
+      pid: 123,
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      stdin: { end: vi.fn() },
+      kill: vi.fn(),
+    });
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => proc.emit('close', 0));
+      return proc;
+    });
+    const injected = 'model; touch /tmp/openswarm-should-not-exist';
+    const adapter: CliAdapter = {
+      name: 'fixture',
+      capabilities: {
+        supportsStreaming: false,
+        supportsJsonOutput: false,
+        supportsModelSelection: true,
+        managedGit: false,
+        supportedSkills: [],
+      },
+      isAvailable: async () => true,
+      getDefaultModel: async () => 'fixture',
+      buildCommand: () => ({ command: 'fixture-cli', args: ['--model', injected] }),
+      parseWorkerOutput: () => ({ success: true, summary: '', filesChanged: [], commands: [], output: '' }),
+      parseReviewerOutput: () => ({ decision: 'approve', feedback: '', issues: [], suggestions: [] }),
+    };
+
+    await expect(spawnCli(adapter, { prompt: 'hello', cwd: process.cwd() })).resolves.toMatchObject({ exitCode: 0 });
+    expect(spawnMock).toHaveBeenCalledWith(
+      'fixture-cli',
+      ['--model', injected],
+      expect.objectContaining({ shell: false }),
+    );
+  });
+});

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -28,13 +28,16 @@ export async function spawnCli(
 
   const promptFile = `/tmp/openswarm-prompt-${Date.now()}.txt`;
   await fs.writeFile(promptFile, options.prompt);
+  let cleanupPaths: string[] = [];
 
   try {
-    const { command, args, stdinFile } = adapter.buildCommand({
+    const commandSpec = adapter.buildCommand({
       ...options,
       // Pass the temp file path as the prompt so buildCommand can reference it
       prompt: promptFile,
     });
+    const { command, args, stdinFile } = commandSpec;
+    cleanupPaths = commandSpec.cleanupPaths ?? [];
 
     const stdin = stdinFile ? await fs.readFile(stdinFile) : undefined;
     const startTime = Date.now();
@@ -147,6 +150,9 @@ export async function spawnCli(
       await fs.unlink(promptFile);
     } catch {
       // Ignore cleanup errors
+    }
+    for (const cleanupPath of cleanupPaths) {
+      await fs.rm(cleanupPath, { recursive: true, force: true }).catch(() => {});
     }
   }
 }

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -14,7 +14,7 @@ import { codexMcpAuthHint } from './errorClassification.js';
 
 /**
  * Spawn a CLI process using the given adapter and options.
- * Handles: temp file write, spawn with shell, timeout/SIGKILL,
+ * Handles: temp file write, argv-safe spawn, timeout/SIGKILL,
  * stdout/stderr buffering, stream parsing via onLog, cleanup.
  */
 export async function spawnCli(
@@ -30,25 +30,27 @@ export async function spawnCli(
   await fs.writeFile(promptFile, options.prompt);
 
   try {
-    const { command, args } = adapter.buildCommand({
+    const { command, args, stdinFile } = adapter.buildCommand({
       ...options,
       // Pass the temp file path as the prompt so buildCommand can reference it
       prompt: promptFile,
     });
 
-    const cmd = [command, ...args].join(' ');
+    const stdin = stdinFile ? await fs.readFile(stdinFile) : undefined;
     const startTime = Date.now();
 
     return await new Promise<CliRunResult>((resolve, reject) => {
-      const proc = spawn(cmd, {
-        shell: true,
+      const proc = spawn(command, args, {
+        shell: false,
         cwd: options.cwd,
         // Inject OpenSwarm's bundled node_modules/.bin (gives workers access
         // to `cxt` and other shipped CLIs) without touching the user's shell
         // PATH or ~/.claude/ config.
         env: buildWorkerEnv(process.env),
-        stdio: ['ignore', 'pipe', 'pipe'],
+        stdio: [stdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
       });
+
+      if (stdin) proc.stdin?.end(stdin);
 
       // Register process for tracking if context provided
       if (options.processContext && proc.pid) {

--- a/src/adapters/claude.test.ts
+++ b/src/adapters/claude.test.ts
@@ -3,28 +3,30 @@ import { ClaudeCliAdapter } from './claude.js';
 
 describe('ClaudeCliAdapter.buildCommand', () => {
   it('wires the memory MCP server via --mcp-config and keeps bypass permissions', () => {
-    const { command } = new ClaudeCliAdapter().buildCommand({
+    const { command, args, stdinFile } = new ClaudeCliAdapter().buildCommand({
       prompt: '/tmp/prompt.txt',
       cwd: '/tmp/project',
       model: 'claude-sonnet-4',
     });
-    expect(command).toContain('claude -p');
-    expect(command).toContain('--permission-mode bypassPermissions');
-    expect(command).toContain('--mcp-config');
-    expect(command).toMatch(/--mcp-config \S+mcp\.json/);
+    expect(command).toBe('claude');
+    expect(args).toContain('-p');
+    expect(args).toContain('bypassPermissions');
+    expect(args).toContain('--mcp-config');
+    expect(args[args.indexOf('--mcp-config') + 1]).toMatch(/mcp\.json$/);
+    expect(stdinFile).toBe('/tmp/prompt.txt');
   });
 
   it('omits the memory MCP config when memoryTools=false', () => {
-    const { command } = new ClaudeCliAdapter().buildCommand({
+    const { command, args } = new ClaudeCliAdapter().buildCommand({
       prompt: '/tmp/prompt.txt',
       cwd: '/tmp/project',
       model: 'claude-sonnet-4',
       memoryTools: false,
     });
 
-    expect(command).toContain('claude -p');
-    expect(command).toContain('--permission-mode bypassPermissions');
-    expect(command).not.toContain('--mcp-config');
+    expect(command).toBe('claude');
+    expect(args).toContain('bypassPermissions');
+    expect(args).not.toContain('--mcp-config');
   });
 });
 
@@ -32,20 +34,25 @@ describe('ClaudeCliAdapter.buildCommand model pinning (INT-2509)', () => {
   it('pins --model to the adapter default when the caller omits model', () => {
     // Omitting --model would run the user's PERSONAL default (can be the most
     // expensive tier) — the planner path hits this because it drops claude-* ids.
-    const { command } = new ClaudeCliAdapter().buildCommand({
+    const { args } = new ClaudeCliAdapter().buildCommand({
       prompt: '/tmp/prompt.txt',
       cwd: '/tmp/project',
     });
-    expect(command).toContain('--model sonnet');
+    expect(args.slice(args.indexOf('--model'), args.indexOf('--model') + 2)).toEqual(['--model', 'sonnet']);
   });
 
   it('keeps an explicit model', () => {
-    const { command } = new ClaudeCliAdapter().buildCommand({
+    const { args } = new ClaudeCliAdapter().buildCommand({
       prompt: '/tmp/prompt.txt',
       cwd: '/tmp/project',
       model: 'opus',
     });
-    expect(command).toContain('--model opus');
-    expect(command).not.toContain('--model sonnet');
+    expect(args.slice(args.indexOf('--model'), args.indexOf('--model') + 2)).toEqual(['--model', 'opus']);
+    expect(args).not.toContain('sonnet');
+  });
+
+  it('keeps model metacharacters inside one argv element', () => {
+    const { args } = new ClaudeCliAdapter().buildCommand({ prompt: '/tmp/prompt.txt', cwd: '/tmp', model: 'sonnet; touch /tmp/pwned' });
+    expect(args[args.indexOf('--model') + 1]).toBe('sonnet; touch /tmp/pwned');
   });
 });

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -5,6 +5,7 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { dirname } from 'node:path';
 import type {
   CliAdapter,
   CliRunOptions,
@@ -62,10 +63,16 @@ export class ClaudeCliAdapter implements CliAdapter {
     // Register OpenSwarm's memory MCP server unless the caller needs an isolated run.
     // bypassPermissions auto-allows its tool when present.
     const args = ['-p', '--output-format', 'stream-json', '--verbose', '--permission-mode', 'bypassPermissions'];
-    if (options.memoryTools !== false) args.push('--mcp-config', writeClaudeMcpConfig());
+    const mcpConfig = options.memoryTools !== false ? writeClaudeMcpConfig() : undefined;
+    if (mcpConfig) args.push('--mcp-config', mcpConfig);
     args.push('--model', model);
     if (options.maxTurns) args.push('--max-turns', String(options.maxTurns));
-    return { command: 'claude', args, stdinFile: promptFile };
+    return {
+      command: 'claude',
+      args,
+      stdinFile: promptFile,
+      cleanupPaths: mcpConfig ? [dirname(mcpConfig)] : [],
+    };
   }
 
   async getDefaultModel(): Promise<string> {

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -10,6 +10,7 @@ import type {
   CliRunOptions,
   CliRunResult,
   AdapterCapabilities,
+  CliCommandSpec,
   WorkerResult,
   ReviewResult,
 } from './types.js';
@@ -50,21 +51,21 @@ export class ClaudeCliAdapter implements CliAdapter {
     }
   }
 
-  buildCommand(options: CliRunOptions): { command: string; args: string[] } {
+  buildCommand(options: CliRunOptions): CliCommandSpec {
     // options.prompt is the temp file path (set by spawnCli)
     const promptFile = options.prompt;
     // Always pin a model: omitting --model runs the user's PERSONAL default,
     // which can be the most expensive tier (observed: planner calls landing on
     // claude-fable-5 at ~$0.64 per trivial call). (INT-2509)
-    const modelFlag = ` --model ${options.model ?? CLAUDE_DEFAULT_MODEL}`;
-    const maxTurnsFlag = options.maxTurns ? ` --max-turns ${options.maxTurns}` : '';
+    const model = options.model ?? CLAUDE_DEFAULT_MODEL;
+    if (!model.trim() || model.includes('\0')) throw new Error('Invalid Claude model');
     // Register OpenSwarm's memory MCP server unless the caller needs an isolated run.
     // bypassPermissions auto-allows its tool when present.
-    const mcpConfigFlag = options.memoryTools === false
-      ? ''
-      : ` --mcp-config ${writeClaudeMcpConfig()}`;
-    const cmd = `echo "" | claude -p "$(cat ${promptFile})" --output-format stream-json --verbose --permission-mode bypassPermissions${mcpConfigFlag}${modelFlag}${maxTurnsFlag}`;
-    return { command: cmd, args: [] };
+    const args = ['-p', '--output-format', 'stream-json', '--verbose', '--permission-mode', 'bypassPermissions'];
+    if (options.memoryTools !== false) args.push('--mcp-config', writeClaudeMcpConfig());
+    args.push('--model', model);
+    if (options.maxTurns) args.push('--max-turns', String(options.maxTurns));
+    return { command: 'claude', args, stdinFile: promptFile };
   }
 
   async getDefaultModel(): Promise<string> {

--- a/src/adapters/codex.test.ts
+++ b/src/adapters/codex.test.ts
@@ -5,48 +5,49 @@ describe('CodexCliAdapter', () => {
   const adapter = new CodexCliAdapter();
 
   it('builds a codex exec command with sandbox json mode', () => {
-    const { command } = adapter.buildCommand({
+    const { command, args, stdinFile } = adapter.buildCommand({
       prompt: '/tmp/prompt.txt',
       cwd: '/tmp/project',
       model: 'gpt-5-codex',
     });
 
-    expect(command).toContain('codex exec');
-    expect(command).toContain('--json');
+    expect(command).toBe('codex');
+    expect(args).toContain('exec');
+    expect(args).toContain('--json');
     // --full-auto was deprecated in codex 0.137 → --sandbox workspace-write (INT-1699)
-    expect(command).toContain('--sandbox workspace-write');
-    expect(command).not.toContain('--full-auto');
-    expect(command).toContain('--skip-git-repo-check');
-    expect(command).toContain("-m 'gpt-5-codex'");
+    expect(args).toContain('workspace-write');
+    expect(args).not.toContain('--full-auto');
+    expect(args).toContain('--skip-git-repo-check');
+    expect(args.slice(args.indexOf('-m'), args.indexOf('-m') + 2)).toEqual(['-m', 'gpt-5-codex']);
     // Memory MCP server is registered so codex can call search_memory (INT-1855)
-    expect(command).toContain("-c 'mcp_servers.openswarm_memory.command=");
-    expect(command).toContain("-c 'mcp_servers.openswarm_memory.args=[");
+    expect(args.some((arg) => arg.startsWith('mcp_servers.openswarm_memory.command='))).toBe(true);
+    expect(args.some((arg) => arg.startsWith('mcp_servers.openswarm_memory.args=['))).toBe(true);
+    expect(stdinFile).toBe('/tmp/prompt.txt');
   });
 
   it('omits the memory MCP flags when memoryTools=false', () => {
-    const { command } = adapter.buildCommand({
+    const { args } = adapter.buildCommand({
       prompt: '/tmp/prompt.txt',
       cwd: '/tmp/project',
       model: 'gpt-5-codex',
       memoryTools: false,
     });
 
-    expect(command).toContain('codex exec');
-    expect(command).not.toContain('openswarm_memory');
-    expect(command).not.toContain("mcp_servers.openswarm_memory");
+    expect(args).toContain('exec');
+    expect(args.join(' ')).not.toContain('openswarm_memory');
   });
 
   it('substitutes a claude model with the codex default and warns', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
-      const { command } = adapter.buildCommand({
+      const { args } = adapter.buildCommand({
         prompt: '/tmp/prompt.txt',
         cwd: '/tmp/project',
         model: 'claude-sonnet-4-20250514',
       });
       // Should not pass the claude model through to the codex CLI.
-      expect(command).not.toContain('claude-sonnet');
-      expect(command).toContain("-m 'gpt-5-codex'");
+      expect(args).not.toContain('claude-sonnet-4-20250514');
+      expect(args.slice(args.indexOf('-m'), args.indexOf('-m') + 2)).toEqual(['-m', 'gpt-5-codex']);
       // Warning emitted at least once for this model name.
       const messages = warn.mock.calls.map((c) => String(c[0]));
       expect(messages.some((m) => m.includes('claude-sonnet-4-20250514'))).toBe(true);

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -10,13 +10,14 @@ import type {
   CliRunOptions,
   CliRunResult,
   AdapterCapabilities,
+  CliCommandSpec,
   WorkerResult,
   ReviewResult,
 } from './types.js';
 import { t } from '../locale/index.js';
 import { AuthProfileStore, ensureValidToken } from '../auth/index.js';
 import { getCodexModelIds } from './codexModels.js';
-import { codexMcpConfigFlags } from './memoryMcp.js';
+import { codexMcpConfigArgs } from './memoryMcp.js';
 import { parseReviewerResult } from './resultParsing.js';
 
 const execFileAsync = promisify(execFile);
@@ -69,17 +70,17 @@ export class CodexCliAdapter implements CliAdapter {
     return first ?? CODEX_DEFAULT_MODEL;
   }
 
-  buildCommand(options: CliRunOptions): { command: string; args: string[] } {
+  buildCommand(options: CliRunOptions): CliCommandSpec {
     const promptFile = options.prompt;
     const resolvedModel = options.model ? coerceCodexModel(options.model) : undefined;
-    const modelFlag = resolvedModel ? ` -m ${shellEscape(resolvedModel)}` : '';
     // `--full-auto` was deprecated in codex 0.137 (warns, still runs). Its documented
     // replacement is `--sandbox workspace-write`: same low-friction policy (writes
     // confined to the workspace, no approval prompts in non-interactive `exec`). (INT-1699)
     // Register OpenSwarm's memory MCP server unless the caller needs an isolated run.
-    const memoryFlags = options.memoryTools === false ? '' : ` ${codexMcpConfigFlags()}`;
-    const cmd = `cat ${shellEscape(promptFile)} | codex exec --json --sandbox workspace-write --skip-git-repo-check${modelFlag}${memoryFlags}`;
-    return { command: cmd, args: [] };
+    const args = ['exec', '--json', '--sandbox', 'workspace-write', '--skip-git-repo-check'];
+    if (resolvedModel) args.push('-m', resolvedModel);
+    if (options.memoryTools !== false) args.push(...codexMcpConfigArgs());
+    return { command: 'codex', args, stdinFile: promptFile };
   }
 
   parseStreamingChunk(
@@ -122,10 +123,6 @@ export class CodexCliAdapter implements CliAdapter {
     // contract belong to the shared parser used by every in-process adapter.
     return parseReviewerResult(resultText);
   }
-}
-
-function shellEscape(value: string): string {
-  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 /**

--- a/src/adapters/codexResponses.test.ts
+++ b/src/adapters/codexResponses.test.ts
@@ -78,7 +78,12 @@ describe('parseWorkerOutput command backfill', () => {
 
 describe('selectDefaultCodexResponseModel', () => {
   it('prefers the stable default when the live catalog includes it', () => {
-    expect(selectDefaultCodexResponseModel(['gpt-5.3-codex-spark', 'gpt-5.4-mini', 'gpt-5.5'])).toBe('gpt-5.5');
+    expect(selectDefaultCodexResponseModel([
+      'gpt-5.3-codex-spark',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+    ])).toBe('gpt-5.6-terra');
   });
 
   it('does not pick Spark implicitly when another model is available', () => {
@@ -86,7 +91,7 @@ describe('selectDefaultCodexResponseModel', () => {
   });
 
   it('does not choose Spark implicitly even if it is the only discovered model', () => {
-    expect(selectDefaultCodexResponseModel(['gpt-5.3-codex-spark'])).toBe('gpt-5.5');
+    expect(selectDefaultCodexResponseModel(['gpt-5.3-codex-spark'])).toBe('gpt-5.6-terra');
   });
 });
 
@@ -96,7 +101,7 @@ describe('unsupported-model fallback', () => {
     const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
       const target = String(url);
       if (target.includes('/backend-api/codex/models')) {
-        return new Response(JSON.stringify({ models: [{ slug: 'gpt-5.5', priority: 1 }] }), { status: 200 });
+        return new Response(JSON.stringify({ models: [{ slug: 'gpt-5.6-terra', priority: 1 }] }), { status: 200 });
       }
 
       const body = JSON.parse(String(init?.body ?? '{}')) as { model?: string };
@@ -129,7 +134,7 @@ describe('unsupported-model fallback', () => {
     await callApi([{ role: 'user', content: 'first' }], []);
     await callApi([{ role: 'user', content: 'second' }], []);
 
-    expect(requestedModels).toEqual(['unsupported-model', 'gpt-5.5', 'gpt-5.5']);
+    expect(requestedModels).toEqual(['unsupported-model', 'gpt-5.6-terra', 'gpt-5.6-terra']);
   });
 });
 

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -25,7 +25,9 @@ import { isInfraError } from './errorClassification.js';
 import { getCodexModelIds } from './codexModels.js';
 
 const CODEX_RESPONSES_URL = 'https://chatgpt.com/backend-api/codex/responses';
-const DEFAULT_MODEL = 'gpt-5.5';
+// Balanced default for unpinned work. Role configs can select Sol for
+// quality-first work and Luna for high-volume/light work.
+const DEFAULT_MODEL = 'gpt-5.6-terra';
 const PROFILE_KEY = 'openai-gpt:default';
 const SPARK_MODEL = 'gpt-5.3-codex-spark';
 

--- a/src/adapters/gpt.refresh.test.ts
+++ b/src/adapters/gpt.refresh.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AuthProfile, AuthProfileStore } from '../auth/index.js';
+
+const ensureValidToken = vi.hoisted(() => vi.fn(async () => 'refreshed-token'));
+
+vi.mock('../auth/index.js', () => ({
+  AuthProfileStore: class {},
+  ensureValidToken,
+}));
+
+import { refreshExpiredProfileForRetry } from './gpt.js';
+
+describe('GPT forced token refresh', () => {
+  it('clones a frozen auth profile instead of mutating shared state', async () => {
+    const profile: AuthProfile = Object.freeze({
+      type: 'oauth',
+      provider: 'openai-gpt',
+      access: 'old-token',
+      refresh: 'refresh-token',
+      expires: 123,
+      clientId: 'client-id',
+    });
+    const setProfile = vi.fn();
+    const store = {
+      getProfile: vi.fn(() => profile),
+      setProfile,
+    } as unknown as AuthProfileStore;
+
+    await expect(refreshExpiredProfileForRetry(store)).resolves.toBe('refreshed-token');
+    expect(profile.expires).toBe(123);
+    expect(setProfile).toHaveBeenCalledWith('openai-gpt:default', { ...profile, expires: 0 });
+    expect(setProfile.mock.calls[0][1]).not.toBe(profile);
+  });
+});

--- a/src/adapters/gpt.ts
+++ b/src/adapters/gpt.ts
@@ -171,7 +171,7 @@ export class GptCliAdapter implements CliAdapter {
           // 401 → 토큰 갱신 후 1회 재시도
           if (res.status === 401 && !retried) {
             retried = true;
-            token = await refreshAndRetry(store);
+            token = await refreshExpiredProfileForRetry(store);
             return doCall(token);
           }
 
@@ -206,14 +206,13 @@ export class GptCliAdapter implements CliAdapter {
 
 // Streamed chat/completions responses are parsed by consumeChatCompletionsStream.
 
-async function refreshAndRetry(store: AuthProfileStore): Promise<string> {
+export async function refreshExpiredProfileForRetry(store: AuthProfileStore): Promise<string> {
   const profile = store.getProfile(PROFILE_KEY);
   if (!profile) {
     throw new Error('No auth profile found');
   }
   // 강제 갱신 (expires를 0으로 설정)
-  profile.expires = 0;
-  store.setProfile(PROFILE_KEY, profile);
+  store.setProfile(PROFILE_KEY, { ...profile, expires: 0 });
   return ensureValidToken(store, PROFILE_KEY);
 }
 

--- a/src/adapters/lmstudio.test.ts
+++ b/src/adapters/lmstudio.test.ts
@@ -8,6 +8,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { LmStudioAdapter } from './lmstudio.js';
+import { LocalModelAdapter } from './local.js';
 import { getAdapter } from './index.js';
 
 describe('LmStudioAdapter', () => {
@@ -67,6 +68,7 @@ describe('LmStudioAdapter', () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(new Response(JSON.stringify({ data: [{ id: 'gemma-4-26b-a4b-it-mlx' }] }), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ data: [{ id: 'gemma-4-26b-a4b-it-mlx' }] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: [{ id: 'gemma-4-26b-a4b-it-mlx' }] }), { status: 200 }))
       .mockResolvedValueOnce(new Response('data: {"choices":[{"delta":{"role":"assistant","content":"LM Studio is ready."},"finish_reason":"stop"}]}\n\ndata: [DONE]\n', { status: 200, headers: { 'Content-Type': 'text/event-stream' } }));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -88,5 +90,29 @@ describe('LmStudioAdapter', () => {
     expect(chatCall?.[0]).toBe('http://127.0.0.1:4321/v1/chat/completions');
     const body = JSON.parse(chatCall?.[1]?.body as string) as { model: string };
     expect(body.model).toBe('gemma-4-26b-a4b-it-mlx');
+  });
+
+  it('rediscovers a healthy endpoint when the previously selected server disappears', async () => {
+    const stream = 'data: {"choices":[{"delta":{"role":"assistant","content":"fallback"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n';
+    let primaryHealthChecks = 0;
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url === 'http://primary/v1/models') {
+        primaryHealthChecks += 1;
+        if (primaryHealthChecks > 1) throw new TypeError('primary offline');
+      }
+      if (url.endsWith('/v1/chat/completions')) {
+        return new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+      }
+      return new Response(JSON.stringify({ data: [{ id: 'local-model' }] }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const adapter = new LocalModelAdapter({ endpoints: ['http://primary', 'http://fallback'] });
+    await expect(adapter.isAvailable()).resolves.toBe(true);
+    expect(adapter.getActiveUrl()).toBe('http://primary');
+
+    await expect(adapter.run({ prompt: 'hello', cwd: process.cwd() })).resolves.toMatchObject({ exitCode: 0 });
+    expect(adapter.getActiveUrl()).toBe('http://fallback');
+    expect(fetchMock.mock.calls.at(-1)?.[0]).toBe('http://fallback/v1/chat/completions');
   });
 });

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -75,6 +75,7 @@ export class LocalModelAdapter implements CliAdapter {
   }
 
   async isAvailable(): Promise<boolean> {
+    this.activeUrl = null;
     const candidates = this.configuredUrl
       ? [this.configuredUrl, ...this.endpoints]
       : this.endpoints;
@@ -135,18 +136,17 @@ export class LocalModelAdapter implements CliAdapter {
   async run(options: CliRunOptions): Promise<CliRunResult> {
     const startTime = Date.now();
 
-    // 서버 연결 확인
-    if (!this.activeUrl) {
-      const available = await this.isAvailable();
-      if (!available) {
-        return {
-          exitCode: 1,
-          stdout: '',
-          stderr: `${this.noServerMessage}\n` +
-            `Checked: ${(this.configuredUrl ? [this.configuredUrl, ...this.endpoints] : this.endpoints).join(', ')}`,
-          durationMs: Date.now() - startTime,
-        };
-      }
+    // Re-probe on every run: a previously selected local server can disappear
+    // while another configured endpoint remains healthy.
+    const available = await this.isAvailable();
+    if (!available) {
+      return {
+        exitCode: 1,
+        stdout: '',
+        stderr: `${this.noServerMessage}\n` +
+          `Checked: ${(this.configuredUrl ? [this.configuredUrl, ...this.endpoints] : this.endpoints).join(', ')}`,
+        durationMs: Date.now() - startTime,
+      };
     }
 
     const model = options.model ?? await this.getDefaultModel();

--- a/src/adapters/memoryMcp.ts
+++ b/src/adapters/memoryMcp.ts
@@ -45,12 +45,21 @@ export function writeClaudeMcpConfig(): string {
  * `codex exec` (TOML dotted paths; values are TOML literals — JSON quoting works).
  */
 export function codexMcpConfigFlags(): string {
+  const args = codexMcpConfigArgs();
+  const flags: string[] = [];
+  for (let i = 0; i < args.length; i += 2) {
+    flags.push(`-c '${args[i + 1].replaceAll("'", "'\\''")}'`);
+  }
+  return flags.join(' ');
+}
+
+/** Argv-safe config overrides for codex exec. */
+export function codexMcpConfigArgs(): string[] {
   const { command, args } = memoryServerLaunch();
   const argsToml = '[' + args.map((a) => JSON.stringify(a)).join(', ') + ']';
   const overrides = [
     `mcp_servers.${MEMORY_MCP_NAME}.command=${JSON.stringify(command)}`,
     `mcp_servers.${MEMORY_MCP_NAME}.args=${argsToml}`,
   ];
-  // Single-quote each override for the shell (inner double quotes are preserved).
-  return overrides.map((o) => `-c '${o}'`).join(' ');
+  return overrides.flatMap((override) => ['-c', override]);
 }

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -623,11 +623,11 @@ export async function executeTool(
       default:
         // MCP tools (named `server__tool`) route to their server via the MCP client.
         if (isMcpTool(name)) {
-          const text = await callMcpTool(name, (args ?? {}) as Record<string, unknown>);
+          const result = await callMcpTool(name, (args ?? {}) as Record<string, unknown>);
           return {
             tool_call_id: callId,
-            content: text,
-            is_error: text.startsWith('MCP error') || text.startsWith('MCP tool not registered'),
+            content: result.content,
+            is_error: result.isError,
           };
         }
         return { tool_call_id: callId, content: `Unknown tool: ${name}`, is_error: true };

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -133,6 +133,8 @@ export interface CliCommandSpec {
   args: string[];
   /** Feed this file to child stdin without involving a shell or argv. */
   stdinFile?: string;
+  /** Adapter-owned temporary paths removed after the child settles. */
+  cleanupPaths?: string[];
 }
 
 /**

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -128,6 +128,13 @@ export interface AdapterCapabilities {
   supportedSkills: string[];
 }
 
+export interface CliCommandSpec {
+  command: string;
+  args: string[];
+  /** Feed this file to child stdin without involving a shell or argv. */
+  stdinFile?: string;
+}
+
 /**
  * CLI adapter interface — all adapters must implement this
  */
@@ -147,8 +154,8 @@ export interface CliAdapter {
    */
   getDefaultModel(): Promise<string>;
 
-  /** Build the shell command and args for execution */
-  buildCommand(options: CliRunOptions): { command: string; args: string[] };
+  /** Build an executable + argv. Shell interpretation is never applied. */
+  buildCommand(options: CliRunOptions): CliCommandSpec;
 
   /**
    * Parse incremental stdout chunks for live log streaming.

--- a/src/agents/agentBus.test.ts
+++ b/src/agents/agentBus.test.ts
@@ -3,6 +3,9 @@
 // Test Status: Complete
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdir, utimes, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
 import { AgentBus, createBus, type StepCompletedPayload, type ContextUpdatePayload, type FileChangedPayload } from './agentBus.js';
 
 describe('agentBus', () => {
@@ -32,6 +35,11 @@ describe('agentBus', () => {
       const bus = createBus(customId);
 
       expect(bus).toBeDefined();
+    });
+
+    it('rejects execution IDs that can escape the bus directory', () => {
+      expect(() => createBus('../outside')).toThrow('Invalid AgentBus execution ID');
+      expect(() => createBus('/absolute')).toThrow('Invalid AgentBus execution ID');
     });
 
     it('should generate unique IDs for different buses', () => {
@@ -236,6 +244,21 @@ describe('agentBus', () => {
       expect(await first.getData('second')).toBe('two');
       await first.cleanup();
       await second.cleanup();
+    });
+
+    it('recovers a stale context lock left by a crashed process', async () => {
+      const executionId = `stale-lock-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const staleBus = createBus(executionId);
+      await staleBus.init('workflow-123');
+      const lockPath = resolve(homedir(), '.openswarm', 'bus', executionId, 'context.lock');
+      await mkdir(lockPath);
+      const old = new Date(Date.now() - 60_000);
+      await utimes(lockPath, old, old);
+
+      await staleBus.setData('recovered', true);
+
+      expect(await staleBus.getData('recovered')).toBe(true);
+      await staleBus.cleanup();
     });
 
     it('should set custom data', async () => {
@@ -576,6 +599,31 @@ describe('agentBus', () => {
       expect(received).toHaveBeenCalledTimes(2);
       await publisher.cleanup();
       await subscriber.cleanup();
+    });
+
+    it('does not skip a later-written message whose filename sorts earlier', async () => {
+      const executionId = `ordering-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const orderingBus = createBus(executionId);
+      await orderingBus.init('workflow-123');
+      const messagesPath = resolve(homedir(), '.openswarm', 'bus', executionId, 'messages');
+      const received = vi.fn();
+      orderingBus.on('log', received);
+      const message = (id: string) => JSON.stringify({
+        id,
+        timestamp: 1,
+        type: 'log',
+        sender: 'test',
+        executionId,
+        payload: id,
+      });
+
+      await writeFile(resolve(messagesPath, '1000-z.json'), message('z'));
+      await orderingBus.pollOnce();
+      await writeFile(resolve(messagesPath, '1000-a.json'), message('a'));
+      await orderingBus.pollOnce();
+
+      expect(received).toHaveBeenCalledTimes(2);
+      await orderingBus.cleanup();
     });
 
     it('should start polling', async () => {

--- a/src/agents/agentBus.test.ts
+++ b/src/agents/agentBus.test.ts
@@ -582,6 +582,28 @@ describe('agentBus', () => {
   });
 
   describe('Polling', () => {
+    it('coalesces overlapping polls while an async listener is still running', async () => {
+      const executionId = `slow-listener-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const publisher = createBus(executionId);
+      const subscriber = createBus(executionId);
+      await publisher.init('workflow-123');
+      let release!: () => void;
+      const listener = vi.fn(() => new Promise<void>((resolve) => { release = resolve; }));
+      subscriber.on('log', listener);
+      await publisher.publish('log', 'step-1', 'message');
+
+      const first = subscriber.pollOnce();
+      await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(1));
+      const overlapping = subscriber.pollOnce();
+      expect(overlapping).toBe(first);
+      release();
+      await Promise.all([first, overlapping]);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      await publisher.cleanup();
+      await subscriber.cleanup();
+    });
+
     it('isolates listener failures and still advances to later messages', async () => {
       const executionId = `listeners-${Date.now()}-${Math.random()}`;
       const publisher = createBus(executionId);

--- a/src/agents/agentBus.test.ts
+++ b/src/agents/agentBus.test.ts
@@ -221,6 +221,23 @@ describe('agentBus', () => {
   });
 
   describe('Context Updates', () => {
+    it('serializes context mutations across bus instances', async () => {
+      const executionId = `concurrent-${Date.now()}-${Math.random()}`;
+      const first = createBus(executionId);
+      const second = createBus(executionId);
+      await first.init('workflow-123');
+
+      await Promise.all([
+        first.setData('first', 'one'),
+        second.setData('second', 'two'),
+      ]);
+
+      expect(await first.getData('first')).toBe('one');
+      expect(await first.getData('second')).toBe('two');
+      await first.cleanup();
+      await second.cleanup();
+    });
+
     it('should set custom data', async () => {
       await bus.init('workflow-123');
 
@@ -542,6 +559,25 @@ describe('agentBus', () => {
   });
 
   describe('Polling', () => {
+    it('isolates listener failures and still advances to later messages', async () => {
+      const executionId = `listeners-${Date.now()}-${Math.random()}`;
+      const publisher = createBus(executionId);
+      const subscriber = createBus(executionId);
+      await publisher.init('workflow-123');
+      const received = vi.fn();
+      subscriber.on('log', () => { throw new Error('listener boom'); });
+      subscriber.on('log', received);
+
+      await publisher.publish('log', 'step-1', 'first');
+      await subscriber.pollOnce();
+      await publisher.publish('log', 'step-1', 'second');
+      await subscriber.pollOnce();
+
+      expect(received).toHaveBeenCalledTimes(2);
+      await publisher.cleanup();
+      await subscriber.cleanup();
+    });
+
     it('should start polling', async () => {
       await bus.init('workflow-123');
 

--- a/src/agents/agentBus.ts
+++ b/src/agents/agentBus.ts
@@ -91,6 +91,17 @@ export interface SharedContext {
 // Bus Implementation (File-based)
 
 const BUS_DIR = resolve(homedir(), '.openswarm/bus');
+const CONTEXT_LOCK_STALE_MS = 30_000;
+
+function assertExecutionId(executionId: string): void {
+  if (
+    !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(executionId) ||
+    executionId === '.' ||
+    executionId === '..'
+  ) {
+    throw new Error(`Invalid AgentBus execution ID: ${JSON.stringify(executionId)}`);
+  }
+}
 
 /**
  * Message bus class
@@ -102,10 +113,11 @@ export class AgentBus {
   private listeners: Map<MessageType, Array<(msg: AgentMessage) => void>> = new Map();
   private pollInterval: NodeJS.Timeout | null = null;
   private pollInFlight = false;
-  private lastMessageId: string = '';
+  private readonly processedMessageIds = new Set<string>();
   private readonly contextLockPath: string;
 
   constructor(executionId: string) {
+    assertExecutionId(executionId);
     this.executionId = executionId;
     this.contextPath = resolve(BUS_DIR, executionId, 'context.json');
     this.messagesPath = resolve(BUS_DIR, executionId, 'messages');
@@ -256,7 +268,9 @@ export class AgentBus {
         await fs.mkdir(this.contextLockPath);
         break;
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'EEXIST' || Date.now() >= deadline) throw error;
+        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+        if (await this.recoverStaleContextLock()) continue;
+        if (Date.now() >= deadline) throw error;
         await new Promise((resolve) => setTimeout(resolve, 5));
       }
     }
@@ -264,6 +278,21 @@ export class AgentBus {
       return await operation();
     } finally {
       await fs.rmdir(this.contextLockPath).catch(() => {});
+    }
+  }
+
+  private async recoverStaleContextLock(): Promise<boolean> {
+    try {
+      const stats = await fs.stat(this.contextLockPath);
+      if (Date.now() - stats.mtimeMs < CONTEXT_LOCK_STALE_MS) return false;
+      const stalePath = `${this.contextLockPath}.stale.${process.pid}.${Math.random().toString(36).slice(2)}`;
+      await fs.rename(this.contextLockPath, stalePath);
+      await fs.rm(stalePath, { recursive: true, force: true });
+      console.warn(`[AgentBus] Recovered stale context lock for ${this.executionId}`);
+      return true;
+    } catch (error) {
+      if (['ENOENT', 'EEXIST'].includes((error as NodeJS.ErrnoException).code ?? '')) return false;
+      throw error;
     }
   }
 
@@ -346,7 +375,7 @@ export class AgentBus {
     try {
       const files = await fs.readdir(this.messagesPath);
       const newFiles = files
-        .filter(f => f.endsWith('.json') && f > this.lastMessageId)
+        .filter(f => f.endsWith('.json') && !this.processedMessageIds.has(f))
         .sort();
 
       for (const file of newFiles) {
@@ -365,7 +394,7 @@ export class AgentBus {
           }
         }
 
-        this.lastMessageId = file;
+        this.processedMessageIds.add(file);
       }
     } catch {
       // Ignore

--- a/src/agents/agentBus.ts
+++ b/src/agents/agentBus.ts
@@ -110,9 +110,9 @@ export class AgentBus {
   private executionId: string;
   private contextPath: string;
   private messagesPath: string;
-  private listeners: Map<MessageType, Array<(msg: AgentMessage) => void>> = new Map();
+  private listeners: Map<MessageType, Array<(msg: AgentMessage) => void | Promise<void>>> = new Map();
   private pollInterval: NodeJS.Timeout | null = null;
-  private pollInFlight = false;
+  private pollPromise: Promise<void> | null = null;
   private readonly processedMessageIds = new Set<string>();
   private readonly contextLockPath: string;
 
@@ -334,7 +334,7 @@ export class AgentBus {
   /**
    * Register message listener
    */
-  on(type: MessageType, callback: (msg: AgentMessage) => void): void {
+  on(type: MessageType, callback: (msg: AgentMessage) => void | Promise<void>): void {
     if (!this.listeners.has(type)) {
       this.listeners.set(type, []);
     }
@@ -347,14 +347,8 @@ export class AgentBus {
   startPolling(intervalMs: number = 1000): void {
     if (this.pollInterval) return;
 
-    this.pollInterval = setInterval(async () => {
-      if (this.pollInFlight) return;
-      this.pollInFlight = true;
-      try {
-        await this.pollOnce();
-      } finally {
-        this.pollInFlight = false;
-      }
+    this.pollInterval = setInterval(() => {
+      void this.pollOnce();
     }, intervalMs);
   }
 
@@ -371,7 +365,15 @@ export class AgentBus {
   /**
    * Check for new messages
    */
-  async pollOnce(): Promise<void> {
+  pollOnce(): Promise<void> {
+    if (this.pollPromise) return this.pollPromise;
+    this.pollPromise = this.checkNewMessages().finally(() => {
+      this.pollPromise = null;
+    });
+    return this.pollPromise;
+  }
+
+  private async checkNewMessages(): Promise<void> {
     try {
       const files = await fs.readdir(this.messagesPath);
       const newFiles = files
@@ -387,7 +389,7 @@ export class AgentBus {
         if (callbacks) {
           for (const cb of callbacks) {
             try {
-              cb(message);
+              await cb(message);
             } catch (error) {
               console.warn(`[AgentBus] Listener failed for ${message.type}:`, error instanceof Error ? error.message : String(error));
             }

--- a/src/agents/agentBus.ts
+++ b/src/agents/agentBus.ts
@@ -101,12 +101,15 @@ export class AgentBus {
   private messagesPath: string;
   private listeners: Map<MessageType, Array<(msg: AgentMessage) => void>> = new Map();
   private pollInterval: NodeJS.Timeout | null = null;
+  private pollInFlight = false;
   private lastMessageId: string = '';
+  private readonly contextLockPath: string;
 
   constructor(executionId: string) {
     this.executionId = executionId;
     this.contextPath = resolve(BUS_DIR, executionId, 'context.json');
     this.messagesPath = resolve(BUS_DIR, executionId, 'messages');
+    this.contextLockPath = resolve(BUS_DIR, executionId, 'context.lock');
   }
 
   /**
@@ -172,75 +175,48 @@ export class AgentBus {
    * Handle step completion
    */
   private async handleStepCompleted(payload: StepCompletedPayload): Promise<void> {
-    const context = await this.getContext();
-    if (!context) return;
-
-    context.stepOutputs[payload.stepId] = payload.output;
-
-    if (payload.changedFiles) {
-      for (const file of payload.changedFiles) {
-        if (!context.changedFiles.includes(file)) {
-          context.changedFiles.push(file);
+    await this.mutateContext((context) => {
+      context.stepOutputs[payload.stepId] = payload.output;
+      if (payload.changedFiles) {
+        for (const file of payload.changedFiles) {
+          if (!context.changedFiles.includes(file)) context.changedFiles.push(file);
         }
       }
-    }
-
-    await this.saveContext(context);
+    });
   }
 
   /**
    * Handle context update
    */
   private async handleContextUpdate(payload: ContextUpdatePayload): Promise<void> {
-    const context = await this.getContext();
-    if (!context) return;
-
-    switch (payload.operation) {
-      case 'set':
-        context.data[payload.key] = payload.value;
-        break;
-      case 'append':
-        if (!Array.isArray(context.data[payload.key])) {
-          context.data[payload.key] = [];
-        }
-        (context.data[payload.key] as unknown[]).push(payload.value);
-        break;
-      case 'delete':
-        delete context.data[payload.key];
-        break;
-    }
-
-    await this.saveContext(context);
+    await this.mutateContext((context) => {
+      switch (payload.operation) {
+        case 'set': context.data[payload.key] = payload.value; break;
+        case 'append':
+          if (!Array.isArray(context.data[payload.key])) context.data[payload.key] = [];
+          (context.data[payload.key] as unknown[]).push(payload.value);
+          break;
+        case 'delete': delete context.data[payload.key]; break;
+      }
+    });
   }
 
   /**
    * Handle file change
    */
   private async handleFileChanged(payload: FileChangedPayload): Promise<void> {
-    const context = await this.getContext();
-    if (!context) return;
-
-    if (!context.changedFiles.includes(payload.path)) {
-      context.changedFiles.push(payload.path);
-    }
-
-    await this.saveContext(context);
+    await this.mutateContext((context) => {
+      if (!context.changedFiles.includes(payload.path)) context.changedFiles.push(payload.path);
+    });
   }
 
   /**
    * Handle error
    */
   private async handleError(stepId: string, message: string): Promise<void> {
-    const context = await this.getContext();
-    if (!context) return;
-
-    context.errors.push({
-      stepId,
-      message,
-      timestamp: Date.now(),
+    await this.mutateContext((context) => {
+      context.errors.push({ stepId, message, timestamp: Date.now() });
     });
-
-    await this.saveContext(context);
   }
 
   /**
@@ -259,7 +235,36 @@ export class AgentBus {
    * Save context
    */
   private async saveContext(context: SharedContext): Promise<void> {
-    await fs.writeFile(this.contextPath, JSON.stringify(context, null, 2));
+    const temp = `${this.contextPath}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+    await fs.writeFile(temp, JSON.stringify(context, null, 2), { mode: 0o600 });
+    await fs.rename(temp, this.contextPath);
+  }
+
+  private async mutateContext(mutator: (context: SharedContext) => void): Promise<void> {
+    await this.withContextLock(async () => {
+      const context = await this.getContext();
+      if (!context) return;
+      mutator(context);
+      await this.saveContext(context);
+    });
+  }
+
+  private async withContextLock<T>(operation: () => Promise<T>): Promise<T> {
+    const deadline = Date.now() + 10_000;
+    while (true) {
+      try {
+        await fs.mkdir(this.contextLockPath);
+        break;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'EEXIST' || Date.now() >= deadline) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+    }
+    try {
+      return await operation();
+    } finally {
+      await fs.rmdir(this.contextLockPath).catch(() => {});
+    }
   }
 
   /**
@@ -314,7 +319,13 @@ export class AgentBus {
     if (this.pollInterval) return;
 
     this.pollInterval = setInterval(async () => {
-      await this.checkNewMessages();
+      if (this.pollInFlight) return;
+      this.pollInFlight = true;
+      try {
+        await this.pollOnce();
+      } finally {
+        this.pollInFlight = false;
+      }
     }, intervalMs);
   }
 
@@ -331,7 +342,7 @@ export class AgentBus {
   /**
    * Check for new messages
    */
-  private async checkNewMessages(): Promise<void> {
+  async pollOnce(): Promise<void> {
     try {
       const files = await fs.readdir(this.messagesPath);
       const newFiles = files
@@ -346,7 +357,11 @@ export class AgentBus {
         const callbacks = this.listeners.get(message.type);
         if (callbacks) {
           for (const cb of callbacks) {
-            cb(message);
+            try {
+              cb(message);
+            } catch (error) {
+              console.warn(`[AgentBus] Listener failed for ${message.type}:`, error instanceof Error ? error.message : String(error));
+            }
           }
         }
 

--- a/src/agents/draftAnalyzer.test.ts
+++ b/src/agents/draftAnalyzer.test.ts
@@ -84,6 +84,10 @@ describe('runDraftAnalysis fallback', () => {
     expect(adapterModule.getAdapter).not.toHaveBeenCalledWith('claude');
     // Single adapter attempt only — quota error breaks out to best-effort, no fallback.
     expect(adapterModule.spawnCli).toHaveBeenCalledTimes(1);
+    expect(adapterModule.spawnCli).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ model: 'gpt-5.6-luna' }),
+    );
     // Pipeline continues with a best-effort (insufficient) draft.
     expect(result.sufficient).toBe(false);
   });

--- a/src/agents/draftAnalyzer.ts
+++ b/src/agents/draftAnalyzer.ts
@@ -28,6 +28,11 @@ import type { AdapterName } from '../adapters/types.js';
  * updates) — it is one constant per provider, easy to bump.
  */
 const DRAFT_MODELS: Partial<Record<AdapterName, string>> = {
+  // Drafting is a high-volume classification/routing pass, so the efficient
+  // GPT-5.6 tier is the right default. Downstream implementation/review still
+  // use their independently configured Terra/Sol tiers.
+  codex: 'gpt-5.6-luna',
+  'codex-responses': 'gpt-5.6-luna',
   // Capable but cost-aware model for the brief (INT-1915): the drafter runs on
   // EVERY task, and claude -p loads the full personal env (~39k tokens/call), so
   // opus on every brief was too costly. sonnet keeps the brief faithful at a

--- a/src/agents/pairMetrics.test.ts
+++ b/src/agents/pairMetrics.test.ts
@@ -1,0 +1,66 @@
+import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testHome = vi.hoisted(() => ({
+  path: `/tmp/openswarm-pair-metrics-${process.pid}`,
+}));
+
+vi.mock('node:os', () => ({ homedir: () => testHome.path }));
+
+import {
+  getRecentSessions,
+  getSummary,
+  recordSession,
+  resetPairMetricsForTests,
+  type PairSessionRecord,
+} from './pairMetrics.js';
+
+const metricsDir = `${testHome.path}/.openswarm/metrics`;
+const recordsFile = `${metricsDir}/pair-records.json`;
+
+function record(sessionId: string): PairSessionRecord {
+  return {
+    sessionId,
+    taskId: `task-${sessionId}`,
+    taskTitle: sessionId,
+    result: 'approved',
+    attempts: 1,
+    maxAttempts: 3,
+    durationMs: 100,
+    filesChanged: 1,
+    startedAt: 1,
+    finishedAt: 2,
+  };
+}
+
+describe('pair metrics persistence', () => {
+  beforeEach(async () => {
+    await rm(testHome.path, { recursive: true, force: true });
+    resetPairMetricsForTests();
+  });
+
+  afterEach(async () => {
+    resetPairMetricsForTests();
+    await rm(testHome.path, { recursive: true, force: true });
+  });
+
+  it('serializes concurrent records without losing either session', async () => {
+    await Promise.all([recordSession(record('one')), recordSession(record('two'))]);
+
+    expect((await getRecentSessions(10)).map((item) => item.sessionId).sort()).toEqual(['one', 'two']);
+    expect(JSON.parse(await readFile(recordsFile, 'utf8'))).toHaveLength(2);
+    expect((await stat(recordsFile)).mode & 0o777).toBe(0o600);
+  });
+
+  it('fails safe when persisted records are malformed', async () => {
+    await mkdir(metricsDir, { recursive: true });
+    await writeFile(recordsFile, JSON.stringify([{ sessionId: 'partial' }]));
+
+    expect(await getSummary()).toMatchObject({ totalSessions: 0, approved: 0 });
+    expect(await getRecentSessions()).toEqual([]);
+  });
+
+  it('rejects invalid incoming records before touching storage', async () => {
+    await expect(recordSession({ ...record('bad'), attempts: -1 })).rejects.toThrow('Invalid pair session record');
+  });
+});

--- a/src/agents/pairMetrics.ts
+++ b/src/agents/pairMetrics.ts
@@ -57,16 +57,32 @@ const SUMMARY_FILE = path.join(METRICS_DIR, 'pair-summary.json');
 let recordsCache: PairSessionRecord[] = [];
 let summaryCache: PairMetricsSummary | null = null;
 let initialized = false;
+let mutationQueue: Promise<void> = Promise.resolve();
+
+function isFiniteNonNegative(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+export function isPairSessionRecord(value: unknown): value is PairSessionRecord {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.sessionId === 'string' && record.sessionId.length > 0
+    && typeof record.taskId === 'string'
+    && typeof record.taskTitle === 'string'
+    && ['approved', 'rejected', 'failed', 'cancelled'].includes(String(record.result))
+    && isFiniteNonNegative(record.attempts)
+    && isFiniteNonNegative(record.maxAttempts)
+    && isFiniteNonNegative(record.durationMs)
+    && isFiniteNonNegative(record.filesChanged)
+    && isFiniteNonNegative(record.startedAt)
+    && isFiniteNonNegative(record.finishedAt);
+}
 
 /**
  * Ensure metrics directory exists
  */
 async function ensureDir(): Promise<void> {
-  try {
-    await fs.mkdir(METRICS_DIR, { recursive: true });
-  } catch {
-    // Already exists
-  }
+  await fs.mkdir(METRICS_DIR, { recursive: true, mode: 0o700 });
 }
 
 /**
@@ -77,7 +93,9 @@ async function loadRecords(): Promise<PairSessionRecord[]> {
     await ensureDir();
     try {
       const data = await fs.readFile(RECORDS_FILE, 'utf-8');
-      recordsCache = JSON.parse(data);
+      const parsed: unknown = JSON.parse(data);
+      if (!Array.isArray(parsed) || !parsed.every(isPairSessionRecord)) throw new Error('Invalid pair metrics record file');
+      recordsCache = parsed;
     } catch {
       recordsCache = [];
     }
@@ -91,7 +109,7 @@ async function loadRecords(): Promise<PairSessionRecord[]> {
  */
 async function saveRecords(): Promise<void> {
   await ensureDir();
-  await fs.writeFile(RECORDS_FILE, JSON.stringify(recordsCache, null, 2));
+  await atomicWriteJson(RECORDS_FILE, recordsCache);
 }
 
 /**
@@ -99,8 +117,14 @@ async function saveRecords(): Promise<void> {
  */
 async function saveSummary(): Promise<void> {
   if (summaryCache) {
-    await fs.writeFile(SUMMARY_FILE, JSON.stringify(summaryCache, null, 2));
+    await atomicWriteJson(SUMMARY_FILE, summaryCache);
   }
+}
+
+async function atomicWriteJson(file: string, value: unknown): Promise<void> {
+  const temp = `${file}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+  await fs.writeFile(temp, JSON.stringify(value, null, 2), { mode: 0o600 });
+  await fs.rename(temp, file);
 }
 
 // Public API
@@ -109,21 +133,31 @@ async function saveSummary(): Promise<void> {
  * Record session result
  */
 export async function recordSession(record: PairSessionRecord): Promise<void> {
-  await loadRecords();
+  if (!isPairSessionRecord(record)) throw new Error('Invalid pair session record');
+  const operation = mutationQueue.then(async () => {
+    await loadRecords();
 
-  // Prevent duplicates
-  const exists = recordsCache.some(r => r.sessionId === record.sessionId);
-  if (!exists) {
-    recordsCache.push(record);
+    // Prevent duplicates
+    const exists = recordsCache.some(r => r.sessionId === record.sessionId);
+    if (!exists) {
+      recordsCache.push(record);
 
-    // Keep only the last 1000 records
-    if (recordsCache.length > 1000) {
-      recordsCache = recordsCache.slice(-1000);
+      // Keep only the last 1000 records
+      if (recordsCache.length > 1000) recordsCache = recordsCache.slice(-1000);
+
+      await saveRecords();
+      await updateSummary();
     }
+  });
+  mutationQueue = operation.catch(() => {});
+  return operation;
+}
 
-    await saveRecords();
-    await updateSummary();
-  }
+export function resetPairMetricsForTests(): void {
+  recordsCache = [];
+  summaryCache = null;
+  initialized = false;
+  mutationQueue = Promise.resolve();
 }
 
 /**

--- a/src/agents/pairPipeline.coverage.test.ts
+++ b/src/agents/pairPipeline.coverage.test.ts
@@ -378,7 +378,11 @@ describe('PairPipeline coverage extension', () => {
 
     const result = await pipeline.run(task(), process.cwd());
 
-    expect(result.success).toBe(false);
+    expect(result).toMatchObject({
+      success: false,
+      failureSignal: 'stuck',
+      stuckReason: expect.stringContaining('Same error repeated'),
+    });
     // Stuck detection fires before a 4th worker call would happen.
     expect(runWorker).toHaveBeenCalledTimes(3);
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('STUCK DETECTED'));

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -840,6 +840,7 @@ export class PairPipeline extends EventEmitter {
       // Stuck detection check (before iteration starts)
       const stuckCheck = this.stuckDetector.check();
       if (stuckCheck.isStuck) {
+        context.stuckReason = stuckCheck.reason;
         console.error(`[${context.taskPrefix}] STUCK DETECTED: ${stuckCheck.reason}`);
         console.error(`[${context.taskPrefix}] Suggestion: ${stuckCheck.suggestion}`);
         this.emit('stuck', {
@@ -1262,7 +1263,6 @@ export class PairPipeline extends EventEmitter {
     const session = context.session;
     const finalStatus = session.status as PipelineResult['finalStatus'] || 'failed';
     const success = finalStatus === 'approved';
-
     // Aggregate costs from all stages
     const stageCosts: (CostInfo | undefined)[] = [];
     if (context.workerResult?.costInfo) stageCosts.push(context.workerResult.costInfo);
@@ -1272,18 +1272,18 @@ export class PairPipeline extends EventEmitter {
     if (context.auditorResult?.costInfo) stageCosts.push(context.auditorResult.costInfo);
     if (context.skillDocumenterResult?.costInfo) stageCosts.push(context.skillDocumenterResult.costInfo);
     const totalCost = stageCosts.length > 0 ? aggregateCosts(stageCosts) : undefined;
-
     if (totalCost) {
       console.log(`[${context.taskPrefix}] Total cost: ${formatCost(totalCost)}`);
       broadcastEvent({ type: 'task:cost', data: { taskId: context.task.id, cost: totalCost } });
     }
-
     const result: PipelineResult = {
       success,
       sessionId: context.session.id,
       stages,
       finalStatus,
-      failureSignal: context.guardsResult?.results.some(r => r.blocking && !r.passed) || context.testerResult?.success === false ? 'gate-fail' : undefined,
+      failureSignal: context.stuckReason ? 'stuck'
+        : context.guardsResult?.results.some(r => r.blocking && !r.passed) || context.testerResult?.success === false ? 'gate-fail' : undefined,
+      stuckReason: context.stuckReason,
       totalDuration: Date.now() - startTime,
       iterations: context.currentIteration,
       workerResult: context.workerResult,

--- a/src/agents/pairPipelineTypes.ts
+++ b/src/agents/pairPipelineTypes.ts
@@ -68,7 +68,8 @@ export interface PipelineResult {
   sessionId: string;
   stages: StageResult[];
   finalStatus: 'approved' | 'rejected' | 'failed' | 'cancelled' | 'decomposed' | 'superseded' | 'rate_limited' | 'infra_error';
-  failureSignal?: 'gate-fail' | 'timeout';
+  failureSignal?: 'gate-fail' | 'timeout' | 'stuck';
+  stuckReason?: string;
   rateLimitResetsAt?: number;
   totalDuration: number;
   iterations: number;
@@ -121,6 +122,8 @@ export interface PipelineContext {
   trustedVerifyInputFingerprint?: string;
   /** Deferred capture error so invalid manifests retain tester-stage failure semantics. */
   trustedVerifyError?: unknown;
+  /** Pair-level stagnation detector reason, preserved so the scheduler does not rerun the same loop. */
+  stuckReason?: string;
 }
 
 export type PipelineEventType = 'stage:start' | 'stage:complete' | 'stage:fail' | 'iteration:start' | 'iteration:complete' | 'iteration:fail' | 'pipeline:complete' | 'pipeline:fail' | 'fanout:gate' | 'halt';

--- a/src/agents/pairWebhook.test.ts
+++ b/src/agents/pairWebhook.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { sendWebhook, type WebhookPayload } from './pairWebhook.js';
+
+afterEach(() => vi.unstubAllGlobals());
+
+const payload: WebhookPayload = {
+  event: 'pair_started',
+  timestamp: '2026-07-22T00:00:00.000Z',
+  session: { id: 's', taskId: 't', taskTitle: 'task', status: 'running', attempts: 1, maxAttempts: 2, durationMs: 0 },
+};
+
+describe('sendWebhook', () => {
+  it('passes a bounded signal and cancels an unread response body', async () => {
+    const cancel = vi.fn(async () => {});
+    const response = { ok: false, status: 500, statusText: 'bad', body: { cancel } } as unknown as Response;
+    const fetchMock = vi.fn(async () => response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(sendWebhook('https://example.test/hook', payload)).resolves.toMatchObject({ success: false, statusCode: 500 });
+    expect((fetchMock.mock.calls[0][1] as RequestInit).signal).toBeInstanceOf(AbortSignal);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agents/pairWebhook.ts
+++ b/src/agents/pairWebhook.ts
@@ -210,7 +210,9 @@ export async function notifyPairCancelled(
 /**
  * Send Webhook (common)
  */
-async function sendWebhook(url: string, payload: WebhookPayload): Promise<WebhookResult> {
+const WEBHOOK_TIMEOUT_MS = 10_000;
+
+export async function sendWebhook(url: string, payload: WebhookPayload): Promise<WebhookResult> {
   try {
     const response = await fetch(url, {
       method: 'POST',
@@ -219,20 +221,20 @@ async function sendWebhook(url: string, payload: WebhookPayload): Promise<Webhoo
         'User-Agent': 'OpenSwarm/1.0',
       },
       body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
     });
-
-    if (response.ok) {
-      return {
+    const result = response.ok
+      ? {
         success: true,
         statusCode: response.status,
-      };
-    }
-
-    return {
+      }
+      : {
       success: false,
       statusCode: response.status,
       error: `HTTP ${response.status}: ${response.statusText}`,
-    };
+      };
+    await response.body?.cancel().catch(() => {});
+    return result;
   } catch (err) {
     return {
       success: false,
@@ -298,13 +300,15 @@ export async function sendDiscordWebhook(
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ embeds: [embed] }),
+      signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
     });
-
-    return {
+    const result = {
       success: response.ok,
       statusCode: response.status,
       error: response.ok ? undefined : `HTTP ${response.status}`,
     };
+    await response.body?.cancel().catch(() => {});
+    return result;
   } catch (err) {
     return {
       success: false,

--- a/src/agents/pipelineGuards.coverage.test.ts
+++ b/src/agents/pipelineGuards.coverage.test.ts
@@ -8,7 +8,7 @@
 // ============================================
 
 import { execFileSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -48,7 +48,7 @@ describe('pipelineGuards — additional coverage', () => {
     writeFileSync(tscFixture, '#!/bin/sh\nif [ -f bad.ts ]; then exit 1; fi\n');
     chmodSync(tscFixture, 0o755);
     const ruffFixture = join(fixtureBin, 'ruff');
-    writeFileSync(ruffFixture, '#!/bin/sh\nshift\nif grep -q "import os" "$@"; then exit 1; fi\n');
+    writeFileSync(ruffFixture, '#!/bin/sh\nif [ -n "$RUFF_ARGS_LOG" ]; then printf "%s\\n" "$@" > "$RUFF_ARGS_LOG"; fi\nshift\nif grep -q "import os" "$@"; then exit 1; fi\n');
     chmodSync(ruffFixture, 0o755);
     originalPath = process.env.PATH;
     process.env.PATH = `${fixtureBin}:${originalPath ?? ''}`;
@@ -56,6 +56,7 @@ describe('pipelineGuards — additional coverage', () => {
 
   afterEach(() => {
     process.env.PATH = originalPath;
+    delete process.env.RUFF_ARGS_LOG;
     if (existsSync(repo)) rmSync(repo, { recursive: true, force: true });
   });
 
@@ -104,6 +105,19 @@ describe('pipelineGuards — additional coverage', () => {
       const issues = guardIssues(res, 'qualityGate');
       expect(issues.some(i => i.includes('Ruff check failed'))).toBe(true);
       expect(res.allPassed).toBe(false);
+    }, 30000);
+
+    it('separates Ruff options from adversarial Python filenames with --', async () => {
+      const file = '--select.py';
+      const argsLog = join(repo, 'ruff-args.txt');
+      process.env.RUFF_ARGS_LOG = argsLog;
+      writeFileSync(join(repo, file), 'x = 1\n');
+
+      const res = await runGuards(mockWorker([file]), repo, { qualityGate: true });
+
+      expect(res.allPassed).toBe(true);
+      expect(readFileSync(argsLog, 'utf8').trim().split('\n')).toEqual(['check', '--', file]);
+      delete process.env.RUFF_ARGS_LOG;
     }, 30000);
   });
 

--- a/src/agents/pipelineGuards.ts
+++ b/src/agents/pipelineGuards.ts
@@ -110,7 +110,7 @@ async function runQualityGate(
 
   if (pyFiles.length > 0) {
     try {
-      await execFileAsync('ruff', ['check', ...pyFiles], {
+      await execFileAsync('ruff', ['check', '--', ...pyFiles], {
         cwd: projectPath,
         timeout: 60_000,
       });

--- a/src/auth/linearPkce.test.ts
+++ b/src/auth/linearPkce.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseLinearTokenResponse } from './linearPkce.js';
+import { isValidLinearCallback, parseLinearTokenResponse } from './linearPkce.js';
 
 describe('parseLinearTokenResponse', () => {
   it('requires access, refresh, and a positive expiry', () => {
@@ -9,5 +9,14 @@ describe('parseLinearTokenResponse', () => {
     expect(() => parseLinearTokenResponse({ access_token: 'a', expires_in: 3600 })).toThrow(/refresh_token/);
     expect(() => parseLinearTokenResponse({ access_token: 'a', refresh_token: '', expires_in: 3600 })).toThrow(/refresh_token/);
     expect(() => parseLinearTokenResponse({ access_token: 'a', refresh_token: 'r', expires_in: 0 })).toThrow(/expires_in/);
+  });
+});
+
+describe('Linear callback validation', () => {
+  it('requires matching state for both success and OAuth error callbacks', () => {
+    expect(isValidLinearCallback('code', null, 'expected', 'expected')).toBe(true);
+    expect(isValidLinearCallback(null, 'access_denied', 'expected', 'expected')).toBe(true);
+    expect(isValidLinearCallback(null, 'access_denied', 'attacker', 'expected')).toBe(false);
+    expect(isValidLinearCallback('code', null, null, 'expected')).toBe(false);
   });
 });

--- a/src/auth/linearPkce.test.ts
+++ b/src/auth/linearPkce.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { parseLinearTokenResponse } from './linearPkce.js';
+
+describe('parseLinearTokenResponse', () => {
+  it('requires access, refresh, and a positive expiry', () => {
+    expect(parseLinearTokenResponse({ access_token: 'a', refresh_token: 'r', expires_in: 3600 })).toEqual({
+      accessToken: 'a', refreshToken: 'r', expiresIn: 3600,
+    });
+    expect(() => parseLinearTokenResponse({ access_token: 'a', expires_in: 3600 })).toThrow(/refresh_token/);
+    expect(() => parseLinearTokenResponse({ access_token: 'a', refresh_token: '', expires_in: 3600 })).toThrow(/refresh_token/);
+    expect(() => parseLinearTokenResponse({ access_token: 'a', refresh_token: 'r', expires_in: 0 })).toThrow(/expires_in/);
+  });
+});

--- a/src/auth/linearPkce.ts
+++ b/src/auth/linearPkce.ts
@@ -73,6 +73,15 @@ export function parseLinearTokenResponse(value: unknown): LinearFlowResult {
   return { accessToken: tokens.access_token, refreshToken: tokens.refresh_token, expiresIn: tokens.expires_in };
 }
 
+export function isValidLinearCallback(
+  code: string | null,
+  error: string | null,
+  returnedState: string | null,
+  expectedState: string,
+): boolean {
+  return returnedState === expectedState && (!!code || !!error);
+}
+
 /**
  * Linear OAuth 2.0 PKCE flow.
  *   1. generate PKCE verifier/challenge + state
@@ -138,6 +147,16 @@ export async function runLinearPkceFlow(options: LinearFlowOptions = {}): Promis
         return;
       }
 
+      if (!isValidLinearCallback(code, error, returnedState, state)) {
+        settlement.finish();
+        clearTimeout(timeout);
+        res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(errorHtml('Invalid callback parameters'));
+        server.close();
+        reject(new Error('Invalid Linear callback: missing code or state mismatch'));
+        return;
+      }
+
       if (error) {
         settlement.finish();
         clearTimeout(timeout);
@@ -148,20 +167,10 @@ export async function runLinearPkceFlow(options: LinearFlowOptions = {}): Promis
         return;
       }
 
-      if (!code || returnedState !== state) {
-        settlement.finish();
-        clearTimeout(timeout);
-        res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
-        res.end(errorHtml('Invalid callback parameters'));
-        server.close();
-        reject(new Error('Invalid Linear callback: missing code or state mismatch'));
-        return;
-      }
-
       try {
         const tokenBody = new URLSearchParams({
           grant_type: 'authorization_code',
-          code,
+          code: code!,
           code_verifier: codeVerifier,
           redirect_uri: redirectUri,
           client_id: clientId,

--- a/src/auth/linearPkce.ts
+++ b/src/auth/linearPkce.ts
@@ -8,6 +8,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 import { randomBytes, createHash } from 'node:crypto';
 import { AuthProfileStore, type AuthProfile } from './oauthStore.js';
 import { openBrowser } from './openBrowser.js';
+import { PkceSettlement, TOKEN_EXCHANGE_TIMEOUT_MS } from './pkceSettlement.js';
 
 // ----- Constants -----
 
@@ -61,6 +62,17 @@ export interface LinearFlowOptions {
   scopes?: string;
 }
 
+export function parseLinearTokenResponse(value: unknown): LinearFlowResult {
+  if (!value || typeof value !== 'object') throw new Error('Linear token response is not an object');
+  const tokens = value as Record<string, unknown>;
+  if (typeof tokens.access_token !== 'string' || !tokens.access_token) throw new Error('Linear token response missing access_token');
+  if (typeof tokens.refresh_token !== 'string' || !tokens.refresh_token) throw new Error('Linear token response missing refresh_token');
+  if (typeof tokens.expires_in !== 'number' || !Number.isFinite(tokens.expires_in) || tokens.expires_in <= 0) {
+    throw new Error('Linear token response has invalid expires_in');
+  }
+  return { accessToken: tokens.access_token, refreshToken: tokens.refresh_token, expiresIn: tokens.expires_in };
+}
+
 /**
  * Linear OAuth 2.0 PKCE flow.
  *   1. generate PKCE verifier/challenge + state
@@ -91,18 +103,19 @@ export async function runLinearPkceFlow(options: LinearFlowOptions = {}): Promis
   const authUrl = `${LINEAR_AUTH_ENDPOINT}?${authParams.toString()}`;
 
   return new Promise<LinearFlowResult>((resolve, reject) => {
-    let settled = false;
+    const settlement = new PkceSettlement();
+    const exchangeAbort = new AbortController();
 
     const timeout = setTimeout(() => {
-      if (!settled) {
-        settled = true;
+      if (settlement.finish()) {
+        exchangeAbort.abort(new Error('Linear login timed out'));
         server.close();
         reject(new Error('Linear login timed out (120s). 다시 시도하세요.'));
       }
     }, LOGIN_TIMEOUT_MS);
 
     const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-      if (settled) {
+      if (settlement.settled) {
         res.writeHead(400);
         res.end();
         return;
@@ -119,8 +132,14 @@ export async function runLinearPkceFlow(options: LinearFlowOptions = {}): Promis
       const returnedState = url.searchParams.get('state');
       const error = url.searchParams.get('error');
 
+      if (!settlement.tryClaim()) {
+        res.writeHead(409);
+        res.end('OAuth callback already being processed');
+        return;
+      }
+
       if (error) {
-        settled = true;
+        settlement.finish();
         clearTimeout(timeout);
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(errorHtml(error));
@@ -130,7 +149,7 @@ export async function runLinearPkceFlow(options: LinearFlowOptions = {}): Promis
       }
 
       if (!code || returnedState !== state) {
-        settled = true;
+        settlement.finish();
         clearTimeout(timeout);
         res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(errorHtml('Invalid callback parameters'));
@@ -152,6 +171,7 @@ export async function runLinearPkceFlow(options: LinearFlowOptions = {}): Promis
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           body: tokenBody.toString(),
+          signal: AbortSignal.any([exchangeAbort.signal, AbortSignal.timeout(TOKEN_EXCHANGE_TIMEOUT_MS)]),
         });
 
         if (!tokenRes.ok) {
@@ -159,24 +179,16 @@ export async function runLinearPkceFlow(options: LinearFlowOptions = {}): Promis
           throw new Error(`Token exchange failed (${tokenRes.status}): ${errText.slice(0, 300)}`);
         }
 
-        const tokens = (await tokenRes.json()) as {
-          access_token: string;
-          refresh_token?: string;
-          expires_in: number;
-        };
+        const result = parseLinearTokenResponse(await tokenRes.json());
 
-        settled = true;
+        if (!settlement.finish()) return;
         clearTimeout(timeout);
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(successHtml());
         server.close();
-        resolve({
-          accessToken: tokens.access_token,
-          refreshToken: tokens.refresh_token ?? '',
-          expiresIn: tokens.expires_in,
-        });
+        resolve(result);
       } catch (err) {
-        settled = true;
+        if (!settlement.finish()) return;
         clearTimeout(timeout);
         res.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(errorHtml(String(err)));
@@ -192,8 +204,8 @@ export async function runLinearPkceFlow(options: LinearFlowOptions = {}): Promis
     });
 
     server.on('error', (err) => {
-      if (!settled) {
-        settled = true;
+      if (settlement.finish()) {
+        exchangeAbort.abort(err);
         clearTimeout(timeout);
         reject(new Error(`Callback server error: ${err.message}`));
       }

--- a/src/auth/openrouterPkce.ts
+++ b/src/auth/openrouterPkce.ts
@@ -8,6 +8,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 import { randomBytes, createHash } from 'node:crypto';
 import { AuthProfileStore, type AuthProfile } from './oauthStore.js';
 import { openBrowser } from './openBrowser.js';
+import { PkceSettlement, TOKEN_EXCHANGE_TIMEOUT_MS } from './pkceSettlement.js';
 
 // ----- Constants -----
 
@@ -75,18 +76,19 @@ export async function runOpenRouterPkceFlow(
   const authUrl = `${OPENROUTER_AUTH_ENDPOINT}?${authParams.toString()}`;
 
   return new Promise<OpenRouterFlowResult>((resolve, reject) => {
-    let settled = false;
+    const settlement = new PkceSettlement();
+    const exchangeAbort = new AbortController();
 
     const timeout = setTimeout(() => {
-      if (!settled) {
-        settled = true;
+      if (settlement.finish()) {
+        exchangeAbort.abort(new Error('OpenRouter login timed out'));
         server.close();
         reject(new Error('OpenRouter login timed out (120s). 다시 시도하세요.'));
       }
     }, LOGIN_TIMEOUT_MS);
 
     const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-      if (settled) {
+      if (settlement.settled) {
         res.writeHead(400);
         res.end();
         return;
@@ -103,8 +105,14 @@ export async function runOpenRouterPkceFlow(
       const code = url.searchParams.get('code');
       const error = url.searchParams.get('error');
 
+      if (!settlement.tryClaim()) {
+        res.writeHead(409);
+        res.end('OAuth callback already being processed');
+        return;
+      }
+
       if (error) {
-        settled = true;
+        settlement.finish();
         clearTimeout(timeout);
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(errorHtml(error));
@@ -114,7 +122,7 @@ export async function runOpenRouterPkceFlow(
       }
 
       if (!code) {
-        settled = true;
+        settlement.finish();
         clearTimeout(timeout);
         res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(errorHtml('Missing authorization code'));
@@ -132,6 +140,7 @@ export async function runOpenRouterPkceFlow(
             code_verifier: codeVerifier,
             code_challenge_method: 'S256',
           }),
+          signal: AbortSignal.any([exchangeAbort.signal, AbortSignal.timeout(TOKEN_EXCHANGE_TIMEOUT_MS)]),
         });
 
         if (!exchangeRes.ok) {
@@ -155,14 +164,14 @@ export async function runOpenRouterPkceFlow(
           userId: payload.user_id ?? undefined,
         };
 
-        settled = true;
+        if (!settlement.finish()) return;
         clearTimeout(timeout);
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(successHtml());
         server.close();
         resolve(result);
       } catch (err) {
-        settled = true;
+        if (!settlement.finish()) return;
         clearTimeout(timeout);
         res.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(errorHtml(String(err)));
@@ -178,8 +187,8 @@ export async function runOpenRouterPkceFlow(
     });
 
     server.on('error', (err) => {
-      if (!settled) {
-        settled = true;
+      if (settlement.finish()) {
+        exchangeAbort.abort(err);
         clearTimeout(timeout);
         reject(new Error(`Callback server error: ${err.message}`));
       }

--- a/src/auth/pkceSettlement.test.ts
+++ b/src/auth/pkceSettlement.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { PkceSettlement } from './pkceSettlement.js';
+
+describe('PkceSettlement', () => {
+  it('allows exactly one callback to claim an exchange', () => {
+    const settlement = new PkceSettlement();
+    expect(settlement.tryClaim()).toBe(true);
+    expect(settlement.tryClaim()).toBe(false);
+    expect(settlement.finish()).toBe(true);
+    expect(settlement.finish()).toBe(false);
+    expect(settlement.settled).toBe(true);
+  });
+});

--- a/src/auth/pkceSettlement.ts
+++ b/src/auth/pkceSettlement.ts
@@ -1,0 +1,23 @@
+export class PkceSettlement {
+  private state: 'pending' | 'claimed' | 'settled' = 'pending';
+
+  /** Atomically reserve the one callback allowed to perform an exchange. */
+  tryClaim(): boolean {
+    if (this.state !== 'pending') return false;
+    this.state = 'claimed';
+    return true;
+  }
+
+  /** Return true only for the first terminal completion. */
+  finish(): boolean {
+    if (this.state === 'settled') return false;
+    this.state = 'settled';
+    return true;
+  }
+
+  get settled(): boolean {
+    return this.state === 'settled';
+  }
+}
+
+export const TOKEN_EXCHANGE_TIMEOUT_MS = 30_000;

--- a/src/automation/autonomousRunner.durable.test.ts
+++ b/src/automation/autonomousRunner.durable.test.ts
@@ -290,6 +290,42 @@ describe('AutonomousRunner durable completion race', () => {
     internal.durableRuns.close();
   });
 
+  it('resumes durable NEEDS_HUMAN when an operator moves a stuck issue to Todo', async () => {
+    const [{ AutonomousRunner }, execution] = await Promise.all([
+      import('./autonomousRunner.js'),
+      import('./runnerExecution.js'),
+    ]);
+    const unstick = vi.fn(async () => {});
+    execution.setTaskSource({
+      kind: 'linear', fetchTasks: vi.fn(async () => []), getExecutionComments: vi.fn(async () => []),
+      updateState: vi.fn(async () => true), addComment: vi.fn(async () => {}),
+      createTask: vi.fn(), createSubIssue: vi.fn(), logPairStart: vi.fn(),
+      logPairComplete: vi.fn(), logBlocked: vi.fn(), logStuck: vi.fn(), unstick,
+      logHalt: vi.fn(), markAsDecomposed: vi.fn(),
+    } as unknown as ITaskSource);
+    const runner = new AutonomousRunner({
+      linearTeamId: 'team', allowedProjects: ['/repo'], heartbeatSchedule: '0 * * * *',
+      autoExecute: true, maxConsecutiveTasks: 1, cooldownSeconds: 0, dryRun: true,
+      automationLedgerMode: 'primary', automationDbPath: join(root, 'stuck-recovery.db'),
+    });
+    const internal = runner as unknown as InternalRunner;
+    internal.durableRuns.importLegacyRun({
+      issueId: 'stuck-issue', source: 'linear', identifier: 'INT-STUCK', title: 'retry me',
+      projectPath: '/repo', state: 'NEEDS_HUMAN',
+    });
+    const task: TaskItem = {
+      id: 'stuck-issue', issueId: 'stuck-issue', issueIdentifier: 'INT-STUCK', source: 'linear',
+      title: 'retry me', priority: 2, createdAt: Date.now(), linearState: 'Todo',
+      labels: ['swarm:stuck'], linearProject: { id: 'project', name: 'Repo' },
+    };
+
+    expect(internal.filterAlreadyProcessed([task])).toEqual([task]);
+    expect(internal.durableRuns.getRun('stuck-issue')).toMatchObject({ state: 'READY' });
+    await Promise.resolve();
+    expect(unstick).toHaveBeenCalledWith('stuck-issue');
+    internal.durableRuns.close();
+  });
+
   it('recovers a PR published before process death without rerunning the pipeline', async () => {
     const [{ AutonomousRunner }, execution] = await Promise.all([
       import('./autonomousRunner.js'),

--- a/src/automation/autonomousRunner.infraError.test.ts
+++ b/src/automation/autonomousRunner.infraError.test.ts
@@ -105,6 +105,29 @@ describe('AutonomousRunner infra_error handling (INT-2010)', () => {
     expect(history.every((entry: { failureCause?: string }) => entry.failureCause === 'infra')).toBe(true);
   });
 
+  it('parks a pair-level stuck result once without replaying the outer retry budget', async () => {
+    const source = mockTaskSource();
+    runnerExecution.setTaskSource(source);
+    const runner = new AutonomousRunner(cfg());
+    const scheduler = (runner as unknown as { scheduler: TaskScheduler }).scheduler;
+    const stuck: PipelineResult = {
+      ...result('failed'),
+      failureSignal: 'stuck',
+      stuckReason: 'Same error repeated 3 times: schema validation failed',
+      taskContext: { issueIdentifier: 'INT-1', projectPath: '/repo', taskTitle: 'Edit some files' },
+    };
+
+    scheduler.startTask(task(), '/repo', async () => stuck);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(source.logStuck).toHaveBeenCalledTimes(1);
+    expect(source.logStuck).toHaveBeenCalledWith(
+      'ISSUE-1', 'autonomous-runner', expect.stringContaining('Same error repeated 3 times'),
+    );
+    const state = JSON.parse(readFileSync(join(tempDir, 'runner-task-state.json'), 'utf8'));
+    expect(state.failed['ISSUE-1']).toBe(4);
+  });
+
   it('does not persist a superseded open issue as completed (INT-2568)', async () => {
     const source = mockTaskSource();
     runnerExecution.setTaskSource(source);

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -542,6 +542,39 @@ export class AutonomousRunner {
         return;
       }
 
+      // The bounded pair loop already proved stagnation (same error/output or
+      // repeated REVISE). Retrying the whole pipeline would only replay the same
+      // loop up to MAX_RETRY_COUNT times, multiplying cost and STUCK log noise.
+      if (result.failureSignal === 'stuck' && task.issueId) {
+        const failureDetail = result.stuckReason
+          ?? pickFailureDetail([result.lastReviewFeedback, result.reviewResult?.feedback, result.workerResult?.error])
+          ?? 'Pair pipeline detected repeated non-progress.';
+        this.completedTaskIds.add(task.issueId);
+        this.failedTaskCounts.set(task.issueId, AutonomousRunner.MAX_RETRY_COUNT);
+        clearRetryTime(task.issueId, this.failedTaskRetryTimes);
+        recordLastFailureDetail(this.taskStateRef, task.issueId, failureDetail);
+        if (this.durableRuns.isPrimary) {
+          this.durableRuns.markNeedsHuman(task.issueId, `Pair pipeline stuck: ${failureDetail}`);
+        }
+        this.saveTaskState();
+        if (result.taskContext?.projectPath) {
+          await removePreservedWorktreeAt(result.taskContext.projectPath)
+            .catch((err) => console.warn('[Worktree] STUCK cleanup failed:', err));
+        }
+        try {
+          await execution.syncFailureState(task, `Pair pipeline stuck: ${failureDetail}`);
+          await getTaskSource()?.logStuck(
+            task.issueId,
+            'autonomous-runner',
+            `Pair pipeline detected repeated non-progress; another full retry would repeat the same loop.\n\n**Reason:**\n${failureDetail}`,
+          );
+          console.log(`[Scheduler] Issue ${task.issueId} marked STUCK from pair-level stagnation (no outer retry)`);
+        } catch (err) {
+          console.error('[Scheduler] Failed to update pair-level STUCK issue state:', err);
+        }
+        return;
+      }
+
       console.log(`[Scheduler] Task failed: ${taskCtx} ${task.title}`);
       broadcastEvent({ type: 'task:completed', data: { taskId: task.id, success: false, duration: result.totalDuration } });
       await reportToDiscord(formatPipelineResultEmbed(result));
@@ -798,8 +831,7 @@ export class AutonomousRunner {
       if (
         this.durableRuns.isPrimary
         && durableRun?.state === 'NEEDS_HUMAN'
-        && !isStuck
-        && task.linearState === 'Todo'
+        && ['Todo', 'In Progress', 'In Review'].includes(task.linearState ?? '')
       ) {
         const resumed = this.durableRuns.resumeNeedsHuman(id);
         if (resumed) {
@@ -900,7 +932,7 @@ export class AutonomousRunner {
         console.warn(`[AutonomousRunner] Failed to clear stuck label for ${id}:`, err));
     }
     if (stuckSkipped > 0) {
-      this.syslog(`🛑 Skipped ${stuckSkipped} stuck issue(s) (retries exhausted — remove the \`${STUCK_LABEL}\` label or move to Todo to retry)`);
+      this.syslog(`🛑 Skipped ${stuckSkipped} stuck issue(s) (retries exhausted — remove the \`${STUCK_LABEL}\` label or move to Todo / In Progress to retry)`);
     }
     if (recovered > 0) {
       this.saveTaskState();

--- a/src/automation/ciWorker.test.ts
+++ b/src/automation/ciWorker.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { MIN_CI_CHECK_INTERVAL_MS, validateCIWorkerInterval } from './ciWorker.js';
+
+describe('validateCIWorkerInterval', () => {
+  it('accepts the default and minimum interval', () => {
+    expect(validateCIWorkerInterval(undefined)).toBe(300_000);
+    expect(validateCIWorkerInterval(MIN_CI_CHECK_INTERVAL_MS)).toBe(MIN_CI_CHECK_INTERVAL_MS);
+  });
+
+  it.each([NaN, Infinity, -1, 0, 999, 1000.5])('rejects invalid interval %s', (value) => {
+    expect(() => validateCIWorkerInterval(value)).toThrow(/checkIntervalMs/);
+  });
+});

--- a/src/automation/ciWorker.ts
+++ b/src/automation/ciWorker.ts
@@ -42,6 +42,16 @@ export interface FailureAnalysis {
   suggestion?: string;
 }
 
+export const MIN_CI_CHECK_INTERVAL_MS = 1_000;
+
+export function validateCIWorkerInterval(value: number | undefined): number {
+  const interval = value ?? 5 * 60 * 1000;
+  if (!Number.isSafeInteger(interval) || interval < MIN_CI_CHECK_INTERVAL_MS) {
+    throw new RangeError(`CI worker checkIntervalMs must be a finite integer >= ${MIN_CI_CHECK_INTERVAL_MS}`);
+  }
+  return interval;
+}
+
 // CI Worker
 
 export class CIWorker {
@@ -51,11 +61,11 @@ export class CIWorker {
 
   constructor(config: CIWorkerConfig) {
     this.config = {
-      checkIntervalMs: config.checkIntervalMs ?? 5 * 60 * 1000, // 5 minutes
+      ...config,
+      checkIntervalMs: validateCIWorkerInterval(config.checkIntervalMs),
       autoRetry: config.autoRetry ?? false,
       createIssues: config.createIssues ?? true,
       maxAgeDays: config.maxAgeDays ?? 30,
-      ...config,
     };
   }
 

--- a/src/automation/runnerFailureCause.test.ts
+++ b/src/automation/runnerFailureCause.test.ts
@@ -9,6 +9,7 @@ describe('pipeline history failure causes (INT-2659)', () => {
     ['no-changes', { success: false, finalStatus: 'failed', workerFilesChanged: 0 }],
     ['gate-fail', { success: false, finalStatus: 'failed', workerFilesChanged: 1, failureSignal: 'gate-fail' }],
     ['timeout', { success: false, finalStatus: 'infra_error', failureSignal: 'timeout' }],
+    ['stuck', { success: false, finalStatus: 'failed', failureSignal: 'stuck' }],
     ['cancelled', { success: false, finalStatus: 'cancelled' }],
   ] as const)('classifies %s from structural fields', (expected, signals) => {
     expect(classifyFailureCause(signals)).toBe(expected);

--- a/src/automation/runnerState.ts
+++ b/src/automation/runnerState.ts
@@ -301,12 +301,12 @@ export interface PipelineHistoryEntry {
   completedAt: string; // ISO-8601
 }
 
-export type FailureCause = 'reviewer-reject' | 'infra' | 'rate-limit' | 'no-changes' | 'gate-fail' | 'timeout' | 'cancelled';
+export type FailureCause = 'reviewer-reject' | 'infra' | 'rate-limit' | 'no-changes' | 'gate-fail' | 'timeout' | 'stuck' | 'cancelled';
 
 export interface FailureCauseSignals {
   success: boolean;
   finalStatus: string;
-  failureSignal?: 'gate-fail' | 'timeout';
+  failureSignal?: 'gate-fail' | 'timeout' | 'stuck';
   workerFilesChanged?: number;
   reviewerDecision?: string;
 }
@@ -318,6 +318,7 @@ export function classifyFailureCause(signals: FailureCauseSignals): FailureCause
   if (signals.finalStatus === 'rate_limited') return 'rate-limit';
   if (signals.failureSignal === 'timeout') return 'timeout';
   if (signals.finalStatus === 'infra_error') return 'infra';
+  if (signals.failureSignal === 'stuck') return 'stuck';
   if (signals.workerFilesChanged === 0) return 'no-changes';
   if (signals.failureSignal === 'gate-fail') return 'gate-fail';
   if (signals.finalStatus === 'rejected' || signals.reviewerDecision === 'reject' || signals.reviewerDecision === 'revise') return 'reviewer-reject';
@@ -327,7 +328,7 @@ export function classifyFailureCause(signals: FailureCauseSignals): FailureCause
 export function aggregateFailureCauses(entries: PipelineHistoryEntry[]): Record<FailureCause, number> {
   const counts: Record<FailureCause, number> = {
     'reviewer-reject': 0, infra: 0, 'rate-limit': 0, 'no-changes': 0,
-    'gate-fail': 0, timeout: 0, cancelled: 0,
+    'gate-fail': 0, timeout: 0, stuck: 0, cancelled: 0,
   };
   for (const entry of entries) if (entry.failureCause) counts[entry.failureCause]++;
   return counts;

--- a/src/automation/scheduler.coverage.test.ts
+++ b/src/automation/scheduler.coverage.test.ts
@@ -16,7 +16,7 @@
 // `~/.openswarm/schedules.json` or spawns a real `claude` process.
 
 import { EventEmitter } from 'node:events';
-import { rm } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDateLocale, t } from '../locale/index.js';
 import { getTimeWindowConfig, setTimeWindowConfig } from '../support/timeWindow.js';
@@ -215,21 +215,21 @@ describe('scheduler coverage', () => {
       ).toBe(true);
     });
 
-    it('logs and swallows an error for an invalid cron expression instead of throwing', async () => {
+    it('rejects an invalid cron expression before persisting it', async () => {
       await expect(
         addSchedule('bad-cron-job', testHome.path, 'do work', 'not a valid cron at all'),
-      ).resolves.toBeTruthy();
+      ).rejects.toThrow();
 
-      expect(
-        vi
-          .mocked(console.error)
-          .mock.calls.some(
-            ([msg]) => typeof msg === 'string' && msg.includes('Failed to start cron for bad-cron-job'),
-          ),
-      ).toBe(true);
-      // The schedule is still persisted even though its cron never started.
-      expect((await listSchedules()).find((s) => s.name === 'bad-cron-job')).toBeTruthy();
+      expect((await listSchedules()).find((s) => s.name === 'bad-cron-job')).toBeUndefined();
     });
+  });
+
+  it('fails visibly when the persisted schedule file is corrupt', async () => {
+    const scheduleDir = `${testHome.path}/.openswarm`;
+    await mkdir(scheduleDir, { recursive: true });
+    await writeFile(`${scheduleDir}/schedules.json`, '{not-json');
+
+    await expect(listSchedules()).rejects.toThrow('Failed to load schedules');
   });
 
   // ==========================================================
@@ -423,6 +423,22 @@ describe('scheduler coverage', () => {
       ).toBe(true);
     });
 
+    it('merges a completed run with the latest persisted failure counter', async () => {
+      const job = await addSchedule('concurrent-state-job', testHome.path, 'do work', '0 3 * * *');
+      spawnMock.mockImplementationOnce(() => createMockProc());
+      const pending = runNow(job.id, true);
+      await vi.waitFor(() => expect(spawned.processes).toHaveLength(1));
+
+      const scheduleFile = `${testHome.path}/.openswarm/schedules.json`;
+      const latest = await listSchedules();
+      latest[0].consecutiveFailures = 1;
+      await writeFile(scheduleFile, JSON.stringify(latest));
+      spawned.processes[0].emit('close', 1);
+      await pending;
+
+      expect((await listSchedules())[0].consecutiveFailures).toBe(2);
+    });
+
     it('caps recent results at MAX_RESULTS by evicting the oldest entry', async () => {
       await addSchedule('bulk-job', testHome.path, 'do work', '0 3 * * *');
 
@@ -514,6 +530,19 @@ describe('scheduler coverage', () => {
     expect(
       vi.mocked(console.log).mock.calls.some(([msg]) => typeof msg === 'string' && msg.includes('Loading 2 schedules')),
     ).toBe(true);
+  });
+
+  it('can start all schedules repeatedly without retaining duplicate cron jobs', async () => {
+    await addSchedule('idempotent-start', testHome.path, 'do work', '0 3 * * *');
+
+    await startAllSchedules();
+    await startAllSchedules();
+
+    expect(
+      vi.mocked(console.log).mock.calls.filter(
+        ([msg]) => typeof msg === 'string' && msg.includes('Started cron for idempotent-start'),
+      ),
+    ).toHaveLength(3);
   });
 
   it('kills a running process when stopping all schedules', async () => {

--- a/src/automation/scheduler.ts
+++ b/src/automation/scheduler.ts
@@ -98,10 +98,32 @@ async function loadSchedules(): Promise<ScheduledJob[]> {
   try {
     await fs.mkdir(SCHEDULE_DIR, { recursive: true });
     const data = await fs.readFile(SCHEDULE_FILE, 'utf-8');
-    return JSON.parse(data);
-  } catch {
-    return [];
+    const parsed: unknown = JSON.parse(data);
+    if (!Array.isArray(parsed) || !parsed.every(isScheduledJob)) {
+      throw new Error('schedule file does not contain a valid schedule array');
+    }
+    return parsed;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw new Error(
+      `Failed to load schedules from ${SCHEDULE_FILE}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
   }
+}
+
+function isScheduledJob(value: unknown): value is ScheduledJob {
+  if (!value || typeof value !== 'object') return false;
+  const job = value as Record<string, unknown>;
+  return (
+    typeof job.id === 'string' && job.id.length > 0 &&
+    typeof job.name === 'string' && job.name.length > 0 &&
+    typeof job.projectPath === 'string' &&
+    typeof job.prompt === 'string' &&
+    typeof job.schedule === 'string' && job.schedule.length > 0 &&
+    typeof job.enabled === 'boolean' &&
+    typeof job.createdAt === 'number' && Number.isFinite(job.createdAt)
+  );
 }
 
 /**
@@ -109,7 +131,9 @@ async function loadSchedules(): Promise<ScheduledJob[]> {
  */
 async function saveSchedules(schedules: ScheduledJob[]): Promise<void> {
   await fs.mkdir(SCHEDULE_DIR, { recursive: true });
-  await fs.writeFile(SCHEDULE_FILE, JSON.stringify(schedules, null, 2));
+  const tempFile = `${SCHEDULE_FILE}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(tempFile, JSON.stringify(schedules, null, 2), { mode: 0o600 });
+  await fs.rename(tempFile, SCHEDULE_FILE);
 }
 
 /**
@@ -133,6 +157,13 @@ function intervalToCron(interval: string): string {
     default:
       return interval;
   }
+}
+
+function validateScheduleExpression(schedule: string): string {
+  const cronExpr = intervalToCron(schedule.trim());
+  const probe = new Cron(cronExpr, { paused: true });
+  probe.stop();
+  return cronExpr;
 }
 
 /**
@@ -293,24 +324,29 @@ async function runScheduledJob(
     }
 
     // Update last run + consecutive-failure tracking; auto-pause on repeated failure.
-    const fs = nextFailureState(job.consecutiveFailures ?? 0, success);
     const schedules = await loadSchedules();
+    const latest = schedules.find((schedule) => schedule.id === job.id);
+    if (!latest) {
+      console.log(`[Scheduler] Job "${job.name}" was removed while running; skipping state update`);
+      return success;
+    }
+    const failureState = nextFailureState(latest.consecutiveFailures ?? 0, success);
     const updated = schedules.map((s) =>
       s.id === job.id
         ? {
             ...s,
             lastRun: Date.now(),
-            consecutiveFailures: fs.consecutiveFailures,
-            enabled: fs.autoPause ? false : s.enabled,
+            consecutiveFailures: failureState.consecutiveFailures,
+            enabled: failureState.autoPause ? false : s.enabled,
           }
         : s
     );
     await saveSchedules(updated);
 
-    if (fs.autoPause) {
+    if (failureState.autoPause) {
       activeJobs.get(job.id)?.stop();
       activeJobs.delete(job.id);
-      const msg = `[Scheduler] Job "${job.name}" auto-paused after ${fs.consecutiveFailures} consecutive failures — fix it and re-enable with \`openswarm schedule pause ${job.name}\``;
+      const msg = `[Scheduler] Job "${job.name}" auto-paused after ${failureState.consecutiveFailures} consecutive failures — fix it and re-enable with \`openswarm schedule pause ${job.name}\``;
       console.warn(msg);
       resultListener?.({ ...result, output: `${result.output}\n${msg}`.trim() });
     }
@@ -335,6 +371,7 @@ export async function addSchedule(
   schedule: string,
   createdBy?: string
 ): Promise<ScheduledJob> {
+  validateScheduleExpression(schedule);
   const schedules = await loadSchedules();
 
   // Check for duplicates
@@ -411,6 +448,7 @@ export async function toggleSchedule(
   if (!job) return null;
 
   job.enabled = !job.enabled;
+  if (job.enabled) validateScheduleExpression(job.schedule);
   await saveSchedules(schedules);
 
   // Toggle cron job
@@ -434,20 +472,21 @@ export async function toggleSchedule(
 async function startCronJob(job: ScheduledJob): Promise<void> {
   if (!job.enabled) return;
 
-  const cronExpr = intervalToCron(job.schedule);
-
-  try {
-    const cron = new Cron(cronExpr, () => {
-      void runScheduledJob(job).catch((err) => {
-        console.error(`[Scheduler] Job ${job.name} error:`, err);
-      });
-    });
-
-    activeJobs.set(job.id, cron);
-    console.log(`[Scheduler] Started cron for ${job.name}: ${cronExpr}`);
-  } catch (err) {
-    console.error(`[Scheduler] Failed to start cron for ${job.name}:`, err);
+  const cronExpr = validateScheduleExpression(job.schedule);
+  const existing = activeJobs.get(job.id);
+  if (existing) {
+    existing.stop();
+    activeJobs.delete(job.id);
   }
+
+  const cron = new Cron(cronExpr, () => {
+    void runScheduledJob(job).catch((err) => {
+      console.error(`[Scheduler] Job ${job.name} error:`, err);
+    });
+  });
+
+  activeJobs.set(job.id, cron);
+  console.log(`[Scheduler] Started cron for ${job.name}: ${cronExpr}`);
 }
 
 /**
@@ -456,6 +495,10 @@ async function startCronJob(job: ScheduledJob): Promise<void> {
 export async function startAllSchedules(): Promise<void> {
   const schedules = await loadSchedules();
   console.log(`[Scheduler] Loading ${schedules.length} schedules...`);
+
+  for (const job of schedules) {
+    if (job.enabled) validateScheduleExpression(job.schedule);
+  }
 
   for (const job of schedules) {
     if (job.enabled) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 // OpenSwarm - CLI Entry Point
 // `openswarm run`, `openswarm init`, `openswarm validate`, `openswarm chat`, `openswarm start`
 
-import { Command, InvalidArgumentError } from 'commander';
+import { Command } from 'commander';
 import { writeFileSync, existsSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -14,6 +14,7 @@ import { loadConfig, validateConfig, generateSampleConfig } from './core/config.
 import { loadEnvFile } from './core/envFile.js';
 import { initTelemetry, track } from './telemetry/telemetry.js';
 import { maybeAutoUpdate } from './support/updateNotifier.js';
+import { parsePositiveIntegerOption, parseTcpPortOption } from './cli/optionParsers.js';
 
 // Load .env so CLI commands (e.g. `auth login --provider linear` reading
 // LINEAR_OAUTH_CLIENT_ID) see the same env the daemon does. Idempotent; never
@@ -27,18 +28,6 @@ const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8
 const VERSION = pkg.version;
 
 const program = new Command();
-
-function parsePositiveIntegerOption(value: string): number {
-  const trimmed = value.trim();
-  if (!/^[1-9]\d*$/.test(trimmed)) {
-    throw new InvalidArgumentError('must be a positive integer');
-  }
-  const parsed = Number(trimmed);
-  if (!Number.isSafeInteger(parsed)) {
-    throw new InvalidArgumentError('must be a safe positive integer');
-  }
-  return parsed;
-}
 
 function loadTelemetryEnabledQuietly(quiet: boolean): boolean | undefined {
   if (!quiet) return loadConfig().telemetry?.enabled;
@@ -400,7 +389,7 @@ program
   .description('Execute a task via the running daemon (auto-starts if needed)')
   .argument('<prompt>', 'Task prompt to execute')
   .option('--path <path>', 'Project path (default: cwd)')
-  .option('--timeout <seconds>', 'Timeout in seconds (default: 600)', parseInt)
+  .option('--timeout <seconds>', 'Timeout in seconds (default: 600)', parsePositiveIntegerOption)
   .option('--no-auto-start', 'Do not auto-start the service')
   .option('--local', 'Execute locally without daemon')
   .option('--pipeline', 'Full pipeline: worker + reviewer + tester + documenter')
@@ -541,10 +530,10 @@ program
 program
   .command('dash')
   .description('Open the web dashboard in a browser')
-  .option('-p, --port <port>', 'Port number', '3847')
+  .option('-p, --port <port>', 'Port number', parseTcpPortOption, 3847)
   .option('--no-open', 'Start server without opening browser')
-  .action(async (opts: { port: string; open: boolean }) => {
-    const port = parseInt(opts.port, 10);
+  .action(async (opts: { port: number; open: boolean }) => {
+    const port = opts.port;
     const { startWebServer } = await import('./support/web.js');
     await startWebServer(port);
     console.log(`Dashboard running at http://localhost:${port}`);
@@ -640,9 +629,8 @@ authCmd
   .description('Login via OAuth/PKCE (gpt, openrouter, linear)')
   .option('--provider <provider>', 'Provider to authenticate (gpt | openrouter | linear)', 'gpt')
   .option('--client-id <clientId>', 'GPT only: override OAuth Client ID (defaults to the public Codex client)')
-  .option('--api-key <apiKey>', 'OpenRouter only: skip browser flow and store this sk-or-* key directly')
-  .option('--port <port>', 'Callback server port', parseInt)
-  .action(async (opts: { provider: string; clientId?: string; apiKey?: string; port?: number }) => {
+  .option('--port <port>', 'Callback server port', parseTcpPortOption)
+  .action(async (opts: { provider: string; clientId?: string; port?: number }) => {
     const { handleAuthLogin } = await import('./cli/authHandler.js');
     await handleAuthLogin(opts.provider, opts);
   });

--- a/src/cli/authHandler.ts
+++ b/src/cli/authHandler.ts
@@ -38,8 +38,6 @@ function assertProvider(provider: string): asserts provider is Provider {
 export interface AuthLoginOpts {
   clientId?: string;
   port?: number;
-  /** OpenRouter: PKCE 없이 직접 입력받은 API key */
-  apiKey?: string;
 }
 
 /**
@@ -71,14 +69,8 @@ export async function handleAuthLogin(
 }
 
 async function loginOpenRouter(opts: AuthLoginOpts): Promise<void> {
-  // 1) Explicit --api-key wins.
-  if (opts.apiKey) {
-    saveOpenRouterApiKey(opts.apiKey);
-    console.log(`[Auth] OpenRouter API key 저장 완료: ${PROFILE_KEYS.openrouter}`);
-    return;
-  }
-
-  // 2) OPENROUTER_API_KEY env (headless / CI).
+  // API keys must never be supplied through argv because process listings and
+  // shell history expose them. Use the environment or hidden prompt instead.
   const envKey = process.env.OPENROUTER_API_KEY?.trim();
   if (envKey) {
     saveOpenRouterApiKey(envKey);
@@ -88,7 +80,7 @@ async function loginOpenRouter(opts: AuthLoginOpts): Promise<void> {
     return;
   }
 
-  // 3) PKCE browser flow (primary path).
+  // PKCE browser flow (primary path).
   try {
     await loginAndSaveOpenRouterProfile(opts.port);
     return;
@@ -98,7 +90,7 @@ async function loginOpenRouter(opts: AuthLoginOpts): Promise<void> {
     console.error('[Auth] API 키 직접 입력으로 전환합니다.');
   }
 
-  // 4) Interactive API-key fallback when PKCE could not complete.
+  // Interactive API-key fallback when PKCE could not complete.
   const manualKey = await promptForApiKey();
   saveOpenRouterApiKey(manualKey);
   console.log(`[Auth] OpenRouter API key 저장 완료: ${PROFILE_KEYS.openrouter}`);
@@ -106,7 +98,7 @@ async function loginOpenRouter(opts: AuthLoginOpts): Promise<void> {
 
 function promptForApiKey(): Promise<string> {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    throw new Error('비대화형 환경에서는 --api-key 또는 OPENROUTER_API_KEY를 사용하세요.');
+    throw new Error('비대화형 환경에서는 OPENROUTER_API_KEY를 사용하세요.');
   }
 
   return password({ message: 'OpenRouter API key (hidden):' }).then((answer) => {

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -9,7 +9,7 @@
 
 import { spawn, execFile } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
-import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync, statSync } from 'node:fs';
+import { closeSync, existsSync, fstatSync, mkdirSync, openSync, readFileSync, readSync, unlinkSync, writeFileSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -267,11 +267,29 @@ export async function stopExternalDaemon(timeoutMs = 10_000): Promise<ExternalSt
  * show why the daemon exited when it dies during startup.
  */
 export function readLogTail(lines = 20): string {
+  if (!Number.isSafeInteger(lines) || lines <= 0) return '';
+  let fd: number | null = null;
   try {
-    const content = readFileSync(LOG_FILE, 'utf8');
-    return content.split('\n').slice(-lines).join('\n').trimEnd();
+    fd = openSync(LOG_FILE, 'r');
+    const size = fstatSync(fd).size;
+    const chunks: Buffer[] = [];
+    const blockSize = 64 * 1024;
+    let position = size;
+    let newlineCount = 0;
+    while (position > 0 && newlineCount <= lines) {
+      const length = Math.min(blockSize, position);
+      position -= length;
+      const chunk = Buffer.allocUnsafe(length);
+      readSync(fd, chunk, 0, length, position);
+      chunks.unshift(chunk);
+      for (const byte of chunk) if (byte === 0x0a) newlineCount++;
+    }
+    const content = Buffer.concat(chunks).toString('utf8').trimEnd();
+    return content ? content.split('\n').slice(-lines).join('\n') : '';
   } catch {
     return '(log file unavailable)';
+  } finally {
+    if (fd !== null) closeSync(fd);
   }
 }
 

--- a/src/cli/fixCommand.test.ts
+++ b/src/cli/fixCommand.test.ts
@@ -109,9 +109,15 @@ describe('parseFailingFiles (INT-2267)', () => {
     expect(files).toEqual(['lib/util.py', 'src/cli/fixCommand.test.ts', 'src/cli/fixCommand.ts']);
   });
 
-  it('ignores absolute paths and non-source text', () => {
+  it('ignores absolute paths without a repository boundary', () => {
     expect(parseFailingFiles('all good, no files here')).toEqual([]);
     expect(parseFailingFiles('/usr/lib/node/x.js failed')).toEqual([]);
+  });
+
+  it('normalizes absolute paths inside the project and rejects external paths', () => {
+    const root = '/work/repo';
+    const output = '/work/repo/src/app.ts(2,1): error\n/usr/lib/node/x.js failed';
+    expect(parseFailingFiles(output, root)).toEqual(['src/app.ts']);
   });
 
   it('extracts paths from cargo and pytest output (INT-2303)', () => {

--- a/src/cli/fixCommand.ts
+++ b/src/cli/fixCommand.ts
@@ -15,7 +15,7 @@
 
 import { execFile } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { balanceAreasToConcurrency, type AuditArea } from './reviewAudit.js';
 import { runPool } from '../support/concurrencyPool.js';
 import { startProgressHeartbeat } from './reviewProgress.js';
@@ -218,6 +218,7 @@ export function resolveProjectChecks(probe: ProjectProbe, requested?: string[]):
 
 const SOURCE_EXT = 'tsx?|jsx?|mjs|cjs|py|rs|go|java|kt|kts|scala|rb|php|swift|c|cc|cpp|cxx|h|hpp|cs|ex|exs|lua|jl|zig|nim';
 const FILE_RE = new RegExp(String.raw`(?:^|[\s('"\`])((?:[\w.\-]+\/)*[\w.\-]+\.(?:${SOURCE_EXT}))`, 'g');
+const ABS_FILE_RE = new RegExp(String.raw`(?:^|[\s('"\`])((?:\/[\w.\-]+)+\.(?:${SOURCE_EXT}))`, 'g');
 
 /**
  * Extract repo-relative source file paths mentioned in check output — the files
@@ -226,12 +227,21 @@ const FILE_RE = new RegExp(String.raw`(?:^|[\s('"\`])((?:[\w.\-]+\/)*[\w.\-]+\.(
  * pytest `file.py::test`). Pure; caller filters to files that exist. Deduped,
  * `./` stripped.
  */
-export function parseFailingFiles(output: string): string[] {
+export function parseFailingFiles(output: string, projectPath?: string): string[] {
   const out = new Set<string>();
   for (const m of output.matchAll(FILE_RE)) {
     let p = m[1];
     while (p.startsWith('./')) p = p.slice(2);
     if (p && !p.startsWith('/')) out.add(p);
+  }
+  if (projectPath) {
+    const root = resolve(projectPath);
+    for (const m of output.matchAll(ABS_FILE_RE)) {
+      const absolute = resolve(m[1]);
+      const rel = relative(root, absolute);
+      if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) continue;
+      if (rel) out.add(rel);
+    }
   }
   return [...out];
 }
@@ -374,7 +384,7 @@ async function runAllChecks(
     const hb = tty ? startProgressHeartbeat(`${check.key}…`) : null;
     const { passed, output } = await runCheck(check, cwd);
     hb?.stop();
-    const files = passed ? [] : parseFailingFiles(output).filter((f) => exists(f, cwd));
+    const files = passed ? [] : parseFailingFiles(output, cwd).filter((f) => exists(f, cwd));
     outcomes.push({ key: check.key, passed, output, files });
     log(passed ? `  ${status.ok(check.key)}` : `  ${status.err(`${check.key} — ${files.length} file(s)`)}`);
   }

--- a/src/cli/optionParsers.test.ts
+++ b/src/cli/optionParsers.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { parsePositiveIntegerOption, parseTcpPortOption } from './optionParsers.js';
+
+describe('strict CLI numeric options', () => {
+  it.each(['0', '-1', '1.5', '10abc', 'Infinity', ''])('rejects malformed positive integers: %s', (value) => {
+    expect(() => parsePositiveIntegerOption(value)).toThrow('positive integer');
+  });
+
+  it('accepts a safe positive integer with surrounding whitespace', () => {
+    expect(parsePositiveIntegerOption(' 600 ')).toBe(600);
+  });
+
+  it.each(['0', '65536', '1.5', 'abc'])('rejects invalid TCP ports: %s', (value) => {
+    expect(() => parseTcpPortOption(value)).toThrow();
+  });
+
+  it.each([['1', 1], ['65535', 65535]])('accepts TCP port boundary %s', (value, expected) => {
+    expect(parseTcpPortOption(value)).toBe(expected);
+  });
+});

--- a/src/cli/optionParsers.ts
+++ b/src/cli/optionParsers.ts
@@ -1,0 +1,21 @@
+import { InvalidArgumentError } from 'commander';
+
+export function parsePositiveIntegerOption(value: string): number {
+  const trimmed = value.trim();
+  if (!/^[1-9]\d*$/.test(trimmed)) {
+    throw new InvalidArgumentError('must be a positive integer');
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new InvalidArgumentError('must be a safe positive integer');
+  }
+  return parsed;
+}
+
+export function parseTcpPortOption(value: string): number {
+  const port = parsePositiveIntegerOption(value);
+  if (port > 65_535) {
+    throw new InvalidArgumentError('must be a TCP port between 1 and 65535');
+  }
+  return port;
+}

--- a/src/core/daemonLifecycle.test.ts
+++ b/src/core/daemonLifecycle.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rmSync } from 'node:fs';
+import { cleanupDaemonPid, createShutdownHandler } from './daemonLifecycle.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function pidFile(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'openswarm-daemon-lifecycle-'));
+  dirs.push(dir);
+  const file = join(dir, 'openswarm.pid');
+  writeFileSync(file, '123');
+  return file;
+}
+
+describe('daemon lifecycle', () => {
+  it('removes a daemon PID after startup failure', () => {
+    const file = pidFile();
+    cleanupDaemonPid(true, file);
+    expect(existsSync(file)).toBe(false);
+  });
+
+  it('coalesces repeated shutdown signals into one stop and exit', async () => {
+    const file = pidFile();
+    let release!: () => void;
+    const stop = vi.fn(() => new Promise<void>((resolve) => { release = resolve; }));
+    const exit = vi.fn();
+    const shutdown = createShutdownHandler({ isDaemon: true, pidFile: file, stop, exit });
+
+    const first = shutdown('SIGINT');
+    const second = shutdown('SIGTERM');
+    expect(first).toBe(second);
+    expect(stop).toHaveBeenCalledTimes(1);
+    release();
+    await first;
+
+    expect(exit).toHaveBeenCalledOnce();
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(existsSync(file)).toBe(false);
+  });
+});

--- a/src/core/daemonLifecycle.ts
+++ b/src/core/daemonLifecycle.ts
@@ -1,0 +1,40 @@
+import { unlinkSync } from 'node:fs';
+
+export function cleanupDaemonPid(isDaemon: boolean, pidFile: string): void {
+  if (!isDaemon) return;
+  try {
+    unlinkSync(pidFile);
+  } catch {
+    // Missing/already-cleaned PID files are harmless.
+  }
+}
+
+export interface ShutdownHandlerOptions {
+  isDaemon: boolean;
+  pidFile: string;
+  stop: () => Promise<void>;
+  exit: (code: number) => void;
+  log?: (message: string, error?: unknown) => void;
+}
+
+/** Return one shared shutdown promise so repeated signals cannot race cleanup. */
+export function createShutdownHandler(options: ShutdownHandlerOptions): (signal: string) => Promise<void> {
+  let inFlight: Promise<void> | null = null;
+  return (signal: string): Promise<void> => {
+    if (inFlight) return inFlight;
+    inFlight = (async () => {
+      options.log?.(`\nReceived ${signal}, shutting down...`);
+      let exitCode = 0;
+      try {
+        await options.stop();
+      } catch (error) {
+        exitCode = 1;
+        options.log?.('Failed to stop service cleanly:', error);
+      } finally {
+        cleanupDaemonPid(options.isDaemon, options.pidFile);
+        options.exit(exitCode);
+      }
+    })();
+    return inFlight;
+  };
+}

--- a/src/discord/discordCore.helpers.test.ts
+++ b/src/discord/discordCore.helpers.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { clampDiscordText, startTypingIndicator } from './discordCore.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('Discord outbound bounds', () => {
+  it('clamps embed descriptions to the exact Discord limit', () => {
+    const value = clampDiscordText('x'.repeat(5000), 4096);
+    expect(value).toHaveLength(4096);
+    expect(value.endsWith('…')).toBe(true);
+  });
+
+  it('observes initial and repeated typing failures without unhandled rejection', async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const sendTyping = vi.fn(async () => { throw new Error('no permission'); });
+    const timer = startTypingIndicator({ sendTyping }, 100);
+    await vi.runOnlyPendingTimersAsync();
+    clearInterval(timer);
+    expect(sendTyping.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/src/discord/discordCore.lifecycle.test.ts
+++ b/src/discord/discordCore.lifecycle.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const discord = vi.hoisted(() => ({
+  instances: [] as Array<{
+    once: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+    login: ReturnType<typeof vi.fn>;
+    destroy: ReturnType<typeof vi.fn>;
+    user: { tag: string };
+    channels: { fetch: ReturnType<typeof vi.fn> };
+  }>,
+  nextLoginError: null as Error | null,
+}));
+
+vi.mock('discord.js', async () => {
+  const actual = await vi.importActual<typeof import('discord.js')>('discord.js');
+  return {
+    ...actual,
+    Client: class {
+      once = vi.fn();
+      on = vi.fn();
+      login = vi.fn(async () => {
+        const error = discord.nextLoginError;
+        discord.nextLoginError = null;
+        if (error) throw error;
+        return 'token';
+      });
+      destroy = vi.fn(async () => {});
+      user = { tag: 'test-bot' };
+      channels = { fetch: vi.fn() };
+      constructor() {
+        discord.instances.push(this);
+      }
+    },
+  };
+});
+
+import { client, initDiscord, stopDiscord } from './discordCore.js';
+
+describe('Discord client lifecycle', () => {
+  afterEach(async () => {
+    await stopDiscord();
+    discord.instances.length = 0;
+    discord.nextLoginError = null;
+  });
+
+  it('destroys the old client before a successful replacement', async () => {
+    await initDiscord('first-token', 'channel');
+    const first = discord.instances[0];
+    await initDiscord('second-token', 'channel');
+    const second = discord.instances[1];
+
+    expect(first.destroy).toHaveBeenCalledTimes(1);
+    expect(second.login).toHaveBeenCalledWith('second-token');
+    expect(client).toBe(second);
+  });
+
+  it('destroys a replacement whose login fails and does not retain it', async () => {
+    discord.nextLoginError = new Error('login failed');
+    await expect(initDiscord('bad-token', 'channel')).rejects.toThrow('login failed');
+
+    expect(discord.instances[0].destroy).toHaveBeenCalledTimes(1);
+    expect(client).toBeNull();
+  });
+});

--- a/src/discord/discordCore.ts
+++ b/src/discord/discordCore.ts
@@ -273,7 +273,13 @@ export function setCallbacks(callbacks: {
 export async function initDiscord(token: string, channelId: string): Promise<void> {
   reportChannelId = channelId;
 
-  client = new Client({
+  // Reconfiguration/restart must not leave the old websocket client alive.
+  if (client) {
+    await client.destroy();
+    client = null;
+  }
+
+  const nextClient = new Client({
     intents: [
       GatewayIntentBits.Guilds,
       GatewayIntentBits.GuildMessages,
@@ -281,13 +287,19 @@ export async function initDiscord(token: string, channelId: string): Promise<voi
     ],
   });
 
-  client.once(Events.ClientReady, () => {
-    console.log(`Discord bot logged in as ${client?.user?.tag}`);
+  nextClient.once(Events.ClientReady, () => {
+    console.log(`Discord bot logged in as ${nextClient.user?.tag}`);
   });
 
-  client.on('messageCreate', handleMessage);
+  nextClient.on('messageCreate', handleMessage);
 
-  await client.login(token);
+  try {
+    await nextClient.login(token);
+    client = nextClient;
+  } catch (error) {
+    await nextClient.destroy().catch(() => {});
+    throw error;
+  }
 }
 
 // Handler function imports (used within functions to prevent lazy load issues)
@@ -492,7 +504,7 @@ export async function reportEvent(event: SwarmEvent): Promise<void> {
 
   const embed = new EmbedBuilder()
     .setTitle(`${emoji} [${event.session}] ${event.type.replace(/_/g, ' ')}`)
-    .setDescription(event.message)
+    .setDescription(clampDiscordText(event.message, 4096))
     .setColor(event.type.includes('failed') || event.type === 'error' ? 0xff0000 : 0x00ae86)
     .setTimestamp(event.timestamp);
 
@@ -522,6 +534,27 @@ export function formatTimeAgo(timestamp: number): string {
   if (hours > 0) return t('common.timeAgo.hoursAgo', { n: hours });
   if (minutes > 0) return t('common.timeAgo.minutesAgo', { n: minutes });
   return t('common.timeAgo.justNow');
+}
+
+export function clampDiscordText(value: string, limit: number): string {
+  if (value.length <= limit) return value;
+  if (limit <= 1) return '…'.slice(0, limit);
+  return `${value.slice(0, limit - 1)}…`;
+}
+
+export function startTypingIndicator(
+  channel: { sendTyping: () => Promise<unknown> },
+  intervalMs = 8_000,
+): NodeJS.Timeout {
+  const send = () => {
+    void channel.sendTyping().catch((error) => {
+      console.warn('[Discord] Typing indicator failed:', error instanceof Error ? error.message : String(error));
+    });
+  };
+  send();
+  const timer = setInterval(send, intervalMs);
+  timer.unref?.();
+  return timer;
 }
 
 /**
@@ -622,8 +655,7 @@ export async function handleChat(msg: Message): Promise<void> {
   // Show typing indicator (refresh every 8 seconds)
   let typingInterval: NodeJS.Timeout | null = null;
   if ('sendTyping' in channel) {
-    channel.sendTyping();
-    typingInterval = setInterval(() => channel.sendTyping(), 8000);
+    typingInterval = startTypingIndicator(channel);
   }
 
   // Add current message to history (response updated later)

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,12 +21,13 @@ if (envLoad.path !== null) {
 delete process.env['CLAUDECODE'];
 delete process.env['CLAUDE_CODE_ENTRYPOINT'];
 
-import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadConfig, validateConfig } from './core/config.js';
 import { startService, stopService } from './core/service.js';
 import { DAEMON_PATHS } from './cli/daemon.js';
+import { cleanupDaemonPid, createShutdownHandler } from './core/daemonLifecycle.js';
 
 // index.js lives at <pkg>/dist/index.js → package.json is one level up.
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -88,21 +89,13 @@ async function main(): Promise<void> {
 
   // Signal handlers
   const isDaemon = process.env.OPENSWARM_DAEMON === '1';
-  const shutdown = async (signal: string): Promise<void> => {
-    console.log(`\nReceived ${signal}, shutting down...`);
-    let exitCode = 0;
-    try {
-      await stopService();
-    } catch (err) {
-      exitCode = 1;
-      console.error('Failed to stop service cleanly:', err);
-    } finally {
-      if (isDaemon) {
-        try { unlinkSync(DAEMON_PATHS.PID_FILE); } catch { /* ignore */ }
-      }
-      process.exit(exitCode);
-    }
-  };
+  const shutdown = createShutdownHandler({
+    isDaemon,
+    pidFile: DAEMON_PATHS.PID_FILE,
+    stop: stopService,
+    exit: (code) => process.exit(code),
+    log: (message, error) => error === undefined ? console.log(message) : console.error(message, error),
+  });
 
   process.on('SIGINT', () => shutdown('SIGINT'));
   process.on('SIGTERM', () => shutdown('SIGTERM'));
@@ -114,11 +107,13 @@ async function main(): Promise<void> {
     console.log('OpenSwarm is running. Press Ctrl+C to stop.');
   } catch (err) {
     console.error('Failed to start service:', err);
+    cleanupDaemonPid(isDaemon, DAEMON_PATHS.PID_FILE);
     process.exit(1);
   }
 }
 
 main().catch((err) => {
   console.error('Fatal error:', err);
+  cleanupDaemonPid(process.env.OPENSWARM_DAEMON === '1', DAEMON_PATHS.PID_FILE);
   process.exit(1);
 });

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -1543,6 +1543,8 @@ export async function getStuckIssues(): Promise<{
       reason = 'Blocked by dependencies';
     } else if (labelNames.includes('needs-help')) {
       reason = 'Needs manual intervention';
+    } else if (labelNames.includes(STUCK_LABEL)) {
+      reason = 'Automatic retries exhausted';
     }
 
     failedIssues.push({

--- a/src/mcp/mcpClient.test.ts
+++ b/src/mcp/mcpClient.test.ts
@@ -196,6 +196,16 @@ describe('initMcpTools / callMcpTool regressions', () => {
     clientMock.callTool.mockResolvedValue({ content: [{ type: 'text', text: 'done' }] });
     await expect(callMcpTool('svc__ok', {})).resolves.toEqual({ content: 'done', isError: false });
   });
+
+  it('keeps the truncation marker inside the configured result cap', async () => {
+    clientMock.listTools.mockResolvedValue({ tools: [{ name: 'large', inputSchema: { type: 'object' } }] });
+    await initMcpTools(registry);
+    clientMock.callTool.mockResolvedValue({ content: [{ type: 'text', text: 'x'.repeat(25_000) }] });
+
+    const result = await callMcpTool('svc__large', {});
+    expect(result.content).toHaveLength(20_000);
+    expect(result.content).toContain('[truncated MCP tool result');
+  });
 });
 
 describe('withDeadline', () => {

--- a/src/mcp/mcpClient.test.ts
+++ b/src/mcp/mcpClient.test.ts
@@ -10,6 +10,7 @@ import {
   resolveMcpTools,
   initMcpTools,
   callMcpTool,
+  withDeadline,
 } from './mcpClient.js';
 import type { ToolDefinition } from '../adapters/tools.js';
 
@@ -170,7 +171,7 @@ describe('initMcpTools / callMcpTool regressions', () => {
     const defs = await initMcpTools(registry);
 
     expect(defs.map((d) => d.function.name)).toEqual(['svc__ok_tool']);
-    expect(await callMcpTool('svc__bad.tool', {})).toBe('MCP tool not registered: svc__bad.tool');
+    expect(await callMcpTool('svc__bad.tool', {})).toEqual({ content: 'MCP tool not registered: svc__bad.tool', isError: true });
   });
 
   it('propagates MCP callTool isError responses as tool failures', async () => {
@@ -183,8 +184,28 @@ describe('initMcpTools / callMcpTool regressions', () => {
       isError: true,
     });
 
-    await expect(callMcpTool('svc__fail_tool', {})).resolves.toBe(
-      'MCP error calling svc__fail_tool: permission denied',
-    );
+    await expect(callMcpTool('svc__fail_tool', {})).resolves.toEqual({
+      content: 'MCP error calling svc__fail_tool: permission denied',
+      isError: true,
+    });
+  });
+
+  it('returns a typed successful result', async () => {
+    clientMock.listTools.mockResolvedValue({ tools: [{ name: 'ok', inputSchema: { type: 'object' } }] });
+    await initMcpTools(registry);
+    clientMock.callTool.mockResolvedValue({ content: [{ type: 'text', text: 'done' }] });
+    await expect(callMcpTool('svc__ok', {})).resolves.toEqual({ content: 'done', isError: false });
+  });
+});
+
+describe('withDeadline', () => {
+  it('rejects a stalled MCP operation at its deadline', async () => {
+    vi.useFakeTimers();
+    const pending = new Promise<never>(() => {});
+    const result = withDeadline(pending, 25, 'MCP test');
+    const assertion = expect(result).rejects.toThrow('MCP test timed out after 25ms');
+    await vi.advanceTimersByTimeAsync(25);
+    await assertion;
+    vi.useRealTimers();
   });
 });

--- a/src/mcp/mcpClient.ts
+++ b/src/mcp/mcpClient.ts
@@ -394,5 +394,7 @@ function renderMcpToolContent(content: Array<{ type?: string; text?: string }>):
       break;
     }
   }
-  return truncated ? `${out}\n[truncated MCP tool result at ${MAX_MCP_TOOL_RESULT_CHARS} chars]` : out;
+  if (!truncated) return out;
+  const marker = `\n[truncated MCP tool result at ${MAX_MCP_TOOL_RESULT_CHARS} chars]`;
+  return `${out.slice(0, MAX_MCP_TOOL_RESULT_CHARS - marker.length)}${marker}`;
 }

--- a/src/mcp/mcpClient.ts
+++ b/src/mcp/mcpClient.ts
@@ -35,6 +35,8 @@ const MCP_STDIO_ENV_ALLOWLIST = new Set([
   'PATHEXT',
 ]);
 const MAX_MCP_TOOL_RESULT_CHARS = 20_000;
+const MCP_CONNECT_TIMEOUT_MS = 15_000;
+const MCP_OPERATION_TIMEOUT_MS = 30_000;
 const EMPTY_INPUT_SCHEMA: Record<string, unknown> = { type: 'object', properties: {} };
 
 interface ServerConfig {
@@ -219,11 +221,24 @@ function safeInheritedEnv(): Record<string, string> {
   return env;
 }
 
+export async function withDeadline<T>(operation: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([operation, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 async function withClient<T>(cfg: ServerConfig, fn: (c: Client) => Promise<T>): Promise<T> {
   const client = new Client({ name: 'openswarm', version: '0.7.0' }, { capabilities: {} });
   try {
-    await client.connect(makeTransport(cfg));
-    return await fn(client);
+    await withDeadline(client.connect(makeTransport(cfg)), MCP_CONNECT_TIMEOUT_MS, 'MCP connect');
+    return await withDeadline(fn(client), MCP_OPERATION_TIMEOUT_MS, 'MCP operation');
   } finally {
     await client.close().catch(() => {});
   }
@@ -339,19 +354,24 @@ export async function resolveMcpTools(
 }
 
 /** Execute a `server__tool` call against its MCP server. Returns text content. */
-export async function callMcpTool(qualified: string, args: Record<string, unknown>): Promise<string> {
+export interface McpCallResult {
+  content: string;
+  isError: boolean;
+}
+
+export async function callMcpTool(qualified: string, args: Record<string, unknown>): Promise<McpCallResult> {
   const entry = serverByTool[qualified];
-  if (!entry) return `MCP tool not registered: ${qualified}`;
+  if (!entry) return { content: `MCP tool not registered: ${qualified}`, isError: true };
   try {
     const result = (await withClient(entry.cfg, (c) =>
       c.callTool({ name: entry.toolName, arguments: args }),
     )) as { content?: Array<{ type?: string; text?: string }>; isError?: boolean };
     const content = Array.isArray(result.content) ? result.content : [];
     const text = renderMcpToolContent(content);
-    if (result.isError) return `MCP error calling ${qualified}: ${text || '(empty error result)'}`;
-    return text || '(empty result)';
+    if (result.isError) return { content: `MCP error calling ${qualified}: ${text || '(empty error result)'}`, isError: true };
+    return { content: text || '(empty result)', isError: false };
   } catch (err) {
-    return `MCP error calling ${qualified}: ${err instanceof Error ? err.message : String(err)}`;
+    return { content: `MCP error calling ${qualified}: ${err instanceof Error ? err.message : String(err)}`, isError: true };
   }
 }
 

--- a/src/runners/cliRunner.test.ts
+++ b/src/runners/cliRunner.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  stop: vi.fn(),
+  handlers: new Map<string, (payload: unknown) => void>(),
+}));
+
+vi.mock('../adapters/index.js', () => ({
+  getAdapter: () => ({ isAvailable: async () => true }),
+  getDefaultAdapterName: () => 'test',
+  listAvailableAdapters: async () => ['test'],
+}));
+
+vi.mock('../agents/pairPipeline.js', () => ({
+  PairPipeline: class {
+    on(event: string, handler: (payload: unknown) => void): void {
+      mocks.handlers.set(event, handler);
+    }
+    async run(): Promise<never> {
+      mocks.handlers.get('stage:start')?.({ stage: 'worker' });
+      throw new Error('pipeline boom');
+    }
+  },
+}));
+
+vi.mock('../cli/reviewProgress.js', () => ({
+  startProgressHeartbeat: () => ({ stop: mocks.stop }),
+}));
+
+import { runCli } from './cliRunner.js';
+
+describe('CLI runner failure cleanup', () => {
+  const originalIsTTY = process.stdout.isTTY;
+
+  afterEach(() => {
+    mocks.stop.mockReset();
+    mocks.handlers.clear();
+    vi.restoreAllMocks();
+    Object.defineProperty(process.stdout, 'isTTY', { value: originalIsTTY, configurable: true });
+  });
+
+  it('stops the live progress heartbeat before exiting on a pipeline error', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    await expect(runCli({ task: 'test', projectPath: process.cwd() })).rejects.toThrow('exit:1');
+    expect(mocks.stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/runners/cliRunner.ts
+++ b/src/runners/cliRunner.ts
@@ -217,6 +217,7 @@ export async function runCli(options: CliRunOptions): Promise<void> {
   try {
     result = await pipeline.run(task, projectPath);
   } catch (error) {
+    stopHeartbeat();
     console.error('\n  Pipeline execution failed:', error instanceof Error ? error.message : error);
     process.exit(1);
   }

--- a/src/support/chatBackend.execution.test.ts
+++ b/src/support/chatBackend.execution.test.ts
@@ -1,0 +1,86 @@
+import { dirname } from 'node:path';
+import { existsSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CliAdapter } from '../adapters/types.js';
+
+const getAdapter = vi.hoisted(() => vi.fn());
+
+vi.mock('../adapters/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../adapters/index.js')>();
+  return { ...actual, getAdapter };
+});
+
+import { runChatCompletion } from './chatBackend.js';
+
+function cliAdapter(buildCommand: CliAdapter['buildCommand']): CliAdapter {
+  return {
+    name: 'codex',
+    capabilities: {
+      supportsStreaming: true,
+      supportsJsonOutput: true,
+      supportsModelSelection: true,
+      managedGit: false,
+      supportedSkills: [],
+    },
+    isAvailable: async () => true,
+    getDefaultModel: async () => 'gpt-5-codex',
+    buildCommand,
+    parseWorkerOutput: () => ({ success: true, summary: '', filesChanged: [], commands: [], output: '' }),
+    parseReviewerOutput: () => ({ decision: 'approve', feedback: '', issues: [], suggestions: [] }),
+  };
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe('runChatCompletion CLI fallback', () => {
+  it('stores prompts in an unpredictable owner-only temp path and removes it', async () => {
+    let promptPath = '';
+    getAdapter.mockReturnValue(cliAdapter((options) => {
+      promptPath = options.prompt;
+      const script = [
+        "const fs = require('node:fs')",
+        'const p = process.argv[1]',
+        'const payload = JSON.stringify({ path: p, mode: fs.statSync(p).mode & 0o777, content: fs.readFileSync(p, \'utf8\') })',
+        "console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: payload } }))",
+      ].join(';');
+      return { command: process.execPath, args: ['-e', script, options.prompt] };
+    }));
+
+    const result = await runChatCompletion({
+      prompt: 'sensitive prompt',
+      provider: 'codex',
+      timeoutMs: 5000,
+    });
+    const payload = JSON.parse(result.response) as { path: string; mode: number; content: string };
+
+    expect(payload.path).toBe(promptPath);
+    expect(payload.mode).toBe(0o600);
+    expect(payload.content).toBe('sensitive prompt');
+    expect(promptPath).toMatch(/openswarm-chat-[^/]+\/prompt\.txt$/);
+    expect(existsSync(promptPath)).toBe(false);
+    expect(existsSync(dirname(promptPath))).toBe(false);
+  });
+
+  it('terminates the spawned CLI process when the caller aborts', async () => {
+    let promptPath = '';
+    getAdapter.mockReturnValue(cliAdapter((options) => {
+      promptPath = options.prompt;
+      return { command: process.execPath, args: ['-e', 'setInterval(() => {}, 1000)'] };
+    }));
+    const controller = new AbortController();
+    const startedAt = Date.now();
+    const pending = runChatCompletion({
+      prompt: 'cancel me',
+      provider: 'codex',
+      timeoutMs: 5000,
+      signal: controller.signal,
+    });
+
+    setTimeout(() => controller.abort(), 50);
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(Date.now() - startedAt).toBeLessThan(2000);
+    expect(existsSync(promptPath)).toBe(false);
+    expect(existsSync(dirname(promptPath))).toBe(false);
+  });
+});

--- a/src/support/chatBackend.test.ts
+++ b/src/support/chatBackend.test.ts
@@ -3,7 +3,13 @@ import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { curatedModels, getDefaultChatModel, buildRepoContext } from './chatBackend.js';
+import {
+  CHAT_MODEL_ALIASES,
+  buildRepoContext,
+  curatedModels,
+  getDefaultChatModel,
+  inferProviderFromModel,
+} from './chatBackend.js';
 
 describe('curatedModels (INT-1961)', () => {
   it('includes the provider default first and dedupes', () => {
@@ -17,6 +23,21 @@ describe('curatedModels (INT-1961)', () => {
     for (const p of ['codex', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter', 'atlascloud'] as const) {
       const m = curatedModels(p);
       expect(m).toContain(getDefaultChatModel(p));
+    }
+  });
+
+  it('maps Codex Responses aliases to the GPT-5.6 capability tiers', () => {
+    expect(getDefaultChatModel('codex-responses')).toBe('gpt-5.6-terra');
+    expect(CHAT_MODEL_ALIASES['codex-responses']).toEqual(expect.objectContaining({
+      big: 'gpt-5.6-sol',
+      medium: 'gpt-5.6-terra',
+      small: 'gpt-5.6-luna',
+    }));
+  });
+
+  it('infers codex-responses for bare GPT-5.6 tier slugs', () => {
+    for (const tier of ['sol', 'terra', 'luna']) {
+      expect(inferProviderFromModel(`gpt-5.6-${tier}`)).toBe('codex-responses');
     }
   });
 });

--- a/src/support/chatBackend.ts
+++ b/src/support/chatBackend.ts
@@ -1,6 +1,7 @@
 import { spawn, execFileSync } from 'node:child_process';
-import { writeFile, unlink } from 'node:fs/promises';
+import { mkdtemp, rmdir, unlink, writeFile } from 'node:fs/promises';
 import { existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 import type { AdapterName } from '../adapters/index.js';
 import { getAdapter, getDefaultAdapterName } from '../adapters/index.js';
@@ -38,9 +39,9 @@ export const CHAT_MODEL_ALIASES: Record<AdapterName, Record<string, string>> = {
   },
   'codex-responses': {
     // Codex backend tiers (see `openswarm auth models` for the live list).
-    big: 'gpt-5.5',
-    medium: 'gpt-5.4',
-    small: 'gpt-5.4-mini',
+    big: 'gpt-5.6-sol',
+    medium: 'gpt-5.6-terra',
+    small: 'gpt-5.6-luna',
     codex: 'gpt-5.3-codex',
   },
   gpt: {
@@ -95,6 +96,10 @@ export const CHAT_MODEL_ALIASES: Record<AdapterName, Record<string, string>> = {
 
 export function inferProviderFromModel(model?: string): AdapterName {
   if (!model) return getDefaultAdapterName();
+  // The GPT-5.6 capability-tier slugs are served by the ChatGPT Codex backend
+  // in this app. Keep an explicit --provider gpt escape hatch for public-API
+  // callers, but do not silently route a bare tier slug to /v1/chat/completions.
+  if (/^gpt-5\.6-(?:sol|terra|luna)$/i.test(model)) return 'codex-responses';
   if (model.includes('codex')) return 'codex';
   if (model.startsWith('gpt-') || model.startsWith('o3') || model.startsWith('o4')) return 'gpt';
   if (model.includes('/')) return 'openrouter';
@@ -105,7 +110,7 @@ export function inferProviderFromModel(model?: string): AdapterName {
 
 export function getDefaultChatModel(provider: AdapterName): string {
   if (provider === 'codex') return 'gpt-5-codex';
-  if (provider === 'codex-responses') return 'gpt-5.5';
+  if (provider === 'codex-responses') return 'gpt-5.6-terra';
   if (provider === 'gpt') return 'gpt-4o';
   if (provider === 'local') return 'gemma3:4b';
   if (provider === 'lmstudio') return process.env.LMSTUDIO_MODEL ?? 'local-model';
@@ -149,6 +154,13 @@ export function shortenChatModel(model: string): string {
   // OpenRouter: "anthropic/claude-sonnet-4" → "claude-sonnet-4"
   if (model.includes('/')) return model.split('/').pop() ?? model;
   return model;
+}
+
+function chatAbortError(signal?: AbortSignal): Error {
+  if (signal?.reason instanceof Error) return signal.reason;
+  const error = new Error('Chat response cancelled');
+  error.name = 'AbortError';
+  return error;
 }
 
 /**
@@ -275,6 +287,8 @@ async function runChatViaAdapter(
 }
 
 export async function runChatCompletion(options: ChatCompletionOptions): Promise<ChatCompletionResult> {
+  if (options.signal?.aborted) throw chatAbortError(options.signal);
+
   const provider = options.provider ?? inferProviderFromModel(options.model);
   const model = resolveChatModel(options.model, provider);
   const adapter = getAdapter(provider);
@@ -284,10 +298,14 @@ export async function runChatCompletion(options: ChatCompletionOptions): Promise
     return runChatViaAdapter(adapter, provider, model, cwd, options);
   }
 
-  const promptFile = `/tmp/openswarm-chat-${Date.now()}.txt`;
-  await writeFile(promptFile, options.prompt);
+  // CLI adapters consume a prompt path. Use a private, unpredictable directory
+  // and owner-only file instead of exposing prompt contents in a predictable
+  // world-readable /tmp filename.
+  const promptDir = await mkdtemp(join(tmpdir(), 'openswarm-chat-'));
+  const promptFile = join(promptDir, 'prompt.txt');
 
   try {
+    await writeFile(promptFile, options.prompt, { mode: 0o600 });
     const { command, args } = adapter.buildCommand({
       prompt: promptFile,
       cwd,
@@ -309,6 +327,35 @@ export async function runChatCompletion(options: ChatCompletionOptions): Promise
       let startedStreaming = false;
       let thinkingTimer: NodeJS.Timeout | null = null;
       let timeout: NodeJS.Timeout | null = null;
+      let abortKillTimer: NodeJS.Timeout | null = null;
+      let settled = false;
+
+      const cleanupProcessHooks = () => {
+        if (timeout) clearTimeout(timeout);
+        if (thinkingTimer) clearTimeout(thinkingTimer);
+        if (abortKillTimer) clearTimeout(abortKillTimer);
+        options.signal?.removeEventListener('abort', onAbort);
+      };
+
+      const settle = (action: () => void) => {
+        if (settled) return;
+        settled = true;
+        cleanupProcessHooks();
+        action();
+      };
+
+      const onAbort = () => {
+        proc.kill('SIGTERM');
+        // A child can trap/ignore SIGTERM. Do not let cancellation leave an
+        // orphaned model process behind indefinitely.
+        abortKillTimer = setTimeout(() => {
+          if (proc.exitCode === null) proc.kill('SIGKILL');
+        }, 1000);
+        abortKillTimer.unref();
+      };
+
+      if (options.signal?.aborted) onAbort();
+      else options.signal?.addEventListener('abort', onAbort, { once: true });
 
       const resetThinkingTimer = () => {
         if (!options.onText) return;
@@ -354,17 +401,20 @@ export async function runChatCompletion(options: ChatCompletionOptions): Promise
       if ((options.timeoutMs ?? 180000) > 0) {
         timeout = setTimeout(() => {
           proc.kill('SIGKILL');
-          reject(new Error('Chat response timeout'));
+          settle(() => reject(new Error('Chat response timeout')));
         }, options.timeoutMs ?? 180000);
       }
 
       proc.on('close', (code) => {
-        if (timeout) clearTimeout(timeout);
-        if (thinkingTimer) clearTimeout(thinkingTimer);
         flushLines(true);
 
+        if (options.signal?.aborted) {
+          settle(() => reject(chatAbortError(options.signal)));
+          return;
+        }
+
         if (code !== 0 && !stdout.trim()) {
-          reject(new Error(stderr.trim() || `${provider} exited with code ${code}`));
+          settle(() => reject(new Error(stderr.trim() || `${provider} exited with code ${code}`)));
           return;
         }
 
@@ -372,25 +422,28 @@ export async function runChatCompletion(options: ChatCompletionOptions): Promise
         const cost = undefined;
         const tokens = undefined;
 
-        resolve({
+        settle(() => resolve({
           response: response || '[No response]',
           provider,
           model,
           sessionId: capturedSessionId || undefined,
           cost,
           tokens,
-        });
+        }));
       });
 
       proc.on('error', (error) => {
-        if (timeout) clearTimeout(timeout);
-        if (thinkingTimer) clearTimeout(thinkingTimer);
-        reject(error);
+        settle(() => reject(options.signal?.aborted ? chatAbortError(options.signal) : error));
       });
     });
   } finally {
     try {
       await unlink(promptFile);
+    } catch {
+      // Ignore temp cleanup errors.
+    }
+    try {
+      await rmdir(promptDir);
     } catch {
       // Ignore temp cleanup errors.
     }

--- a/src/support/web.lifecycle.test.ts
+++ b/src/support/web.lifecycle.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AutonomousRunner } from '../automation/autonomousRunner.js';
+
+const lifecycle = vi.hoisted(() => ({
+  watchFile: vi.fn(),
+  unwatchFile: vi.fn(),
+  startHealthChecker: vi.fn(),
+  stopHealthChecker: vi.fn(),
+  pollers: [] as NodeJS.Timeout[],
+}));
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return { ...actual, watchFile: lifecycle.watchFile, unwatchFile: lifecycle.unwatchFile };
+});
+
+vi.mock('../adapters/processRegistry.js', async () => {
+  const actual = await vi.importActual<typeof import('../adapters/processRegistry.js')>('../adapters/processRegistry.js');
+  return {
+    ...actual,
+    startHealthChecker: lifecycle.startHealthChecker,
+    stopHealthChecker: lifecycle.stopHealthChecker,
+  };
+});
+
+vi.mock('./gitStatus.js', async () => {
+  const actual = await vi.importActual<typeof import('./gitStatus.js')>('./gitStatus.js');
+  return {
+    ...actual,
+    startGitStatusPoller: vi.fn(() => {
+      const timer = setInterval(() => {}, 60_000);
+      timer.unref();
+      lifecycle.pollers.push(timer);
+      return timer;
+    }),
+  };
+});
+
+import { setWebRunner, startWebServer, stopWebServer } from './web.js';
+
+describe('web lifecycle ownership', () => {
+  afterEach(async () => {
+    await stopWebServer();
+    for (const timer of lifecycle.pollers) clearInterval(timer);
+    lifecycle.pollers.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('releases and recreates watcher, health timer, poller, and server across start-stop-start', async () => {
+    const runner = {
+      enableProject: vi.fn(),
+      disableProject: vi.fn(),
+      getEnabledProjects: vi.fn(() => []),
+      getAllowedProjects: vi.fn(() => []),
+      updateAllowedProjects: vi.fn(),
+      registerProjectPath: vi.fn(),
+    } as unknown as AutonomousRunner;
+    setWebRunner(runner);
+
+    await startWebServer(0);
+    await stopWebServer();
+    await startWebServer(0);
+    await stopWebServer();
+
+    expect(lifecycle.watchFile).toHaveBeenCalledTimes(2);
+    expect(lifecycle.unwatchFile).toHaveBeenCalledTimes(2);
+    expect(lifecycle.startHealthChecker).toHaveBeenCalledTimes(2);
+    expect(lifecycle.stopHealthChecker).toHaveBeenCalledTimes(2);
+    expect(lifecycle.pollers).toHaveLength(2);
+  });
+});

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -3,7 +3,7 @@
 // ============================================
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
-import { writeFileSync, readFileSync, existsSync, watchFile } from 'node:fs';
+import { writeFileSync, readFileSync, existsSync, watchFile, unwatchFile, type Stats } from 'node:fs';
 import { readdir, stat } from 'node:fs/promises';
 import { join, resolve as resolvePath, dirname, basename } from 'node:path';
 import { homedir } from 'node:os';
@@ -19,7 +19,7 @@ import { getGraph, toProjectSlug, getProjectHealth, scanAndCache, listGraphs } f
 import { getProjectGitInfo, startGitStatusPoller } from './gitStatus.js';
 import { getActiveMonitors, registerMonitor, unregisterMonitor } from '../automation/longRunningMonitor.js';
 import type { LongRunningMonitorConfig } from '../core/types.js';
-import { getAllProcesses, killProcess, startHealthChecker } from '../adapters/processRegistry.js';
+import { getAllProcesses, killProcess, startHealthChecker, stopHealthChecker } from '../adapters/processRegistry.js';
 import { setDefaultAdapter, isKnownAdapter, listAdapterNames } from '../adapters/index.js';
 import * as memory from '../memory/index.js';
 import { PairPipeline, type PipelineResult } from '../agents/pairPipeline.js';
@@ -373,6 +373,7 @@ export function applyReposConfig(runner: AutonomousRunner, cfg: ReposConfig = lo
 }
 
 let reposWatcherStarted = false;
+let reposWatcherListener: ((curr: Stats, prev: Stats) => void) | null = null;
 /**
  * Poll the repo registry file and reload when it changes, so external writers
  * (CLI `openswarm add`/`remove`, hand edits) show up in the dashboard within a
@@ -383,7 +384,7 @@ let reposWatcherStarted = false;
 function startReposWatcher(): void {
   if (reposWatcherStarted) return;
   reposWatcherStarted = true;
-  watchFile(REPOS_FILE, { interval: 3000 }, (curr, prev) => {
+  reposWatcherListener = (curr, prev) => {
     if (curr.mtimeMs === prev.mtimeMs) return;
     const runner = runnerRef;
     if (!runner) return;
@@ -393,7 +394,16 @@ function startReposWatcher(): void {
     } catch (e) {
       console.warn('[Web] repos reload failed:', e instanceof Error ? e.message : e);
     }
-  });
+  };
+  watchFile(REPOS_FILE, { interval: 3000 }, reposWatcherListener);
+}
+
+export function stopReposWatcher(): void {
+  if (reposWatcherListener) {
+    unwatchFile(REPOS_FILE, reposWatcherListener);
+    reposWatcherListener = null;
+  }
+  reposWatcherStarted = false;
 }
 
 /**
@@ -443,6 +453,8 @@ export async function startWebServer(port: number = 3847): Promise<void> {
     console.log('Web interface already running, skipping...');
     return;
   }
+
+  if (runnerRef) startReposWatcher();
 
   return new Promise((resolve, reject) => {
     server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
@@ -1423,9 +1435,17 @@ export async function stopWebServer(): Promise<void> {
     clearInterval(gitStatusPoller);
     gitStatusPoller = null;
   }
+  stopHealthChecker();
+  stopReposWatcher();
 
   if (server) {
-    server.close();
+    const current = server;
     server = null;
+    await new Promise<void>((resolve, reject) => {
+      current.close((error) => {
+        if (!error || (error as NodeJS.ErrnoException).code === 'ERR_SERVER_NOT_RUNNING') resolve();
+        else reject(error);
+      });
+    });
   }
 }

--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -95,11 +95,12 @@ describe('resolveSharedPaths (INT-2415)', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('auto-detects node_modules/.venv/venv that exist at the repo root', () => {
+  it('auto-detects node_modules and verification virtualenvs that exist at the repo root', () => {
     mkdirSync(join(repo, 'node_modules'), { recursive: true });
+    mkdirSync(join(repo, '.venv-verify'), { recursive: true });
     mkdirSync(join(repo, '.venv'), { recursive: true });
     // venv is absent → excluded; only existing candidates are returned.
-    expect(resolveSharedPaths(repo, null).sort()).toEqual(['.venv', 'node_modules']);
+    expect(resolveSharedPaths(repo, null).sort()).toEqual(['.venv', '.venv-verify', 'node_modules']);
   });
 
   it('returns [] when no auto-detect candidates exist', () => {

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -138,7 +138,7 @@ function assertManagedWorktreePath(repoPath: string, worktreePath: string): stri
 // deps/DBs are read-mostly, so parallel workers sharing them is safe.
 
 /** Always-gitignored dependency dirs safe to auto-link without a config. */
-const AUTO_SHARED_CANDIDATES = ['node_modules', '.venv', 'venv'];
+const AUTO_SHARED_CANDIDATES = ['node_modules', '.venv-verify', '.venv', 'venv'];
 
 interface SandboxConfig {
   sandbox?: { sharedPaths?: string[] } | null;

--- a/src/telemetry/telemetry.test.ts
+++ b/src/telemetry/telemetry.test.ts
@@ -91,6 +91,13 @@ describe('track() transport', () => {
     await expect(track({ command: 'run' })).resolves.toBeUndefined();
   });
 
+  it('cancels the unused response body', async () => {
+    const cancel = vi.fn(async () => {});
+    vi.stubGlobal('fetch', vi.fn(async () => ({ body: { cancel } } as unknown as Response)));
+    await track({ command: 'run' });
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
   it('unrefs the timeout so fire-and-forget telemetry does not keep the process alive', async () => {
     const realSetTimeout = globalThis.setTimeout;
     const unref = vi.fn();

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -169,12 +169,13 @@ export async function track(opts: TrackOptions): Promise<void> {
       timer.unref();
     }
     try {
-      await fetch(endpoint, {
+      const response = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'User-Agent': `OpenSwarm/${version}` },
         body: JSON.stringify(payload),
         signal: controller.signal,
       });
+      await response.body?.cancel().catch(() => {});
     } finally {
       clearTimeout(timer);
     }

--- a/src/verify/discover.test.ts
+++ b/src/verify/discover.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -10,7 +10,10 @@ const roots: string[] = [];
 async function fixture(files: Record<string, string>): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'openswarm-verify-discover-'));
   roots.push(root);
-  await Promise.all(Object.entries(files).map(([name, content]) => writeFile(join(root, name), content, 'utf8')));
+  await Promise.all(Object.entries(files).map(async ([name, content]) => {
+    await mkdir(dirname(join(root, name)), { recursive: true });
+    await writeFile(join(root, name), content, 'utf8');
+  }));
   return root;
 }
 
@@ -45,6 +48,16 @@ describe('discoverVerifyCommands', () => {
     const root = await fixture({ [name]: content });
     expect(await discoverVerifyCommands(root)).toEqual([
       { name: 'pytest', run: 'python -m pytest -x -q', kind: 'test', timeoutMs: 300_000 },
+    ]);
+  });
+
+  it('prefers the repository verification virtualenv for pytest', async () => {
+    const root = await fixture({
+      'pytest.ini': '[pytest]\n',
+      '.venv-verify/bin/python': '#!/bin/sh\n',
+    });
+    expect(await discoverVerifyCommands(root)).toEqual([
+      { name: 'pytest', run: './.venv-verify/bin/python -m pytest -x -q', kind: 'test', timeoutMs: 300_000 },
     ]);
   });
 

--- a/src/verify/discover.ts
+++ b/src/verify/discover.ts
@@ -12,6 +12,16 @@ async function readText(path: string): Promise<string | null> {
   return readFile(path, 'utf8').catch(() => null);
 }
 
+async function pythonCommand(projectPath: string): Promise<string> {
+  const candidates = process.platform === 'win32'
+    ? ['.venv-verify/Scripts/python.exe', '.venv/Scripts/python.exe', 'venv/Scripts/python.exe']
+    : ['.venv-verify/bin/python', '.venv/bin/python', 'venv/bin/python'];
+  for (const candidate of candidates) {
+    if (await exists(join(projectPath, candidate))) return `./${candidate}`;
+  }
+  return 'python';
+}
+
 function command(name: string, run: string, kind: VerifyCommand['kind']): VerifyCommand {
   return { name, run, kind, timeoutMs: DEFAULT_TIMEOUT_MS };
 }
@@ -50,7 +60,7 @@ export async function discoverVerifyCommands(projectPath: string): Promise<Verif
   const pyproject = await readText(join(projectPath, 'pyproject.toml'));
   const setupCfg = await readText(join(projectPath, 'setup.cfg'));
   if (pytestIni || pyproject?.includes('[tool.pytest.ini_options]') || setupCfg?.includes('[tool:pytest]')) {
-    commands.push(command('pytest', 'python -m pytest -x -q', 'test'));
+    commands.push(command('pytest', `${await pythonCommand(projectPath)} -m pytest -x -q`, 'test'));
   }
 
   // Rust repositories use Cargo's native test runner.

--- a/src/verify/runner.test.ts
+++ b/src/verify/runner.test.ts
@@ -273,6 +273,15 @@ describe('runVerify', () => {
     expect(evidence).toMatchObject({ headStatus: 'fail', baseStatus: 'fail', newFailure: false });
   });
 
+  it('normalizes isolated worktree paths when comparing the same failure', async () => {
+    const [evidence] = await runVerify({
+      projectPath: repo,
+      commands: [verify('printf "%s\\npre-existing failure\\n" "$PWD"; exit 1')],
+      baseRef: 'HEAD',
+    });
+    expect(evidence).toMatchObject({ headStatus: 'fail', baseStatus: 'fail', newFailure: false });
+  });
+
   it('marks an additional head failure as new when base already fails', async () => {
     await writeFile(join(repo, 'existing-failure'), 'yes\n', 'utf8');
     git('add', 'existing-failure');
@@ -317,6 +326,20 @@ describe('runVerify', () => {
     });
 
     expect(evidence).toMatchObject({ headStatus: 'fail', baseStatus: 'fail', newFailure: true });
+  });
+
+  it('waives the same pre-existing missing environment dependency after a manifest change', async () => {
+    await writeFile(join(repo, 'pyproject.toml'), '[project]\nname = "fixture"\n', 'utf8');
+    git('add', 'pyproject.toml');
+    git('commit', '-m', 'base python manifest');
+    await writeFile(join(repo, 'pyproject.toml'), '[project]\nname = "fixture"\nversion = "1"\n', 'utf8');
+
+    const [evidence] = await runVerify({
+      projectPath: repo,
+      commands: [verify("printf '%s\\nModuleNotFoundError: No module named '\"'\"'slack_bolt'\"'\"'\\n' \"$PWD\"; exit 1")],
+      baseRef: 'HEAD',
+    });
+    expect(evidence).toMatchObject({ headStatus: 'fail', baseStatus: 'fail', newFailure: false });
   });
 
   it.each(['Cargo.toml', 'go.mod'])('invalidates baseline failures when %s changes', async (name) => {

--- a/src/verify/runner.ts
+++ b/src/verify/runner.ts
@@ -36,6 +36,7 @@ interface CommandResult {
   status: 'pass' | 'fail' | 'infra';
   output: string;
   outputFingerprint?: string;
+  environmentFailure?: boolean;
   baselineEnvironmentChanged?: boolean;
 }
 
@@ -68,6 +69,27 @@ function hasSameFailure(base: CommandResult, head: CommandResult): boolean {
   return base.outputFingerprint !== undefined && base.outputFingerprint === head.outputFingerprint;
 }
 
+function normalizeFailureOutput(output: string, projectRoot: string): string {
+  const escapedRoot = projectRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return output
+    .replace(new RegExp(escapedRoot, 'g'), '<PROJECT>')
+    .replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'), '')
+    .replace(/(=+ .*? in )\d+(?:\.\d+)?s( =+)/g, '$1<DURATION>$2')
+    .replace(/(Ran \d+ tests? in )\d+(?:\.\d+)?s/g, '$1<DURATION>')
+    .replace(/(finished in )\d+(?:\.\d+)?s/gi, '$1<DURATION>');
+}
+
+function isEnvironmentFailure(output: string): boolean {
+  return [
+    /ModuleNotFoundError:\s*No module named\b/i,
+    /ImportError:\s*No module named\b/i,
+    /Cannot find module ['"]/i,
+    /could not find [`']?Cargo\.toml/i,
+    /failed to (?:load|read) manifest for workspace member/i,
+    /Cargo\.toml.*(?:No such file or directory|os error 2)/i,
+  ].some((pattern) => pattern.test(output));
+}
+
 function appendTail(current: Buffer, chunk: Buffer): Buffer {
   const combined = Buffer.concat([current, chunk]);
   return combined.length <= OUTPUT_TAIL_BYTES ? combined : combined.subarray(combined.length - OUTPUT_TAIL_BYTES);
@@ -98,15 +120,28 @@ async function runCommand(command: VerifyCommand, root: string, env: NodeJS.Proc
       detached,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-    child.stdout.on('data', (chunk: Buffer) => { outputHash.update(chunk); output = appendTail(output, chunk); });
-    child.stderr.on('data', (chunk: Buffer) => { outputHash.update(chunk); output = appendTail(output, chunk); });
+    const record = (chunk: Buffer) => {
+      outputHash.update(normalizeFailureOutput(chunk.toString('utf8'), cwd));
+      output = appendTail(output, chunk);
+    };
+    child.stdout.on('data', record);
+    child.stderr.on('data', record);
 
     const finish = (status: CommandResult['status'], extra = '') => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      if (extra) { outputHash.update(extra); output = appendTail(output, Buffer.from(extra)); }
-      resolveResult({ status, output: output.toString('utf8'), outputFingerprint: outputHash.digest('hex') });
+      if (extra) {
+        outputHash.update(normalizeFailureOutput(extra, cwd));
+        output = appendTail(output, Buffer.from(extra));
+      }
+      const outputText = output.toString('utf8');
+      resolveResult({
+        status,
+        output: outputText,
+        outputFingerprint: outputHash.digest('hex'),
+        environmentFailure: status === 'fail' && isEnvironmentFailure(outputText),
+      });
     };
     const timer = setTimeout(() => {
       timedOut = true;
@@ -327,12 +362,14 @@ export async function runVerify(options: RunVerifyOptions): Promise<VerifyEviden
     const rawOutputTail = Buffer.from(`[base]\n${base.output}\n[head]\n${head.output}`, 'utf8')
       .subarray(-OUTPUT_TAIL_BYTES)
       .toString('utf8');
+    const sameFailure = base.status === 'fail' && hasSameFailure(base, head);
+    const sameEnvironmentFailure = !!(sameFailure && base.environmentFailure && head.environmentFailure);
     evidence.push({
       command,
       baseStatus: base.status,
       headStatus: 'fail',
       newFailure: base.status === 'pass'
-        || (base.status === 'fail' && (base.baselineEnvironmentChanged || !hasSameFailure(base, head))),
+        || (base.status === 'fail' && (!sameFailure || (!!base.baselineEnvironmentChanged && !sameEnvironmentFailure))),
       rawOutputTail,
       durationMs: Date.now() - started,
     });


### PR DESCRIPTION
## What changed

- replaced shell-built adapter commands with argv-safe process spawning and temporary-resource cleanup
- made CLI numeric parsing, daemon startup/shutdown, patch parsing, Ruff invocation, auth secret input, deterministic checks, log tailing, and failure cleanup fail safely
- hardened local/GPT model refresh behavior, PKCE settlement, webhook/MCP/telemetry deadlines, Discord and web lifecycle ownership
- serialized AgentBus, pair-metrics, scheduler, and CI-worker state transitions with atomic persistence and deterministic concurrency regressions

## Why

The 2026-07-21 OpenSwarm audit grouped these runtime-safety findings into Sprint 1. The common root causes were shell interpretation, permissive parsing, unbounded network/lifecycle operations, and read-modify-write races.

## Impact

Malformed input now fails before startup, secrets do not enter process argv, repeated lifecycle calls are idempotent, and concurrent workers cannot silently lose the covered state updates.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test -- --reporter=dot` — 225 files, 3036 passed, 1 skipped
- focused race/lifecycle suite — 77 passed, then AgentBus async-poll suite 52 passed
- runtime CLI checks reject `--timeout 10abc` and port `65536`; auth help exposes no API-key argv option
- `openswarm review --max --no-linear` completed across 32 areas: 0 rejected, 98 repository-wide follow-ups retained for planned S2/S3
- focused committed-diff review found no structured issue payload, but returned REVISE because historical defects remain in touched modules; those out-of-scope findings remain tracked for later milestones

## Linear

Closes INT-2938
Closes INT-2939
Closes INT-2940
Closes INT-2941
Closes INT-2944
Closes INT-2945
Closes INT-2946
Closes INT-2947
Closes INT-2948
Closes INT-2953
Closes INT-2954
Closes INT-2955
Closes INT-2956

Stacked on #311 so the PR contains only Sprint 1 hardening changes.