### PR TITLE
fix(agents): three defects that returned the wrong answer without failing

### DIFF
--- a/src/agents/agentBus.ts
+++ b/src/agents/agentBus.ts
@@ -7,6 +7,7 @@ import { resolve } from 'path';
 import { homedir } from 'os';
 import * as fs from 'fs/promises';
 import { existsSync } from 'fs';
+import { atomicWriteFile } from '../support/atomicFile.js';
 
 // Types
 
@@ -168,9 +169,13 @@ export class AgentBus {
       payload,
     };
 
-    // Save message
+    // Save message. Atomic (write-temp + fsync + rename) because the consumers
+    // here poll with readdir + readFile: an in-place write makes the filename
+    // visible to readdir before its contents are complete, so a poller can read
+    // a truncated message and fail to parse it. rename publishes the name and
+    // the content in one step.
     const messagePath = resolve(this.messagesPath, `${message.id}.json`);
-    await fs.writeFile(messagePath, JSON.stringify(message, null, 2));
+    await atomicWriteFile(messagePath, JSON.stringify(message, null, 2), 0o644);
     if (++this.publishedSincePrune >= 100) {
       this.publishedSincePrune = 0;
       await this.pruneMessages();

--- a/src/agents/agentBus.ts
+++ b/src/agents/agentBus.ts
@@ -174,8 +174,14 @@ export class AgentBus {
     // visible to readdir before its contents are complete, so a poller can read
     // a truncated message and fail to parse it. rename publishes the name and
     // the content in one step.
+    //
+    // Owner-only (the helper's default), matching context.json beside it. The
+    // mode is not incidental here: atomicWriteFile chmods explicitly after the
+    // rename, so passing a wider mode would override even a restrictive umask
+    // that the previous plain writeFile respected — and these payloads carry
+    // agent prompts, outputs and errors.
     const messagePath = resolve(this.messagesPath, `${message.id}.json`);
-    await atomicWriteFile(messagePath, JSON.stringify(message, null, 2), 0o644);
+    await atomicWriteFile(messagePath, JSON.stringify(message, null, 2));
     if (++this.publishedSincePrune >= 100) {
       this.publishedSincePrune = 0;
       await this.pruneMessages();

--- a/src/agents/agentPair.ts
+++ b/src/agents/agentPair.ts
@@ -309,8 +309,14 @@ export function cancelSession(sessionId: string): boolean {
     return false; // Already terminated
   }
 
-  updateSessionStatus(sessionId, 'cancelled');
+  // Record the reason before the transition, not after. Moving to a terminal
+  // status archives the session, and archiving deletes it from `sessions` —
+  // after which addMessage's lookup misses and returns silently, so the
+  // cancellation notice never reached the transcript the user reads.
+  // archiveSession stores the same object reference, so a message added here
+  // is carried into the history.
   addMessage(sessionId, 'system', 'Session has been cancelled.');
+  updateSessionStatus(sessionId, 'cancelled');
   return true;
 }
 

--- a/src/agents/pipelineGuards.ts
+++ b/src/agents/pipelineGuards.ts
@@ -426,7 +426,13 @@ async function literalExistsInHeadSource(projectPath: string, literal: string): 
   try {
     const { stdout } = await execFileAsync(
       'git',
-      ['grep', '-F', '-l', literal, 'HEAD', '--', '.'],
+      // `-e` is required, not stylistic. Without it git parses a literal that
+      // begins with `-` as an option and exits with "unknown option", which
+      // lands in the catch below and reports "not present in HEAD". This guard
+      // is blocking, so a contract literal like "--output-format" made the
+      // pipeline reject correct work. `-F` fixes the match semantics but does
+      // not stop option parsing of the pattern itself.
+      ['grep', '-F', '-l', '-e', literal, 'HEAD', '--', '.'],
       { cwd: projectPath, timeout: 10_000 },
     );
     return stdout

--- a/src/agents/silentWrongAnswers.test.ts
+++ b/src/agents/silentWrongAnswers.test.ts
@@ -1,0 +1,215 @@
+// ============================================
+// OpenSwarm - defects that produce a wrong answer silently
+// ============================================
+//
+// None of these three threw, logged, or failed a check. Each one just returned
+// the wrong thing, which is why they survived several audit rounds.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFile } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, watch, writeFileSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { addMessage, cancelSession, clearAllSessions, createPairSession, getSessionHistory } from './agentPair.js';
+import { runGuards } from './pipelineGuards.js';
+
+const execFileAsync = promisify(execFile);
+const roots: string[] = [];
+
+function tempRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+/** A git repo whose HEAD already declares `literal`, with an unstaged test that uses it. */
+async function repoWithLiteralInHead(literal: string): Promise<string> {
+  const repo = tempRoot('openswarm-guard-');
+  writeFileSync(join(repo, 'app.ts'), `export const header = ${JSON.stringify(literal)};\n`);
+  await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd: repo });
+  await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+  await execFileAsync('git', ['config', 'user.name', 'test'], { cwd: repo });
+  await execFileAsync('git', ['add', '.'], { cwd: repo });
+  await execFileAsync('git', ['commit', '-qm', 'init'], { cwd: repo });
+
+  writeFileSync(
+    join(repo, 'app.test.ts'),
+    `it('sends the header', () => { expect(req.headers).toContain(${JSON.stringify(literal)}); });\n`,
+  );
+  return repo;
+}
+
+const workerResult = {
+  success: true,
+  summary: 'added a test',
+  filesChanged: ['app.test.ts'],
+  commands: [],
+  output: '',
+};
+
+describe('contractEvidence guard with a literal that looks like an option', () => {
+  // literalExistsInHeadSource asks git whether the literal exists in HEAD.
+  // Without `-e`, git parses a literal beginning with `-` as an option and
+  // exits with "unknown option"; the catch turns that into "not present in
+  // HEAD". This guard is blocking, so the pipeline rejected correct work.
+  it('does not flag a literal that HEAD already declares', async () => {
+    const repo = await repoWithLiteralInHead('--x-trace-id:');
+
+    const result = await runGuards(workerResult as never, repo, { contractEvidenceCheck: true });
+
+    const contract = result.results.find((r) => r.guard === 'contractEvidence');
+    expect(contract?.issues ?? []).toEqual([]);
+  }, 30_000);
+
+  // The guard must still do its job for a literal that is genuinely new, or
+  // "stop blocking correct work" would just mean "stop checking".
+  it('still flags a literal that appears only in the test', async () => {
+    const repo = await repoWithLiteralInHead('--x-trace-id:');
+    writeFileSync(
+      join(repo, 'app.test.ts'),
+      `it('sends it', () => { expect(req.headers).toContain("--x-invented-header:"); });\n`,
+    );
+
+    const result = await runGuards(workerResult as never, repo, { contractEvidenceCheck: true });
+
+    const contract = result.results.find((r) => r.guard === 'contractEvidence');
+    expect((contract?.issues ?? []).join('\n')).toContain('--x-invented-header:');
+  }, 30_000);
+});
+
+describe('cancelSession', () => {
+  const newSession = () =>
+    createPairSession({
+      taskId: `task-${Math.random().toString(36).slice(2)}`,
+      taskTitle: 'do a thing',
+      taskDescription: 'details',
+      projectPath: '/repo',
+    });
+
+  beforeEach(() => clearAllSessions());
+  afterEach(() => clearAllSessions());
+
+  // Moving to a terminal status archives the session, and archiving removes it
+  // from the live map — so a message added afterwards was silently dropped and
+  // the cancellation notice never reached the transcript the user reads.
+  it('records why the session ended', () => {
+    const session = newSession();
+
+    expect(cancelSession(session.id)).toBe(true);
+
+    const archived = getSessionHistory(10).find((s) => s.id === session.id);
+    expect(archived?.status).toBe('cancelled');
+    expect(archived?.messages.some((m) => /cancelled/i.test(m.content))).toBe(true);
+  });
+
+  it('refuses to cancel a session that already ended', () => {
+    const session = newSession();
+    expect(cancelSession(session.id)).toBe(true);
+    expect(cancelSession(session.id)).toBe(false);
+  });
+
+  it('is a no-op for an unknown session', () => {
+    expect(cancelSession('does-not-exist')).toBe(false);
+  });
+
+  // Guards the ordering directly: anything added after archiving is lost, so
+  // the archived transcript must already be complete.
+  it('carries earlier messages into the archive', () => {
+    const session = newSession();
+    addMessage(session.id, 'worker', 'partial progress');
+
+    cancelSession(session.id);
+
+    const archived = getSessionHistory(10).find((s) => s.id === session.id);
+    expect(archived?.messages.map((m) => m.content)).toContain('partial progress');
+  });
+});
+
+describe('AgentBus.publish', () => {
+  let home: string;
+
+  /** Load AgentBus with BUS_DIR pointed at a temp home (it is module-level). */
+  async function loadBus() {
+    vi.resetModules();
+    vi.doMock('node:os', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:os')>();
+      return { ...actual, default: { ...actual, homedir: () => home }, homedir: () => home };
+    });
+    vi.doMock('os', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:os')>();
+      return { ...actual, default: { ...actual, homedir: () => home }, homedir: () => home };
+    });
+    return await import('./agentBus.js');
+  }
+
+  beforeEach(() => {
+    home = tempRoot('openswarm-bus-home-');
+  });
+
+  afterEach(() => {
+    vi.doUnmock('node:os');
+    vi.doUnmock('os');
+  });
+
+  const messagesDir = (executionId: string) => resolve(home, '.openswarm/bus', executionId, 'messages');
+
+  // A polling loop cannot reliably catch the window, so this watches the
+  // directory and reads each file the instant its name appears — which is
+  // exactly what an in-place write exposes and a rename does not. Measured
+  // against a plain fs.writeFile of this size, a watcher observes the file
+  // empty or truncated every time.
+  it('never exposes a message file before its contents are complete', async () => {
+    const { AgentBus } = await loadBus();
+    const bus = new AgentBus('exec-1');
+    await bus.init('wf-1');
+
+    const dir = messagesDir('exec-1');
+    const partial: string[] = [];
+    let complete = 0;
+    const watcher = watch(dir, (_event, name) => {
+      if (!name || !name.toString().endsWith('.json')) return;
+      let raw: string;
+      try {
+        raw = readFileSync(join(dir, name.toString()), 'utf-8');
+      } catch {
+        return; // the rename has not landed yet — nothing is visible, which is correct
+      }
+      if (raw.length === 0) { partial.push(`${name} empty`); return; }
+      try {
+        JSON.parse(raw);
+        complete++;
+      } catch {
+        partial.push(`${name} truncated at ${raw.length} bytes`);
+      }
+    });
+
+    try {
+      const big = 'x'.repeat(20_000_000);
+      await Promise.all(
+        Array.from({ length: 4 }, (_, i) => bus.publish('context_update', 'planner', { big, i })),
+      );
+      await new Promise((r) => setTimeout(r, 300));
+    } finally {
+      watcher.close();
+    }
+
+    expect(partial).toEqual([]);
+    expect(complete).toBeGreaterThan(0);
+  }, 30_000);
+
+  it('leaves no temp files behind', async () => {
+    const { AgentBus } = await loadBus();
+    const bus = new AgentBus('exec-2');
+    await bus.init('wf-2');
+    await bus.publish('context_update', 'planner', { note: 'small' });
+
+    const files = await readdir(messagesDir('exec-2'));
+    expect(files.every((f) => f.endsWith('.json'))).toBe(true);
+  });
+});

