### PR TITLE
chore(release): v0.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.19.2 — 2026-07-26
+
+### Fixed
+
+- **A concurrent open no longer crashes startup** — switching a database to WAL takes a brief exclusive lock, and `busy_timeout` does not cover it: a connection holding a read transaction makes `PRAGMA journal_mode = WAL` wait out the entire timeout and then throw `SQLITE_BUSY`. Since the daemon, the CLI and the dashboard all open these stores while the machine is under agent load, a single attempt turned "someone else opened it at the same moment" into a hard failure inside a constructor. The conversion now retries within a bounded budget, shared by all three stores; `SqliteIssueStore` and `SqliteRegistryStore` additionally had no `busy_timeout` at all. Measured at load ~11, the multi-process cases failed 6/6 runs before and 0/6 after. (#327)
+- **Shared config files are written atomically** — `repos.json`, `openswarm.json` and `ci-state.json` were rewritten in place while other processes read them, and each degraded into silent data loss rather than a visible error. A torn read of `repos.json` made the loader fall back to an empty config, so reconciliation disabled **every running project**; `openswarm.json` surfaced as `RepoMetadataError`; `ci-state.json` silently reset each repository's health timeline. All three now use the write-temp + fsync + rename helper the CLI already used for `repos.json`. `loadCIState` also stopped treating a corrupt file like a missing one. (#325)
+- **An EPIPE no longer takes down the daemon** — `commentOnPR` pipes the comment body through gh's stdin, and if gh exits first the stream emits `'error'`. Node rethrows an unhandled `'error'` event as an uncaught exception, and because it arrives asynchronously the function's own `try/catch` never saw it. Six gh readers also inherited Node's 1MB `maxBuffer` instead of the 4MB the shared helper uses, so long review threads — the ones most worth reading — failed with `ERR_CHILD_PROCESS_STDOUT_MAXBUFFER`. (#326)
+
+### Changed
+
+- **The dashboard's Tailscale URL is detected at runtime** — the address was a literal belonging to one developer's node, committed to a public repository and wrong for everyone else the moment Tailscale reassigned it. It is now read from this host's `100.64.0.0/10` interface, and the line is omitted entirely when Tailscale is not up. (#325)
+
 ## 0.19.1 — 2026-07-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.19.1",
+      "version": "0.19.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Releases the three fixes merged since v0.19.1, all from the audit backlog.

| PR | Fix |
|---|---|
| #327 | WAL conversion retries instead of crashing a constructor on a concurrent open |
| #325 | `repos.json` / `openswarm.json` / `ci-state.json` written atomically; hardcoded Tailscale address removed |
| #326 | stdin EPIPE no longer kills the daemon; six gh readers get the 4MB buffer |

All three were verified by mutation — every fix has a test that goes red when the fix is reverted — and each passed `openswarm review` (#327 after two REVISE rounds, both addressed).

## Verification

- Full suite on merged main: **245 files, 3271 passed, 1 skipped**
- Version bump touches **only the three version lines**; no reformatting of `package.json` or `package-lock.json`
- `tsc --noEmit` clean

Merging this triggers the release workflow (npm publish → tag → GitHub release), per the version-bump flow in `release.yml`.

## Not included

Dependabot #320 (`fast-uri` 3.1.2→3.1.4 security advisory, `hono`) is still open. It is a lockfile-only transitive bump and would be a sensible addition to a release, but changing the dependency tree is a call for the repo owner rather than something to fold in silently — flagging it here instead.
