### PR TITLE
fix(auth): stop one provider's bad token response from wiping every credential

### DIFF
--- a/src/auth/linearPkce.ts
+++ b/src/auth/linearPkce.ts
@@ -9,6 +9,7 @@ import { randomBytes, createHash } from 'node:crypto';
 import { AuthProfileStore, type AuthProfile } from './oauthStore.js';
 import { openBrowser } from './openBrowser.js';
 import { PkceSettlement, TOKEN_EXCHANGE_TIMEOUT_MS } from './pkceSettlement.js';
+import { parseTokenResponse } from './tokenResponse.js';
 
 // ----- Constants -----
 
@@ -62,15 +63,18 @@ export interface LinearFlowOptions {
   scopes?: string;
 }
 
+/**
+ * Validate Linear's authorization-code exchange response.
+ *
+ * Thin wrapper over the shared validator. This is an exchange, so a refresh
+ * token is mandatory — it is the only point at which one is issued.
+ */
 export function parseLinearTokenResponse(value: unknown): LinearFlowResult {
-  if (!value || typeof value !== 'object') throw new Error('Linear token response is not an object');
-  const tokens = value as Record<string, unknown>;
-  if (typeof tokens.access_token !== 'string' || !tokens.access_token) throw new Error('Linear token response missing access_token');
-  if (typeof tokens.refresh_token !== 'string' || !tokens.refresh_token) throw new Error('Linear token response missing refresh_token');
-  if (typeof tokens.expires_in !== 'number' || !Number.isFinite(tokens.expires_in) || tokens.expires_in <= 0) {
-    throw new Error('Linear token response has invalid expires_in');
-  }
-  return { accessToken: tokens.access_token, refreshToken: tokens.refresh_token, expiresIn: tokens.expires_in };
+  const { accessToken, refreshToken, expiresIn } = parseTokenResponse(value, {
+    provider: 'Linear',
+    requireRefreshToken: true,
+  });
+  return { accessToken, refreshToken: refreshToken as string, expiresIn };
 }
 
 export function isValidLinearCallback(

--- a/src/auth/oauthPkce.ts
+++ b/src/auth/oauthPkce.ts
@@ -8,6 +8,7 @@ import { randomBytes, createHash } from 'node:crypto';
 import { AuthProfileStore, type AuthProfile } from './oauthStore.js';
 import { openBrowser } from './openBrowser.js';
 import { PkceSettlement, TOKEN_EXCHANGE_TIMEOUT_MS } from './pkceSettlement.js';
+import { parseTokenResponse } from './tokenResponse.js';
 
 // Constants
 
@@ -172,11 +173,18 @@ export async function runOAuthPkceFlow(options: OAuthFlowOptions = {}): Promise<
           throw new Error(`Token exchange failed (${tokenRes.status}): ${errText.slice(0, 300)}`);
         }
 
