### PR TITLE
feat(cli): add openswarm provider to show or switch the active provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ openswarm start                  # Start full daemon (requires config.yaml)
 openswarm run "Fix the bug" -p ~/my-project   # Run a single task
 openswarm exec "Run tests" --local --pipeline # Execute via daemon
 openswarm init                   # Interactive setup wizard (provider auth, Linear OAuth, config)
+openswarm provider               # Show/switch the active provider (interactive picker)
+openswarm provider claude        # Switch straight to a provider — a running daemon switches in place
 openswarm doctor                 # Diagnose environment (runtime, native deps, providers, ports)
 openswarm validate               # Validate config.yaml
 
@@ -200,7 +202,7 @@ adapter: codex   # one of: codex · codex-responses · gpt · openrouter · atla
 | `lmstudio` | LM Studio (OpenAI-compatible, local) | loaded LM Studio model (`LMSTUDIO_MODEL`) | None |
 | `local` | Ollama (local, auto-detected) | gemma, llama, qwen, mistral, … | None |
 
-> **Claude Code (`claude -p`)** is supported as an **opt-in fallback** (and powers the `claude -p` chat path) — install the `claude` CLI and authenticate it; `openswarm init` and `openswarm doctor` detect it. It is **not** a selectable `adapter:` value.
+> **Claude Code (`claude -p`)** is supported as an **opt-in fallback** (and powers the `claude -p` chat path) — install the `claude` CLI and authenticate it; `openswarm init` and `openswarm doctor` detect it. It is a valid `adapter:` value, but opt-in: nothing falls back to it automatically. Switch to it when another provider runs out of quota with `openswarm provider claude`.
 
 The `openrouter` adapter runs OpenSwarm's own agentic tool loop (read/search/edit/bash with verification guards), enables ZDR (`data_collection: deny`) for non-OpenAI models, and applies Anthropic prompt caching automatically. Local backends are auto-detected on standard ports (Ollama `:11434`, LM Studio `:1234`); use `lmstudio` for a dedicated LM Studio endpoint (`LMSTUDIO_BASE_URL`, default `http://localhost:1234`).
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -525,6 +525,17 @@ program
     console.log(`  logs:   ${status.logFile}`);
   });
 
+// openswarm provider
+
+program
+  .command('provider')
+  .description('Show or switch the active AI provider (interactive picker when no name is given)')
+  .argument('[name]', 'Provider to switch to — omit for the picker')
+  .action(async (name?: string) => {
+    const { runProviderCommand } = await import('./cli/providerCommand.js');
+    process.exitCode = await runProviderCommand(name);
+  });
+
 // openswarm dash
 
 program

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -336,4 +336,4 @@ export async function getDaemonStatusFull(): Promise<DaemonStatus> {
 }
 
 export const DAEMON_PATHS = { STATE_DIR, LOG_DIR, PID_FILE, LOG_FILE } as const;
-export { LAUNCHD_LABEL };
+export { LAUNCHD_LABEL, DAEMON_PORT };

--- a/src/cli/providerCommand.test.ts
+++ b/src/cli/providerCommand.test.ts
@@ -10,8 +10,22 @@ vi.mock('../core/providerOverride.js', () => ({
 }));
 vi.mock('../core/config.js', () => ({ loadConfig: loadConfigMock }));
 
+const selectMock = vi.hoisted(() => vi.fn());
+vi.mock('@inquirer/prompts', () => ({ select: selectMock }));
+
 const fetchMock = vi.fn();
 vi.stubGlobal('fetch', fetchMock);
