### PR TITLE
chore(release): v0.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.19.3 — 2026-07-26
+
+### Fixed
+
+- **One provider's bad token response no longer wipes every credential** — all providers share `auth-profiles.json`, and the store validated it as a whole on load, so a single malformed profile quarantined the file and logged the user out of everything. Token responses were cast rather than parsed, so a 200 carrying an error body wrote an undefined access token and a `NaN` expiry: a bad Linear response cost the user their ChatGPT credentials. Responses are now validated at every endpoint (GPT exchange, Linear exchange, refresh), `setProfile` refuses to persist a profile that would fail the load check, `load()` drops individual unusable profiles with a warning instead of failing the whole file, and `save()` applies only the keys it touched onto the current file so a second process cannot roll back the other's `refresh_token` rotation. (#329)
+
 ## 0.19.2 — 2026-07-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Releases #329, the most severe finding remaining in the audit backlog: **a malformed token response from one provider could delete every provider's credentials.**

All providers share `auth-profiles.json`, and the store validated it as a whole on load — one bad profile quarantined the file and logged the user out of everything. Because token responses were cast rather than parsed, a 200 carrying an error body wrote an undefined access token and a `NaN` expiry, so a bad Linear response cost the user their ChatGPT login.

Four layers now stand between a bad response and that outcome: validation at every token endpoint, `setProfile` refusing profiles that would fail the load check, per-profile rather than per-file recovery on load, and a merge-on-write `save()` that cannot roll back another process's `refresh_token` rotation.

## Verification

- Every layer pinned by a test verified with **mutation** — including a second attempt at the refresh-path test, whose first version passed with the fix reverted because a different layer caught it
- Full suite on merged main: **247 files, 3307 passed, 1 skipped**
- `openswarm review`: APPROVE, 0 issues
- Version bump touches **only the three version lines**; no reformatting

Merging this triggers the release workflow (npm publish → tag → GitHub release).

## Known limitation, shipped deliberately

`save()` narrows the write race rather than closing it: two writers rotating the **same** key concurrently still read-then-write. Different keys — the CLI-beside-daemon case that actually lost unrelated providers — are safe. This is documented in the code rather than left for the next reader.

## Not included

Dependabot #320 (`fast-uri` security advisory, `hono`) is still open. Lockfile-only transitive bump; changing the dependency tree is the repo owner's call, so it is flagged rather than folded in.
