### PR TITLE
fix(automation): align conflict-aware same-repo admission across scheduler and durable claims

### DIFF
--- a/src/automation/autonomousRunner.coverage.test.ts
+++ b/src/automation/autonomousRunner.coverage.test.ts
@@ -26,10 +26,19 @@ import type { DecisionResult, TaskItem } from '../orchestration/decisionEngine.j
 import type { AutonomousConfig } from './runnerTypes.js';
 import type { ITaskSource } from './taskSource.js';
 
-const detectFileConflictsMock = vi.hoisted(() => vi.fn());
+const { detectFileConflictsMock, resolveTaskFileScopeMock, fileScopesConflictMock } = vi.hoisted(() => ({
+  detectFileConflictsMock: vi.fn(),
+  resolveTaskFileScopeMock: vi.fn(async (task: TaskItem) => {
+    task.fileScope ??= [`scope/${task.id}`];
+    return task.fileScope;
+  }),
+  fileScopesConflictMock: vi.fn(() => false),
+}));
 
 vi.mock('../orchestration/conflictDetector.js', () => ({
   detectFileConflicts: detectFileConflictsMock,
+  resolveTaskFileScope: resolveTaskFileScopeMock,
+  fileScopesConflict: fileScopesConflictMock,
 }));
 
 // writeProviderOverride writes unconditionally to ~/.config/openswarm/ (no dryRun
@@ -239,6 +248,31 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
       expect(detectFileConflictsMock).toHaveBeenCalledWith([first, second], '/repo');
     });
 
