### PR TITLE
chore(release): v0.19.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.19.5 — 2026-07-26
+
+### Fixed
+
+- **A blocking guard stopped rejecting correct work** — `literalExistsInHeadSource` asked git whether a contract literal exists in HEAD without passing `-e`, so git parsed a literal beginning with `-` as an option and exited with "unknown option". The catch turned that into "not present in HEAD", and since this guard blocks, a contract literal like `--x-trace-id:` made the pipeline reject valid changes. (#333)
+- **Cancelling a session records why** — the "Session has been cancelled." message was added after the terminal status transition, which archives the session and removes it from the live map, so the message was silently dropped and never reached the transcript the user reads. (#333)
+- **Bus messages cannot be read half-written** — message files were written in place while three consumers poll the directory with `readdir` + `readFile`, so a poller could see a filename before its contents were complete. Now written atomically. (#333)
+
+### Security
+
+- **Agent bus messages are owner-only** — these files carry agent prompts, outputs and errors. They are now written at `0o600`, matching `context.json` beside them, instead of relying on the process umask. (#333)
+
 ## 0.19.4 — 2026-07-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.19.4",
+      "version": "0.19.5",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Releases #333 — three defects that returned the wrong answer without failing, plus a permissions tightening found during its review.

| | Symptom |
|---|---|
| `git grep` without `-e` | A **blocking** guard rejected correct work whenever a contract literal began with `-` |
| `cancelSession` ordering | The cancellation notice never reached the transcript the user reads |
| Non-atomic bus writes | A poller could read a message file before its contents were complete |
| **Bus file mode** | Message files carrying agent prompts and outputs were left to the process umask; now `0o600` |

## Verification

- Full suite on merged main: **250 files, 3334 passed, 1 skipped**
- Every fix pinned by a mutation-verified test
- `openswarm review`: APPROVE, 0 issues
- Version bump touches only the three version lines

## Worth recording

Two problems in this PR were introduced by the fixes themselves and caught by review, not by my own checks:

- Passing `0o644` to `atomicWriteFile` looked like preserving existing behaviour. It was not: the helper `chmod`s explicitly after the rename, so it *widened* permissions past a restrictive umask that the previous plain `writeFile` respected. The value had been copied from the decision made for `openswarm.json`, a tracked repo file — a different situation carried over without re-deriving.
- The atomicity test relied on the filename `fs.watch` passes its callback. Node permits that to be null, so on such a platform the test would have observed nothing and failed for a reason unrelated to what it checks.

Both were re-measured by mutation after fixing: plain `writeFile` fails 3 runs out of 3, and restoring `0o644` fails the new owner-only test.

Merging this triggers the release workflow (npm publish → tag → GitHub release).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is version metadata and changelog only; behavioral risk lives in the already-merged #333 fixes, not in this release bump.
> 
> **Overview**
> **Release v0.19.5** — bumps `package.json` / lockfile from **0.19.4** to **0.19.5** and adds a **CHANGELOG** entry for work merged in **#333** (the implementation is not in this diff).
> 
> The release notes cover: **`literalExistsInHeadSource`** now passes **`-e`** to git so blocking HEAD checks don’t treat literals starting with `-` as CLI options; **session cancel** appends the cancellation message before the terminal status transition so it stays on the live transcript; **agent bus** messages are written **atomically** so directory pollers can’t read partial JSON; and bus message files are **`0o600`** so sensitive agent payloads aren’t left to the process umask.
> 
> Merging is intended to trigger the existing **npm publish / tag / GitHub release** workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05285ff1feff50fb0a7c49002c37e744965b5961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->