### PR TITLE
ci(release): install the Linux verification sandbox before the release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,19 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
+      # Verification runs each command inside an OS sandbox and fails closed
+      # without one; on Linux that sandbox is bubblewrap, which the runner image
+      # does not ship. ubuntu-24.04 also restricts unprivileged user namespaces
+      # through AppArmor, which bwrap needs for its network namespace. Same setup
+      # as the Tests job in ci.yml — without it the release gate fails on every
+      # src/verify test.
+      - name: Install the Linux verification sandbox
+        if: steps.ver.outputs.exists == 'false'
+        run: |
+          sudo apt-get update && sudo apt-get install -y bubblewrap
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+          bwrap --ro-bind / / --unshare-net --dev /dev --proc /proc -- /bin/sh -lc 'echo sandbox-ok'
+
       - if: steps.ver.outputs.exists == 'false'
         run: npm ci
 


### PR DESCRIPTION
v0.19.0's release run failed: the gate's `npm test` had no OS sandbox, so every `src/verify` test failed closed with `[security] OS verification sandbox is unavailable`. Nothing was published or tagged.

`ci.yml` got the bubblewrap setup when the S4 sandbox landed; `release.yml` did not. This mirrors it — install bubblewrap, lift the ubuntu-24.04 AppArmor restriction on unprivileged user namespaces, and smoke-test `bwrap` so a future runner-image change fails at setup instead of as opaque verify failures.

After this merges, v0.19.0 is released by dispatching `release.yml` manually (the automatic trigger only fires on `package.json` changes, and that bump is already on main).