--- a/src/agents/silentWrongAnswers.test.ts
+++ b/src/agents/silentWrongAnswers.test.ts
@@ -7,7 +7,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { execFile } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, watch, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync, watch, writeFileSync } from 'node:fs';
 import { readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -163,11 +163,15 @@ describe('AgentBus.publish', () => {
 
   const messagesDir = (executionId: string) => resolve(home, '.openswarm/bus', executionId, 'messages');
 
-  // A polling loop cannot reliably catch the window, so this watches the
-  // directory and reads each file the instant its name appears — which is
-  // exactly what an in-place write exposes and a rename does not. Measured
-  // against a plain fs.writeFile of this size, a watcher observes the file
-  // empty or truncated every time.
+  // Reads each file the instant it becomes visible — exactly what an in-place
+  // write exposes and a rename does not. Measured against a plain fs.writeFile
+  // of this size, this observes the file empty or truncated on every run.
+  //
+  // The watcher is only a trigger: node's fs.watch may deliver an event with a
+  // null filename, and relying on that name would make this observe nothing at
+  // all on such a platform and then fail for the wrong reason. Every event
+  // rescans the directory, and a short interval backs the watcher up so the
+  // test does not depend on watch being delivered at all.
   it('never exposes a message file before its contents are complete', async () => {
     const { AgentBus } = await loadBus();
     const bus = new AgentBus('exec-1');
@@ -175,37 +179,73 @@ describe('AgentBus.publish', () => {
 
     const dir = messagesDir('exec-1');
     const partial: string[] = [];
-    let complete = 0;
-    const watcher = watch(dir, (_event, name) => {
-      if (!name || !name.toString().endsWith('.json')) return;
-      let raw: string;
-      try {
-        raw = readFileSync(join(dir, name.toString()), 'utf-8');
-      } catch {
-        return; // the rename has not landed yet — nothing is visible, which is correct
-      }
-      if (raw.length === 0) { partial.push(`${name} empty`); return; }
-      try {
-        JSON.parse(raw);
-        complete++;
-      } catch {
-        partial.push(`${name} truncated at ${raw.length} bytes`);
-      }
-    });
+    const completed = new Set<string>();
 
+    const scan = (): void => {
+      let names: string[];
+      try {
+        names = readdirSync(dir);
+      } catch {
+        return;
+      }
+      for (const name of names) {
+        if (!name.endsWith('.json') || completed.has(name)) continue;
+        let raw: string;
+        try {
+          raw = readFileSync(join(dir, name), 'utf-8');
+        } catch {
+          continue; // the rename has not landed — nothing is visible, which is correct
+        }
+        if (raw.length === 0) { partial.push(`${name} empty`); continue; }
+        try {
+          JSON.parse(raw);
+          completed.add(name);
+        } catch {
+          partial.push(`${name} truncated at ${raw.length} bytes`);
+        }
+      }
+    };
+
+    const watcher = watch(dir, scan);
+    const ticker = setInterval(scan, 1);
     try {
       const big = 'x'.repeat(20_000_000);
       await Promise.all(
         Array.from({ length: 4 }, (_, i) => bus.publish('context_update', 'planner', { big, i })),
       );
-      await new Promise((r) => setTimeout(r, 300));
+      // Wait for all four to be observed intact rather than for a fixed delay.
+      const deadline = Date.now() + 10_000;
+      while (completed.size < 4 && Date.now() < deadline) {
+        scan();
+        await new Promise((r) => setTimeout(r, 5));
+      }
     } finally {
+      clearInterval(ticker);
       watcher.close();
     }
 
     expect(partial).toEqual([]);
-    expect(complete).toBeGreaterThan(0);
+    expect(completed.size).toBe(4);
   }, 30_000);
+
+  // The mode is not incidental: atomicWriteFile chmods explicitly after the
+  // rename, so a wider mode passed here would override even a restrictive
+  // umask that the previous plain writeFile respected. These payloads carry
+  // agent prompts, outputs and errors, and context.json beside them is
+  // owner-only.
+  it('keeps message files owner-only', async () => {
+    const { AgentBus } = await loadBus();
+    const bus = new AgentBus('exec-3');
+    await bus.init('wf-3');
+    await bus.publish('context_update', 'planner', { note: 'secret-ish' });
+
+    const dir = messagesDir('exec-3');
+    const files = readdirSync(dir).filter((f) => f.endsWith('.json'));
+    expect(files.length).toBeGreaterThan(0);
+    for (const file of files) {
+      expect(statSync(join(dir, file)).mode & 0o077).toBe(0);
+    }
+  });
 
   it('leaves no temp files behind', async () => {
     const { AgentBus } = await loadBus();

--- a/src/agents/silentWrongAnswers.test.ts
+++ b/src/agents/silentWrongAnswers.test.ts
@@ -28,20 +28,28 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-/** A git repo whose HEAD already declares `literal`, with an unstaged test that uses it. */
-async function repoWithLiteralInHead(literal: string): Promise<string> {
+// Fixture sources are written out as complete, literal strings rather than
+// assembled from a variable. Interpolating a value into generated source is the
+// code-construction pattern CodeQL flags (js/bad-code-sanitization), and it is
+// right to: JSON.stringify escapes for JSON, not for a JS string literal.
+// Nothing here needs to be parameterised, so the pattern is simply removed.
+const HEAD_SOURCE = 'export const header = "--x-trace-id:";\n';
+const TEST_USING_HEAD_LITERAL =
+  'it("sends the header", () => { expect(req.headers).toContain("--x-trace-id:"); });\n';
+const TEST_USING_INVENTED_LITERAL =
+  'it("sends it", () => { expect(req.headers).toContain("--x-invented-header:"); });\n';
+
+/** A git repo whose HEAD declares the trace-id header, plus an unstaged test file. */
+async function repoWithLiteralInHead(testSource: string): Promise<string> {
   const repo = tempRoot('openswarm-guard-');
-  writeFileSync(join(repo, 'app.ts'), `export const header = ${JSON.stringify(literal)};\n`);
+  writeFileSync(join(repo, 'app.ts'), HEAD_SOURCE);
   await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd: repo });
   await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
   await execFileAsync('git', ['config', 'user.name', 'test'], { cwd: repo });
   await execFileAsync('git', ['add', '.'], { cwd: repo });
   await execFileAsync('git', ['commit', '-qm', 'init'], { cwd: repo });
 
-  writeFileSync(
-    join(repo, 'app.test.ts'),
-    `it('sends the header', () => { expect(req.headers).toContain(${JSON.stringify(literal)}); });\n`,
-  );
+  writeFileSync(join(repo, 'app.test.ts'), testSource);
   return repo;
 }
 
@@ -59,7 +67,7 @@ describe('contractEvidence guard with a literal that looks like an option', () =
   // exits with "unknown option"; the catch turns that into "not present in
   // HEAD". This guard is blocking, so the pipeline rejected correct work.
   it('does not flag a literal that HEAD already declares', async () => {
-    const repo = await repoWithLiteralInHead('--x-trace-id:');
+    const repo = await repoWithLiteralInHead(TEST_USING_HEAD_LITERAL);
 
     const result = await runGuards(workerResult as never, repo, { contractEvidenceCheck: true });
 
@@ -70,11 +78,7 @@ describe('contractEvidence guard with a literal that looks like an option', () =
   // The guard must still do its job for a literal that is genuinely new, or
   // "stop blocking correct work" would just mean "stop checking".
   it('still flags a literal that appears only in the test', async () => {
-    const repo = await repoWithLiteralInHead('--x-trace-id:');
-    writeFileSync(
-      join(repo, 'app.test.ts'),
-      `it('sends it', () => { expect(req.headers).toContain("--x-invented-header:"); });\n`,
-    );
+    const repo = await repoWithLiteralInHead(TEST_USING_INVENTED_LITERAL);
 
     const result = await runGuards(workerResult as never, repo, { contractEvidenceCheck: true });
 


### PR DESCRIPTION
## Summary

Three defects from the audit backlog that share a shape: **none of them threw, logged, or failed a check.** Each just returned the wrong answer, which is why they survived several audit rounds.

### 1. A blocking guard rejected correct work

`literalExistsInHeadSource` asks git whether a contract literal exists in HEAD via `git grep -F -l <literal>`. Without `-e`, git parses a literal beginning with `-` as an **option** and exits with `unknown option`. That lands in the catch, which reports "not present in HEAD" — and this guard is `blocking`, so a contract literal like `--x-trace-id:` made the pipeline reject correct work.

Measured directly before fixing:

```
$ git grep -F -l "--output-format" HEAD -- .
error: unknown option `output-format'

$ git grep -F -l -e "--output-format" HEAD -- .
HEAD:src/adapters/base.ts   …
```

The **other** `git grep` call in the same file already passed `-e`. The correct form was sitting next to the broken one — the same shape as the Discord 3900-vs-1900 split and the `repos.json` atomic write earlier in this backlog.

### 2. Cancellation was never recorded

`cancelSession` wrote `"Session has been cancelled."` *after* transitioning to a terminal status. That transition archives the session, archiving deletes it from the live map, and `addMessage`'s lookup then misses and returns silently — so the notice never reached the transcript the user reads. The two calls are now reversed; `archiveSession` stores the same object reference, so a message added first is carried into the history.

### 3. Bus messages could be read half-written

`agentBus.publish` wrote message files in place while three consumers poll the directory with `readdir` + `readFile`. An in-place write makes the filename visible before the contents are complete. Now uses the shared atomic helper. (The temp file's `.tmp` suffix is excluded by the existing `.endsWith('.json')` filters — checked all three consumers.)

## Two tests needed a second attempt

**The atomicity test was vacuous.** Polling in a loop could not catch the window — plain `writeFile` passed **3 runs out of 3**. It now watches the directory and reads each file the instant its name appears, which is precisely what an in-place write exposes and a rename does not. Against plain `writeFile` it fails **3 out of 3**.

**The git guard test proved the wrong thing.** The first version ran `git grep` directly, so it demonstrated git's behaviour rather than the code's — removing `-e` from the source left it **green**. It now drives `runGuards` against a real repository fixture, and includes the inverse case (a literal that appears only in the test *must* still be flagged) so "stop blocking correct work" cannot be satisfied by no longer checking.

## Verification

| Mutation | Test that went red |
|---|---|
| drop `-e` from `git grep` | `does not flag a literal that HEAD already declares` |
| restore the `cancelSession` ordering | `records why the session ended` |
| `atomicWriteFile` → `fs.writeFile` | `never exposes a message file before its contents are complete` (3/3 runs) |

- Full suite: **250 files, 3333 passed, 1 skipped**
- `tsc --noEmit` clean, `oxlint` 0 warnings
- `openswarm review`: **APPROVE**, 0 issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted bug fixes with strong regression tests; behavior changes are narrowly scoped to guards, session cancel, and bus persistence.
> 
> **Overview**
> Fixes three agent-pipeline bugs that **failed silently** (wrong outcome, no throw or log) and adds regression tests in `silentWrongAnswers.test.ts`.
> 
> **Contract evidence guard:** `literalExistsInHeadSource` now passes `-e` to `git grep` so literals starting with `-` (e.g. `--x-trace-id:`) are not parsed as options; previously git errored, the catch reported “not in HEAD,” and the **blocking** guard rejected valid work.
> 
> **Session cancel:** `cancelSession` appends the cancellation system message **before** `updateSessionStatus('cancelled')`, so the notice is not dropped when archiving removes the session from the live map.
> 
> **Agent bus:** `AgentBus.publish` writes message JSON via `atomicWriteFile` instead of in-place `writeFile`, so directory pollers never see a `.json` name with truncated content; owner-only permissions are preserved.
> 
> Tests drive `runGuards` on real git fixtures, assert archived cancel transcripts, and race-publish large payloads against `fs.watch` + directory rescans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9407aa1448886c0cb6f51f6864c7b3109e913fc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->