+
+/** Run the command as if attached to a terminal, then restore the real flag. */
+async function withTty<T>(run: () => Promise<T>): Promise<T> {
+  const original = process.stdin.isTTY;
+  Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+  try {
+    return await run();
+  } finally {
+    Object.defineProperty(process.stdin, 'isTTY', { value: original, configurable: true });
+  }
+}
 
 function statsResponse(adapters: unknown) {
   return { ok: true, json: async () => ({ adapters }) };
@@ -20,6 +34,7 @@ function statsResponse(adapters: unknown) {
 describe('provider command helpers', () => {
   beforeEach(() => {
     fetchMock.mockReset();
+    selectMock.mockReset();
     readProviderOverrideMock.mockReset();
     writeProviderOverrideMock.mockReset();
     loadConfigMock.mockReset();
@@ -148,6 +163,81 @@ describe('provider command helpers', () => {
       expect(log.mock.calls[0]?.[0]).toContain('Already running');
       // Only the status probe ran — no switch was attempted.
       expect(fetchMock).toHaveBeenCalledTimes(1);
+      log.mockRestore();
+    });
+
+    it('switches to the provider chosen in the interactive picker', async () => {
+      fetchMock
+        .mockResolvedValueOnce(statsResponse({ defaultAdapter: 'codex-responses' }))
+        .mockResolvedValueOnce({ ok: true, text: async () => '{"ok":true}' });
+      selectMock.mockResolvedValue('claude');
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const { runProviderCommand } = await import('./providerCommand.js');
+      const code = await withTty(() => runProviderCommand(undefined));
+
+      expect(code).toBe(0);
+      // The picker offers the live registry, with the running provider preselected.
+      const options = selectMock.mock.calls[0][0] as { default: string; choices: Array<{ value: string }> };
+      expect(options.default).toBe('codex-responses');
+      expect(options.choices.map(c => c.value)).toContain('claude');
+      expect(writeProviderOverrideMock).toHaveBeenCalledWith('claude');
+      expect(log.mock.calls.map(c => String(c[0])).join('\n')).toContain('running daemon is using it now');
+      log.mockRestore();
+    });
+
+    it('leaves the provider untouched when the picker is cancelled', async () => {
+      fetchMock.mockResolvedValue(statsResponse({ defaultAdapter: 'codex-responses' }));
+      // @inquirer throws ExitPromptError on Ctrl+C rather than resolving.
+      selectMock.mockRejectedValue(new Error('User force closed the prompt'));
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const { runProviderCommand } = await import('./providerCommand.js');
+      const code = await withTty(() => runProviderCommand(undefined));
+
+      expect(code).toBe(0);
+      expect(writeProviderOverrideMock).not.toHaveBeenCalled();
+      expect(log.mock.calls.map(c => String(c[0])).join('\n')).toContain('Cancelled');
+      log.mockRestore();
+    });
+
+    it('reports a no-op when the picker selects the provider already running', async () => {
+      fetchMock.mockResolvedValue(statsResponse({ defaultAdapter: 'claude' }));
+      selectMock.mockResolvedValue('claude');
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const { runProviderCommand } = await import('./providerCommand.js');
+
+      expect(await withTty(() => runProviderCommand(undefined))).toBe(0);
+      expect(log.mock.calls.map(c => String(c[0])).join('\n')).toContain('Already running');
+      expect(writeProviderOverrideMock).not.toHaveBeenCalled();
+      log.mockRestore();
+    });
+
+    it('fails with a nonzero code when a live daemon refuses the switch', async () => {
+      fetchMock
+        .mockResolvedValueOnce(statsResponse({ defaultAdapter: 'codex' }))
+        .mockResolvedValueOnce({ ok: false, status: 400, text: async () => 'Invalid provider' });
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { runProviderCommand } = await import('./providerCommand.js');
+
+      expect(await runProviderCommand('claude')).toBe(1);
+      expect(error.mock.calls[0]?.[0]).toContain('Provider switch failed');
+      expect(writeProviderOverrideMock).not.toHaveBeenCalled();
+      error.mockRestore();
+    });
+
+    it('says the choice applies on the next start when no daemon is running', async () => {
+      fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+      readProviderOverrideMock.mockReturnValue('codex');
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const { runProviderCommand } = await import('./providerCommand.js');
+
+      expect(await runProviderCommand('claude')).toBe(0);
+      expect(writeProviderOverrideMock).toHaveBeenCalledWith('claude');
+      expect(log.mock.calls.map(c => String(c[0])).join('\n')).toContain('applies on the next start');
       log.mockRestore();
     });
 

--- a/src/cli/providerCommand.test.ts
+++ b/src/cli/providerCommand.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const readProviderOverrideMock = vi.hoisted(() => vi.fn());
+const writeProviderOverrideMock = vi.hoisted(() => vi.fn());
+const loadConfigMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../core/providerOverride.js', () => ({
+  readProviderOverride: readProviderOverrideMock,
+  writeProviderOverride: writeProviderOverrideMock,
+}));
+vi.mock('../core/config.js', () => ({ loadConfig: loadConfigMock }));
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+function statsResponse(adapters: unknown) {
+  return { ok: true, json: async () => ({ adapters }) };
+}
+
+describe('provider command helpers', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    readProviderOverrideMock.mockReset();
+    writeProviderOverrideMock.mockReset();
+    loadConfigMock.mockReset();
+    loadConfigMock.mockReturnValue({ adapter: 'codex-responses' });
+  });
+
+  describe('getProviderStatus', () => {
+    it('prefers the live daemon and reports its enabled roles', async () => {
+      fetchMock.mockResolvedValue(statsResponse({
+        defaultAdapter: 'claude',
+        worker: { adapter: 'claude', model: 'sonnet', enabled: true },
+        reviewer: { adapter: 'claude', model: 'sonnet', enabled: true },
+        tester: { adapter: 'claude', enabled: false },
+      }));
+
+      const { getProviderStatus } = await import('./providerCommand.js');
+      const status = await getProviderStatus();
+
+      expect(status).toMatchObject({ active: 'claude', source: 'daemon', daemonRunning: true });
+      // A disabled role is not part of what the daemon is actually running.
+      expect(status.roles).toEqual([
+        { role: 'worker', adapter: 'claude', model: 'sonnet' },
+        { role: 'reviewer', adapter: 'claude', model: 'sonnet' },
+      ]);
+      expect(readProviderOverrideMock).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the persisted override when no daemon answers', async () => {
+      fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+      readProviderOverrideMock.mockReturnValue('claude');
+
+      const { getProviderStatus } = await import('./providerCommand.js');
+
+      expect(await getProviderStatus()).toEqual({
+        active: 'claude', source: 'override', daemonRunning: false, roles: [],
+      });
+    });
+
+    it('falls back to config.yaml when there is neither a daemon nor an override', async () => {
+      fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+      readProviderOverrideMock.mockReturnValue(undefined);
+
+      const { getProviderStatus } = await import('./providerCommand.js');
+
+      expect(await getProviderStatus()).toMatchObject({ active: 'codex-responses', source: 'config' });
+    });
+
+    it('ignores an unknown daemon adapter name rather than reporting it as active', async () => {
+      fetchMock.mockResolvedValue(statsResponse({ defaultAdapter: 'retired-provider' }));
+      readProviderOverrideMock.mockReturnValue('gpt');
+
+      const { getProviderStatus } = await import('./providerCommand.js');
+
+      expect(await getProviderStatus()).toMatchObject({ active: 'gpt', source: 'override' });
+    });
+
+    it('uses the registry default when the config is unreadable', async () => {
+      fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+      readProviderOverrideMock.mockReturnValue(undefined);
+      loadConfigMock.mockImplementation(() => { throw new Error('no config.yaml'); });
+
+      const { getProviderStatus } = await import('./providerCommand.js');
+
+      expect(await getProviderStatus()).toMatchObject({ active: 'codex', source: 'config' });
+    });
+  });
+
+  describe('applyProvider', () => {
+    it('switches a running daemon in place and persists the choice', async () => {
+      fetchMock.mockResolvedValue({ ok: true, text: async () => '{"ok":true}' });
+
+      const { applyProvider } = await import('./providerCommand.js');
+      const result = await applyProvider('claude');
+
+      expect(result).toEqual({ live: true });
+      expect(writeProviderOverrideMock).toHaveBeenCalledWith('claude');
+      const [url, init] = fetchMock.mock.calls[0] as [string, { method: string; body: string }];
+      expect(url).toContain('/api/provider');
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body)).toEqual({ provider: 'claude' });
+    });
+
+    it('persists nothing when a reachable daemon rejects the switch', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 400, text: async () => 'Invalid provider' });
+
+      const { applyProvider } = await import('./providerCommand.js');
+      const result = await applyProvider('claude');
+
+      // A written override here would describe a provider the live process is not using.
+      expect(result.live).toBe(false);
+      expect(result.error).toContain('400');
+      expect(writeProviderOverrideMock).not.toHaveBeenCalled();
+    });
+
+    it('records the override for the next boot when no daemon is reachable', async () => {
+      fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const { applyProvider } = await import('./providerCommand.js');
+
+      expect(await applyProvider('claude')).toEqual({ live: false });
+      expect(writeProviderOverrideMock).toHaveBeenCalledWith('claude');
+    });
+  });
+
+  describe('runProviderCommand', () => {
+    it('rejects an unknown provider name against the live registry', async () => {
+      fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+      readProviderOverrideMock.mockReturnValue('codex');
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { runProviderCommand } = await import('./providerCommand.js');
+
+      expect(await runProviderCommand('not-a-provider')).toBe(1);
+      expect(error.mock.calls[0]?.[0]).toContain('Unknown provider');
+      expect(writeProviderOverrideMock).not.toHaveBeenCalled();
+      error.mockRestore();
+    });
+
+    it('is a no-op when the daemon already runs the requested provider', async () => {
+      fetchMock.mockResolvedValue(statsResponse({ defaultAdapter: 'claude' }));
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const { runProviderCommand } = await import('./providerCommand.js');
+
+      expect(await runProviderCommand('claude')).toBe(0);
+      expect(log.mock.calls[0]?.[0]).toContain('Already running');
+      // Only the status probe ran — no switch was attempted.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      log.mockRestore();
+    });
+
+    it('prints status instead of prompting when stdin is not a TTY', async () => {
+      fetchMock.mockResolvedValue(statsResponse({
+        defaultAdapter: 'claude',
+        worker: { adapter: 'claude', model: 'sonnet', enabled: true },
+      }));
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const isTTY = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+
+      const { runProviderCommand } = await import('./providerCommand.js');
+      const code = await runProviderCommand(undefined);
+
+      Object.defineProperty(process.stdin, 'isTTY', { value: isTTY, configurable: true });
+      expect(code).toBe(0);
+      expect(log.mock.calls.map(c => String(c[0])).join('\n')).toContain('Provider: claude');
+      expect(writeProviderOverrideMock).not.toHaveBeenCalled();
+      log.mockRestore();
+    });
+  });
+});

