### PR TITLE
fix(support,github): write shared config files atomically, drop hardcoded Tailscale IP

### DIFF
--- a/src/github/ciState.test.ts
+++ b/src/github/ciState.test.ts
@@ -1,0 +1,102 @@
+// ============================================
+// OpenSwarm - CI state persistence tests
+// ============================================
+//
+// ci-state.json holds each repo's health timeline (brokenSince, lastReminder).
+// Two independent callers write it — core/service.ts checkGitHubCI and
+// automation/ciWorker.ts — with no lock between them, and loadCIState's
+// fallback is an empty state. That combination is what makes the write's
+// atomicity load-bearing: a reader that catches a half-written file silently
+// resets every repo's history instead of reporting a problem.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+let home: string;
+
+/**
+ * Load a fresh copy of github.js with homedir() pointed at a temp directory.
+ * CI_STATE_PATH is computed at module load, so the mock has to be in place
+ * before the import — hence resetModules + dynamic import per test.
+ */
+async function loadModule() {
+  vi.resetModules();
+  vi.doMock('node:os', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:os')>();
+    return { ...actual, default: { ...actual, homedir: () => home }, homedir: () => home };
+  });
+  return await import('./github.js');
+}
+
+const ciStatePath = () => resolve(home, '.openswarm', 'ci-state.json');
+
+describe('CI state persistence', () => {
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'openswarm-cistate-'));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    vi.doUnmock('node:os');
+    vi.restoreAllMocks();
+  });
+
+  it('round-trips state through save and load', async () => {
+    const { saveCIState, loadCIState } = await loadModule();
+    await saveCIState({
+      repos: { 'owner/repo': { status: 'broken', brokenSince: '2026-07-01T00:00:00.000Z' } },
+      updatedAt: 'ignored',
+    } as never);
+
+    const loaded = await loadCIState();
+    expect(loaded.repos['owner/repo']).toMatchObject({ brokenSince: '2026-07-01T00:00:00.000Z' });
+  });
+
+  it('creates the .openswarm directory when it does not exist yet', async () => {
+    const { saveCIState } = await loadModule();
+    await saveCIState({ repos: {}, updatedAt: '' } as never);
+    expect(statSync(ciStatePath()).isFile()).toBe(true);
+  });
+
+  // The observable difference between an in-place rewrite and write-temp+rename:
+  // truncating in place keeps the inode, renaming installs a new one. A reader
+  // holding the old inode therefore never sees a partially written file.
+  it('replaces ci-state.json atomically rather than rewriting it in place', async () => {
+    const { saveCIState } = await loadModule();
+    await saveCIState({ repos: {}, updatedAt: '' } as never);
+    const inodeBefore = statSync(ciStatePath()).ino;
+
+    const many = Object.fromEntries(
+      Array.from({ length: 40 }, (_, i) => [`owner/repo-${i}`, { status: 'broken', brokenSince: '2026-07-01T00:00:00.000Z' }]),
+    );
+    await saveCIState({ repos: many, updatedAt: '' } as never);
+
+    expect(statSync(ciStatePath()).ino).not.toBe(inodeBefore);
+    expect(JSON.parse(readFileSync(ciStatePath(), 'utf-8')).repos['owner/repo-39']).toBeDefined();
+  });
+
+  it('returns empty state and stays quiet when the file has never been written', async () => {
+    const { loadCIState } = await loadModule();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(loadCIState()).resolves.toMatchObject({ repos: {} });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  // A corrupt file and a missing file both end up as "empty state", but only one
+  // of them means real history was just thrown away. Collapsing them into one
+  // silent catch is how a wiped health timeline goes unnoticed.
+  it('warns when the state file exists but cannot be parsed', async () => {
+    const { loadCIState } = await loadModule();
+    await mkdir(resolve(home, '.openswarm'), { recursive: true });
+    writeFileSync(ciStatePath(), '{ "repos": { "owner/repo": ');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(loadCIState()).resolves.toMatchObject({ repos: {} });
+    expect(warn).toHaveBeenCalled();
+    expect(String(warn.mock.calls[0]?.[0])).toMatch(/corrupt/i);
+  });
+});

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -6,7 +6,8 @@ import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { homedir } from 'node:os';
 import { resolve } from 'node:path';
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
+import { atomicWriteFile } from '../support/atomicFile.js';
 import { getDateLocale } from '../locale/index.js';
 
 const execFileAsync = promisify(execFile);
