### PR TITLE
chore(release): v0.19.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.19.4 — 2026-07-26
+
+### Fixed
+
+- **Long Discord output arrived, instead of not arriving at all** — `sendToChannel` split at 3900 characters because a comment confused the embed *description* limit (4096) with the message *content* limit (2000). Every chunk it produced was rejected by the API, and content between 2001 and 3900 was not split at all and failed the same way, so long reports simply never appeared. Both send paths now share one constant below the real limit. (#331)
+- **Replies attach to the message they answer** — history responses were written to the last entry in the channel. Two messages in one channel are handled concurrently and do not finish in arrival order, so whichever finished first overwrote the newer message's slot: the newer message got no answer and the older one displayed a reply to a question nobody asked. Matched by message id now, and a response whose entry has aged out is dropped rather than misfiled. (#331)
+- **`!dev` progress stops when the task does** — the 10s progress timer was never disarmed on a failure path, so a stale "in progress" reply arrived ten seconds after the error had been reported. It is now disarmed from the task's completion callback, which fires for both a normal close and a spawn error, plus the two pre-launch paths that never reach it. (#331)
+
+### Security
+
+- Bumped `fast-uri` (GHSA-v2hh-gcrm-f6hx) and `hono` via the npm_and_yarn group. (#320)
+
 ## 0.19.3 — 2026-07-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.19.3",
+      "version": "0.19.4",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Releases the Discord delivery fixes (#331) and the dependabot security bump (#320) that landed on main.

| Fix | Symptom |
|---|---|
| Message chunk size | Long output was **rejected by the API entirely** — the splitter used the embed limit (4096) rather than the content limit (2000), so no chunk it produced was valid |
| Reply matching | Concurrent messages in one channel overwrote each other's history slots: one message lost its answer, another displayed a reply to a question nobody asked |
| Progress timer | A stale "in progress" reply arrived ten seconds after the task had already failed |
| `fast-uri` / `hono` | GHSA-v2hh-gcrm-f6hx and group bump |

## Verification

- Full suite on merged main: **249 files, 3325 passed, 1 skipped**
- Every fix pinned by a mutation-verified test
- `openswarm review`: APPROVE, 0 issues
- Version bump touches **only the three version lines**

## Worth recording

The first version of the progress-timer fix was wrong, and the Codex review bot caught it. Disarming in a `finally` after `await runDevTask` looked right but `runDevTask` returns as soon as the child's listeners are registered — it never awaits the process — so the flag was set before the first chunk arrived and **suppressed progress for the entire run**. The fix had silenced the feature it was meant to protect.

The tests had hidden it: the mock made `runDevTask` block until released, describing a function this codebase does not have. Both were corrected in the same PR, and the rewritten tests fail against the earlier version.

Merging this triggers the release workflow (npm publish → tag → GitHub release).