--- a/src/cli/providerCommand.ts
+++ b/src/cli/providerCommand.ts
@@ -1,0 +1,236 @@
+// ============================================
+// OpenSwarm - `openswarm provider [name]`
+// ============================================
+//
+// Show or switch the active AI provider from the terminal.
+//
+// The dashboard has had a provider toggle since INT-1901 (POST /api/provider
+// switches the LIVE daemon and persists the choice), but the CLI could only
+// READ the override (cli.ts). An operator whose provider ran out of quota had
+// to open a browser or hand-edit provider-override.json and restart the daemon.
+//
+//   openswarm provider          → interactive picker (current provider preselected)
+//   openswarm provider claude   → switch straight to the `claude -p` delegate
+//
+// A running daemon is switched in place; with no daemon we only record the
+// override, which service.ts re-applies on the next boot.
+
+import { isKnownAdapter, listAdapterNames } from '../adapters/index.js';
+import type { AdapterName } from '../adapters/types.js';
+import { readProviderOverride, writeProviderOverride } from '../core/providerOverride.js';
+import { loadConfig } from '../core/config.js';
+import { DAEMON_PORT } from './daemon.js';
+
+/**
+ * One-line hints for the interactive picker. Names always come from the live
+ * adapter registry — a hardcoded provider list is exactly what made the
+ * dashboard reject `claude` in INT-1901 — so a registered adapter with no hint
+ * here still shows up, just without a description.
+ */
+const PROVIDER_HINTS: Partial<Record<AdapterName, string>> = {
+  'codex-responses': 'ChatGPT subscription (OAuth) — Codex models, native loop',
+  codex: 'External codex CLI (delegated)',
+  claude: 'Claude Code CLI (claude -p) — opt-in fallback',
+  gpt: 'OpenAI ChatGPT OAuth (chat/completions)',
+  openrouter: 'OpenRouter API key or OAuth (any model)',
+  atlascloud: 'Atlas Cloud API key (OpenAI-compatible models)',
+  lmstudio: 'Local LM Studio server (no account)',
+  local: 'Local Ollama models (no account)',
+};
+
+/** Where the reported provider came from, in precedence order. */
+export type ProviderSource = 'daemon' | 'override' | 'config';
+
+export interface RoleSummary {
+  role: string;
+  adapter?: string;
+  model?: string;
+}
+
+export interface ProviderStatus {
+  active: AdapterName;
+  source: ProviderSource;
+  daemonRunning: boolean;
+  /** Per-role adapter/model as the daemon currently sees it (daemon source only). */
+  roles: RoleSummary[];
+}
+
+interface StatsAdapters {
+  defaultAdapter?: string;
+  [role: string]: unknown;
+}
+
+function baseUrl(port: number): string {
+  return `http://127.0.0.1:${port}`;
+}
+
+/** Ask the running daemon which adapter it is actually using right now. */
+async function fetchDaemonAdapters(port: number, timeoutMs = 1500): Promise<StatsAdapters | null> {
+  try {
+    const res = await fetch(`${baseUrl(port)}/api/stats`, { signal: AbortSignal.timeout(timeoutMs) });
+    if (!res.ok) return null;
+    const stats = await res.json() as { adapters?: StatsAdapters };
+    return stats.adapters ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function readRoles(adapters: StatsAdapters): RoleSummary[] {
+  const roles: RoleSummary[] = [];
+  for (const [role, value] of Object.entries(adapters)) {
+    if (role === 'defaultAdapter' || value === null || typeof value !== 'object') continue;
+    const entry = value as { adapter?: unknown; model?: unknown; enabled?: unknown };
+    if (entry.enabled === false) continue;
+    roles.push({
+      role,
+      adapter: typeof entry.adapter === 'string' ? entry.adapter : undefined,
+      model: typeof entry.model === 'string' ? entry.model : undefined,
+    });
+  }
+  return roles;
+}
+
+/** Same precedence the CLI boot path uses: live daemon → persisted override → config.yaml. */
+export async function getProviderStatus(port = DAEMON_PORT): Promise<ProviderStatus> {
+  const adapters = await fetchDaemonAdapters(port);
+  const live = adapters?.defaultAdapter;
+  if (typeof live === 'string' && isKnownAdapter(live)) {
+    return { active: live, source: 'daemon', daemonRunning: true, roles: readRoles(adapters!) };
+  }
+
+  const override = readProviderOverride();
+  if (override) return { active: override, source: 'override', daemonRunning: false, roles: [] };
+
+  let configured: string | undefined;
+  try {
+    configured = loadConfig().adapter;
+  } catch {
+    // No readable config yet (fresh install) — fall through to the registry default.
+  }
+  const active = configured && isKnownAdapter(configured) ? configured : 'codex';
+  return { active, source: 'config', daemonRunning: false, roles: [] };
+}
+
+export interface ApplyResult {
+  /** True when a running daemon accepted the switch and is already using it. */
+  live: boolean;
+  /** Set when a reachable daemon refused the switch; nothing was persisted. */
+  error?: string;
+}
+
+/**
+ * Switch the active provider. A reachable daemon is switched in place so the
+ * change applies to work already in flight; otherwise the override file alone
+ * carries the choice into the next boot.
+ */
+export async function applyProvider(next: AdapterName, port = DAEMON_PORT): Promise<ApplyResult> {
+  let reachable = false;
+  try {
+    const res = await fetch(`${baseUrl(port)}/api/provider`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider: next }),
+      signal: AbortSignal.timeout(5000),
+    });
+    reachable = true;
+    if (!res.ok) {
+      // The daemon is up but refused. Persisting the override anyway would leave
+      // the file describing a provider the live process is not using.
+      const detail = await res.text().catch(() => '');
+      return {
+        live: false,
+        error: `daemon rejected the switch (HTTP ${res.status})${detail ? `: ${detail.slice(0, 200)}` : ''}`,
+      };
+    }
+  } catch {
+    // Unreachable — no daemon to update, so the override file is the whole job.
+  }
+
+  // The daemon persists this itself via switchProvider(), but only when an
+  // autonomous runner is attached. Writing here too is idempotent and covers
+  // the dashboard-only daemon as well as the no-daemon case.
+  writeProviderOverride(next);
+  return { live: reachable };
+}
+
+function describeStatus(status: ProviderStatus): string[] {
+  const where = status.source === 'daemon'
+    ? 'live daemon'
+    : status.source === 'override'
+      ? 'saved override (daemon not running)'
+      : 'config.yaml (daemon not running)';
+  const lines = [`Provider: ${status.active}  (${where})`];
+  for (const role of status.roles) {
+    lines.push(`  ${role.role}: ${role.adapter ?? '?'}${role.model ? ` / ${role.model}` : ''}`);
+  }
+  return lines;
+}
+
+async function pickProvider(current: AdapterName): Promise<AdapterName | null> {
+  const { select } = await import('@inquirer/prompts');
+  try {
+    return await select<AdapterName>({
+      message: 'Select the AI provider',
+      default: current,
+      choices: listAdapterNames().map(name => ({
+        name: name === current ? `${name} (current)` : name,
+        value: name,
+        description: PROVIDER_HINTS[name],
+      })),
+    });
+  } catch {
+    // Ctrl+C / Esc — @inquirer throws ExitPromptError rather than resolving.
+    return null;
+  }
+}
+
+/**
+ * Entry point for `openswarm provider [name]`. Returns the process exit code
+ * so cli.ts stays a thin registration layer.
+ */
+export async function runProviderCommand(requested?: string): Promise<number> {
+  const status = await getProviderStatus();
+  let target = requested;
+
+  if (target === undefined) {
+    // A picker needs a terminal. Piped/CI invocations get the status instead of
+    // a prompt that would hang or render as garbage.
+    if (!process.stdin.isTTY) {
+      for (const line of describeStatus(status)) console.log(line);
+      console.log(`\nPass a name to switch: openswarm provider <${listAdapterNames().join('|')}>`);
+      return 0;
+    }
+    for (const line of describeStatus(status)) console.log(line);
+    console.log('');
+    const picked = await pickProvider(status.active);
+    if (picked === null) {
+      console.log('Cancelled — provider unchanged.');
+      return 0;
+    }
+    target = picked;
+  }
+
+  if (!isKnownAdapter(target)) {
+    console.error(`Unknown provider "${target}". Valid: ${listAdapterNames().join(', ')}`);
+    return 1;
+  }
+
+  if (target === status.active && status.source === 'daemon') {
+    console.log(`Already running on "${target}" — nothing to do.`);
+    return 0;
+  }
+
+  const result = await applyProvider(target);
+  if (result.error) {
+    console.error(`Provider switch failed: ${result.error}`);
+    return 1;
+  }
+
+  if (result.live) {
+    console.log(`Provider switched to "${target}" — the running daemon is using it now.`);
+  } else {
+    console.log(`Provider set to "${target}". No daemon is running; it applies on the next start.`);
+  }
+  return 0;
+}

