### PR TITLE
chore(release): v0.19.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.19.7 — 2026-07-26
+
+### Fixed
+
+- **Patch operations stop destroying files they were meant to leave alone** — "Add File" wrote unconditionally, so an op naming an existing file replaced it with no error raised and nothing recorded as an update. "Move to" did the same to its destination, and worse: a destination whose contents could not be snapshotted is skipped by rollback, so the overwrite outlived a failure that reported nothing had been applied. Both now refuse and name the path. Rollback also distinguishes a path that was absent from one it merely could not read, and only removes files this patch actually created — previously it deleted mode-000 files, dangling symlinks, and files written by another process after the snapshot was taken. (#337)
+
+### Security
+
+- **CLI prompts are no longer written to a predictable path in shared /tmp** — `/tmp/openswarm-prompt-${Date.now()}.txt` had millisecond resolution, so parallel workers could overwrite each other's prompt and run each other's task; it used the default file mode, leaving task content readable by every local user; and the predictable name in a world-writable directory could be pre-created as a symlink by another local user. The prompt now lives in a per-call `mkdtemp` directory (0700) as a 0600 file, removed on every exit path. (#337)
+
 ## 0.19.6 — 2026-07-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.19.6",
+      "version": "0.19.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Releases #337. Two of the four items are data loss and one is a local-disclosure issue, so this is worth shipping on its own.

| | Symptom |
|---|---|
| `Add File` on an existing path | Replaced the file, **no error, not recorded as an update** |
| `Move to` an occupied path | Same, and the overwrite **survived rollback** when the destination could not be snapshotted |
| Rollback of unreadable paths | Deleted mode-000 files, dangling symlinks, and files another process wrote after the snapshot |
| CLI prompt file | Predictable name in shared `/tmp`, default mode, millisecond collisions — parallel workers could **run each other's task** |

## Verification

- Full suite on merged main: **253 files, 3370 passed, 1 skipped**
- Every protection verified independently by mutation
- `openswarm review`: APPROVE, 0 issues
- Version bump touches only the three version lines

## Worth recording

Three of these were found by review *after* my own checks passed, and two of them were introduced by my own fixes:

- Adding the Add File guard made rollback reachable on a path it would then **delete** — turning a prevented overwrite into a destroyed file, strictly worse than the original bug.
- My first attempt at scoping rollback marked every path the loop *reached*, which still deleted a raced-in file. The distinction that matters is not "did we try this path" but "did we write it".

Two test fixtures were also non-discriminating and were corrected before commit: one checked permissions after the directory had already been cleaned up, and one used a mode-000 destination where the OS refuses the write anyway, so it passed with or without the fix.

Merging this triggers the release workflow (npm publish → tag → GitHub release).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only; behavioral fixes are already covered in #337 and this PR does not change runtime code.
> 
> **Overview**
> **Release v0.19.7** — version lines in `package.json`, `package-lock.json`, and a new **0.19.7** section in `CHANGELOG.md` (no application code in this diff).
> 
> The changelog records what ships from **#337**:
> 
> **Fixed — patch operations:** `Add File` and `Move to` no longer silently overwrite existing paths; rollback only removes files the patch actually created and no longer deletes unrelated paths (mode-000 files, post-snapshot races, unreadable destinations that skipped restore).
> 
> **Security — CLI prompts:** task prompts move from a predictable `/tmp/openswarm-prompt-${Date.now()}.txt` into a per-call `mkdtemp` directory (`0700`) with a `0600` file, cleaned up on all exit paths.
> 
> Merging triggers the usual release workflow (npm publish, tag, GitHub release).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a14688d2c97d8d2d86896297082ed7b74012ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->