-        const tokens = (await tokenRes.json()) as {
-          access_token: string;
-          refresh_token: string;
-          expires_in: number;
-          id_token?: string;
+        // Validated before any of it reaches an AuthProfile: a 200 carrying an
+        // error body would otherwise be stored with an undefined access token
+        // and a NaN expiry, which fails the store's load-time check and used to
+        // take every other provider's credentials with it. An exchange is the
+        // only point a refresh token is issued, so it is required here.
+        const raw: unknown = await tokenRes.json();
+        const parsed = parseTokenResponse(raw, { provider: 'ChatGPT', requireRefreshToken: true });
+        const tokens = {
+          access_token: parsed.accessToken,
+          refresh_token: parsed.refreshToken as string,
+          expires_in: parsed.expiresIn,
+          id_token: (raw as { id_token?: unknown }).id_token as string | undefined,
         };
 
         // Codex 백엔드(/responses, /models)는 `chatgpt-account-id` 헤더를 요구한다.

--- a/src/auth/oauthStore.test.ts
+++ b/src/auth/oauthStore.test.ts
@@ -1,0 +1,263 @@
+// ============================================
+// OpenSwarm - auth profile store tests
+// ============================================
+//
+// The store keeps every provider's credentials in one file, which made its
+// failure modes shared: a malformed profile written by one provider used to
+// fail the whole-file check and quarantine the file, logging the user out of
+// every other provider too. These tests pin the blast radius.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let home: string;
+
+/** Load a fresh copy of the module with homedir() pointed at a temp directory. */
+async function loadModule() {
+  vi.resetModules();
+  vi.doMock('node:os', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:os')>();
+    return { ...actual, default: { ...actual, homedir: () => home }, homedir: () => home };
+  });
+  return await import('./oauthStore.js');
+}
+
+const storePath = () => join(home, '.openswarm', 'auth-profiles.json');
+
+const validProfile = (over: Record<string, unknown> = {}) => ({
+  type: 'oauth',
+  provider: 'openai-gpt',
+  access: 'access-token',
+  refresh: 'refresh-token',
+  expires: 4_000_000_000_000,
+  clientId: 'client',
+  ...over,
+});
+
+function writeStore(profiles: Record<string, unknown>, version: unknown = 1): void {
+  mkdirSync(join(home, '.openswarm'), { recursive: true });
+  writeFileSync(storePath(), JSON.stringify({ version, profiles }, null, 2));
+}
+
+function readStore(): { profiles: Record<string, { access: string; refresh: string }> } {
+  return JSON.parse(readFileSync(storePath(), 'utf-8'));
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'openswarm-auth-'));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  vi.doUnmock('node:os');
+  vi.restoreAllMocks();
+});
+
+describe('AuthProfileStore.load', () => {
+  it('reads back the profiles it was given', async () => {
+    writeStore({ 'gpt:default': validProfile() });
+    const { AuthProfileStore } = await loadModule();
+    expect(new AuthProfileStore().getProfile('gpt:default')).toMatchObject({ access: 'access-token' });
+  });
+
+  // The regression this whole change is about: one provider's malformed entry
+  // must not cost the user their other providers' credentials.
+  it('keeps the good profiles when one is malformed', async () => {
+    writeStore({
+      'gpt:default': validProfile(),
+      // What an unvalidated token response used to persist.
+      'linear:default': validProfile({ provider: 'linear', access: undefined, expires: Number.NaN }),
+    });
+    const { AuthProfileStore } = await loadModule();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const store = new AuthProfileStore();
+
+    expect(store.getProfile('gpt:default')).toMatchObject({ access: 'access-token' });
+    expect(store.getProfile('linear:default')).toBeNull();
+    expect(existsSync(storePath())).toBe(true);
+    expect(readdirSync(join(home, '.openswarm')).filter((f) => f.includes('.corrupt-'))).toEqual([]);
+  });
+
+  it('says which profiles it dropped so the user can re-auth just those', async () => {
+    writeStore({ 'gpt:default': validProfile(), 'linear:default': { provider: 'linear' } });
+    const { AuthProfileStore } = await loadModule();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    new AuthProfileStore();
+
+    expect(warn).toHaveBeenCalled();
+    expect(String(warn.mock.calls[0]?.[0])).toContain('linear:default');
+  });
+
+  // Quarantine is still right when there is genuinely nothing to salvage.
+  it.each([
+    ['unparseable JSON', () => { mkdirSync(join(home, '.openswarm'), { recursive: true }); writeFileSync(storePath(), '{ not json'); }],
+    ['a wrong schema version', () => writeStore({ 'gpt:default': validProfile() }, 2)],
+  ])('quarantines the file on %s', async (_label, corrupt) => {
+    corrupt();
+    const { AuthProfileStore } = await loadModule();
+
+    expect(() => new AuthProfileStore()).toThrow(/corrupt/);
+    expect(readdirSync(join(home, '.openswarm')).some((f) => f.includes('.corrupt-'))).toBe(true);
+  });
+
+  it('starts empty when the store does not exist yet', async () => {
+    const { AuthProfileStore } = await loadModule();
+    expect(new AuthProfileStore().listProfiles()).toEqual({});
+  });
+});
+
+describe('AuthProfileStore.setProfile', () => {
+  // Last line of defence: nothing that would fail the load check may reach disk.
+  it('refuses a profile that would make the store unloadable', async () => {
+    const { AuthProfileStore } = await loadModule();
+    const store = new AuthProfileStore();
+
+    expect(() =>
+      store.setProfile('linear:default', validProfile({ access: undefined }) as never),
+    ).toThrow(/invalid auth profile/i);
+    expect(existsSync(storePath())).toBe(false);
+  });
+
+  it('stores a valid profile', async () => {
+    const { AuthProfileStore } = await loadModule();
+    const store = new AuthProfileStore();
+    store.setProfile('gpt:default', validProfile() as never);
+    expect(readStore().profiles['gpt:default'].access).toBe('access-token');
+  });
+});
+
+describe('AuthProfileStore.save concurrency', () => {
+  // Two processes — CLI beside daemon, or two overlapping refreshes — each hold
+  // a snapshot from construction. Writing that snapshot wholesale rolled back
+  // the other's refresh_token rotation, and a rolled-back refresh token fails
+  // the next refresh with invalid_grant.
+  it('does not roll back another writer rotation of a different provider', async () => {
+    writeStore({ 'gpt:default': validProfile(), 'linear:default': validProfile({ provider: 'linear' }) });
+    const { AuthProfileStore } = await loadModule();
+
+    const first = new AuthProfileStore();
+    const second = new AuthProfileStore();
+
+    // `second` rotates linear while `first` still holds the pre-rotation view.
+    second.setProfile('linear:default', validProfile({ provider: 'linear', refresh: 'rotated-by-second' }) as never);
+    // `first` then writes its own provider.
+    first.setProfile('gpt:default', validProfile({ refresh: 'rotated-by-first' }) as never);
+
+    const onDisk = readStore().profiles;
+    expect(onDisk['gpt:default'].refresh).toBe('rotated-by-first');
+    expect(onDisk['linear:default'].refresh).toBe('rotated-by-second');
+  });
+
+  it('still applies a delete against the current file', async () => {
+    writeStore({ 'gpt:default': validProfile(), 'linear:default': validProfile({ provider: 'linear' }) });
+    const { AuthProfileStore } = await loadModule();
+
+    const first = new AuthProfileStore();
+    const second = new AuthProfileStore();
+
+    second.setProfile('linear:default', validProfile({ provider: 'linear', refresh: 'rotated' }) as never);
+    expect(first.deleteProfile('gpt:default')).toBe(true);
+
+    const onDisk = readStore().profiles;
+    expect(onDisk['gpt:default']).toBeUndefined();
+    expect(onDisk['linear:default'].refresh).toBe('rotated');
+  });
+});
+
+describe('ensureValidToken', () => {
+  const expiring = () => validProfile({ expires: Date.now() + 1_000 }); // inside the refresh buffer
+
+  function mockTokenEndpoint(status: number, body: unknown): void {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+        text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+      })) as never,
+    );
+  }
+
+  it('returns the existing token when it is not close to expiry', async () => {
+    writeStore({ 'gpt:default': validProfile() });
+    const { AuthProfileStore, ensureValidToken } = await loadModule();
+    vi.stubGlobal('fetch', vi.fn(() => { throw new Error('must not be called'); }) as never);
+
+    await expect(ensureValidToken(new AuthProfileStore(), 'gpt:default')).resolves.toBe('access-token');
+  });
+
+  it('stores a refreshed token', async () => {
+    writeStore({ 'gpt:default': expiring() });
+    const { AuthProfileStore, ensureValidToken } = await loadModule();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockTokenEndpoint(200, { access_token: 'fresh', refresh_token: 'rotated', expires_in: 3600 });
+
+    await expect(ensureValidToken(new AuthProfileStore(), 'gpt:default')).resolves.toBe('fresh');
+    expect(readStore().profiles['gpt:default']).toMatchObject({ access: 'fresh', refresh: 'rotated' });
+  });
+
+  // The path that used to poison the store: a 200 whose body is not a token.
+  // Casting it wrote access=undefined and expires=NaN, and the next load then
+  // quarantined the file and took every other provider with it.
+  it.each([
+    ['an error body', { error: 'invalid_grant' }],
+    ['an empty body', {}],
+    ['a body with no expiry', { access_token: 'fresh' }],
+  ])('refuses to persist %s returned with 200', async (_label, body) => {
+    writeStore({ 'gpt:default': expiring(), 'linear:default': validProfile({ provider: 'linear' }) });
+    const { AuthProfileStore, ensureValidToken } = await loadModule();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockTokenEndpoint(200, body);
+
+    await expect(ensureValidToken(new AuthProfileStore(), 'gpt:default')).rejects.toThrow();
+
+    // The old token is still there, and the unrelated provider is untouched.
+    const onDisk = readStore().profiles;
+    expect(onDisk['gpt:default'].access).toBe('access-token');
+    expect(onDisk['linear:default'].access).toBe('access-token');
+  });
+
+  // setProfile's guard also stops a bad refresh from reaching disk, so "it
+  // throws" alone cannot tell the two layers apart. The difference is *when*:
+  // validating the response first leaves the in-memory profile intact, whereas
+  // assigning from a cast response corrupts the live object before the write is
+  // refused — and getProfile hands that same object to the next caller for the
+  // rest of the process.
+  it('leaves the in-memory profile usable after a bad refresh', async () => {
+    writeStore({ 'gpt:default': expiring() });
+    const { AuthProfileStore, ensureValidToken } = await loadModule();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockTokenEndpoint(200, { error: 'invalid_grant' });
+    const store = new AuthProfileStore();
+
+    await expect(ensureValidToken(store, 'gpt:default')).rejects.toThrow();
+
+    const after = store.getProfile('gpt:default');
+    expect(after?.access).toBe('access-token');
+    expect(Number.isFinite(after?.expires)).toBe(true);
+  });
+
+  it('keeps the existing refresh token when the provider omits it', async () => {
+    writeStore({ 'gpt:default': expiring() });
+    const { AuthProfileStore, ensureValidToken } = await loadModule();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockTokenEndpoint(200, { access_token: 'fresh', expires_in: 3600 });
+
+    await expect(ensureValidToken(new AuthProfileStore(), 'gpt:default')).resolves.toBe('fresh');
+    expect(readStore().profiles['gpt:default'].refresh).toBe('refresh-token');
+  });
+
+  it('tells the user how to re-auth when the endpoint rejects the refresh', async () => {
+    writeStore({ 'gpt:default': expiring() });
+    const { AuthProfileStore, ensureValidToken } = await loadModule();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockTokenEndpoint(400, 'invalid_grant');
+
+    await expect(ensureValidToken(new AuthProfileStore(), 'gpt:default')).rejects.toThrow(/auth login/);
+  });
+});

