### PR TITLE
fix(verify): make the failure fingerprint stable so pre-existing failures stop reading as regressions

### DIFF
--- a/src/verify/fingerprintStability.test.ts
+++ b/src/verify/fingerprintStability.test.ts
@@ -1,0 +1,117 @@
+// INT-2961 / audit 2026-07-26 (src/verify) — the failure fingerprint has to be
+// identical for two runs of the SAME failure, because `hasSameFailure` uses it to
+// decide whether a failing command is a pre-existing failure or a regression the
+// change introduced. Two things made it differ between the base and head runs:
+//
+//   1. only the command's `cwd` was path-normalized, so with a subdirectory cwd
+//      every path outside it — sibling files, and the sandbox's isolated
+//      HOME/TMPDIR next to the project root — kept its random `mkdtemp` prefix;
+//   2. stdout and stderr were recorded into one buffer as chunks arrived, so OS
+//      scheduling decided the byte order and identical output could hash two ways.
+//
+// Both produced the same user-visible bug: a pre-existing failure reported as a
+// new regression. These tests pin the normalization contract that fixes (1); (2)
+// is structural (per-stream capture, concatenated in a fixed order) and is
+// covered by the stdout+stderr case at the bottom.
+import { describe, expect, it } from 'vitest';
+import { normalizeFailureOutput } from './runner.js';
+
+const SANDBOX_A = '/tmp/openswarm-verify-head-aaaa';
+const SANDBOX_B = '/tmp/openswarm-verify-head-bbbb';
+
+function paths(sandbox: string): Array<[string, string]> {
+  // Mirrors the call site: project root plus the isolated HOME/TMPDIR that sit
+  // beside it inside the same sandbox.
+  return [
+    [`${sandbox}/worktree`, '<PROJECT>'],
+    [`${sandbox}/home`, '<HOME>'],
+    [`${sandbox}/tmp`, '<TMP>'],
+  ];
+}
+
+describe('normalizeFailureOutput', () => {
+  it('makes two sandboxes produce identical text for the same failure', () => {
+    const failure = (sandbox: string) =>
+      [
+        `  File "${sandbox}/worktree/src/app.ts", line 3`,
+        `  imported from ${sandbox}/worktree/src/lib/util.ts`,
+        `  cache: ${sandbox}/home/.cache/build`,
+        `  scratch: ${sandbox}/tmp/pytest-0`,
+      ].join('\n');
+
+    expect(normalizeFailureOutput(failure(SANDBOX_A), paths(SANDBOX_A))).toBe(
+      normalizeFailureOutput(failure(SANDBOX_B), paths(SANDBOX_B)),
+    );
+  });
+
+  it('normalizes paths outside the command cwd — the subdirectory-cwd bug', () => {
+    // A command with `cwd: packages/api` fails, but the traceback points at a
+    // sibling package. Normalizing only the cwd left this line sandbox-specific.
+    const out = (s: string) => `error in ${s}/worktree/packages/web/index.ts`;
+
+    const a = normalizeFailureOutput(out(SANDBOX_A), paths(SANDBOX_A));
+
+    expect(a).toBe(normalizeFailureOutput(out(SANDBOX_B), paths(SANDBOX_B)));
+    expect(a).not.toContain('openswarm-verify-head');
+  });
+
+  it('normalizes the isolated HOME and TMPDIR, not just the project', () => {
+    const a = normalizeFailureOutput(`${SANDBOX_A}/home/.npm/_logs/x.log`, paths(SANDBOX_A));
+
+    expect(a).toBe('<HOME>/.npm/_logs/x.log');
+  });
+
+  it('substitutes the longest path first so a nested path keeps its own label', () => {
+    // '<sandbox>' contains '<sandbox>/worktree'. If the ancestor were replaced
+    // first the project label would never be reachable.
+    const withAncestor: Array<[string, string]> = [
+      [SANDBOX_A, '<SANDBOX>'],
+      [`${SANDBOX_A}/worktree`, '<PROJECT>'],
+    ];
+
+    const out = normalizeFailureOutput(`${SANDBOX_A}/worktree/src/a.ts`, withAncestor);
+
+    expect(out).toBe('<PROJECT>/src/a.ts');
+  });
+
+  it('treats regex metacharacters in a path literally', () => {
+    const weird = '/tmp/build (1)+test';
+
+    const out = normalizeFailureOutput(`${weird}/src/a.ts`, [[weird, '<PROJECT>']]);
+
+    expect(out).toBe('<PROJECT>/src/a.ts');
+  });
+
+  it('ignores empty paths instead of matching everywhere', () => {
+    // An empty needle would otherwise splice the label between every character.
+    expect(normalizeFailureOutput('abc', [['', '<X>']])).toBe('abc');
+  });
+
+  it('still strips ANSI colour and run durations', () => {
+    const esc = String.fromCharCode(27);
+
+    const out = normalizeFailureOutput(
+      `${esc}[31mFAIL${esc}[0m\n=== 1 failed in 4.21s ===\nRan 3 tests in 0.09s\nfinished in 2.5s`,
+      [],
+    );
+
+    expect(out).not.toContain(esc);
+    expect(out).toContain('<DURATION>');
+    expect(out).not.toContain('4.21s');
+    expect(out).not.toContain('0.09s');
+    expect(out).not.toContain('2.5s');
+  });
+
+  it('is stable for output that mixes stdout and stderr content', () => {
+    // The fingerprint is now built stdout-then-stderr rather than in arrival
+    // order, so the two streams' relative timing cannot change the hash input.
+    // Here the same logical content is normalized from both orderings.
+    const stdout = `running ${SANDBOX_A}/worktree/src/a.ts\n`;
+    const stderr = `error: ${SANDBOX_A}/worktree/src/b.ts\n`;
+
+    const fixedOrder = normalizeFailureOutput(stdout + stderr, paths(SANDBOX_A));
+
+    expect(fixedOrder).toBe('running <PROJECT>/src/a.ts\nerror: <PROJECT>/src/b.ts\n');
+    expect(fixedOrder).not.toContain('openswarm-verify-head');
+  });
+});