+    it('defers a candidate whose scope overlaps an already-running worktree', async () => {
+      const r = new AutonomousRunner(cfg({
+        allowSameProjectConcurrent: true, worktreeMode: true, maxConcurrentTasks: 3,
+      }));
+      const internal = r as unknown as Internal;
+      const candidate = task({ id: 'candidate', fileScope: ['src/shared.ts'] });
+      const activeTask = task({ id: 'active', fileScope: ['src/shared.ts'] });
+      fileScopesConflictMock.mockReturnValueOnce(true);
+      internal.scheduler.getRunningTasks = () => [{
+        runId: 'active-run',
+        task: activeTask,
+        projectPath: '/repo',
+        startedAt: Date.now(),
+        promise: Promise.resolve(pipelineResult('approved', { success: true })),
+        executorSettled: Promise.resolve(),
+        abortController: new AbortController(),
+      }];
+
+      const safe = await internal.detectSafeCandidateIds([{ task: candidate, projectPath: '/repo' }]);
+
+      expect(safe).toEqual(new Set());
+      expect(fileScopesConflictMock).toHaveBeenCalledWith(candidate.fileScope, activeTask.fileScope);
+      expect(detectFileConflictsMock).not.toHaveBeenCalled();
+    });
+
     it('serializes a repository when conflict analysis cannot prove tasks disjoint', () => {
       const candidates = [
         { task: task({ id: 'first' }), projectPath: '/repo' },
@@ -255,10 +289,12 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
       expect(internal.sameProjectCandidateCap()).toBeNull();
     });
 
-    it('sameProjectCandidateCap is null when maxConcurrentPerProject is unset', () => {
-      const r = new AutonomousRunner(cfg({ allowSameProjectConcurrent: true, worktreeMode: true }));
+    it('sameProjectCandidateCap uses the shared safe default when the setting is omitted', () => {
+      const r = new AutonomousRunner(cfg({
+        allowSameProjectConcurrent: true, worktreeMode: true, maxConcurrentTasks: 4,
+      }));
       const internal = r as unknown as Internal;
-      expect(internal.sameProjectCandidateCap()).toBeNull();
+      expect(internal.sameProjectCandidateCap()).toBe(2);
     });
 
     it('sameProjectCandidateCap clamps between 1 and maxConcurrentTasks', () => {

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -61,7 +61,11 @@ import { loadRepoMetadata } from '../support/repoMetadata.js';
 import { STUCK_LABEL } from '../linear/index.js';
 import { refreshGraph, toProjectSlug } from '../knowledge/index.js';
 import { checkAllMonitors, getActiveMonitors } from './longRunningMonitor.js';
-import { detectFileConflicts } from '../orchestration/conflictDetector.js';
+import {
+  detectFileConflicts,
+  fileScopesConflict,
+  resolveTaskFileScope,
+} from '../orchestration/conflictDetector.js';
 import { resolveAdapterDefaultModel } from '../agents/stageModelResolver.js';
 import type { AutonomousConfig, RunnerState } from './runnerTypes.js';
 import type { AdapterName } from '../adapters/types.js';
@@ -88,6 +92,17 @@ export type { ProjectInfo } from './runnerState.js';
 
 let runnerInstance: AutonomousRunner | null = null;
 const DECISION_SELECTION_OVERSAMPLE = 3;
+
+/** One source of truth for scheduler, heartbeat, and durable admission. */
+export function effectiveProjectConcurrency(config: Pick<AutonomousConfig,
+  'allowSameProjectConcurrent' | 'worktreeMode' | 'maxConcurrentPerProject' | 'maxConcurrentTasks'
+>): number {
+  const globalCap = Math.max(1, Math.floor(config.maxConcurrentTasks ?? 1));
+  const parallel = (config.allowSameProjectConcurrent ?? true) && (config.worktreeMode ?? false);
+  if (!parallel) return 1;
+  const requested = Math.floor(config.maxConcurrentPerProject ?? Math.min(2, globalCap));
+  return Math.max(1, Math.min(requested, globalCap));
+}
 
 export type RunnableCandidate = { task: TaskItem; projectPath: string };
 
@@ -219,10 +234,7 @@ export class AutonomousRunner {
 
   private sameProjectCandidateCap(): number | null {
     const sameProjectParallel = (this.config.allowSameProjectConcurrent ?? true) && (this.config.worktreeMode ?? false);
-    if (!sameProjectParallel || this.config.maxConcurrentPerProject == null) return null;
-    const cap = Math.floor(this.config.maxConcurrentPerProject);
-    const maxConcurrent = this.config.maxConcurrentTasks ?? 1;
-    return Math.max(1, Math.min(cap, maxConcurrent));
+    return sameProjectParallel ? effectiveProjectConcurrency(this.config) : null;
   }
 
   private currentProjectLoad(projectPath: string): number {
@@ -338,7 +350,7 @@ export class AutonomousRunner {
     this.scheduler = initScheduler({
       maxConcurrent: config.maxConcurrentTasks ?? 1,
       allowSameProjectConcurrent: config.allowSameProjectConcurrent ?? true,
-      maxConcurrentPerProject: config.maxConcurrentPerProject,
+      maxConcurrentPerProject: effectiveProjectConcurrency(config),
       worktreeMode: config.worktreeMode ?? false,
     });
 
@@ -348,8 +360,7 @@ export class AutonomousRunner {
       mode: ledgerMode,
       dbPath: config.automationDbPath,
       leaseMs: config.automationLeaseMs,
-      // Same-repo parallelism is never implicit at the durable admission layer.
-      maxActiveForProject: config.maxConcurrentPerProject ?? 1,
+      maxActiveForProject: effectiveProjectConcurrency(config),
     });
 
     // Set up scheduler event handling
@@ -1059,8 +1070,9 @@ export class AutonomousRunner {
         && (this.config.allowSameProjectConcurrent ?? true);
       admission = {
         maxConcurrent: sameRepoParallelAllowed
-          ? (metadata?.automation?.maxConcurrent ?? this.config.maxConcurrentPerProject ?? 1)
+          ? (metadata?.automation?.maxConcurrent ?? effectiveProjectConcurrency(this.config))
           : 1,
+        conflictScope: task.fileScope,
         maxAttemptsPerHour: metadata?.automation?.maxAttemptsPerHour ?? 12,
         maxFailuresPerHour: metadata?.automation?.maxFailuresPerHour ?? 6,
         maxCostUsdPerDay: metadata?.automation?.maxCostUsdPerDay,
@@ -2036,14 +2048,27 @@ export class AutonomousRunner {
     // Detect file conflicts per project using Knowledge Graph
     const safeTasks = new Set<string>(); // task IDs safe to enqueue
     for (const [projPath, group] of byProject) {
-      if (group.length <= 1) {
-        // 단일 태스크 → 충돌 없음
-        for (const c of group) safeTasks.add(c.task.id);
-        continue;
-      }
-
       try {
-        const result = await detectFileConflicts(group.map(c => c.task), projPath);
+        await Promise.all(group.map(c => resolveTaskFileScope(c.task, projPath)));
+
+        // A later heartbeat must compare new candidates with workers that are
+        // already editing another worktree. Candidate-vs-candidate detection
+        // alone leaves a race window across heartbeat cycles.
+        const active = this.scheduler.getRunningTasks()
+          .filter(running => normalizeProjectPath(running.projectPath) === projPath);
+        const runnable = group.filter(candidate => {
+          const conflict = active.some(running => fileScopesConflict(
+            candidate.task.fileScope,
+            running.task.fileScope,
+          ));
+          if (conflict) {
+            this.syslog(`Conflict with active worktree — deferring: ${candidate.task.issueIdentifier || candidate.task.id.slice(0, 8)} ${candidate.task.title}`);
+          }
+          return !conflict;
+        });
+        if (runnable.length === 0) continue;
+
+        const result = await detectFileConflicts(runnable.map(c => c.task), projPath);
 
         for (const t of result.safe) {
           safeTasks.add(t.id);

--- a/src/automation/durableRunCoordinator.test.ts
+++ b/src/automation/durableRunCoordinator.test.ts
@@ -72,6 +72,32 @@ describe('DurableRunCoordinator', () => {
     second.close();
   });
 
+  it('runs disjoint same-repository scopes concurrently in separate worktrees', async () => {
+    const path = dbPath();
+    const first = new DurableRunCoordinator({ mode: 'primary', dbPath: path, instanceId: 'a', maxActiveForProject: 2 });
+    const second = new DurableRunCoordinator({ mode: 'primary', dbPath: path, instanceId: 'b', maxActiveForProject: 2 });
+    const firstTask = { ...task('PAR-A'), fileScope: ['src/a.ts'] };
+    const secondTask = { ...task('PAR-B'), fileScope: ['src/b.ts'] };
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+
+    const firstRun = first.execute(firstTask, '/repo', async () => {
+      await held;
+      return result();
+    }, { admission: { maxConcurrent: 2, conflictScope: firstTask.fileScope } });
+    await Promise.resolve();
+    const secondResult = await second.execute(secondTask, '/repo', async () => result(), {
+      admission: { maxConcurrent: 2, conflictScope: secondTask.fileScope },
+    });
+
+    expect(secondResult.success).toBe(true);
+    expect(first.getRun('PAR-A')?.state).toBe('EXECUTING');
+    release();
+    expect((await firstRun).success).toBe(true);
+    first.close();
+    second.close();
+  });
+
   it('records worktree, verification, publication, and durable sync state', async () => {
     const coordinator = new DurableRunCoordinator({ mode: 'primary', dbPath: dbPath(), instanceId: 'daemon' });
     const pipeline = await coordinator.execute(task('FLOW'), '/repo', async (hooks) => {

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -41,6 +41,8 @@ export interface DurableExecuteOptions {
 
 export interface RepositoryAdmissionPolicy {
   maxConcurrent?: number;
+  /** Predicted repository-relative write set used for atomic conflict admission. */
+  conflictScope?: string[];
   maxAttemptsPerHour?: number;
   maxFailuresPerHour?: number;
   maxCostUsdPerDay?: number;
@@ -179,6 +181,7 @@ export class DurableRunCoordinator {
       metadata: {
         projectId: task.linearProject?.id,
         projectName: task.linearProject?.name,
+        fileScope: task.fileScope,
       },
     }, now);
 
@@ -214,6 +217,7 @@ export class DurableRunCoordinator {
       ownerInstanceId: this.instanceId,
       leaseMs: this.leaseMs,
       maxActiveForProject: options.admission?.maxConcurrent ?? this.maxActiveForProject,
+      conflictScope: options.admission?.conflictScope,
       maxAttemptsPerHour: options.admission?.maxAttemptsPerHour,
       maxFailuresPerHour: options.admission?.maxFailuresPerHour,
       maxCostUsdPerDay: options.admission?.maxCostUsdPerDay,

--- a/src/automation/runLedger.test.ts
+++ b/src/automation/runLedger.test.ts
@@ -16,13 +16,14 @@ function createDbPath(): string {
   return join(root, 'automation.db');
 }
 
-function register(ledger: RunLedger, issueId: string, projectPath = '/repo'): void {
+function register(ledger: RunLedger, issueId: string, projectPath = '/repo', fileScope?: string[]): void {
   ledger.registerRun({
     issueId,
     source: 'linear',
     identifier: issueId,
     title: `Task ${issueId}`,
     projectPath,
+    metadata: fileScope ? { fileScope } : undefined,
   }, 1_000);
 }
 
@@ -162,6 +163,44 @@ describe('RunLedger claim and fencing races', () => {
     second.close();
   });
 
+  it('admits disjoint same-repository scopes and rejects an overlapping scope atomically', () => {
+    const ledger = new RunLedger(createDbPath());
+    register(ledger, 'SCOPE-A', '/same-repo', ['src/a.ts']);
+    register(ledger, 'SCOPE-B', '/same-repo', ['src/b.ts']);
+    register(ledger, 'SCOPE-OVERLAP', '/same-repo', ['./SRC/A.ts']);
+
+    expect(ledger.claimRun('SCOPE-A', {
+      ownerInstanceId: 'a', leaseMs: 1_000, now: 2_000,
+      maxActiveForProject: 3, conflictScope: ['src/a.ts'],
+    })).not.toBeNull();
+    expect(ledger.claimRun('SCOPE-B', {
+      ownerInstanceId: 'b', leaseMs: 1_000, now: 2_001,
+      maxActiveForProject: 3, conflictScope: ['src/b.ts'],
+    })).not.toBeNull();
+    expect(ledger.claimRun('SCOPE-OVERLAP', {
+      ownerInstanceId: 'c', leaseMs: 1_000, now: 2_002,
+      maxActiveForProject: 3, conflictScope: ['./SRC/A.ts'],
+    })).toBeNull();
+    expect(ledger.listRuns(['CLAIMED'])).toHaveLength(2);
+    ledger.close();
+  });
+
+  it('fails closed when either side of a parallel repository claim has unknown scope', () => {
+    const ledger = new RunLedger(createDbPath());
+    register(ledger, 'KNOWN', '/same-repo', ['src/known.ts']);
+    register(ledger, 'UNKNOWN', '/same-repo');
+    const known = ledger.claimRun('KNOWN', {
+      ownerInstanceId: 'known', leaseMs: 1_000, now: 2_000,
+      maxActiveForProject: 2, conflictScope: ['src/known.ts'],
+    });
+    expect(known).not.toBeNull();
+    expect(ledger.claimRun('UNKNOWN', {
+      ownerInstanceId: 'unknown', leaseMs: 1_000, now: 2_001,
+      maxActiveForProject: 2,
+    })).toBeNull();
+    ledger.close();
+  });
+
   it('rejects a late callback after lease expiry and replacement', () => {
     const dbPath = createDbPath();
     const oldDaemon = new RunLedger(dbPath);
@@ -280,6 +319,29 @@ describe('RunLedger claim and fencing races', () => {
     const verify = new RunLedger(path);
     expect(verify.listRuns(['CLAIMED'])).toHaveLength(1);
     verify.close();
+  }, 30_000);
+
+  it('atomically separates disjoint and overlapping scopes across real OS processes', async () => {
+    const tsxCli = resolve('node_modules/tsx/dist/cli.mjs');
+    const fixture = resolve('src/automation/runLedgerClaimProcess.fixture.ts');
+
+    const disjointPath = createDbPath();
+    const disjoint = await Promise.all(['a', 'b', 'c'].map((scope, index) =>
+      execFileAsync(process.execPath, [
+        tsxCli, fixture, disjointPath, `DISJOINT-${index}`, `owner-${index}`,
+        '2000', '3', `src/${scope}.ts`,
+      ]),
+    ));
+    expect(disjoint.filter(({ stdout }) => stdout.trim() === 'claimed')).toHaveLength(3);
+
+    const overlapPath = createDbPath();
+    const overlapping = await Promise.all(Array.from({ length: 3 }, (_, index) =>
+      execFileAsync(process.execPath, [
+        tsxCli, fixture, overlapPath, `OVERLAP-${index}`, `owner-${index}`,
+        '2000', '3', 'src/shared.ts',
+      ]),
+    ));
+    expect(overlapping.filter(({ stdout }) => stdout.trim() === 'claimed')).toHaveLength(1);
   }, 30_000);
 
   it('fails closed without a partial claim when the SQLite writer is busy', () => {

--- a/src/automation/runLedger.ts
+++ b/src/automation/runLedger.ts
@@ -4,6 +4,8 @@ import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { ACTIVE_LEASE_STATES, ALLOWED_TRANSITIONS, AUTOMATION_SCHEMA_VERSION, CLAIMABLE_STATES, RUN_STATES } from './runLedgerTypes.js';
+import { admitsConflictScope } from './runLedgerScope.js';
+import { migrateAutomationSchema } from './runLedgerSchema.js';
 import type {
   AttemptResultInput,
   ClaimOptions,
@@ -147,145 +149,13 @@ export class RunLedger {
       this.db.pragma('journal_mode = WAL');
       this.db.pragma('foreign_keys = ON');
       this.db.pragma('synchronous = FULL');
-      this.migrate();
+      migrateAutomationSchema(this.db);
     } catch (error) {
       this.db.close();
       throw error;
     }
   }
 
-  private migrate(): void {
-    const migrate = this.db.transaction(() => {
-      this.db.exec(`
-      CREATE TABLE IF NOT EXISTS automation_meta (
-        key TEXT PRIMARY KEY,
-        value TEXT NOT NULL
-      );
-
-      CREATE TABLE IF NOT EXISTS automation_runs (
-        issue_id TEXT PRIMARY KEY,
-        source TEXT NOT NULL,
-        identifier TEXT,
-        title TEXT,
-        project_path TEXT NOT NULL,
-        state TEXT NOT NULL,
-        state_version INTEGER NOT NULL DEFAULT 1,
-        attempt_no INTEGER NOT NULL DEFAULT 0,
-        owner_instance_id TEXT,
-        lease_token TEXT,
-        lease_epoch INTEGER NOT NULL DEFAULT 0,
-        lease_expires_at INTEGER,
-        retry_at INTEGER,
-        branch_name TEXT,
-        worktree_path TEXT,
-        pr_url TEXT,
-        head_sha TEXT,
-        last_error_code TEXT,
-        last_error_message TEXT,
-        discovered_at INTEGER NOT NULL,
-        started_at INTEGER,
-        updated_at INTEGER NOT NULL,
-        completed_at INTEGER,
-        metadata_json TEXT
-      );
-
-      CREATE TABLE IF NOT EXISTS automation_attempts (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        issue_id TEXT NOT NULL,
-        attempt_no INTEGER NOT NULL,
-        lease_epoch INTEGER NOT NULL,
-        status TEXT NOT NULL,
-        stage TEXT NOT NULL,
-        started_at INTEGER NOT NULL,
-        finished_at INTEGER,
-        result_json TEXT,
-        error_code TEXT,
-        error_message TEXT,
-        result_status TEXT,
-        success INTEGER,
-        cost_usd REAL,
-        UNIQUE(issue_id, attempt_no),
-        FOREIGN KEY (issue_id) REFERENCES automation_runs(issue_id) ON DELETE CASCADE
-      );
-
-      CREATE TABLE IF NOT EXISTS automation_effects (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        issue_id TEXT NOT NULL,
-        attempt_no INTEGER NOT NULL,
-        kind TEXT NOT NULL,
-        dedupe_key TEXT NOT NULL UNIQUE,
-        payload_json TEXT NOT NULL,
-        status TEXT NOT NULL DEFAULT 'pending',
-        attempts INTEGER NOT NULL DEFAULT 0,
-        available_at INTEGER NOT NULL,
-        owner_instance_id TEXT,
-        delivery_token TEXT,
-        lease_epoch INTEGER NOT NULL DEFAULT 0,
-        lease_expires_at INTEGER,
-        last_error TEXT,
-        created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL,
-        applied_at INTEGER,
-        FOREIGN KEY (issue_id) REFERENCES automation_runs(issue_id) ON DELETE CASCADE
-      );
-
-      CREATE TABLE IF NOT EXISTS automation_events (
-        sequence INTEGER PRIMARY KEY AUTOINCREMENT,
-        issue_id TEXT NOT NULL,
-        attempt_no INTEGER,
-        kind TEXT NOT NULL,
-        from_state TEXT,
-        to_state TEXT,
-        data_json TEXT,
-        created_at INTEGER NOT NULL,
-        FOREIGN KEY (issue_id) REFERENCES automation_runs(issue_id) ON DELETE CASCADE
-      );
-
-      CREATE TABLE IF NOT EXISTS automation_repo_circuits (
-        project_path TEXT PRIMARY KEY,
-        reason TEXT NOT NULL,
-        opened_at INTEGER NOT NULL,
-        open_until INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_automation_runs_state_retry
-        ON automation_runs(state, retry_at, updated_at);
-      CREATE INDEX IF NOT EXISTS idx_automation_runs_project_state
-        ON automation_runs(project_path, state, lease_expires_at);
-      CREATE INDEX IF NOT EXISTS idx_automation_runs_worktree
-        ON automation_runs(worktree_path) WHERE worktree_path IS NOT NULL;
-      CREATE INDEX IF NOT EXISTS idx_automation_effects_delivery
-        ON automation_effects(status, available_at, lease_expires_at, id);
-      CREATE INDEX IF NOT EXISTS idx_automation_events_issue
-        ON automation_events(issue_id, sequence);
-    `);
-
-    // v1 -> v2 is additive and safe under WAL. SQLite has no ADD COLUMN IF NOT
-    // EXISTS, so inspect first for idempotent crash-restart migration.
-      const attemptColumns = new Set(
-        (this.db.pragma('table_info(automation_attempts)') as Array<{ name: string }>).map((column) => column.name),
-      );
-      if (!attemptColumns.has('result_status')) this.db.exec('ALTER TABLE automation_attempts ADD COLUMN result_status TEXT');
-      if (!attemptColumns.has('success')) this.db.exec('ALTER TABLE automation_attempts ADD COLUMN success INTEGER');
-      if (!attemptColumns.has('cost_usd')) this.db.exec('ALTER TABLE automation_attempts ADD COLUMN cost_usd REAL');
-      this.db.exec(`CREATE INDEX IF NOT EXISTS idx_automation_attempts_budget
-        ON automation_attempts(started_at, success, cost_usd)`);
-
-      const current = this.db.prepare('SELECT value FROM automation_meta WHERE key = ?').get('schema_version') as { value: string } | undefined;
-      if (current && Number(current.value) > AUTOMATION_SCHEMA_VERSION) {
-        throw new Error(`automation.db schema ${current.value} is newer than supported ${AUTOMATION_SCHEMA_VERSION}`);
-      }
-      this.db.prepare(`
-        INSERT INTO automation_meta(key, value) VALUES('schema_version', ?)
-        ON CONFLICT(key) DO UPDATE SET value = excluded.value
-      `).run(String(AUTOMATION_SCHEMA_VERSION));
-    });
-    // Schema inspection + ALTER must be one writer-serialized unit. Two daemon
-    // generations can overlap during launchd restart; a deferred migration lets
-    // both observe the old schema and race the same ADD COLUMN.
-    migrate.immediate();
-  }
 
   registerRun(input: RegisterRunInput, now = Date.now()): RunRecord {
     if (!input.issueId.trim()) throw new Error('issueId is required');
@@ -604,16 +474,26 @@ export class RunLedger {
         }
       }
 
-      const activeCount = (this.db.prepare(`
-        SELECT COUNT(*) AS count FROM automation_runs
+      const activeRows = this.db.prepare(`
+        SELECT issue_id, state, metadata_json FROM automation_runs
         WHERE project_path = ?
           AND (
             state IN (${placeholders(ACTIVE_LEASE_STATES)})
             OR state = 'NEEDS_RECONCILE'
           )
           AND issue_id <> ?
-      `).get(row.project_path, ...ACTIVE_LEASE_STATES, issueId) as { count: number }).count;
-      if (activeCount >= maxActive) return null;
+      `).all(row.project_path, ...ACTIVE_LEASE_STATES, issueId) as Array<Pick<RunRow, 'issue_id' | 'state' | 'metadata_json'>>;
+      if (activeRows.length >= maxActive) return null;
+
+      // The cap controls capacity; the write scope controls safety inside that
+      // capacity. Both checks happen in the same SQLite transaction as the
+      // claim, so two daemon instances cannot race disjoint scheduler views.
+      if (maxActive > 1) {
+        const activeScopes = activeRows
+          .filter(active => ACTIVE_LEASE_STATES.includes(active.state as RunState))
+          .map(active => parseJson(active.metadata_json));
+        if (!admitsConflictScope(options.conflictScope, activeScopes)) return null;
+      }
 
       const epoch = row.lease_epoch + 1;
       const attemptNo = row.attempt_no + 1;

--- a/src/automation/runLedgerClaimProcess.fixture.ts
+++ b/src/automation/runLedgerClaimProcess.fixture.ts
@@ -1,6 +1,6 @@
 import { RunLedger } from './runLedger.js';
 
-const [dbPath, issueId, ownerInstanceId, nowText] = process.argv.slice(2);
+const [dbPath, issueId, ownerInstanceId, nowText, maxActiveText, scopeText] = process.argv.slice(2);
 if (!dbPath || !issueId || !ownerInstanceId || !nowText) {
   throw new Error('usage: runLedgerClaimProcess.fixture.ts <db> <issue> <owner> <now>');
 }
@@ -13,11 +13,13 @@ try {
     identifier: issueId,
     title: `Process race ${issueId}`,
     projectPath: '/process-repo',
+    metadata: scopeText ? { fileScope: [scopeText] } : undefined,
   }, Number(nowText) - 1);
   const claimed = ledger.claimRun(issueId, {
     ownerInstanceId,
     leaseMs: 60_000,
-    maxActiveForProject: 1,
+    maxActiveForProject: maxActiveText ? Number(maxActiveText) : 1,
+    conflictScope: scopeText ? [scopeText] : undefined,
     now: Number(nowText),
   });
   process.stdout.write(claimed ? 'claimed\n' : 'blocked\n');

--- a/src/automation/runLedgerSchema.ts
+++ b/src/automation/runLedgerSchema.ts
@@ -1,0 +1,143 @@
+// ============================================
+// OpenSwarm - Run ledger schema
+// ============================================
+//
+// Table/index definitions and the forward migration for automation.db. Kept
+// beside the ledger rather than inside it so the ~130 lines of DDL do not
+// crowd out the run-state logic that actually changes.
+
+import type Database from 'better-sqlite3';
+import { AUTOMATION_SCHEMA_VERSION } from './runLedgerTypes.js';
+
+export function migrateAutomationSchema(db: Database.Database): void {
+    const migrate = db.transaction(() => {
+      db.exec(`
+      CREATE TABLE IF NOT EXISTS automation_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS automation_runs (
+        issue_id TEXT PRIMARY KEY,
+        source TEXT NOT NULL,
+        identifier TEXT,
+        title TEXT,
+        project_path TEXT NOT NULL,
+        state TEXT NOT NULL,
+        state_version INTEGER NOT NULL DEFAULT 1,
+        attempt_no INTEGER NOT NULL DEFAULT 0,
+        owner_instance_id TEXT,
+        lease_token TEXT,
+        lease_epoch INTEGER NOT NULL DEFAULT 0,
+        lease_expires_at INTEGER,
+        retry_at INTEGER,
+        branch_name TEXT,
+        worktree_path TEXT,
+        pr_url TEXT,
+        head_sha TEXT,
+        last_error_code TEXT,
+        last_error_message TEXT,
+        discovered_at INTEGER NOT NULL,
+        started_at INTEGER,
+        updated_at INTEGER NOT NULL,
+        completed_at INTEGER,
+        metadata_json TEXT
+      );
+
+      CREATE TABLE IF NOT EXISTS automation_attempts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        issue_id TEXT NOT NULL,
+        attempt_no INTEGER NOT NULL,
+        lease_epoch INTEGER NOT NULL,
+        status TEXT NOT NULL,
+        stage TEXT NOT NULL,
+        started_at INTEGER NOT NULL,
+        finished_at INTEGER,
+        result_json TEXT,
+        error_code TEXT,
+        error_message TEXT,
+        result_status TEXT,
+        success INTEGER,
+        cost_usd REAL,
+        UNIQUE(issue_id, attempt_no),
+        FOREIGN KEY (issue_id) REFERENCES automation_runs(issue_id) ON DELETE CASCADE
+      );
+
+      CREATE TABLE IF NOT EXISTS automation_effects (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        issue_id TEXT NOT NULL,
+        attempt_no INTEGER NOT NULL,
+        kind TEXT NOT NULL,
+        dedupe_key TEXT NOT NULL UNIQUE,
+        payload_json TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        attempts INTEGER NOT NULL DEFAULT 0,
+        available_at INTEGER NOT NULL,
+        owner_instance_id TEXT,
+        delivery_token TEXT,
+        lease_epoch INTEGER NOT NULL DEFAULT 0,
+        lease_expires_at INTEGER,
+        last_error TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        applied_at INTEGER,
+        FOREIGN KEY (issue_id) REFERENCES automation_runs(issue_id) ON DELETE CASCADE
+      );
+
+      CREATE TABLE IF NOT EXISTS automation_events (
+        sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+        issue_id TEXT NOT NULL,
+        attempt_no INTEGER,
+        kind TEXT NOT NULL,
+        from_state TEXT,
+        to_state TEXT,
+        data_json TEXT,
+        created_at INTEGER NOT NULL,
+        FOREIGN KEY (issue_id) REFERENCES automation_runs(issue_id) ON DELETE CASCADE
+      );
+
+      CREATE TABLE IF NOT EXISTS automation_repo_circuits (
+        project_path TEXT PRIMARY KEY,
+        reason TEXT NOT NULL,
+        opened_at INTEGER NOT NULL,
+        open_until INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_automation_runs_state_retry
+        ON automation_runs(state, retry_at, updated_at);
+      CREATE INDEX IF NOT EXISTS idx_automation_runs_project_state
+        ON automation_runs(project_path, state, lease_expires_at);
+      CREATE INDEX IF NOT EXISTS idx_automation_runs_worktree
+        ON automation_runs(worktree_path) WHERE worktree_path IS NOT NULL;
+      CREATE INDEX IF NOT EXISTS idx_automation_effects_delivery
+        ON automation_effects(status, available_at, lease_expires_at, id);
+      CREATE INDEX IF NOT EXISTS idx_automation_events_issue
+        ON automation_events(issue_id, sequence);
+    `);
+
+    // v1 -> v2 is additive and safe under WAL. SQLite has no ADD COLUMN IF NOT
+    // EXISTS, so inspect first for idempotent crash-restart migration.
+      const attemptColumns = new Set(
+        (db.pragma('table_info(automation_attempts)') as Array<{ name: string }>).map((column) => column.name),
+      );
+      if (!attemptColumns.has('result_status')) db.exec('ALTER TABLE automation_attempts ADD COLUMN result_status TEXT');
+      if (!attemptColumns.has('success')) db.exec('ALTER TABLE automation_attempts ADD COLUMN success INTEGER');
+      if (!attemptColumns.has('cost_usd')) db.exec('ALTER TABLE automation_attempts ADD COLUMN cost_usd REAL');
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_automation_attempts_budget
+        ON automation_attempts(started_at, success, cost_usd)`);
+
+      const current = db.prepare('SELECT value FROM automation_meta WHERE key = ?').get('schema_version') as { value: string } | undefined;
+      if (current && Number(current.value) > AUTOMATION_SCHEMA_VERSION) {
+        throw new Error(`automation.db schema ${current.value} is newer than supported ${AUTOMATION_SCHEMA_VERSION}`);
+      }
+      db.prepare(`
+        INSERT INTO automation_meta(key, value) VALUES('schema_version', ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+      `).run(String(AUTOMATION_SCHEMA_VERSION));
+    });
+    // Schema inspection + ALTER must be one writer-serialized unit. Two daemon
+    // generations can overlap during launchd restart; a deferred migration lets
+    // both observe the old schema and race the same ADD COLUMN.
+    migrate.immediate();
+}

--- a/src/automation/runLedgerScope.ts
+++ b/src/automation/runLedgerScope.ts
@@ -1,0 +1,60 @@
+// ============================================
+// OpenSwarm - Run ledger conflict scope
+// ============================================
+//
+// Predicted write sets for same-repository admission. The ledger keeps these
+// helpers at arm's length so claimRun() reads as a policy decision rather than
+// string normalization, and so the rules can be tested without a database.
+
+/** Scope entries the planner emits when it could not determine a write set. */
+const UNKNOWN_SCOPE_MARKER = 'unknown-file-scope';
+
+/**
+ * Normalize a predicted write set for comparison: repository-relative, forward
+ * slashes, case-insensitive. Anything unusable (non-array, non-string entries,
+ * the unknown marker) drops out, so an empty result means "scope unknown".
+ */
+export function normalizeConflictScope(entries: unknown): Set<string> {
+  if (!Array.isArray(entries)) return new Set();
+  const scope = new Set<string>();
+  for (const entry of entries) {
+    if (typeof entry !== 'string') continue;
+    const normalized = entry.trim().replace(/\\/g, '/').replace(/^\.\//, '').toLowerCase();
+    if (normalized && normalized !== UNKNOWN_SCOPE_MARKER) scope.add(normalized);
+  }
+  return scope;
+}
+
+/** Read the scope a live run recorded in its metadata blob. */
+export function metadataConflictScope(metadata: unknown): Set<string> {
+  if (!metadata || typeof metadata !== 'object') return new Set();
+  return normalizeConflictScope((metadata as { fileScope?: unknown }).fileScope);
+}
+
+export function scopesOverlap(left: Set<string>, right: Set<string>): boolean {
+  for (const file of left) {
+    if (right.has(file)) return true;
+  }
+  return false;
+}
+
+/**
+ * Decide whether a claim may join the runs already live in one repository.
+ *
+ * The cap controls capacity; this controls safety inside that capacity.
+ * Unknown scope on either side fails closed — worktrees isolate filesystem
+ * writes, but they do not make two unknown write sets safe to merge.
+ */
+export function admitsConflictScope(
+  requested: unknown,
+  activeScopes: readonly unknown[],
+): boolean {
+  if (activeScopes.length === 0) return true;
+  const requestedScope = normalizeConflictScope(requested);
+  if (requestedScope.size === 0) return false;
+  for (const active of activeScopes) {
+    const activeScope = metadataConflictScope(active);
+    if (activeScope.size === 0 || scopesOverlap(requestedScope, activeScope)) return false;
+  }
+  return true;
+}

--- a/src/automation/runLedgerTypes.ts
+++ b/src/automation/runLedgerTypes.ts
@@ -114,6 +114,8 @@ export interface ClaimOptions {
   now?: number;
   /** Atomic repository admission cap. Defaults to one active run per repository. */
   maxActiveForProject?: number;
+  /** Normalized predicted write set. Unknown scope serializes against live same-repo claims. */
+  conflictScope?: string[];
   maxAttemptsPerHour?: number;
   maxFailuresPerHour?: number;
   maxCostUsdPerDay?: number;

--- a/src/orchestration/conflictDetector.coverage.test.ts
+++ b/src/orchestration/conflictDetector.coverage.test.ts
@@ -111,7 +111,7 @@ describe('detectFileConflicts Knowledge Graph fallback (no declared fileScope)',
     expect(mockAnalyzeIssue).toHaveBeenCalledWith(PROJECT, 'task B', undefined);
   });
 
-  it('treats KG modules that are entirely volatile/generated paths as unknown scope, not a conflict', async () => {
+  it('serializes KG scopes that reduce to unknown after volatile paths are removed', async () => {
     // Both tasks resolve to a non-null impact, but every module normalizes
     // away (node_modules / dist are filtered as volatile), so `modules.size`
     // is 0 and the code falls through to unknownScopeIndices instead of
@@ -123,8 +123,8 @@ describe('detectFileConflicts Knowledge Graph fallback (no declared fileScope)',
       PROJECT,
     );
 
-    expect(result.conflictGroups).toHaveLength(0);
-    expect(new Set(result.safe.map((t) => t.id))).toEqual(new Set(['A', 'B']));
+    expect(result.conflictGroups).toHaveLength(1);
+    expect(result.safe).toHaveLength(1);
   });
 
   it('treats a failed KG lookup as unknown scope and logs a warning instead of throwing', async () => {
@@ -140,10 +140,10 @@ describe('detectFileConflicts Knowledge Graph fallback (no declared fileScope)',
         PROJECT,
       );
 
-      // Task A's failure makes its scope unknown (soft risk), so it doesn't
-      // force a conflict with B even though B has a real known scope.
-      expect(result.conflictGroups).toHaveLength(0);
-      expect(new Set(result.safe.map((t) => t.id))).toEqual(new Set(['A', 'B']));
+      // Task A's failure makes its scope unknown, so admission fails closed
+      // against B until a later heartbeat can prove the write sets disjoint.
+      expect(result.conflictGroups).toHaveLength(1);
+      expect(result.safe).toHaveLength(1);
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('[ConflictDetector] Impact analysis failed for A:'),
         expect.any(Error),

--- a/src/orchestration/conflictDetector.test.ts
+++ b/src/orchestration/conflictDetector.test.ts
@@ -92,13 +92,14 @@ describe('detectFileConflicts (planner-declared file scope)', () => {
     expect(result.conflictGroups).toHaveLength(0);
   });
 
-  it('treats unknown scope as a soft PR-time risk, not a hard scheduling conflict', async () => {
+  it('serializes unknown scope because merge safety cannot be proven', async () => {
     const result = await detectFileConflicts(
       [task('A', 2, ['unknown-file-scope']), task('B', 2, ['src/shared.ts'])],
       PROJECT,
     );
 
-    expect(new Set(result.safe.map((t) => t.id))).toEqual(new Set(['A', 'B']));
-    expect(result.conflictGroups).toHaveLength(0);
+    expect(result.safe).toHaveLength(1);
+    expect(result.conflictGroups).toHaveLength(1);
+    expect(result.conflictGroups[0].sharedModules).toEqual(['unknown-file-scope']);
   });
 });

--- a/src/orchestration/conflictDetector.ts
+++ b/src/orchestration/conflictDetector.ts
@@ -99,6 +99,48 @@ function isVolatileScopePath(path: string): boolean {
 }
 
 /**
+ * Resolve the best available preflight write scope for one task. The normalized
+ * result is written back to the task so the scheduler and durable admission
+ * layer can make the same decision without repeating Knowledge Graph work.
+ */
+export async function resolveTaskFileScope(task: TaskItem, projectPath: string): Promise<string[]> {
+  const declared = normalizeScope(task.fileScope);
+  if (declared.size > 0) {
+    const scope = [...declared];
+    task.fileScope = scope;
+    return scope;
+  }
+
+  try {
+    const impact = await analyzeIssue(projectPath, task.title, task.description);
+    if (impact) {
+      const inferred = normalizeScope([...impact.directModules, ...impact.dependentModules]);
+      if (inferred.size > 0) {
+        const scope = [...inferred];
+        task.fileScope = scope;
+        return scope;
+      }
+    }
+  } catch (err) {
+    console.warn(`[ConflictDetector] Impact analysis failed for ${task.id}:`, err);
+  }
+
+  task.fileScope = undefined;
+  return [];
+}
+
+/** Unknown scope conflicts fail closed while another same-repo worker is live. */
+export function fileScopesConflict(left: string[] | undefined, right: string[] | undefined): boolean {
+  const a = normalizeScope(left);
+  const b = normalizeScope(right);
+  if (a.size === 0 || b.size === 0) return true;
+  for (const file of a) {
+    if (b.has(file)) return true;
+  }
+  return false;
+}
+
+/**
  * Detect file-scope overlap between tasks. Each task's scope prefers the
  * planner-declared `fileScope` (authoritative), falling back to Knowledge Graph
  * inference (`analyzeIssue`) only when no explicit scope is available.
@@ -109,39 +151,15 @@ export async function detectFileConflicts(
   tasks: TaskItem[],
   projectPath: string,
 ): Promise<ConflictDetectionResult> {
-  if (tasks.length <= 1) {
-    return { safe: tasks, conflictGroups: [] };
-  }
-
   // Step 1: 각 태스크의 영향 모듈 집합 수집
   const taskImpacts: Map<number, Set<string>> = new Map();
   const unknownScopeIndices = new Set<number>();
 
   await Promise.all(
     tasks.map(async (task, idx) => {
-      // Prefer the planner-declared file scope. It is what the worker is
-      // actually constrained to, so it is more accurate than KG inference and
-      // needs no graph lookup.
-      const declared = normalizeScope(task.fileScope);
-      if (declared.size > 0) {
-        taskImpacts.set(idx, declared);
-        return;
-      }
-
-      // Fall back to Knowledge Graph inference when no explicit scope exists.
-      try {
-        const impact = await analyzeIssue(projectPath, task.title, task.description);
-        if (impact) {
-          const modules = normalizeScope([...impact.directModules, ...impact.dependentModules]);
-          if (modules.size > 0) {
-            taskImpacts.set(idx, modules);
-            return;
-          }
-        }
-      } catch (err) {
-        console.warn(`[ConflictDetector] Impact analysis failed for ${task.id}:`, err);
-      }
-      unknownScopeIndices.add(idx);
+      const scope = await resolveTaskFileScope(task, projectPath);
+      if (scope.length > 0) taskImpacts.set(idx, new Set(scope));
+      else unknownScopeIndices.add(idx);
     })
   );
 
@@ -156,9 +174,11 @@ export async function detectFileConflicts(
     for (let j = i + 1; j < tasks.length; j++) {
       const modulesJ = taskImpacts.get(j);
       if (unknownScopeIndices.has(i) || unknownScopeIndices.has(j)) {
-        // Unknown scope is a soft risk, not proof of a file conflict. Let the
-        // PR processor handle any real merge conflicts later instead of
-        // starving worker slots on uncertainty.
+        // Worktrees isolate filesystem writes, but they do not make two unknown
+        // write sets safe to merge. Serialize uncertainty and retry after the
+        // known owner exits.
+        pairShared.set(`${i}:${j}`, new Set([UNKNOWN_SCOPE]));
+        uf.union(i, j);
         continue;
       }
 


### PR DESCRIPTION
## What changed

`allowSameProjectConcurrent` with no `maxConcurrentPerProject` meant the scheduler read the per-repository limit as unlimited while the durable run coordinator defaulted to 1. Independent issues in one repository cycled `queued → started → claim_deferred` forever — kyte-portal measured 70 open issues with 1 running and 14 deferred.

- `effectiveProjectConcurrency()` gives the scheduler, the heartbeat cap, and the ledger one value instead of three defaults.
- `resolveTaskFileScope()` / `fileScopesConflict()` share one scope resolution; unknown scope fails closed rather than racing.
- The heartbeat now compares candidates against workers already running in another worktree, closing the window between heartbeat cycles.
- `claimRun()` checks scope overlap inside the same SQLite transaction as the claim, so two daemons cannot admit conflicting work from disjoint scheduler views.

`runLedger.ts` was 11 lines under the 1500-line commit gate before this, so the scope rules moved to `runLedgerScope.ts` and the DDL to `runLedgerSchema.ts` instead of pushing the file over it.

## Validation

- `npm run typecheck`, `npm run lint` (0/0)
- `vitest run src/automation/ src/orchestration/` — 38 files, 652 passed
- Multi-process claim race covered by the existing OS-process fixture, extended with disjoint and overlapping scopes
- `openswarm review` on the working diff: approve, 0 issues

Closes INT-2927