--- a/src/auth/oauthStore.ts
+++ b/src/auth/oauthStore.ts
@@ -7,6 +7,7 @@ import { readFileSync, existsSync, renameSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { atomicWriteFileSync } from '../support/atomicFile.js';
+import { parseTokenResponse } from './tokenResponse.js';
 
 // Types
 
@@ -53,12 +54,9 @@ function isAuthProfile(value: unknown): value is AuthProfile {
   );
 }
 
-function isAuthProfileFile(value: unknown): value is AuthProfileFile {
-  if (!isRecord(value) || value.version !== 1 || !isRecord(value.profiles)) {
-    return false;
-  }
-  return Object.values(value.profiles).every(isAuthProfile);
-}
+// The old all-or-nothing file validator lived here. It is gone deliberately:
+// requiring every profile to be valid is what let one bad entry quarantine the
+// whole store. load() now checks the envelope and each profile separately.
 
 // Constants
 
@@ -77,43 +75,129 @@ const TOKEN_ENDPOINTS: Record<string, string> = {
 
 export class AuthProfileStore {
   private data: AuthProfileFile;
+  /** Keys this instance changed, so save() only applies those onto the file. */
+  private readonly touched = new Set<string>();
 
   constructor() {
     this.data = this.load();
   }
 
+  /**
+   * Read the store, keeping whatever is still usable.
+   *
+   * A single malformed profile used to fail the whole-file check, which
+   * quarantined the file and logged the user out of *every* provider — one bad
+   * Linear response cost them their GPT credentials too. Individual profiles
+   * that no longer validate are now dropped with a warning and the rest are
+   * kept. The file is only quarantined when it cannot be parsed at all, where
+   * there is genuinely nothing to salvage.
+   */
   private load(): AuthProfileFile {
     if (!existsSync(STORE_PATH)) {
       return { version: 1, profiles: {} };
     }
+
+    let parsed: unknown;
     try {
-      const raw = readFileSync(STORE_PATH, 'utf-8');
-      const parsed: unknown = JSON.parse(raw);
-      if (!isAuthProfileFile(parsed)) throw new Error('auth profile schema validation failed');
-      return parsed;
+      parsed = JSON.parse(readFileSync(STORE_PATH, 'utf-8'));
     } catch (error) {
       const corruptPath = `${STORE_PATH}.corrupt-${Date.now()}`;
       try { renameSync(STORE_PATH, corruptPath); } catch { /* preserve original read error */ }
       throw new Error(`Auth profile store is corrupt; preserved at ${corruptPath}`, { cause: error });
     }
+
+    if (!isRecord(parsed) || parsed.version !== 1 || !isRecord(parsed.profiles)) {
+      const corruptPath = `${STORE_PATH}.corrupt-${Date.now()}`;
+      try { renameSync(STORE_PATH, corruptPath); } catch { /* preserve original read error */ }
+      throw new Error(`Auth profile store is corrupt; preserved at ${corruptPath}`);
+    }
+
+    const profiles: Record<string, AuthProfile> = {};
+    const dropped: string[] = [];
+    for (const [key, value] of Object.entries(parsed.profiles)) {
+      if (isAuthProfile(value)) profiles[key] = value;
+      else dropped.push(key);
+    }
+    if (dropped.length > 0) {
+      console.warn(
+        `[Auth] Ignoring unusable auth profile(s): ${dropped.join(', ')}. ` +
+          `Re-run auth login for those providers; other providers are unaffected.`,
+      );
+    }
+    return { version: 1, profiles };
   }
 
+  /**
+   * Persist the store, merging onto whatever is on disk right now.
+   *
+   * The in-memory map is a snapshot from construction, so writing it wholesale
+   * lets a second process (CLI alongside daemon, or two overlapping refreshes)
+   * roll back the other's refresh_token rotation — and a rolled-back refresh
+   * token fails the next refresh with invalid_grant. Only the keys this
+   * instance actually touched are applied on top of the current file.
+   *
+   * This narrows the race rather than removing it: two writers rotating the
+   * *same* key concurrently still read-then-write, so the later one can land on
+   * a snapshot taken before the earlier write. Closing that needs a lock around
+   * read-modify-write, which is a larger change than this fix. Different keys —
+   * the common CLI-beside-daemon case, and the one that used to lose unrelated
+   * providers' credentials — are now safe.
+   */
   save(): void {
+    const onDisk = existsSync(STORE_PATH) ? this.readProfilesQuietly() : {};
+    for (const key of this.touched) {
+      const profile = this.data.profiles[key];
+      if (profile) onDisk[key] = profile;
+      else delete onDisk[key];
+    }
+    this.data = { version: 1, profiles: { ...onDisk } };
+    this.touched.clear();
     atomicWriteFileSync(STORE_PATH, `${JSON.stringify(this.data, null, 2)}\n`, 0o600);
+  }
+
+  /** Current on-disk profiles, or an empty map if the file is unreadable. */
+  private readProfilesQuietly(): Record<string, AuthProfile> {
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(STORE_PATH, 'utf-8'));
+      if (!isRecord(parsed) || !isRecord(parsed.profiles)) return {};
+      const profiles: Record<string, AuthProfile> = {};
+      for (const [key, value] of Object.entries(parsed.profiles)) {
+        if (isAuthProfile(value)) profiles[key] = value;
+      }
+      return profiles;
+    } catch {
+      // A merge is best-effort: falling back to this instance's own view is
+      // better than refusing to persist a freshly obtained token.
+      return {};
+    }
   }
 
   getProfile(key: string): AuthProfile | null {
     return this.data.profiles[key] ?? null;
   }
 
