### PR TITLE
fix(sqlite): retry the WAL conversion so a concurrent open stops crashing startup

### DIFF
--- a/src/automation/runLedger.test.ts
+++ b/src/automation/runLedger.test.ts
@@ -795,3 +795,65 @@ describe('RunLedger durable outbox races', () => {
     ledger.close();
   });
 });
+
+// Switching a fresh database to WAL takes a brief exclusive lock, and
+// busy_timeout does not rescue it — measured here, a connection holding a read
+// transaction makes `PRAGMA journal_mode = WAL` wait out the whole timeout and
+// then throw SQLITE_BUSY. With a single attempt that turned "another process
+// opened the ledger at the same moment" into a hard startup crash, which is
+// routine for OpenSwarm: the daemon and the CLI both open this file, under
+// agent load, and the multi-process cases above failed 6/6 runs at load ~11
+// before the retry loop and 0/6 after it.
+describe('RunLedger WAL negotiation', () => {
+  // Deliberately named for what it checks: the already-WAL fast path. `first`
+  // finishes the conversion before `second` is constructed, so there is no busy
+  // contention here — the real contention is covered by the multi-process cases
+  // above and by the held-lock case below.
+  it('takes the no-op fast path when the database is already in WAL', () => {
+    const dbPath = createDbPath();
+    const first = new RunLedger(dbPath);
+    const second = new RunLedger(dbPath);
+    register(second, 'WAL-1');
+    expect(second.getRun('WAL-1')).toMatchObject({ issueId: 'WAL-1' });
+    second.close();
+    first.close();
+  });
+
+  it('restores the caller busy_timeout once the conversion is done', () => {
+    const dbPath = createDbPath();
+    const ledger = new RunLedger(dbPath, { busyTimeoutMs: 7_321 });
+    const probe = new Database(dbPath);
+    try {
+      // The conversion runs at a deliberately short timeout so the retry loop
+      // gets many attempts; leaving it there would silently apply a 100ms wait
+      // policy to every later statement.
+      const [row] = (ledger as unknown as { db: Database.Database }).db.pragma('busy_timeout') as Array<{ timeout: number }>;
+      expect(row.timeout).toBe(7_321);
+    } finally {
+      probe.close();
+      ledger.close();
+    }
+  });
+
+  it('gives a bounded, explicit failure when the conversion can never succeed', () => {
+    const dbPath = createDbPath();
+    // Force the database into delete mode, then pin a read transaction open so
+    // the exclusive lock the conversion needs is permanently unavailable.
+    const holder = new Database(dbPath);
+    holder.pragma('journal_mode = DELETE');
+    holder.exec('CREATE TABLE probe(x)');
+    holder.exec('BEGIN');
+    holder.prepare('SELECT * FROM probe').all();
+
+    const started = Date.now();
+    try {
+      expect(() => new RunLedger(dbPath, { busyTimeoutMs: 1_000 })).toThrow(/WAL within \d+ms/);
+      // Bounded: it must give up near its budget rather than retry forever.
+      expect(Date.now() - started).toBeLessThan(8_000);
+    } finally {
+      holder.exec('ROLLBACK');
+      holder.close();
+    }
+  });
+});
+