@@ -330,21 +331,51 @@ export type HealthTransition = {
   brokenSince?: string;
 };
 
-/** Load CI state */
+/**
+ * Load CI state.
+ *
+ * A missing file is the normal first-run case and stays silent. Anything else —
+ * malformed JSON, a permission error — means real brokenSince/lastReminder
+ * history is being discarded, silently resetting every repo's health timeline,
+ * so it is logged rather than swallowed by a bare catch.
+ */
 export async function loadCIState(): Promise<CIState> {
+  const empty = (): CIState => ({ repos: {}, updatedAt: new Date().toISOString() });
+  let data: string;
   try {
-    const data = await readFile(CI_STATE_PATH, 'utf-8');
+    data = await readFile(CI_STATE_PATH, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      console.warn('[CI] Could not read CI state, starting fresh:', err instanceof Error ? err.message : err);
+    }
+    return empty();
+  }
+  try {
     return JSON.parse(data);
-  } catch {
-    return { repos: {}, updatedAt: new Date().toISOString() };
+  } catch (err) {
+    console.warn(
+      `[CI] CI state at ${CI_STATE_PATH} is corrupt — repo health history is being reset:`,
+      err instanceof Error ? err.message : err,
+    );
+    return empty();
   }
 }
 
-/** Save CI state */
+/**
+ * Save CI state.
+ *
+ * Atomic because two independent callers (core/service.ts checkGitHubCI and
+ * automation/ciWorker.ts) each run their own load → modify → save cycle against
+ * this file with no lock. An in-place write lets the other one read a
+ * half-written file, which loadCIState would then treat as "no state" and wipe
+ * the health history. write-temp + rename means a concurrent reader always sees
+ * either the old file or the new one, never a torn one. (This does not make the
+ * read-modify-write sequence itself atomic — overlapping runs can still lose an
+ * update — but it removes the corruption path.)
+ */
 export async function saveCIState(state: CIState): Promise<void> {
-  await mkdir(resolve(homedir(), '.openswarm'), { recursive: true });
   state.updatedAt = new Date().toISOString();
-  await writeFile(CI_STATE_PATH, JSON.stringify(state, null, 2));
+  await atomicWriteFile(CI_STATE_PATH, JSON.stringify(state, null, 2) + '\n');
 }
 
 /**

--- a/src/support/repoMetadata.test.ts
+++ b/src/support/repoMetadata.test.ts
@@ -3,7 +3,7 @@
 // ============================================
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { loadRepoMetadata, saveRepoMetadata, REPO_METADATA_FILENAME, RepoMetadataError } from './repoMetadata.js';
@@ -131,5 +131,39 @@ describe('saveRepoMetadata', () => {
       saveRepoMetadata(dir, { schemaVersion: 1, linear: { projectId: 'not-a-uuid' } }),
     ).rejects.toThrow();
     await expect(loadRepoMetadata(dir)).resolves.toBeNull();
+  });
+
+  // openswarm.json has many concurrent readers (projectMapper, worktreeManager's
+  // linkSharedPaths, the daemon's repo resolution). Rewriting it in place lets a
+  // reader observe a truncated file and fail with RepoMetadataError. An atomic
+  // write is observable here as inode replacement: a plain writeFile truncates
+  // the existing file and keeps its inode, whereas write-temp + rename installs
+  // a new one.
+  it('replaces openswarm.json atomically rather than rewriting it in place', async () => {
+    const filePath = await saveRepoMetadata(dir, { schemaVersion: 1, projectName: 'A' });
+    const inodeBefore = statSync(filePath).ino;
+
+    const longer = {
+      schemaVersion: 1 as const,
+      linear: {
+        teamId: '49b7af95-3cac-4a56-adc7-f19d77dfbe9b',
+        teamKey: 'INTRECT-WITH-A-MUCH-LONGER-KEY',
+        projectId: '74a9d092-7b3c-4d4d-a998-a2c9a8f08e83',
+        projectName: 'OpenSwarm',
+      },
+    };
+    await saveRepoMetadata(dir, longer);
+
+    expect(statSync(filePath).ino).not.toBe(inodeBefore);
+    await expect(loadRepoMetadata(dir)).resolves.toEqual(longer);
+  });
+
+  // atomicWriteFile defaults to 0o600. This file is tracked in the repo and is
+  // meant to be readable like any other checked-in config, so the call has to
+  // opt out of that default — otherwise adopting the atomic helper would
+  // quietly turn openswarm.json owner-only.
+  it('keeps openswarm.json readable beyond its owner', async () => {
+    const filePath = await saveRepoMetadata(dir, { schemaVersion: 1, projectName: 'A' });
+    expect(statSync(filePath).mode & 0o044).not.toBe(0);
   });
 });

--- a/src/support/repoMetadata.ts
+++ b/src/support/repoMetadata.ts
@@ -7,9 +7,10 @@
 // (Linear today, GitHub/etc later) and removes the need for fuzzy
 // name matching, which silently breaks on renames or ambiguous names.
 
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { z } from 'zod';
+import { atomicWriteFile } from './atomicFile.js';
 
 const LinearMappingSchema = z.object({
   teamId: z.string().uuid().optional(),
@@ -131,7 +132,13 @@ export async function loadRepoMetadata(repoPath: string): Promise<RepoMetadata |
 export async function saveRepoMetadata(repoPath: string, meta: RepoMetadata): Promise<string> {
   const validated = RepoMetadataSchema.parse(meta);
   const filePath = join(repoPath, REPO_METADATA_FILENAME);
-  await writeFile(filePath, `${JSON.stringify(validated, null, 2)}\n`, 'utf-8');
+  // Atomic: loadRepoMetadata has many concurrent readers (projectMapper,
+  // worktreeManager.linkSharedPaths, the daemon's repo resolution). An in-place
+  // rewrite lets them observe a half-written file and fail with
+  // RepoMetadataError. 0o644 preserves the mode a plain write produced — this
+  // file lives in the repo and is meant to be readable, unlike the 0o600
+  // config files under the user's home directory.
+  await atomicWriteFile(filePath, `${JSON.stringify(validated, null, 2)}\n`, 0o644);
   return filePath;
 }
 

--- a/src/support/web.reposReload.test.ts
+++ b/src/support/web.reposReload.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { applyReposConfig } from './web.js';
 import type { AutonomousRunner } from '../automation/autonomousRunner.js';
@@ -100,5 +101,38 @@ describe('applyReposConfig — repos.json → runner reconciliation', () => {
     const after1 = [...runner.getEnabledProjects()].sort();
     applyReposConfig(runner as unknown as AutonomousRunner, c);
     expect([...runner.getEnabledProjects()].sort()).toEqual(after1);
+  });
+});
+
+// repos.json has three concurrent participants: the dashboard
+// (saveReposConfig), the CLI (`openswarm add/remove` via
+// projectHandler.saveRepos), and startReposWatcher polling it every 3s. If the
+// dashboard rewrites the file in place, the poller can read it half-written;
+// loadReposConfig's catch then hands back an empty config, and applyReposConfig
+// — as the cases above show — disables every project missing from it. An
+// interrupted write does not merely lose an edit, it tears down the running set.
+//
+// Asserted at the source level rather than by driving the server:
+// saveReposConfig is module-private, reachable only through request handlers,
+// and startWebServer(0) never surfaces the port it bound. The check is
+// correspondingly narrow — it pins the write call, not the concurrency outcome
+// — but it does go red if the atomic write is reverted.
+describe('saveReposConfig write discipline', () => {
+  const source = readFileSync(new URL('./web.ts', import.meta.url), 'utf-8');
+  const body = source.slice(source.indexOf('function saveReposConfig'), source.indexOf('const _reposCfg'));
+
+  it('writes repos.json through the atomic helper', () => {
+    expect(body).toMatch(/atomicWriteFileSync\(REPOS_FILE,/);
+  });
+
+  it('does not write repos.json in place', () => {
+    expect(body).not.toMatch(/(?<!atomic)WriteFileSync\(REPOS_FILE|writeFileSync\(REPOS_FILE/);
+  });
+
+  it('uses the same file mode projectHandler uses for this file', () => {
+    const cli = readFileSync(new URL('../cli/projectHandler.ts', import.meta.url), 'utf-8');
+    const cliMode = cli.match(/atomicWriteFileSync\([^;]*?(0o\d+)\)/)?.[1];
+    expect(cliMode).toBeDefined();
+    expect(body).toContain(cliMode!);
   });
 });

--- a/src/support/web.tailscale.test.ts
+++ b/src/support/web.tailscale.test.ts
@@ -1,0 +1,71 @@
+// ============================================
+// OpenSwarm - Tailscale address detection tests
+// ============================================
+//
+// The dashboard used to print a literal Tailscale address that belonged to one
+// developer's machine. It was committed to a public repo and was wrong for
+// every other user the moment Tailscale reassigned it. These tests pin both
+// halves of the replacement: the address is derived from this host, and the
+// literal never comes back.
+
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+async function withInterfaces(interfaces: Record<string, unknown[]>) {
+  vi.resetModules();
+  vi.doMock('node:os', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:os')>();
+    const networkInterfaces = () => interfaces;
+    return { ...actual, default: { ...actual, networkInterfaces }, networkInterfaces };
+  });
+  const mod = await import('./web.js');
+  return mod.detectTailscaleIP();
+}
+
+const iface = (address: string, over: Record<string, unknown> = {}) => ({
+  address, family: 'IPv4', internal: false, netmask: '255.255.255.255', mac: '00:00:00:00:00:00', cidr: null, ...over,
+});
+
+describe('detectTailscaleIP', () => {
+  it('returns the address in the Tailscale CGNAT range', async () => {
+    await expect(
+      withInterfaces({ en0: [iface('192.168.1.20')], utun3: [iface('100.95.200.28')] }),
+    ).resolves.toBe('100.95.200.28');
+  });
+
+  it('accepts both ends of 100.64.0.0/10', async () => {
+    await expect(withInterfaces({ utun3: [iface('100.64.0.1')] })).resolves.toBe('100.64.0.1');
+    await expect(withInterfaces({ utun3: [iface('100.127.255.254')] })).resolves.toBe('100.127.255.254');
+  });
+
+  // 100.x outside /10 is ordinary public space — a host on 100.128.x is not on
+  // Tailscale, and printing its address as the Tailscale URL would send the
+  // user somewhere wrong.
+  it('rejects 100.x addresses outside the CGNAT range', async () => {
+    await expect(withInterfaces({ en0: [iface('100.128.0.1')] })).resolves.toBeUndefined();
+    await expect(withInterfaces({ en0: [iface('100.63.255.255')] })).resolves.toBeUndefined();
+  });
+
+  it('ignores loopback and IPv6 entries', async () => {
+    await expect(
+      withInterfaces({
+        lo0: [iface('100.95.200.28', { internal: true })],
+        en0: [iface('fd7a:115c:a1e0::1', { family: 'IPv6' })],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when Tailscale is not up', async () => {
+    await expect(withInterfaces({ en0: [iface('192.168.1.20')] })).resolves.toBeUndefined();
+  });
+
+  // Guards the actual regression: a specific node's address baked into a public
+  // source file. A CIDR mention like "100.64.0.0/10" is the range, not someone's
+  // host, so the trailing-prefix form is allowed.
+  it('does not hardcode any Tailscale host address in the source', () => {
+    const source = readFileSync(new URL('./web.ts', import.meta.url), 'utf-8');
+    const literals =
+      source.match(/(?<!\d)100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}(?!\/\d)/g) ?? [];
+    expect(literals).toEqual([]);
+  });
+});

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -3,10 +3,11 @@
 // ============================================
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
-import { writeFileSync, readFileSync, existsSync, watchFile, unwatchFile, type Stats } from 'node:fs';
+import { readFileSync, existsSync, watchFile, unwatchFile, type Stats } from 'node:fs';
 import { readdir, stat } from 'node:fs/promises';
 import { join, resolve as resolvePath, dirname, basename } from 'node:path';
-import { homedir } from 'node:os';
+import { homedir, networkInterfaces } from 'node:os';
+import { atomicWriteFileSync } from './atomicFile.js';
 import { execFile } from 'node:child_process';
 import { getChatHistory } from '../discord/index.js';
 import { addSSEClient, getActiveSSECount, broadcastEvent, getLogBuffer, getStageBuffer, getChatBuffer } from '../core/eventHub.js';
@@ -288,6 +289,37 @@ function loadReposConfig(): ReposConfig {
   return { pinned: [], enabled: [], basePaths: [], removedConfigPaths: [] };
 }
 
+/**
+ * This machine's Tailscale address, or undefined when Tailscale is not up.
+ *
+ * Detected at runtime rather than hardcoded: the previous literal was one
+ * developer's actual node address committed to a public repo, and it went
+ * stale for everyone else the moment Tailscale reassigned it. Tailscale hands
+ * out addresses from the 100.64.0.0/10 CGNAT range, which nothing else on a
+ * normal LAN uses.
+ */
+export function detectTailscaleIP(): string | undefined {
+  for (const addresses of Object.values(networkInterfaces())) {
+    for (const address of addresses ?? []) {
+      if (address.family !== 'IPv4' || address.internal) continue;
+      const [first, second] = address.address.split('.').map(Number);
+      if (first === 100 && second >= 64 && second <= 127) return address.address;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Persist the repos config.
+ *
+ * Atomic (write-temp + fsync + rename) because this file has three concurrent
+ * participants: this process, `openswarm add/remove` via projectHandler's
+ * saveRepos(), and startReposWatcher() polling it every 3s. A plain in-place
+ * write leaves a window where the poller reads a half-written file;
+ * loadReposConfig()'s catch then returns an empty config, and applyReposConfig
+ * computes an empty desired set — disabling every active project. Matches
+ * projectHandler.saveRepos(), which already writes this same path atomically.
+ */
 function saveReposConfig(): void {
   try {
     const cfg: ReposConfig = {
@@ -296,7 +328,7 @@ function saveReposConfig(): void {
       basePaths: Array.from(customBasePaths),
       removedConfigPaths: Array.from(removedConfigPaths),
     };
-    writeFileSync(REPOS_FILE, JSON.stringify(cfg, null, 2));
+    atomicWriteFileSync(REPOS_FILE, JSON.stringify(cfg, null, 2) + '\n', 0o600);
   } catch (e) {
     console.warn('[Web] Failed to save repos config:', e);
   }
@@ -1421,10 +1453,13 @@ export async function startWebServer(port: number = 3847): Promise<void> {
 
     const listenHost = process.env.OPENSWARM_WEB_TOKEN?.trim() ? '0.0.0.0' : '127.0.0.1';
     server.listen(port, listenHost, () => {
-      const tailscaleIP = '100.95.200.28'; // Current Tailscale IP
+      const tailscaleIP = detectTailscaleIP();
       console.log(`Web interface running at:`);
       console.log(`  - http://127.0.0.1:${port} (localhost)`);
-      if (listenHost === '0.0.0.0') console.log(`  - http://${tailscaleIP}:${port} (Tailscale, token required)`);
+      if (listenHost === '0.0.0.0') {
+        if (tailscaleIP) console.log(`  - http://${tailscaleIP}:${port} (Tailscale, token required)`);
+        else console.log(`  - http://<this-host>:${port} (token required)`);
+      }
       gitStatusPoller = startGitStatusPoller(() => Array.from(pinnedProjects));
       startHealthChecker(30000);
       resolve();


### PR DESCRIPTION
## Summary

Clears five findings that the last three audit runs kept re-reporting. Four are the same defect class — a shared config file rewritten in place while other processes read it — and the fifth is a personal network address committed to a public repo.

| File | Concurrent participants | What a torn read did |
|---|---|---|
| `repos.json` | dashboard, `openswarm add/remove`, 3s watcher poll | empty config → **every running project disabled** |
| `openswarm.json` | projectMapper, worktreeManager, daemon repo resolution | `RepoMetadataError` |
| `ci-state.json` | `core/service.ts`, `automation/ciWorker.ts` | health timeline silently reset |

Each now goes through the repo's existing `atomicWriteFile` / `atomicWriteFileSync` (write-temp + fsync + rename). `projectHandler.saveRepos()` already wrote `repos.json` this way — the dashboard was the one path that didn't.

`loadCIState` also stopped treating a corrupt file like a missing one; a parse failure now logs instead of silently discarding `brokenSince`/`lastReminder` history.

## Deliberate choices

- **`openswarm.json` stays `0o644`.** `atomicWriteFile` defaults to `0o600`; this file is tracked in the repo and meant to be readable, so adopting the helper naively would have quietly made it owner-only. A test pins the mode in that direction.
- **`ci-state.json` moves to `0o600`** (the helper default), matching `projectHandler`'s convention for home-directory config. This is a mode change on an existing file — flagging it explicitly.
- **`saveCIState`'s read-modify-write is still unsynchronised.** Overlapping runs can still lose an update. This PR closes the *corruption* path only; the missing lock is a separate design decision.
- **Tailscale address detected at runtime** from the `100.64.0.0/10` CGNAT range, and the URL line is omitted entirely when Tailscale is down — rather than printing a stale address that sends the user nowhere.

## Verification

Every fix is pinned by a test that **fails when the fix is reverted**, confirmed by mutation rather than assumed:

| Mutation | Test that went red |
|---|---|
| `atomicWriteFile` → `writeFile` (openswarm.json) | `replaces openswarm.json atomically…` |
| drop the explicit `0o644` | `keeps openswarm.json readable beyond its owner` |
| `atomicWriteFile` → `writeFile` (ci-state.json) | `replaces ci-state.json atomically…` |
| restore the bare `catch` in `loadCIState` | `warns when the state file exists but cannot be parsed` |
| restore the literal Tailscale IP | `does not hardcode any Tailscale host address…` |
| `atomicWriteFileSync` → `writeFileSync` (repos.json) | all 3 `saveReposConfig write discipline` cases |

Atomicity is asserted as **inode replacement** — the observable difference between truncating in place and renaming a new file over the old one, and the reason a concurrent reader never sees a partial file.

The `saveReposConfig` guard is source-level and labelled as such in the test: the function is module-private, reachable only through request handlers, and `startWebServer(0)` never surfaces the port it bound, so there is no way to drive it over HTTP. It pins the write call, not the concurrency outcome.

Also verified the CI-state tests mock `homedir()` rather than writing the real `~/.openswarm/ci-state.json`.

- Full suite: **242 files, 3243 passed, 1 skipped**
- `tsc --noEmit` clean, `oxlint` 0 warnings
- `openswarm review`: **APPROVE**, 0 issues

## Not in this PR

The reviewer re-raised two pre-existing `github.ts` items — `commentOnPR` has no `error` listener on `proc.stdin` (uncaught EPIPE if `gh` exits early), and `getOpenPRs`/`getPRReviews`/etc. use Node's default 1MB `maxBuffer` instead of `ghExec`'s larger one. Both are real and both are unrelated to this diff; keeping them separate so each gets its own review.