+  /**
+   * Store a profile.
+   *
+   * Validated before it is written: this is the last point at which a profile
+   * that would fail the load-time check can be stopped, and letting one through
+   * used to cost every other provider's credentials.
+   */
   setProfile(key: string, profile: AuthProfile): void {
+    if (!isAuthProfile(profile)) {
+      throw new Error(
+        `Refusing to store an invalid auth profile for "${key}" — it would make the store unloadable.`,
+      );
+    }
     this.data.profiles[key] = profile;
+    this.touched.add(key);
     this.save();
   }
 
   deleteProfile(key: string): boolean {
     if (!(key in this.data.profiles)) return false;
     delete this.data.profiles[key];
+    this.touched.add(key);
     this.save();
     return true;
   }
@@ -172,17 +256,22 @@ export async function ensureValidToken(store: AuthProfileStore, profileKey: stri
     );
   }
 
-  const tokens = (await res.json()) as {
-    access_token: string;
-    refresh_token?: string;
-    expires_in: number;
-  };
+  // Validated, not cast. A 200 carrying an error body — or a proxy's HTML —
+  // would otherwise put `undefined` into access and `NaN` into expires, and
+  // that profile gets written to disk like any other, where it fails the
+  // whole-file schema check on the next load and takes every other provider's
+  // credentials down with it. refresh_token stays optional here: providers may
+  // legitimately keep the existing one on a refresh.
+  const tokens = parseTokenResponse(await res.json(), {
+    provider: profile.provider,
+    requireRefreshToken: false,
+  });
 
