### PR TITLE
fix(memory,issues): stop silently overwriting sessions and mis-scoping stats

### DIFF
--- a/src/issues/linearBridge.ts
+++ b/src/issues/linearBridge.ts
@@ -213,14 +213,22 @@ function mapLinearStatusToLocal(stateName: string): IssueStatus {
   return map[stateName] ?? 'backlog';
 }
 
-function mapStatusToLinear(status: IssueStatus): string {
-  const map: Record<IssueStatus, string> = {
-    backlog: 'Backlog',
-    todo: 'Todo',
-    in_progress: 'In Progress',
-    in_review: 'In Review',
-    done: 'Done',
-    cancelled: 'Cancelled',
+/**
+ * Acceptable Linear workflow-state names for a local status, best first.
+ *
+ * A list rather than a single name because the state name is configured per
+ * workspace, not fixed by the API. Linear's own default is the US spelling
+ * "Canceled", so emitting only "Cancelled" made resolveLinearStateId throw for
+ * every team on the default — that status never synced outward for them.
+ */
+export function mapStatusToLinear(status: IssueStatus): string[] {
+  const map: Record<IssueStatus, string[]> = {
+    backlog: ['Backlog'],
+    todo: ['Todo', 'To Do'],
+    in_progress: ['In Progress'],
+    in_review: ['In Review'],
+    done: ['Done', 'Completed'],
+    cancelled: ['Cancelled', 'Canceled'],
   };
   return map[status];
 }
@@ -248,14 +256,28 @@ function mapPriorityToLinear(priority: IssuePriority): number {
   return map[priority];
 }
 
-async function resolveLinearStateId(stateName: string): Promise<string> {
+/**
+ * Resolve the first candidate state name that this team actually defines.
+ *
+ * Matching is case-insensitive and tries each candidate in order, so a
+ * workspace that spells a state differently still syncs instead of failing.
+ */
+async function resolveLinearStateId(candidates: string[]): Promise<string> {
   if (!linearClient) throw new Error('Linear 클라이언트 미초기화');
 
   const team = await linearClient.team(linearTeamId);
   const states = await team.states();
-  const state = states.nodes.find((s: any) => s.name === stateName);
-  if (!state) throw new Error(`Linear 상태 "${stateName}" 없음`);
-  return state.id;
+
+  for (const candidate of candidates) {
+    const wanted = candidate.toLowerCase();
+    const state = states.nodes.find((s: any) => String(s.name).toLowerCase() === wanted);
+    if (state) return state.id;
+  }
+
+  const available = states.nodes.map((s: any) => s.name).join(', ');
+  throw new Error(
+    `Linear 상태 "${candidates.join('" / "')}" 없음 (팀에 정의된 상태: ${available})`,
+  );
 }
 
 export function isLinearBridgeReady(): boolean {

--- a/src/issues/linearStatusMapping.test.ts
+++ b/src/issues/linearStatusMapping.test.ts
@@ -1,0 +1,47 @@
+// ============================================
+// OpenSwarm - Linear workflow-state name mapping
+// ============================================
+//
+// Workflow state names are configured per workspace, not fixed by the API.
+// Emitting exactly one spelling meant resolveLinearStateId threw for any team
+// that spells a state differently — and Linear's own default for the cancelled
+// state is the US "Canceled", so the bridge failed to sync that status outward
+// for teams that never renamed it.
+
+import { describe, expect, it } from 'vitest';
+import { mapStatusToLinear } from './linearBridge.js';
+
+describe('mapStatusToLinear', () => {
+  it('offers both spellings of the cancelled state', () => {
+    const candidates = mapStatusToLinear('cancelled');
+    expect(candidates).toContain('Cancelled');
+    expect(candidates).toContain('Canceled'); // Linear's default
+  });
+
+  it.each([
+    ['backlog', 'Backlog'],
+    ['todo', 'Todo'],
+    ['in_progress', 'In Progress'],
+    ['in_review', 'In Review'],
+    ['done', 'Done'],
+    ['cancelled', 'Cancelled'],
+  ] as const)('keeps %s resolving to %s first', (status, expected) => {
+    expect(mapStatusToLinear(status)[0]).toBe(expected);
+  });
+
+  it('returns at least one candidate for every status', () => {
+    for (const status of ['backlog', 'todo', 'in_progress', 'in_review', 'done', 'cancelled'] as const) {
+      expect(mapStatusToLinear(status).length).toBeGreaterThan(0);
+    }
+  });
+
+  // Candidates are compared case-insensitively at resolution time, so listing
+  // the same name twice in different cases would be dead weight rather than
+  // extra coverage.
+  it('lists no duplicate candidates', () => {
+    for (const status of ['backlog', 'todo', 'in_progress', 'in_review', 'done', 'cancelled'] as const) {
+      const lowered = mapStatusToLinear(status).map((c) => c.toLowerCase());
+      expect(new Set(lowered).size).toBe(lowered.length);
+    }
+  });
+});

--- a/src/issues/sqliteStore.test.ts
+++ b/src/issues/sqliteStore.test.ts
@@ -61,3 +61,44 @@ describe('SqliteIssueStore durable semantics', () => {
     expect(() => getIssueStore(path('two.db'))).toThrow(/already initialized/);
   });
 });
+
+describe('getStats scoping', () => {
+  // byProject was the one field that ignored the projectId filter, so a
+  // per-project view showed a breakdown counting every project — numbers that
+  // did not add up to the total printed beside them.
+  it('scopes the project breakdown to the requested project', () => {
+    const store = new SqliteIssueStore(path());
+    store.createIssue({ projectId: 'alpha', title: 'a1' });
+    store.createIssue({ projectId: 'alpha', title: 'a2' });
+    store.createIssue({ projectId: 'beta', title: 'b1' });
+
+    const stats = store.getStats('alpha');
+
+    expect(stats.total).toBe(2);
+    expect(stats.byProject).toEqual({ alpha: 2 });
+    store.close();
+  });
+
+  it('agrees with its own total', () => {
+    const store = new SqliteIssueStore(path());
+    store.createIssue({ projectId: 'alpha', title: 'a1' });
+    store.createIssue({ projectId: 'beta', title: 'b1' });
+    store.createIssue({ projectId: 'beta', title: 'b2' });
+
+    for (const project of ['alpha', 'beta']) {
+      const stats = store.getStats(project);
+      const summed = Object.values(stats.byProject).reduce((a, b) => a + b, 0);
+      expect(summed).toBe(stats.total);
+    }
+    store.close();
+  });
+
+  it('still reports every project when no filter is given', () => {
+    const store = new SqliteIssueStore(path());
+    store.createIssue({ projectId: 'alpha', title: 'a1' });
+    store.createIssue({ projectId: 'beta', title: 'b1' });
+
+    expect(store.getStats().byProject).toEqual({ alpha: 1, beta: 1 });
+    store.close();
+  });
+});

--- a/src/issues/sqliteStore.ts
+++ b/src/issues/sqliteStore.ts
@@ -673,10 +673,14 @@ export class SqliteIssueStore implements IIssueStore {
       `SELECT priority, COUNT(*) as cnt FROM issues ${where} GROUP BY priority`
     ).all(...params) as any[]).forEach((r) => { byPriority[r.priority] = r.cnt; });
 
+    // Scoped like every other field here. Without the filter this counted
+    // across all projects while total/byStatus/byPriority counted one, so a
+    // per-project stats view showed a breakdown whose numbers did not add up to
+    // its own total.
     const byProject: Record<string, number> = {};
     (this.db.prepare(
-      'SELECT project_id, COUNT(*) as cnt FROM issues GROUP BY project_id'
-    ).all() as any[]).forEach((r) => { byProject[r.project_id] = r.cnt; });
+      `SELECT project_id, COUNT(*) as cnt FROM issues ${where} GROUP BY project_id`
+    ).all(...params) as any[]).forEach((r) => { byProject[r.project_id] = r.cnt; });
 
     const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
 

