### PR TITLE
fix(github): keep an EPIPE from killing the daemon, give gh readers the shared buffer

### DIFF
--- a/src/github/ghExec.test.ts
+++ b/src/github/ghExec.test.ts
@@ -1,0 +1,132 @@
+// ============================================
+// OpenSwarm - gh subprocess robustness tests
+// ============================================
+//
+// Two failure modes that only show up under load, both re-reported by three
+// consecutive audit runs:
+//
+//  1. commentOnPR pipes the body through gh's stdin. If gh exits before
+//     draining the pipe, the stream emits 'error' (EPIPE). Node rethrows an
+//     unhandled 'error' event as an uncaught exception, and it arrives
+//     asynchronously — so the function's own try/catch cannot catch it and the
+//     process dies instead of logging a failed comment.
+//  2. Six gh readers called execFileAsync directly, inheriting Node's 1MB
+//     maxBuffer default rather than the 4MB ghExec uses. A PR with a long
+//     review thread overflows it and the call fails with
+//     ERR_CHILD_PROCESS_STDOUT_MAXBUFFER.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+
+const execFileMock = vi.hoisted(() => {
+  const fn = vi.fn();
+  (fn as any)[Symbol.for('nodejs.util.promisify.custom')] = (...args: unknown[]) =>
+    new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+      (fn as any)(...args, (err: Error | null, stdout: string, stderr: string) => {
+        if (err) reject(err);
+        else resolve({ stdout, stderr });
+      });
+    });
+  return fn;
+});
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({ execFile: execFileMock, spawn: spawnMock }));
+
+import { checkPRConflicts, commentOnPR, getOpenPRs, getPRBaseBranch, getPRComments, getPRReviewComments, getPRReviews } from './github.js';
+
+/** Options object handed to execFileAsync for the Nth gh invocation. */
+function optionsOfCall(index = 0): { maxBuffer?: number } | undefined {
+  const args = execFileMock.mock.calls[index];
+  return args?.find((a: unknown) => a !== null && typeof a === 'object' && !Array.isArray(a)) as
+    | { maxBuffer?: number }
+    | undefined;
+}
+
+function mockGhStdout(value: string): void {
+  execFileMock.mockImplementationOnce((...args: unknown[]) => {
+    const callback = args.at(-1) as (err: Error | null, stdout: string, stderr: string) => void;
+    callback(null, value, '');
+  });
+}
+
+describe('gh readers use the shared maxBuffer', () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  // 1MB is Node's default — i.e. the option was never passed. These readers pull
+  // whole review threads and comment bodies, which is exactly the payload that
+  // outgrows it.
+  const cases: Array<[string, () => Promise<unknown>, string]> = [
+    ['getOpenPRs', () => getOpenPRs('owner/repo'), '[]'],
+    ['getPRReviews', () => getPRReviews('owner/repo', 1), ''],
+    ['getPRReviewComments', () => getPRReviewComments('owner/repo', 1), ''],
+    ['getPRComments', () => getPRComments('owner/repo', 1), '{"comments":[]}'],
+    ['getPRBaseBranch', () => getPRBaseBranch('owner/repo', 1), '{"baseRefName":"main"}'],
+    ['checkPRConflicts', () => checkPRConflicts('owner/repo', 1), '{"mergeable":"MERGEABLE"}'],
+  ];
+
+  for (const [name, call, stdout] of cases) {
+    it(`${name} raises maxBuffer above Node's 1MB default`, async () => {
+      mockGhStdout(stdout);
+      await call();
+      expect(optionsOfCall()?.maxBuffer).toBeGreaterThanOrEqual(4 * 1024 * 1024);
+    });
+  }
+});
+
+describe('commentOnPR stdin handling', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  function mockGhProcess() {
+    const proc = new EventEmitter() as EventEmitter & { stdin: PassThrough };
+    proc.stdin = new PassThrough();
+    spawnMock.mockReturnValueOnce(proc);
+    return proc;
+  }
+
+  it('resolves when gh exits cleanly', async () => {
+    const proc = mockGhProcess();
+    const done = commentOnPR('owner/repo', 1, 'hello');
+    proc.emit('close', 0);
+    await expect(done).resolves.toBeUndefined();
+  });
+
+  // The regression itself: an 'error' on stdin with no listener is an uncaught
+  // exception, not a rejected promise, so awaiting commentOnPR would not
+  // observe it — the process would go down. Asserting via the process-level
+  // uncaughtException path is what makes this test fail when the listener is
+  // removed; a plain `await expect(...)` would pass either way.
+  it('survives EPIPE when gh exits before reading stdin', async () => {
+    const proc = mockGhProcess();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const uncaught: unknown[] = [];
+    const onUncaught = (err: unknown) => uncaught.push(err);
+    process.on('uncaughtException', onUncaught);
+    try {
+      const done = commentOnPR('owner/repo', 1, 'hello');
+      proc.stdin.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }));
+      proc.emit('close', 1);
+      await done;
+      await new Promise((r) => setImmediate(r));
+    } finally {
+      process.off('uncaughtException', onUncaught);
+    }
+
+    expect(uncaught).toEqual([]);
+  });
+
+  it('logs rather than throwing when gh exits non-zero', async () => {
+    const proc = mockGhProcess();
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const done = commentOnPR('owner/repo', 1, 'hello');
+    proc.emit('close', 1);
+    await expect(done).resolves.toBeUndefined();
+    expect(error).toHaveBeenCalled();
+  });
+});

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -533,10 +533,10 @@ export type PRDetails = PRInfo & {
  */
 export async function getOpenPRs(repo: string): Promise<PRInfo[]> {
   try {
-    const { stdout } = await execFileAsync('gh', [
+    const stdout = await ghExec(
       'pr', 'list', '-R', repo, '--state', 'open',
       '--json', 'number,title,headRefName,createdAt,url,author'
-    ]);
+    );
     const prs = JSON.parse(stdout);
     return prs.map((pr: any) => ({
       repo,
@@ -609,10 +609,10 @@ export type PRReviewComment = {
  */
 export async function getPRReviews(repo: string, prNumber: number): Promise<PRReviewComment[]> {
   try {
-    const { stdout } = await execFileAsync('gh', [
+    const stdout = await ghExec(
       'api', `/repos/${repo}/pulls/${prNumber}/reviews`,
       '--jq', '.[] | {id, author: .user.login, body, state, createdAt: .submitted_at}'
-    ]);
+    );
 
     const lines = stdout.trim().split('\n').filter(Boolean);
     return lines.map((line) => JSON.parse(line));
@@ -627,10 +627,10 @@ export async function getPRReviews(repo: string, prNumber: number): Promise<PRRe
  */
 export async function getPRReviewComments(repo: string, prNumber: number): Promise<PRReviewComment[]> {
   try {
-    const { stdout } = await execFileAsync('gh', [
+    const stdout = await ghExec(
       'api', `/repos/${repo}/pulls/${prNumber}/comments`,
       '--jq', '.[] | {id, author: .user.login, body, path, line, createdAt: .created_at}'
-    ]);
+    );
 
     const lines = stdout.trim().split('\n').filter(Boolean);
     return lines.map((line) => JSON.parse(line));
@@ -641,13 +641,24 @@ export async function getPRReviewComments(repo: string, prNumber: number): Promi
 }
 
 /**
- * Post a comment on a PR (piped via stdin to avoid shell escaping)
+ * Post a comment on a PR (piped via stdin to avoid shell escaping).
+ *
+ * The stdin 'error' listener is not optional. If gh exits before draining the
+ * pipe — unauthenticated, a bad repo, a rate limit — writing to it emits EPIPE
+ * on the stream. An 'error' event with no listener is rethrown by Node as an
+ * uncaught exception, and because it arrives asynchronously the surrounding
+ * try/catch never sees it: the daemon dies instead of logging a failed comment.
+ * Reporting is left to the 'close' handler, which has gh's actual exit code;
+ * this listener only has to keep the event from going unhandled.
  */
 export async function commentOnPR(repo: string, prNumber: number, body: string): Promise<void> {
   try {
     await new Promise<void>((resolve, reject) => {
       const proc = spawn('gh', ['pr', 'comment', String(prNumber), '-R', repo, '--body-file', '-'], {
         stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      proc.stdin.on('error', (err) => {
+        console.error(`[GitHub] stdin closed while sending comment to ${repo}#${prNumber}:`, err);
       });
       proc.stdin.write(body);
       proc.stdin.end();
@@ -671,10 +682,10 @@ export async function getPRComments(repo: string, prNumber: number): Promise<Arr
   createdAt: string;
 }>> {
   try {
-    const { stdout } = await execFileAsync('gh', [
+    const stdout = await ghExec(
       'pr', 'view', String(prNumber), '-R', repo,
-      '--json', 'comments',
-    ]);
+      '--json', 'comments'
+    );
     const data = JSON.parse(stdout);
     return data.comments.map((c: any) => ({
       author: c.author?.login || 'unknown',
@@ -715,9 +726,9 @@ export async function getPRFailedLogs(repo: string, prNumber: number): Promise<s
  */
 export async function getPRBaseBranch(repo: string, prNumber: number): Promise<string> {
   try {
-    const { stdout } = await execFileAsync('gh', [
+    const stdout = await ghExec(
       'pr', 'view', String(prNumber), '-R', repo, '--json', 'baseRefName'
-    ]);
+    );
     const { baseRefName } = JSON.parse(stdout);
     return baseRefName || 'main';
   } catch (err) {
@@ -733,9 +744,9 @@ export async function getPRBaseBranch(repo: string, prNumber: number): Promise<s
  */
 export async function checkPRConflicts(repo: string, prNumber: number): Promise<boolean> {
   try {
-    const { stdout } = await execFileAsync('gh', [
+    const stdout = await ghExec(
       'pr', 'view', String(prNumber), '-R', repo, '--json', 'mergeable'
-    ]);
+    );
     const { mergeable } = JSON.parse(stdout);
     // mergeable can be: "MERGEABLE" | "CONFLICTING" | "UNKNOWN"
     return mergeable === 'CONFLICTING';


### PR DESCRIPTION
## Summary

The two `github.ts` findings the reviewer re-raised on #325, kept separate so each gets its own review.

### 1. An EPIPE could take down the daemon

`commentOnPR` pipes the comment body through gh's stdin. If gh exits before draining that pipe — unauthenticated, bad repo, rate limited — the stream emits `'error'` with `EPIPE`. Node rethrows an unhandled `'error'` event as an **uncaught exception**, and because it arrives asynchronously the function's own `try/catch` never sees it. The daemon dies where it should have logged a failed comment.

Now attaches a stdin `'error'` listener. Reporting stays with the `'close'` handler, which has gh's actual exit code; the listener only has to keep the event from going unhandled.

### 2. Six readers were capped at 1MB

`getOpenPRs`, `getPRReviews`, `getPRReviewComments`, `getPRComments`, `getPRBaseBranch`, `checkPRConflicts` called `execFileAsync` directly, inheriting Node's 1MB `maxBuffer` instead of the 4MB `ghExec` already uses. They pull whole review threads and comment bodies — exactly the payload that outgrows 1MB — so the failure (`ERR_CHILD_PROCESS_STDOUT_MAXBUFFER`) lands on the busiest PRs, the ones most worth reading. Routed through `ghExec`.

## Verification

| Mutation | Test that went red |
|---|---|
| remove the stdin `'error'` listener | `survives EPIPE when gh exits before reading stdin` |
| revert one reader to `execFileAsync` | `getOpenPRs raises maxBuffer above Node's 1MB default` |

The EPIPE test asserts through the process-level `uncaughtException` path rather than awaiting the promise. This matters: `await expect(commentOnPR(...)).resolves` passes **with or without** the listener, because the crash is not a rejection. Testing the real failure mode is the only version of this test that fails when the fix is removed.

- `tsc --noEmit` clean, `oxlint` 0 warnings
- `openswarm review`: **APPROVE**, 0 issues

## Pre-existing flake, not from this PR

`runLedger.test.ts`'s multi-process cases throw `SQLITE_BUSY` at `RunLedger`'s `journal_mode = WAL` pragma. Measured rather than assumed, because a single run pointed the wrong way:

| Tree | Failures |
|---|---|
| unmodified `main` | **4 / 5 runs** |
| with this diff | 1 / 5 runs |

So it is pre-existing and unrelated. It is also a real product concern rather than only a test artifact — `RunLedger` is opened by the daemon and the CLI concurrently, and `busy_timeout` does not reliably cover a `journal_mode` change. Reporting it separately rather than folding an unrelated concurrency fix into this diff.