-  profile.access = tokens.access_token;
-  if (tokens.refresh_token) {
-    profile.refresh = tokens.refresh_token;
+  profile.access = tokens.accessToken;
+  if (tokens.refreshToken) {
+    profile.refresh = tokens.refreshToken;
   }
-  profile.expires = Date.now() + tokens.expires_in * 1000;
+  profile.expires = Date.now() + tokens.expiresIn * 1000;
 
   store.setProfile(profileKey, profile);
   console.log(`[Auth] Token refreshed successfully.`);

--- a/src/auth/tokenResponse.test.ts
+++ b/src/auth/tokenResponse.test.ts
@@ -1,0 +1,73 @@
+// ============================================
+// OpenSwarm - token response validation tests
+// ============================================
+
+import { describe, expect, it } from 'vitest';
+import { parseTokenResponse } from './tokenResponse.js';
+
+const exchange = { provider: 'Linear', requireRefreshToken: true } as const;
+const refresh = { provider: 'openai-gpt', requireRefreshToken: false } as const;
+
+describe('parseTokenResponse', () => {
+  it('accepts a complete response', () => {
+    expect(parseTokenResponse({ access_token: 'a', refresh_token: 'r', expires_in: 3600 }, exchange)).toEqual({
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresIn: 3600,
+    });
+  });
+
+  // The shape that caused the damage: a 200 whose body is not a token. Casting
+  // it wrote `undefined` into access and `NaN` into expires.
+  it.each([
+    ['an error object', { error: 'invalid_grant', error_description: 'expired' }],
+    ['an empty object', {}],
+    ['an HTML error page', '<html>502 Bad Gateway</html>'],
+    ['null', null],
+    ['an array', []],
+  ])('rejects %s', (_label, body) => {
+    expect(() => parseTokenResponse(body, refresh)).toThrow();
+  });
+
+  it.each([
+    ['a blank access_token', { access_token: '', refresh_token: 'r', expires_in: 1 }, /access_token/],
+    ['a non-string access_token', { access_token: 42, refresh_token: 'r', expires_in: 1 }, /access_token/],
+    ['a missing expires_in', { access_token: 'a', refresh_token: 'r' }, /expires_in/],
+    ['a NaN expires_in', { access_token: 'a', refresh_token: 'r', expires_in: Number.NaN }, /expires_in/],
+    ['a zero expires_in', { access_token: 'a', refresh_token: 'r', expires_in: 0 }, /expires_in/],
+    ['a negative expires_in', { access_token: 'a', refresh_token: 'r', expires_in: -1 }, /expires_in/],
+  ])('rejects %s', (_label, body, pattern) => {
+    expect(() => parseTokenResponse(body, exchange)).toThrow(pattern);
+  });
+
+  describe('refresh_token', () => {
+    it('is required for an authorization-code exchange', () => {
+      expect(() => parseTokenResponse({ access_token: 'a', expires_in: 1 }, exchange)).toThrow(/refresh_token/);
+    });
+
+    // A refresh may legitimately omit it — the existing token stays valid.
+    // Requiring it here would reject good responses and block every refresh.
+    it('is optional on a refresh', () => {
+      expect(parseTokenResponse({ access_token: 'a', expires_in: 1 }, refresh)).toEqual({
+        accessToken: 'a',
+        refreshToken: undefined,
+        expiresIn: 1,
+      });
+    });
+
+    // Present-but-wrong is not the same as absent: silently dropping it would
+    // leave the profile holding a token the provider has already rotated away.
+    it.each([['a blank string', ''], ['a number', 7], ['null', null]])(
+      'rejects %s even on a refresh',
+      (_label, value) => {
+        expect(() => parseTokenResponse({ access_token: 'a', refresh_token: value, expires_in: 1 }, refresh)).toThrow(
+          /refresh_token/,
+        );
+      },
+    );
+  });
+
+  it('names the provider in the error so the user knows what to re-auth', () => {
+    expect(() => parseTokenResponse({}, { provider: 'linear', requireRefreshToken: false })).toThrow(/linear/);
+  });
+});

--- a/src/auth/tokenResponse.ts
+++ b/src/auth/tokenResponse.ts
@@ -1,0 +1,66 @@
+// ============================================
+// OpenSwarm - OAuth token response validation
+// ============================================
+//
+// A token endpoint can answer 200 with a body that is not a token: an error
+// object, an HTML error page from a proxy, a truncated response. Casting that
+// to the expected shape puts `undefined` into the access token and `NaN` into
+// the expiry, and a profile in that state is written to disk like any other.
+//
+// The consequence is not local. AuthProfileStore validates the whole file on
+// load, so one malformed profile made every other provider's credentials
+// unloadable — a bad Linear response would log the user out of GPT. Validating
+// at the boundary keeps a bad response from ever reaching disk.
+
+export interface ParsedTokenResponse {
+  accessToken: string;
+  refreshToken?: string;
+  expiresIn: number;
+}
+
+export interface ParseTokenResponseOptions {
+  /** Label used in error messages, e.g. 'Linear'. */
+  provider: string;
+  /**
+   * Whether a refresh token must be present.
+   *
+   * True for an authorization-code exchange, which is the only chance to obtain
+   * one. False for a refresh, where providers may legitimately omit it and keep
+   * the existing token valid — requiring it there would reject good responses.
+   */
+  requireRefreshToken: boolean;
+}
+
+/** Validate an OAuth token response, or throw explaining what is missing. */
+export function parseTokenResponse(
+  value: unknown,
+  { provider, requireRefreshToken }: ParseTokenResponseOptions,
+): ParsedTokenResponse {
+  if (!value || typeof value !== 'object') {
+    throw new Error(`${provider} token response is not an object`);
+  }
+  const tokens = value as Record<string, unknown>;
+
+  if (typeof tokens.access_token !== 'string' || !tokens.access_token) {
+    throw new Error(`${provider} token response missing access_token`);
+  }
+  if (typeof tokens.expires_in !== 'number' || !Number.isFinite(tokens.expires_in) || tokens.expires_in <= 0) {
+    throw new Error(`${provider} token response has invalid expires_in`);
+  }
+
+  const hasRefresh = typeof tokens.refresh_token === 'string' && tokens.refresh_token.length > 0;
+  if (requireRefreshToken && !hasRefresh) {
+    throw new Error(`${provider} token response missing refresh_token`);
+  }
+  // A present-but-wrong refresh_token is rejected either way: silently dropping
+  // it would leave the profile pointing at a token the provider has rotated.
+  if (!hasRefresh && tokens.refresh_token !== undefined) {
+    throw new Error(`${provider} token response has invalid refresh_token`);
+  }
+
+  return {
+    accessToken: tokens.access_token,
+    refreshToken: hasRefresh ? (tokens.refresh_token as string) : undefined,
+    expiresIn: tokens.expires_in,
+  };
+}


### PR DESCRIPTION
## Summary

The most severe finding left in the audit backlog: **one provider's bad token response could delete every provider's credentials.**

All providers share `auth-profiles.json`, and the store validated it *as a whole* on load — one malformed profile failed the check, the file was quarantined, and the user was logged out of everything. Token responses were cast rather than parsed, so a single 200 carrying an error body (or a proxy's HTML) wrote `access=undefined` and `expires=NaN`. A bad Linear response cost the user their ChatGPT credentials.

## Four layers

Any one alone still leaves a path to disk, so all four are in:

| Layer | What it stops |
|---|---|
| **Validate at every endpoint** — GPT PKCE exchange, Linear exchange, refresh | A non-token 200 becoming an `AuthProfile` |
| **`setProfile` refuses invalid profiles** | Anything that would fail the load check reaching disk |
| **`load()` drops per-profile, not per-file** | One bad entry quarantining everyone else's credentials |
| **`save()` merges only touched keys** | A second process rolling back the other's `refresh_token` rotation |

`refresh_token` is **required for an exchange** (the only point one is issued) and **optional on a refresh** (providers may keep the existing token) — requiring it on refresh would reject good responses and block every refresh. Present-but-invalid is rejected either way rather than silently dropped, since dropping it leaves the profile holding a token the provider has already rotated away.

## Deliberately not closed

`save()` **narrows** the last race rather than removing it: two writers rotating the *same* key concurrently still read-then-write, so the later one can land on a stale snapshot. Closing that needs a lock around read-modify-write — a larger change than this fix. Different keys, which is the CLI-beside-daemon case that actually lost unrelated providers, are now safe. This is stated in the code, not left for the next reader to rediscover.

## Verification

| Mutation | Test that went red |
|---|---|
| `load()` back to all-or-nothing | `keeps the good profiles when one is malformed`, `says which profiles it dropped` |
| remove `setProfile` validation | `refuses a profile that would make the store unloadable` |
| `save()` back to wholesale overwrite | `does not roll back another writer rotation`, `still applies a delete against the current file` |
| refresh response back to a cast | `leaves the in-memory profile usable after a bad refresh` |

**The refresh-path test needed a second attempt.** Asserting "it throws" passed with the fix reverted, because `setProfile`'s guard catches it too — the test could not tell the layers apart. What distinguishes them is *when*: validating first leaves the in-memory profile intact, while assigning from a cast response corrupts the live object before the write is refused, and `getProfile` hands that same object to every later caller for the rest of the process. Only after asserting that did mutation turn it red.

- Full suite: **247 files, 3307 passed, 1 skipped**
- `tsc --noEmit` clean, `oxlint` 0 warnings
- `openswarm review`: **APPROVE**, 0 issues

The removed `isAuthProfileFile` is replaced by a comment explaining why an all-or-nothing validator was the bug, so it does not get reintroduced as a tidy-up.