--- a/src/memory/codex.ts
+++ b/src/memory/codex.ts
@@ -15,6 +15,7 @@ import { promises as fs } from 'fs';
 import { resolve, basename, join } from 'path';
 import { getDateLocale } from '../locale/index.js';
 import { homedir } from 'os';
+import { createHash } from 'crypto';
 
 // Codex storage path
 const CODEX_DIR = resolve(homedir(), '.openswarm/codex');
@@ -104,6 +105,21 @@ function slugify(text: string): string {
     .replace(/-+/g, '-')
     .slice(0, 50)
     .replace(/-$/, '');
+}
+
+/**
+ * The part of a session filename that makes it unique.
+ *
+ * Derived from a hash rather than the first N characters of the id. Ids look
+ * like `session-<ms>`, and taking the leading 12 characters left only the first
+ * four digits of the timestamp — a value that stays the same for ~11.6 days
+ * (10^9 ms). Uniqueness therefore collapsed to the `DD-HHMM` prefix plus the
+ * title slug, so two sessions with the same title in the same minute silently
+ * overwrote each other. A hash discriminates whatever shape the id takes,
+ * including a leading- or trailing-common one.
+ */
+export function sessionFilenameSuffix(id: string): string {
+  return createHash('sha256').update(id).digest('hex').slice(0, 12);
 }
 
 /**
@@ -260,7 +276,7 @@ export async function saveSession(
   const date = new Date(session.startedAt);
   const { monthDir, prefix } = getDatePaths(date);
   const slug = slugify(session.title);
-  const sessionSuffix = slugify(session.id || String(session.startedAt)).slice(0, 12);
+  const sessionSuffix = sessionFilenameSuffix(session.id || String(session.startedAt));
 
   // Create monthly directory
   const monthPath = join(CODEX_DIR, monthDir);

--- a/src/memory/sessionFilename.test.ts
+++ b/src/memory/sessionFilename.test.ts
@@ -1,0 +1,64 @@
+// ============================================
+// OpenSwarm - session filename uniqueness tests
+// ============================================
+//
+// Session records are written to `<DD-HHMM>-<title-slug>-<suffix>.md`. The
+// suffix is the only part that separates two sessions started in the same
+// minute with the same title, and it used to be the first 12 characters of
+// `session-<ms>` — which is `session-` plus four digits of the timestamp. Those
+// four digits stay the same for 10^9 ms (~11.6 days), so the suffix was
+// effectively a constant and same-minute sessions silently overwrote each
+// other.
+
+import { describe, expect, it } from 'vitest';
+import { sessionFilenameSuffix } from './codex.js';
+
+/** What the old implementation produced, kept here to pin what changed. */
+const legacySuffix = (id: string) =>
+  id.toLowerCase().replace(/[^\w\s가-힣-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-').slice(0, 50).slice(0, 12);
+
+const AT = 1_785_050_644_884; // an ordinary ms timestamp
+
+describe('sessionFilenameSuffix', () => {
+  it('differs for two sessions started a millisecond apart', () => {
+    expect(sessionFilenameSuffix(`session-${AT}`)).not.toBe(sessionFilenameSuffix(`session-${AT + 1}`));
+  });
+
+  // The exact scenario that lost data: same title, same minute, distinct
+  // sessions. Anything inside one minute has to stay distinguishable.
+  it.each([1, 100, 1_000, 30_000, 59_999])('differs for ids %i ms apart', (deltaMs) => {
+    expect(sessionFilenameSuffix(`session-${AT}`)).not.toBe(sessionFilenameSuffix(`session-${AT + deltaMs}`));
+  });
+
+  // Demonstrates the defect rather than asserting the fix, so the reason for
+  // the change stays legible. The window is 10^9 ms (~11.6 days), but where it
+  // starts depends on the timestamp: from AT the four leading digits hold for
+  // ~10.99 more days, so a week is comfortably inside it and the assertion does
+  // not sit on the boundary.
+  it('replaces a suffix that was constant for more than a week', () => {
+    const aWeek = 7 * 24 * 60 * 60 * 1000;
+    expect(legacySuffix(`session-${AT}`)).toBe(legacySuffix(`session-${AT + aWeek}`));
+    expect(sessionFilenameSuffix(`session-${AT}`)).not.toBe(sessionFilenameSuffix(`session-${AT + aWeek}`));
+  });
+
+  // Ids are not guaranteed to vary at the front — a hash does not care where
+  // the differing part is, which a leading slice did.
+  it('discriminates ids that share a long prefix', () => {
+    expect(sessionFilenameSuffix('a'.repeat(64) + '1')).not.toBe(sessionFilenameSuffix('a'.repeat(64) + '2'));
+  });
+
+  it('discriminates ids that share a long suffix', () => {
+    expect(sessionFilenameSuffix('1' + 'z'.repeat(64))).not.toBe(sessionFilenameSuffix('2' + 'z'.repeat(64)));
+  });
+
+  it('is stable for the same id', () => {
+    expect(sessionFilenameSuffix(`session-${AT}`)).toBe(sessionFilenameSuffix(`session-${AT}`));
+  });
+
+  it('is filename-safe and fixed length', () => {
+    for (const id of [`session-${AT}`, 'with spaces and/slashes', '한글 제목', '']) {
+      const suffix = sessionFilenameSuffix(id);
+      expect(suffix).toMatch(/^[0-9a-f]{12}$/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Three more from the audit backlog, all of the "returns the wrong thing without failing" kind.

### 1. Session records silently overwrote each other

Sessions are written to `<DD-HHMM>-<title-slug>-<suffix>.md`. The suffix is the only thing separating two sessions started in the same minute with the same title — and it was the first 12 characters of `session-<ms>`, which is `session-` (8 chars) plus **four digits** of the timestamp.

Measured rather than reasoned about:

```
now       -> session-1785
+1 second -> session-1785
+1 day    -> session-1785
```

Those four digits hold for 10^9 ms ≈ **11.6 days**, so the suffix was effectively a constant and uniqueness collapsed to minute + title. Now a hash of the id, which discriminates wherever the differing part happens to sit — a leading slice cannot.

### 2. Per-project stats disagreed with themselves

`getStats(projectId)` filtered `total`, `byStatus` and `byPriority` but not `byProject`. A per-project view therefore showed a breakdown counting **every** project, with numbers that did not add up to the total printed beside them.

### 3. The cancelled status never synced to Linear for most teams

Workflow state names are configured per workspace, not fixed by the API, and `resolveLinearStateId` matched exactly one name exactly. **Linear's own default for that state is the US spelling "Canceled"**, so the bridge threw `Linear 상태 "Cancelled" 없음` for every team that never renamed it.

Statuses now carry candidate names (`['Cancelled', 'Canceled']`, `['Todo', 'To Do']`, `['Done', 'Completed']`), matched case-insensitively. A genuine failure now lists the states the team actually defines rather than only the one that was missing.

## Verification

| Mutation | Test that went red |
|---|---|
| suffix back to the leading slice | 9 of 11 `sessionFilenameSuffix` cases |
| drop the `where` clause from `byProject` | `scopes the project breakdown…`, `agrees with its own total` |
| `cancelled: ['Cancelled']` only | `offers both spellings of the cancelled state` |

**One of my own test fixtures was wrong and was corrected before commit.** It asserted the old suffix stayed constant across 11 days — but where the 10^9 ms window starts depends on the timestamp, and from the fixture's value the boundary falls at 10.99 days, so the assertion sat just past the edge. It now uses a week, comfortably inside.

- Full suite: **252 files, 3357 passed, 1 skipped**
- `tsc --noEmit` clean, `oxlint` 0 warnings
- `openswarm review`: **APPROVE**, 0 issues

## Note on the filename change

Existing session files keep their names; only newly written ones use the hash suffix. These are append-only records with no index keyed on the suffix, so no migration is needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted correctness fixes with tests; codex naming only affects newly written files, with no migration.
> 
> **Overview**
> Fixes three bugs where the system returned wrong results without failing loudly.
> 
> **Codex session files** no longer collide when two sessions share the same title in the same minute. The filename suffix was the first 12 characters of `session-<ms>`, which barely varied for ~11.6 days, so writes could overwrite each other. New saves use a **12-character SHA-256 hash of the session id** via `sessionFilenameSuffix`; existing files are unchanged.
> 
> **Per-project issue stats** now scope `byProject` with the same `projectId` filter as `total`, `byStatus`, and `byPriority`, so project breakdown counts match the displayed total.
> 
> **Linear outbound status sync** maps each local status to **ordered candidate workflow names** (e.g. cancelled → `Cancelled` / `Canceled`) and resolves them **case-insensitively**, so teams on Linear’s default **Canceled** spelling no longer fail when pushing cancelled status. Errors list the team’s actual state names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0ed23b8a31607d5a7c34f9d2e47f7f07e23c246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->