### PR TITLE
chore(release): v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.19.1 — 2026-07-26
+
+### Fixed
+
+- **A pre-existing test failure no longer reports as a regression** — `hasSameFailure` waives a failing command when the base and head runs produce the same output fingerprint, but only the command's `cwd` was path-normalized. With a subdirectory `cwd`, everything outside it kept its random sandbox prefix — sibling sources, and the isolated `HOME`/`TMPDIR` beside the project root — and the two runs happen in different `mkdtemp` directories, so identical failures hashed differently. stdout and stderr also shared one fingerprint buffer filled in arrival order, letting OS scheduling change the hash of the same output. Paths are now normalized across the whole sandbox and the streams are captured separately and concatenated in a fixed order. (#321)
+- **Rollback restored the wrong stash** — `stash@{N}` is a position, not an identity: every `git stash push` shifts existing entries down, and the checkpoint reused the index captured at creation time. The `stash` strategy pushes `rollback-preserve-*` immediately before popping, so it reliably restored the stash it had just created and orphaned the checkpoint's — the work a user asked to preserve came back as different changes. The checkpoint stash is now located by its message at pop time, and a missing stash reports failure instead of popping whatever occupies that index. (#322)
+- **One telemetry install id per install** — `getInstallId()` and `maybeShowNotice()` each did read-then-write from a stale read, so on a first run a daemon and a CLI could both mint an id and the later write replaced the other. State was also written in place, so a reader seeing a torn file regenerated the id as if the install were new. Writes now merge against the current file and go through the atomic write helper the rest of the local state already uses. (#323)
+
 ## 0.19.0 — 2026-07-23
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Three fixes from the 2026-07-26 `review --max` audit. All three were **silent** — the failure looked like success.

| # | What was wrong | User-visible effect |
|---|---|---|
| #321 | `verify` fingerprint varied with the sandbox path and with stdout/stderr interleaving | A **pre-existing** test failure reported as a **regression** |
| #322 | `stash@{N}` is a position, and the `stash` strategy pushes a stash right before popping | Rollback restored the stash it had **just created**; the work the user asked to preserve came back as different changes |
| #323 | `getInstallId` / `maybeShowNotice` wrote from a stale read, in place | A first run could mint **two** install ids; a torn file regenerated the id as if the install were new |

Merging this triggers the release workflow (npm publish → tag → GitHub release), per the "merge a version-bump PR" flow in `release.yml`.

## Test plan

- [x] Full suite: **240 files / 3227 passed / 0 failed**
- [x] `npm run lint` 0 errors; `npm run typecheck` clean
- [x] Each fix mutation-tested; #321 and #322 additionally verified **end-to-end** by reverting to the pre-fix code and confirming the bug reproduces (rollback restored `SCRATCH THAT SHOULD NOT WIN` in place of the checkpoint's work, and `newFailure` flipped true for an unchanged failure)
- [x] `package.json` / `package-lock.json` changed on the version line only — no reformatting

Linear: INT-2928, INT-2961