--- a/src/automation/runLedger.ts
+++ b/src/automation/runLedger.ts
@@ -3,6 +3,7 @@ import { mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { enableWalWithRetry } from '../support/sqliteWal.js';
 import { ACTIVE_LEASE_STATES, ALLOWED_TRANSITIONS, AUTOMATION_SCHEMA_VERSION, CLAIMABLE_STATES, RUN_STATES } from './runLedgerTypes.js';
 import { admitsConflictScope } from './runLedgerScope.js';
 import { migrateAutomationSchema } from './runLedgerSchema.js';
@@ -146,7 +147,7 @@ export class RunLedger {
       // Install the wait policy before WAL/schema pragmas: overlapping launchd
       // generations can contend as soon as journal_mode is negotiated.
       this.db.pragma(`busy_timeout = ${busyTimeoutMs}`);
-      this.db.pragma('journal_mode = WAL');
+      enableWalWithRetry(this.db, busyTimeoutMs);
       this.db.pragma('foreign_keys = ON');
       this.db.pragma('synchronous = FULL');
       migrateAutomationSchema(this.db);

--- a/src/issues/sqliteStore.ts
+++ b/src/issues/sqliteStore.ts
@@ -11,6 +11,7 @@ import { createHash } from 'node:crypto';
 import { resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { mkdirSync } from 'node:fs';
+import { DEFAULT_BUSY_TIMEOUT_MS, enableWalWithRetry } from '../support/sqliteWal.js';
 import type {
   Issue, IssueFilter, IssueEvent, IssueEventType,
   Label, Milestone, IssueStatus, IssuePriority, IssueSource,
@@ -105,11 +106,23 @@ export class SqliteIssueStore implements IIssueStore {
     mkdirSync(resolve(path, '..'), { recursive: true });
     this.db = new Database(path);
 
-    // WAL 모드 (동시성 + 성능)
-    this.db.pragma('journal_mode = WAL');
-    this.db.pragma('foreign_keys = ON');
-
-    this.migrate();
+    // WAL for concurrency. Install the wait policy first and retry the
+    // conversion: the CLI, the daemon and the dashboard all open this store, so
+    // a single unguarded attempt turns a concurrent open into a hard crash in
+    // this constructor. See support/sqliteWal.ts.
+    //
+    // Setup can now fail where it previously could not, so the handle has to be
+    // closed on the way out — this store is a module singleton, and a leaked
+    // connection would keep its own locks alive for the life of the process.
+    try {
+      this.db.pragma(`busy_timeout = ${DEFAULT_BUSY_TIMEOUT_MS}`);
+      enableWalWithRetry(this.db, DEFAULT_BUSY_TIMEOUT_MS);
+      this.db.pragma('foreign_keys = ON');
+      this.migrate();
+    } catch (error) {
+      this.db.close();
+      throw error;
+    }
   }
 
   private migrate(): void {

--- a/src/registry/sqliteStore.ts
+++ b/src/registry/sqliteStore.ts
@@ -10,6 +10,7 @@ import { nanoid } from 'nanoid';
 import { resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { mkdirSync } from 'node:fs';
+import { DEFAULT_BUSY_TIMEOUT_MS, enableWalWithRetry } from '../support/sqliteWal.js';
 import type {
   CodeEntity, CodeEntityFilter, EntityKind, EntityStatus, RiskLevel,
   EntityEvent, EntityEventType, EntityWarning, EntityTag,
@@ -173,10 +174,23 @@ export class SqliteRegistryStore {
     mkdirSync(resolve(path, '..'), { recursive: true });
     this.db = new Database(path);
 
-    this.db.pragma('journal_mode = WAL');
-    this.db.pragma('foreign_keys = ON');
-
-    this.migrate();
+    // Install the wait policy before the WAL conversion, then retry the
+    // conversion itself. The CLI, the daemon and the dashboard all open this
+    // store, so a single unguarded attempt turns a concurrent open into a hard
+    // crash in this constructor. See support/sqliteWal.ts.
+    //
+    // Setup can now fail where it previously could not, so the handle has to be
+    // closed on the way out — a leaked connection would keep its own locks
+    // alive for the life of the process.
+    try {
+      this.db.pragma(`busy_timeout = ${DEFAULT_BUSY_TIMEOUT_MS}`);
+      enableWalWithRetry(this.db, DEFAULT_BUSY_TIMEOUT_MS);
+      this.db.pragma('foreign_keys = ON');
+      this.migrate();
+    } catch (error) {
+      this.db.close();
+      throw error;
+    }
   }
 
   private migrate(): void {

--- a/src/support/sqliteStoreCleanup.test.ts
+++ b/src/support/sqliteStoreCleanup.test.ts
@@ -1,0 +1,99 @@
+// ============================================
+// OpenSwarm - store constructor cleanup tests
+// ============================================
+//
+// Adding a retrying WAL conversion gave these constructors a failure path they
+// did not have before: setup can now throw. Both stores are reached through
+// module-level singletons, so a handle left open on that path stays attached to
+// the file for the life of the process.
+//
+// The obvious version of this test — fail the constructor, then check another
+// connection can still convert the database — is worthless: an idle SQLite
+// connection holds no lock, so it passes whether or not the handle leaked
+// (confirmed by mutation before this was rewritten). The leak has to be
+// observed directly, by capturing every Database the constructor opens and
+// asserting its state afterwards.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import RealDatabase from 'better-sqlite3';
+
+const opened = vi.hoisted(() => [] as Array<{ open: boolean }>);
+
+vi.mock('better-sqlite3', async (importOriginal) => {
+  const actual = await importOriginal<{ default: typeof RealDatabase }>();
+  const Wrapped = function (...args: unknown[]) {
+    const Ctor = actual.default as unknown as new (...a: unknown[]) => { open: boolean };
+    const db = new Ctor(...args);
+    opened.push(db);
+    return db;
+  } as unknown as typeof RealDatabase;
+  return { ...actual, default: Wrapped };
+});
+
+const { SqliteIssueStore } = await import('../issues/sqliteStore.js');
+const { SqliteRegistryStore } = await import('../registry/sqliteStore.js');
+
+const roots: string[] = [];
+let holder: InstanceType<typeof RealDatabase> | undefined;
+
+/**
+ * A database that can never convert to WAL: pinned in delete mode with a read
+ * transaction held open, so the exclusive lock the conversion needs is
+ * permanently unavailable.
+ */
+function unconvertibleDbPath(): string {
+  const root = mkdtempSync(join(tmpdir(), 'openswarm-store-cleanup-'));
+  roots.push(root);
+  const path = join(root, 'store.db');
+  holder = new RealDatabase(path);
+  holder.pragma('journal_mode = DELETE');
+  holder.exec('CREATE TABLE probe(x)');
+  holder.exec('BEGIN');
+  holder.prepare('SELECT * FROM probe').all();
+  opened.length = 0; // the holder is fixture setup, not the code under test
+  return path;
+}
+
+beforeEach(() => {
+  opened.length = 0;
+});
+
+afterEach(() => {
+  if (holder) {
+    try {
+      holder.exec('ROLLBACK');
+    } catch {
+      // The transaction may already be gone; closing the handle is what matters.
+    }
+    holder.close();
+    holder = undefined;
+  }
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe.each([
+  ['SqliteIssueStore', (p: string) => new SqliteIssueStore(p) as { close?: () => void }],
+  ['SqliteRegistryStore', (p: string) => new SqliteRegistryStore(p) as { close?: () => void }],
+])('%s constructor', (_name, construct) => {
+  it('closes its handle when WAL setup fails', () => {
+    const path = unconvertibleDbPath();
+
+    expect(() => construct(path)).toThrow(/WAL within \d+ms/);
+
+    expect(opened).toHaveLength(1);
+    expect(opened[0].open).toBe(false);
+  });
+
+  it('keeps the handle open on the success path', () => {
+    const root = mkdtempSync(join(tmpdir(), 'openswarm-store-ok-'));
+    roots.push(root);
+    const store = construct(join(root, 'store.db'));
+
+    expect(opened).toHaveLength(1);
+    expect(opened[0].open).toBe(true);
+    store.close?.();
+  });
+});

--- a/src/support/sqliteWal.test.ts
+++ b/src/support/sqliteWal.test.ts
@@ -1,0 +1,73 @@
+// ============================================
+// OpenSwarm - SQLite WAL negotiation tests
+// ============================================
+
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import { enableWalWithRetry, isRetryableBusyError } from './sqliteWal.js';
+
+describe('isRetryableBusyError', () => {
+  // Extended busy codes must retry like the bare one. Treating them as fatal
+  // would rethrow at construction — the exact crash the retry loop prevents.
+  it.each(['SQLITE_BUSY', 'SQLITE_BUSY_SNAPSHOT', 'SQLITE_BUSY_RECOVERY', 'SQLITE_BUSY_TIMEOUT'])(
+    'retries on %s',
+    (code) => {
+      expect(isRetryableBusyError(Object.assign(new Error('busy'), { code }))).toBe(true);
+    },
+  );
+
+  // Anything else is a real fault and must surface immediately rather than
+  // being swallowed into a retry loop that can only time out.
+  it.each(['SQLITE_CORRUPT', 'SQLITE_READONLY', 'SQLITE_CANTOPEN', 'SQLITE_LOCKED'])(
+    'rethrows on %s',
+    (code) => {
+      expect(isRetryableBusyError(Object.assign(new Error('fatal'), { code }))).toBe(false);
+    },
+  );
+
+  it('rethrows errors that carry no code at all', () => {
+    expect(isRetryableBusyError(new Error('no code'))).toBe(false);
+    expect(isRetryableBusyError(undefined)).toBe(false);
+  });
+});
+
+describe('enableWalWithRetry', () => {
+  it('converts a file database to WAL', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'walhelper-'));
+    const db = new Database(join(dir, 'a.db'));
+    try {
+      enableWalWithRetry(db, 1_000);
+      expect((db.pragma('journal_mode') as Array<{ journal_mode: string }>)[0].journal_mode).toBe('wal');
+    } finally {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // An in-memory database reports 'memory' and can never be WAL. Treating that
+  // as contention makes the loop spin for the whole budget and then fail an
+  // open that previously worked — 13 suite tests went red on exactly this.
+  it('accepts an in-memory database instead of retrying to death', () => {
+    const db = new Database(':memory:');
+    const started = Date.now();
+    try {
+      expect(() => enableWalWithRetry(db, 5_000)).not.toThrow();
+      expect(Date.now() - started).toBeLessThan(1_000);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('leaves the caller busy_timeout in place afterwards', () => {
+    const db = new Database(':memory:');
+    try {
+      enableWalWithRetry(db, 4_321);
+      expect((db.pragma('busy_timeout') as Array<{ timeout: number }>)[0].timeout).toBe(4_321);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/support/sqliteWal.ts
+++ b/src/support/sqliteWal.ts
@@ -1,0 +1,95 @@
+// ============================================
+// OpenSwarm - SQLite WAL negotiation
+// ============================================
+//
+// Every store here is opened by more than one process — the daemon, the CLI,
+// the dashboard — and often at the same moment, on a machine already saturated
+// with agent work. That makes the one-time conversion to WAL a contended
+// operation, and it is not covered by `busy_timeout`: measured in this repo, a
+// connection holding a read transaction makes `PRAGMA journal_mode = WAL` wait
+// out the entire timeout and then throw SQLITE_BUSY.
+//
+// A single attempt therefore turns "someone else opened the store at the same
+// moment" into a hard crash in a constructor. Before this helper existed, the
+// multi-process cases in runLedger.test.ts failed 6/6 runs at load ~11 and 0/6
+// with the retry loop in place.
+
+import type Database from 'better-sqlite3';
+
+/** Wait policy for stores that have no reason to pick their own. */
+export const DEFAULT_BUSY_TIMEOUT_MS = 5_000;
+
+/** Block the current thread. Store constructors are synchronous, so this must be too. */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Whether a SQLite error means "someone else holds it, try again".
+ *
+ * Matched by prefix rather than equality: SQLite also defines extended busy
+ * codes (SQLITE_BUSY_SNAPSHOT, SQLITE_BUSY_RECOVERY, SQLITE_BUSY_TIMEOUT), and
+ * better-sqlite3 does surface extended codes for other classes. One of those
+ * reaching an exact-match check would be rethrown instead of retried — exactly
+ * the startup crash this module exists to prevent. Local probing only ever
+ * produced the bare code, so the prefix is defensive rather than observed, but
+ * it is the cheap direction to be wrong in.
+ */
+export function isRetryableBusyError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return typeof code === 'string' && code.startsWith('SQLITE_BUSY');
+}
+
+/**
+ * Switch a database to WAL, tolerating a concurrent opener.
+ *
+ * Only the very first conversion contends: WAL is a persistent property of the
+ * file, so once any process has flipped it every later `journal_mode = WAL` is
+ * a no-op that returns 'wal' without taking the lock. Retrying is enough. The
+ * loop is bounded so a database that genuinely cannot convert — a permanently
+ * held read transaction, say — still fails with an explicit error instead of
+ * hanging.
+ *
+ * `busyTimeoutMs` is both the caller's steady-state wait policy (restored on
+ * the way out) and the budget for the conversion.
+ */
+export function enableWalWithRetry(db: Database.Database, busyTimeoutMs: number): void {
+  const totalBudgetMs = Math.max(busyTimeoutMs, 1_000);
+  const deadline = Date.now() + totalBudgetMs;
+  let backoffMs = 25;
+  let lastError: unknown;
+
+  // Shorten the wait policy for the duration of the conversion. Left at the
+  // caller's value, the very first attempt burns the whole budget inside one
+  // blocking call and the retry loop never gets a second turn; a short timeout
+  // trades one long wait for many cheap attempts across the same budget.
+  db.pragma('busy_timeout = 100');
+  try {
+    for (;;) {
+      try {
+        const rows = db.pragma('journal_mode = WAL') as Array<{ journal_mode?: string }>;
+        const mode = rows[0]?.journal_mode?.toLowerCase();
+        if (mode === 'wal') return;
+        // An in-memory or temp database reports 'memory' and can never be WAL.
+        // That is a legitimate configuration, not contention: retrying would
+        // spin for the whole budget and then fail an open that used to work.
+        if (mode === 'memory') return;
+        lastError = new Error(`journal_mode stayed '${mode ?? 'unknown'}'`);
+      } catch (error) {
+        if (!isRetryableBusyError(error)) throw error;
+        lastError = error;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Could not switch the database to WAL within ${totalBudgetMs}ms: ${
+            lastError instanceof Error ? lastError.message : String(lastError)
+          }`,
+        );
+      }
+      sleepSync(backoffMs);
+      backoffMs = Math.min(backoffMs * 2, 250);
+    }
+  } finally {
+    db.pragma(`busy_timeout = ${busyTimeoutMs}`);
+  }
+}


### PR DESCRIPTION
## Summary

The `SQLITE_BUSY` failure flagged on #326 turned out to be a real product defect, not a test artifact — and it affected all three SQLite stores.

Switching a database to WAL takes a brief exclusive lock, and **`busy_timeout` does not rescue it**. Probed directly in this repo: a connection holding a read transaction makes `PRAGMA journal_mode = WAL` wait out the *entire* timeout and then throw `SQLITE_BUSY`. With a single attempt, "another process opened the store at the same moment" becomes a hard crash inside a constructor — which is routine for OpenSwarm, where the daemon, the CLI and the dashboard all open these files while the machine is saturated with agent work.

`RunLedger` at least set `busy_timeout` first. `SqliteIssueStore` and `SqliteRegistryStore` did not set it at all.

## Measured, not argued

| Tree | `runLedger.test.ts` multi-process cases | Load avg |
|---|---|---|
| before | **6 / 6 runs failed** | 11.39 |
| after | **0 / 6 runs failed** | 11.89 |

A single earlier run had pointed the *opposite* way — it suggested my own diff caused the failure — which is why this was repeated rather than trusted.

CI passes either way; the failure only appears under sustained load, which is exactly the condition this tool creates.

## Four things that each cost a round

- **In-memory databases report `journal_mode = 'memory'` and can never be WAL.** Retrying that spun the whole budget and then failed opens that previously worked. **13 suite tests caught it** — reasoning alone would not have. Now accepted as terminal.
- **Busy codes are matched by prefix.** SQLite defines extended forms (`SQLITE_BUSY_SNAPSHOT` / `_RECOVERY` / `_TIMEOUT`); an exact match would rethrow them instead of retrying, reinstating the very crash being fixed. Local probing only ever produced the bare code, so this is defensive rather than observed — stated plainly in the code comment.
- **`busy_timeout` is lowered to 100ms only for the conversion**, then restored. Left at the caller's value, the first attempt consumes the entire budget inside one blocking call and the retry loop never gets a second turn.
- **Both store constructors now close their handle on failure.** Setup can throw where it previously could not, and these are module singletons — a leaked connection would outlive the failure.

## Verification

| Mutation | Test that went red |
|---|---|
| single attempt (original code) | `gives a bounded, explicit failure when the conversion can never succeed` |
| drop the `finally` restoring `busy_timeout` | `restores the caller busy_timeout once the conversion is done` |
| exact `=== 'SQLITE_BUSY'` | 3 × `retries on SQLITE_BUSY_*` |
| drop the in-memory acceptance | `accepts an in-memory database instead of retrying to death` |
| drop `this.db.close()` in either store | `closes its handle when WAL setup fails` (both stores) |

**The leak test had to be rewritten.** The obvious version — fail the constructor, then check another connection can still convert the database — **passed with the fix removed**, because an idle SQLite connection holds no lock. It proved nothing. It now captures every `Database` the constructor opens and asserts its state directly, and only then did mutation turn it red.

**One test was renamed rather than kept.** `opens against a database another connection already holds in WAL` was sequential and exercised no contention at all — the first ledger finished converting before the second was constructed. It now says it checks the no-op fast path, which is what it actually does. Real contention is covered by the multi-process cases and by the held-transaction case.

- Full suite: **245 files, 3271 passed, 1 skipped**
- `tsc --noEmit` clean, `oxlint` 0 warnings
- `openswarm review`: **APPROVE**, 0 issues (after two REVISE rounds, both fixed)

Also converts one Korean comment in `issues/sqliteStore.ts` to English on the line being edited, matching repo convention.
