### PR TITLE
fix(rollback): identify the checkpoint stash by message, not by its shifting stash@{N} index

### DIFF
--- a/src/support/rollback.coverage.test.ts
+++ b/src/support/rollback.coverage.test.ts
@@ -305,8 +305,12 @@ describe('rollback.ts coverage', () => {
 
     it('stash strategy restores a pre-existing stash after checking out', async () => {
       writeFileSync(join(repo, 'file.txt'), 'stashed-value\n');
-      execFileSync('git', ['stash', 'push', '-m', 'pre-existing'], { cwd: repo });
-      const stashLine = stashList(repo).split('\n').find(line => line.includes('pre-existing'));
+      // The message must be the one createCheckpoint actually writes: the stash is
+      // now located by message rather than by its (shifting) stash@{N} position,
+      // so a fixture using an arbitrary message describes a checkpoint that
+      // createCheckpoint could never produce.
+      execFileSync('git', ['stash', 'push', '-m', 'openswarm-checkpoint-exec-fixture'], { cwd: repo });
+      const stashLine = stashList(repo).split('\n').find(line => line.includes('openswarm-checkpoint-exec-fixture'));
       const stashId = stashLine?.match(/stash@\{(\d+)\}/)?.[0];
       expect(stashId).toBeDefined();
 

--- a/src/support/rollback.ts
+++ b/src/support/rollback.ts
@@ -47,6 +47,29 @@ export type RollbackStrategy = 'reset_hard' | 'reset_soft' | 'stash' | 'checkout
 // Checkpoint Storage
 
 const CHECKPOINT_DIR = resolve(homedir(), '.openswarm/checkpoints');
+const CHECKPOINT_STASH_PREFIX = 'openswarm-checkpoint-';
+
+function checkpointStashMessage(executionId: string): string {
+  return `${CHECKPOINT_STASH_PREFIX}${executionId}`;
+}
+
+/**
+ * Current `stash@{N}` for a stash identified by its message, or undefined if it
+ * is no longer in the list.
+ *
+ * `stash@{N}` is a POSITION, not an identity: every `git stash push` inserts at
+ * 0 and shifts everything down. The checkpoint's index was captured at creation
+ * time and reused verbatim at pop time, so any stash created in between made it
+ * point at the wrong entry — and the `stash` rollback strategy creates one
+ * itself, immediately before popping, so it reliably restored the
+ * `rollback-preserve-*` stash it had just made and orphaned the checkpoint's.
+ * Resolving by message at pop time is stable under that shifting.
+ */
+async function resolveStashRef(projectPath: string, message: string): Promise<string | undefined> {
+  const { stdout } = await gitExec(projectPath, 'stash', 'list');
+  const line = stdout.split('\n').find((entry) => entry.includes(message));
+  return line?.match(/stash@\{\d+\}/)?.[0];
+}
 
 const CheckpointSchema = z.object({
   id: z.string().min(1),
@@ -209,7 +232,7 @@ export async function createCheckpoint(
     const changedFiles = await getChangedFiles(expandedPath);
     console.log(`[Rollback] Stashing ${changedFiles.length} changed files`);
 
-    const stashMessage = `openswarm-checkpoint-${executionId}`;
+    const stashMessage = checkpointStashMessage(executionId);
     await gitExec(expandedPath, 'stash', 'push', '-m', stashMessage, '--include-untracked');
 
     // Find Stash ID
@@ -301,7 +324,12 @@ async function rollback(
         // Restore stash if it existed
         if (checkpoint.stashId) {
           try {
-            await gitExec(checkpoint.projectPath, 'stash', 'pop', checkpoint.stashId);
+            // Resolved by message, never by the stored index — see resolveStashRef.
+            const stashRef = await resolveStashRef(
+              checkpoint.projectPath, checkpointStashMessage(checkpoint.executionId),
+            );
+            if (!stashRef) throw new Error('checkpoint stash is no longer in the stash list');
+            await gitExec(checkpoint.projectPath, 'stash', 'pop', stashRef);
           } catch (error) {
             const msg = error instanceof Error ? error.message : String(error);
             console.log('[Rollback] Stash pop failed, may have conflicts');
@@ -344,7 +372,13 @@ async function rollback(
         // Restore original stash
         if (checkpoint.stashId) {
           try {
-            await gitExec(checkpoint.projectPath, 'stash', 'pop', checkpoint.stashId);
+            // Must be resolved AFTER the rollback-preserve push above, which
+            // shifted the checkpoint's stash down by one.
+            const stashRef = await resolveStashRef(
+              checkpoint.projectPath, checkpointStashMessage(checkpoint.executionId),
+            );
+            if (!stashRef) throw new Error('checkpoint stash is no longer in the stash list');
+            await gitExec(checkpoint.projectPath, 'stash', 'pop', stashRef);
           } catch (error) {
             const msg = error instanceof Error ? error.message : String(error);
             console.log('[Rollback] Original stash pop failed');

--- a/src/support/rollbackStashIdentity.test.ts
+++ b/src/support/rollbackStashIdentity.test.ts
@@ -1,0 +1,128 @@
+// Audit 2026-07-26 (src/support) — `stash@{N}` is a POSITION, not an identity.
+// Every `git stash push` inserts at 0 and shifts existing entries down, but the
+// checkpoint captured its index at creation time and reused that literal string
+// at pop time. Anything that stashed in between made it point at the wrong
+// entry — and the `stash` rollback strategy pushes one ITSELF immediately before
+// popping, so it reliably restored the `rollback-preserve-*` stash it had just
+// created and left the checkpoint's stash orphaned. The user's preserved work
+// came back as somebody else's changes.
+//
+// These tests drive the real rollback path against a real git repo, with the
+// checkpoint store redirected to a temp HOME so they never touch ~/.openswarm.
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, homedir: () => process.env.OSW_TEST_HOME ?? actual.homedir() };
+});
+
+let sandbox: string;
+let repo: string;
+let previousHome: string | undefined;
+
+function git(...args: string[]): string {
+  return execFileSync('git', ['-C', repo, ...args], { encoding: 'utf8' }).trim();
+}
+
+/** Fresh module instance — CHECKPOINT_DIR is resolved once at import time. */
+async function loadRollback() {
+  vi.resetModules();
+  return await import('./rollback.js');
+}
+
+beforeEach(async () => {
+  sandbox = await mkdtemp(join(tmpdir(), 'osw-rollback-'));
+  previousHome = process.env.OSW_TEST_HOME;
+  process.env.OSW_TEST_HOME = join(sandbox, 'home');
+  repo = join(sandbox, 'repo');
+  execFileSync('git', ['init', '-b', 'main', repo], { stdio: 'pipe' });
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'Test');
+  await writeFile(join(repo, 'tracked.txt'), 'committed\n', 'utf8');
+  git('add', '-A');
+  git('commit', '-m', 'base');
+});
+
+afterEach(async () => {
+  if (previousHome === undefined) delete process.env.OSW_TEST_HOME;
+  else process.env.OSW_TEST_HOME = previousHome;
+  await rm(sandbox, { recursive: true, force: true });
+});
+
+describe('checkpoint stash identity', () => {
+  it('restores the checkpoint stash after another stash shifted its index', async () => {
+    const { createCheckpoint, rollbackToCheckpoint } = await loadRollback();
+
+    await writeFile(join(repo, 'tracked.txt'), 'CHECKPOINT WORK\n', 'utf8');
+    const checkpoint = await createCheckpoint('exec-1', repo);
+    expect(checkpoint.stashId).toBeDefined();
+
+    // Something else stashes afterwards — the checkpoint's entry is now one
+    // position further down, so the index captured above is stale.
+    await writeFile(join(repo, 'tracked.txt'), 'SOMEONE ELSE\n', 'utf8');
+    execFileSync('git', ['-C', repo, 'stash', 'push', '-m', 'unrelated', '--include-untracked'], { stdio: 'pipe' });
+
+    const result = await rollbackToCheckpoint(checkpoint.id, 'reset_hard');
+
+    expect(result.success).toBe(true);
+    expect(await readFile(join(repo, 'tracked.txt'), 'utf8')).toBe('CHECKPOINT WORK\n');
+  });
+
+  it("the stash strategy does not restore the stash it just created itself", async () => {
+    // The sharpest form: this strategy pushes `rollback-preserve-*` and then
+    // pops. With a stored index of stash@{0} it popped its own fresh stash.
+    const { createCheckpoint, rollbackToCheckpoint } = await loadRollback();
+
+    await writeFile(join(repo, 'tracked.txt'), 'CHECKPOINT WORK\n', 'utf8');
+    const checkpoint = await createCheckpoint('exec-2', repo);
+
+    await writeFile(join(repo, 'tracked.txt'), 'UNCOMMITTED AT ROLLBACK TIME\n', 'utf8');
+    const result = await rollbackToCheckpoint(checkpoint.id, 'stash');
+
+    expect(result.success).toBe(true);
+    expect(await readFile(join(repo, 'tracked.txt'), 'utf8')).toBe('CHECKPOINT WORK\n');
+  });
+
+  it('reports failure instead of popping an arbitrary stash when the checkpoint stash is gone', async () => {
+    // Failing loudly beats silently restoring whatever happens to sit at that
+    // index — that is the data-corruption shape this whole fix is about.
+    const { createCheckpoint, rollbackToCheckpoint } = await loadRollback();
+
+    await writeFile(join(repo, 'tracked.txt'), 'CHECKPOINT WORK\n', 'utf8');
+    const checkpoint = await createCheckpoint('exec-3', repo);
+
+    execFileSync('git', ['-C', repo, 'stash', 'drop'], { stdio: 'pipe' });
+    await writeFile(join(repo, 'decoy.txt'), 'decoy\n', 'utf8');
+    execFileSync('git', ['-C', repo, 'stash', 'push', '-m', 'decoy', '--include-untracked'], { stdio: 'pipe' });
+
+    const result = await rollbackToCheckpoint(checkpoint.id, 'reset_hard');
+
+    expect(result.success).toBe(false);
+    expect(result.action).toBe('stash_pop');
+    // The decoy must still be stashed — nothing of it leaked into the worktree.
+    expect(git('stash', 'list')).toContain('decoy');
+  });
+
+  it('leaves a checkpoint with no stash untouched', async () => {
+    const { createCheckpoint, rollbackToCheckpoint } = await loadRollback();
+
+    const checkpoint = await createCheckpoint('exec-4', repo); // clean tree
+    expect(checkpoint.stashId).toBeUndefined();
+
+    const result = await rollbackToCheckpoint(checkpoint.id, 'reset_hard');
+
+    expect(result.success).toBe(true);
+    expect(await readFile(join(repo, 'tracked.txt'), 'utf8')).toBe('committed\n');
+  });
+});
+
+describe('test harness', () => {
+  it('redirects the checkpoint store away from the real home', () => {
+    expect(homedir()).toBe(process.env.OSW_TEST_HOME);
+    expect(homedir()).toContain('osw-rollback-');
+  });
+});


### PR DESCRIPTION
`stash@{N}` is a **position, not an identity**: every `git stash push` inserts at 0 and shifts existing entries down. The checkpoint captured its index at creation time and reused that literal string at pop time, so any stash created in between made it point at a different entry.

The `stash` rollback strategy makes this **deterministic rather than merely possible**:

```ts
// push shifts the checkpoint's stash from stash@{0} to stash@{1}
await gitExec(path, 'stash', 'push', '-m', `rollback-preserve-${Date.now()}`, ...);
await gitExec(path, 'checkout', checkpoint.commitHash);
await gitExec(path, 'stash', 'pop', checkpoint.stashId);  // still says stash@{0}
```

So it popped the `rollback-preserve-*` stash it had **just created**, and orphaned the checkpoint's. The user's preserved work came back as the wrong changes.

## Fix

- The stash is located by the message `createCheckpoint` always writes (`openswarm-checkpoint-<executionId>`), resolved **at pop time** so it is immune to the shifting.
- Derived from `executionId` rather than stored, so checkpoints saved by earlier versions resolve correctly with **no migration**.
- When the stash is no longer in the list, this now **reports failure** instead of popping whatever occupies that index. Silently restoring an unrelated stash is the corruption this fix is about; a loud failure is strictly better.

## About the changed existing test

`rollback.coverage.test.ts` had a fixture that stashed with the message `'pre-existing'` and asserted it was restored. **Its intent is kept** — only the message is aligned with what `createCheckpoint` actually writes, because as written the fixture described a checkpoint that `createCheckpoint` could never produce.

The alternative — falling back to the stored index when the message is not found — would reinstate exactly the bug above, so it was rejected rather than used to keep the fixture untouched.

## Test plan

- [x] Full suite: **239 files / 3217 passed / 0 failed**
- [x] `npm run lint` 0 errors; `npm run typecheck` clean
- [x] **Mutation-tested**: restoring the stored-index pop turns **3 of the new tests red**, including the case where an unrelated stash is silently restored
- [x] 5 new tests drive the real rollback path against a real git repo, with the checkpoint store redirected to a temp HOME so they never touch `~/.openswarm`

Found by the 2026-07-26 `review --max` audit (src/support).

Linear: INT-2928, INT-2961