--- a/src/verify/runner.ts
+++ b/src/verify/runner.ts
@@ -75,10 +75,35 @@ function hasSameFailure(base: CommandResult, head: CommandResult): boolean {
   return base.outputFingerprint !== undefined && base.outputFingerprint === head.outputFingerprint;
 }
 
-function normalizeFailureOutput(output: string, projectRoot: string): string {
-  const escapedRoot = projectRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return output
-    .replace(new RegExp(escapedRoot, 'g'), '<PROJECT>')
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Replace every run-specific absolute path with a stable placeholder.
+ *
+ * `paths` is applied longest-first so a nested path is substituted before the
+ * ancestor containing it; doing the ancestor first would rewrite the shared
+ * prefix and leave the more specific label unreachable.
+ *
+ * This previously received only the command's `cwd`. When a command declared a
+ * subdirectory cwd, every path OUTSIDE that subdirectory — sibling source files,
+ * and the sandbox's isolated HOME/TMPDIR, which sit beside the project root —
+ * kept its randomly-named sandbox prefix. Base and head run in different
+ * `mkdtemp` directories, so those prefixes survived into the fingerprint and made
+ * two runs of the SAME pre-existing failure hash differently. `hasSameFailure`
+ * then reported it as a new regression — exactly what that check exists to
+ * prevent.
+ */
+export function normalizeFailureOutput(output: string, paths: Array<[string, string]>): string {
+  let normalized = output;
+  const ordered = [...paths]
+    .filter(([path]) => path.length > 0)
+    .sort((a, b) => b[0].length - a[0].length);
+  for (const [path, label] of ordered) {
+    normalized = normalized.replace(new RegExp(escapeForRegExp(path), 'g'), label);
+  }
+  return normalized
     .replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'), '')
     .replace(/(=+ .*? in )\d+(?:\.\d+)?s( =+)/g, '$1<DURATION>$2')
     .replace(/(Ran \d+ tests? in )\d+(?:\.\d+)?s/g, '$1<DURATION>')
@@ -182,7 +207,16 @@ async function runCommand(command: VerifyCommand, root: string, env: NodeJS.Proc
   }
   return await new Promise((resolveResult) => {
     let output: Buffer = Buffer.alloc(0);
-    const fingerprintChunks: Buffer[] = [];
+    // Fingerprint bytes are kept per stream and concatenated in a fixed order at
+    // the end (stdout, then stderr, then any synthetic trailer). Recording both
+    // streams into one buffer as chunks arrived made the fingerprint depend on
+    // OS scheduling: the same command emitting the same stdout and stderr could
+    // interleave differently between the base and head runs and hash to two
+    // different values, so `hasSameFailure` saw a pre-existing failure as a new
+    // regression. Per-stream capture makes identical output hash identically.
+    const fingerprintChunks: Record<'stdout' | 'stderr' | 'extra', Buffer[]> = {
+      stdout: [], stderr: [], extra: [],
+    };
     let fingerprintBytes = 0;
     let fingerprintTruncated = false;
     let settled = false;
@@ -194,38 +228,41 @@ async function runCommand(command: VerifyCommand, root: string, env: NodeJS.Proc
       detached,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-    const record = (chunk: Buffer) => {
+    const retainForFingerprint = (stream: 'stdout' | 'stderr' | 'extra', chunk: Buffer) => {
       if (fingerprintBytes < FINGERPRINT_BYTES) {
         const retained = chunk.subarray(0, FINGERPRINT_BYTES - fingerprintBytes);
-        fingerprintChunks.push(retained);
+        fingerprintChunks[stream].push(retained);
         fingerprintBytes += retained.length;
         fingerprintTruncated ||= retained.length < chunk.length;
       } else fingerprintTruncated = true;
+    };
+    const record = (stream: 'stdout' | 'stderr') => (chunk: Buffer) => {
+      retainForFingerprint(stream, chunk);
+      // The human-facing output keeps true arrival order — interleaving is what
+      // makes a log readable. Only the fingerprint needs to be order-independent.
       output = appendTail(output, chunk);
     };
-    child.stdout.on('data', record);
-    child.stderr.on('data', record);
+    child.stdout.on('data', record('stdout'));
+    child.stderr.on('data', record('stderr'));
 
     const finish = (status: CommandResult['status'], extra = '') => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
       if (extra) {
-        const extraBuffer = Buffer.from(extra);
-        if (fingerprintBytes < FINGERPRINT_BYTES) {
-          const retained = extraBuffer.subarray(0, FINGERPRINT_BYTES - fingerprintBytes);
-          fingerprintChunks.push(retained);
-          fingerprintBytes += retained.length;
-          fingerprintTruncated ||= retained.length < extraBuffer.length;
-        } else fingerprintTruncated = true;
+        retainForFingerprint('extra', Buffer.from(extra));
         output = appendTail(output, Buffer.from(extra));
       }
       const outputText = output.toString('utf8');
-      const fingerprintText = Buffer.concat(fingerprintChunks).toString('utf8') + (fingerprintTruncated ? '\n<TRUNCATED>' : '');
+      const fingerprintText = Buffer.concat([
+        ...fingerprintChunks.stdout, ...fingerprintChunks.stderr, ...fingerprintChunks.extra,
+      ]).toString('utf8') + (fingerprintTruncated ? '\n<TRUNCATED>' : '');
       resolveResult({
         status,
         output: outputText,
-        outputFingerprint: createHash('sha256').update(normalizeFailureOutput(fingerprintText, cwd)).digest('hex'),
+        outputFingerprint: createHash('sha256').update(normalizeFailureOutput(fingerprintText, [
+          [root, '<PROJECT>'], [isolatedHome, '<HOME>'], [isolatedTmp, '<TMP>'],
+        ])).digest('hex'),
         environmentFailure: status === 'fail' && isEnvironmentFailure(outputText),
       });
     };


### PR DESCRIPTION
`hasSameFailure` waives a failing command when the base and head runs produce the same output fingerprint. Two things made that fingerprint differ for runs of the **same** failure, so a pre-existing failure was reported as a **new regression** — exactly what the check exists to prevent.

### 1. Only the command's `cwd` was path-normalized

With a subdirectory `cwd`, every path outside it kept its randomly-named sandbox prefix: sibling source files, and the sandbox's isolated `HOME`/`TMPDIR`, which sit beside the project root. Base and head run in different `mkdtemp` directories, so those prefixes went straight into the hash.

Now the project root, HOME and TMPDIR are all normalized — longest path first, so a nested path still gets its own label rather than being swallowed by its ancestor.

### 2. stdout and stderr shared one fingerprint buffer, filled in arrival order

OS scheduling decided the byte order, so the same command emitting the same two streams could interleave differently between runs and hash two ways. They are now captured per stream and concatenated in a fixed order.

The human-facing output still keeps true arrival order — interleaving is what makes a log readable, and only the fingerprint needs to be order-independent.

## Provenance

Found by the **2026-07-26 `review --max`** audit, which covered `src/verify` for the first time — that area was the single reviewer failure in the 2026-07-21 run and is named in INT-2961 as a precondition.

`normalizeFailureOutput` is exported so the normalization contract can be tested directly; it has no other callers.

## Deliberately not included

The same audit raised two more `src/verify` items. Both are **performance, not correctness**, and both change security-sensitive sandbox setup, so bundling them here would put a risky refactor behind a bug fix:

- `createHeadSandbox` materializes a checkout and then deletes it before copying the live tree. Removing the checkout also removes how HEAD gets detached and how the index is populated, so it needs a verified replacement (`update-ref` + `read-tree`) checked against the sandbox's git-state expectations.
- `runVerify` builds one sandbox per command. Hoisting it means commands **share** a sandbox — that trades isolation for speed, which is an owner's call rather than a cleanup.

## Test plan

- [x] Full suite: **3212 passed / 0 failed** (was 3204; +8 new)
- [x] `npm run lint` — 0 errors; `npm run typecheck` — clean
- [x] **Mutation-tested**: dropping the longest-first ordering turns the nested-path test red
- [x] 8 new tests pin the contract: two different sandboxes normalize to identical text, paths outside the cwd are covered, HOME/TMPDIR are covered, regex metacharacters in paths are literal, empty paths are ignored, ANSI/duration stripping still works

Linear: INT-2961 (src/verify precondition), INT-2928