### PR TITLE
chore(release): v0.19.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.19.6 — 2026-07-26
+
+### Fixed
+
+- **Session records no longer overwrite each other** — records are written to `<DD-HHMM>-<title-slug>-<suffix>.md`, and the suffix was the first 12 characters of `session-<ms>`, which is `session-` plus only four digits of the timestamp. Those four digits hold for 10^9 ms (~11.6 days), so the suffix was effectively constant and two sessions with the same title in the same minute silently replaced one another. It is now derived from a hash of the session id. (#335)
+- **Per-project issue stats agree with themselves** — `getStats(projectId)` scoped `total`, `byStatus` and `byPriority` to the project but not `byProject`, so the breakdown counted every project and did not add up to the total shown beside it. (#335)
+- **The cancelled status syncs to Linear again** — workflow state names are configured per workspace, and the bridge matched exactly one spelling exactly. Linear's own default for that state is the US "Canceled", so outbound sync threw for every team that never renamed it. Statuses now carry candidate names matched case-insensitively, and a genuine mismatch reports the states the team actually defines. (#335)
+
 ## 0.19.5 — 2026-07-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.19.5",
+      "version": "0.19.6",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Releases #335 — three defects that returned the wrong result without failing.

| | Symptom |
|---|---|
| Session filename suffix | Effectively constant for ~11.6 days, so same-title sessions in one minute **silently overwrote each other** |
| `getStats(projectId)` | The project breakdown counted every project, contradicting the total shown beside it |
| Linear state mapping | The cancelled status never synced outward for teams on Linear's default spelling (`Canceled`) |

## Verification

- Full suite on merged main: **252 files, 3357 passed, 1 skipped**
- Each fix pinned by a mutation-verified test
- `openswarm review`: APPROVE, 0 issues
- Version bump touches only the three version lines

## Worth recording

The filename window was **measured, not reasoned about** — `session-<ms>` sliced to 12 characters leaves four digits of the timestamp, which a probe confirmed identical at +1 second, +1 day, and beyond.

One of my own test fixtures was wrong and corrected before commit: it asserted the old suffix stayed constant across 11 days, but where the 10^9 ms window begins depends on the timestamp, and from that fixture's value the boundary falls at 10.99 days. The assertion sat just past the edge and failed against the *fixed* code. It now uses a week.

Merging this triggers the release workflow (npm publish → tag → GitHub release).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only diff; behavioral changes shipped via #335 are already covered by tests on main.
> 
> **Overview**
> **Release v0.19.6** — bumps `@intrect/openswarm` from **0.19.5** to **0.19.6** in `package.json` / lockfile and adds a **CHANGELOG** entry for **#335** (implementation already on main).
> 
> Documented fixes in this release:
> 
> - **Session record filenames** — suffix no longer comes from the first 12 chars of `session-<ms>` (effectively stable ~11.6 days); it is derived from a **hash of the session id** so same-title sessions in the same minute do not silently overwrite each other.
> - **`getStats(projectId)`** — **`byProject`** is now scoped with the other aggregates when a project id is passed, so project breakdown counts match the displayed total.
> - **Linear cancelled status** — outbound sync matches workflow state names **case-insensitively** with **candidate spellings** (e.g. Linear’s default **Canceled** vs **Cancelled**); real mismatches report the team’s actual states.
> 
> Merging triggers the usual release workflow (npm publish, tag, GitHub release).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa1cc333085f19b49d7c639830d8d4b96a80c0df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->