--- a/src/support/fileLock.ts
+++ b/src/support/fileLock.ts
@@ -45,7 +45,17 @@ export async function withFileLock<T>(
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
       const current = await owner(path);
-      const malformedAndStale = current === null && Date.now() - (await stat(path)).mtimeMs > malformedStaleMs;
+      let malformedAndStale = false;
+      if (current === null) {
+        try {
+          malformedAndStale = Date.now() - (await stat(path)).mtimeMs > malformedStaleMs;
+        } catch (statError) {
+          // The holder released the lock between our failed open and this stat.
+          // That is the normal hand-off, not an error: retry the open.
+          if ((statError as NodeJS.ErrnoException).code !== 'ENOENT') throw statError;
+          continue;
+        }
+      }
       if ((current !== null && !alive(current.pid)) || malformedAndStale) {
         await unlink(path).catch((unlinkError) => {
           if ((unlinkError as NodeJS.ErrnoException).code !== 'ENOENT') throw unlinkError;


### PR DESCRIPTION
## What changed

Provider switching only existed in the dashboard (`POST /api/provider`) and the TUI. The CLI could *read* the persisted override but never set it, so an operator whose provider ran out of quota had to open a browser or hand-edit `provider-override.json` and restart the daemon.

```
openswarm provider          # interactive picker, current provider preselected
openswarm provider claude   # switch straight to the claude -p delegate
```

- A reachable daemon is switched **in place**, so work already in flight moves too; without one the override alone carries the choice into the next boot.
- If a live daemon refuses the switch, nothing is persisted — the file can never describe a provider the running process is not using.
- Non-TTY invocations (pipes, CI) print status instead of hanging on a prompt.
- The picker lists adapters from the live registry rather than a hardcoded set, which is what made the dashboard reject `claude` in INT-1901.

Also corrects the README claim that `claude` is not a selectable `adapter:` value — both `AdapterNameSchema` and `AdapterName` have included it since that fix.

Automatic fallback on quota exhaustion is deliberately **out of scope**: `worker.ts` and `draftAnalyzer.ts` keep cross-provider fallback opt-in.

## Out-of-scope fix carried here

`fix(support): retry the lock open when the holder releases mid-check` is unrelated to the provider command — it repairs a race already on main. `withFileLock` stat'd the lock file to age-out malformed locks, but that stat ran *after* the open failed with EEXIST; when the previous holder unlinked the lock in between, stat threw ENOENT and the caller crashed instead of acquiring the now-free lock. CI surfaced it through the concurrent-holders test in this branch, so it is fixed here rather than left to fail intermittently on main.

## Validation

- `vitest run src/cli/providerCommand.test.ts` — 14 passed; `providerCommand.ts` at 97.5% statements / 100% lines
- `npm run test:coverage` — 237 files, 3,199 passed; statements 90.05%, branches 81.04%, functions 91.1%
- `npm run typecheck`, `npm run lint` (0/0)
- fileLock suite run five times consecutively after the race fix — all green
- Live daemon: non-TTY run reported the running provider and role models; pty run rendered the picker with the current provider preselected; `provider <same>` was a no-op

Closes INT-2997