### PR TITLE
fix(adapters): keep the current turn during compaction, retry 401 per call

### DIFF
--- a/src/adapters/agenticLoop.test.ts
+++ b/src/adapters/agenticLoop.test.ts
@@ -378,3 +378,91 @@ describe('loopResultToCliResult costInfo (INT-2508)', () => {
     expect(cli.executedCommands).toEqual(['npm test']);
   });
 });
+
+describe('compactPriorTurns with a wide tool fan-out', () => {
+  /**
+   * One assistant turn issuing many parallel tool calls — the shape the loop
+   * produces whenever a model batches reads. The tail of the array is then all
+   * tool messages, which is what the boundary alignment could not handle.
+   */
+  function buildFanOut(priorRounds: number, toolsInFinalTurn: number): ChatMessage[] {
+    const messages: ChatMessage[] = [
+      { role: 'system', content: 'You are a worker.' },
+      { role: 'user', content: 'Do the task.' },
+    ];
+    for (let i = 0; i < priorRounds; i++) {
+      messages.push({
+        role: 'assistant',
+        content: `Prior step ${i}`,
+        tool_calls: [{ id: `prior_${i}`, type: 'function', function: { name: 'read_file', arguments: '{}' } }],
+      });
+      messages.push({ role: 'tool', tool_call_id: `prior_${i}`, content: `prior result ${i}` });
+    }
+    messages.push({
+      role: 'assistant',
+      content: 'Reading everything at once',
+      tool_calls: Array.from({ length: toolsInFinalTurn }, (_, i) => ({
+        id: `fan_${i}`,
+        type: 'function' as const,
+        function: { name: 'read_file', arguments: JSON.stringify({ path: `src/f${i}.ts` }) },
+      })),
+    });
+    for (let i = 0; i < toolsInFinalTurn; i++) {
+      messages.push({ role: 'tool', tool_call_id: `fan_${i}`, content: `fan result ${i}` });
+    }
+    return messages;
+  }
+
+  /** Orphan check that allows a run of tool messages after one assistant. */
+  function fanOutHasNoOrphans(messages: ChatMessage[]): boolean {
+    let openIds: string[] = [];
+    for (const m of messages) {
+      if (m.role === 'assistant') {
+        openIds = (m.tool_calls ?? []).map((tc) => tc.id);
+        continue;
+      }
+      if (m.role === 'tool' && !openIds.includes(m.tool_call_id as string)) return false;
+    }
+    return true;
+  }
+
+  // The defect: walking the boundary forward past a tail of tool messages ran
+  // off the end, so the compaction range covered everything — the model lost
+  // the results it had just received and re-ran the same reads.
+  it('keeps the turn whose results just arrived', () => {
+    const messages = buildFanOut(3, 9);
+
+    compactPriorTurns(messages, 8);
+
+    const kept = messages.map((m) => (typeof m.content === 'string' ? m.content : '')).join('\n');
+    expect(kept).toContain('Reading everything at once');
+    for (let i = 0; i < 9; i++) expect(kept).toContain(`fan result ${i}`);
+  });
+
+  it('still compacts the rounds before it', () => {
+    const messages = buildFanOut(3, 9);
+
+    compactPriorTurns(messages, 8);
+
+    const kept = messages.map((m) => (typeof m.content === 'string' ? m.content : '')).join('\n');
+    expect(kept).toContain('[Prior turns compacted]');
+    expect(kept).not.toContain('prior result 0');
+  });
+
+  it('leaves no orphan tool message', () => {
+    const messages = buildFanOut(3, 9);
+    compactPriorTurns(messages, 8);
+    expect(fanOutHasNoOrphans(messages)).toBe(true);
+  });
+
+  it.each([9, 12, 30])('holds for %i parallel tool calls', (toolCount) => {
+    const messages = buildFanOut(2, toolCount);
+
+    compactPriorTurns(messages, 8);
+
+    const kept = messages.map((m) => (typeof m.content === 'string' ? m.content : '')).join('\n');
+    expect(kept).toContain('Reading everything at once');
+    expect(kept).toContain(`fan result ${toolCount - 1}`);
+    expect(fanOutHasNoOrphans(messages)).toBe(true);
+  });
+});

--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -690,10 +690,23 @@ export function compactPriorTurns(messages: ChatMessage[], keepRecent = 8): void
   const headerCount = messages[0]?.role === 'system' ? 2 : 1;
 
   // 최근 keepRecent개 메시지는 보존 — 압축 상한 인덱스 산출
-  let boundary = Math.max(headerCount, messages.length - keepRecent);
+  const desired = Math.max(headerCount, messages.length - keepRecent);
   // 보존 경계를 assistant 시작점으로 정렬 (orphan tool 메시지 방지)
+  let boundary = desired;
   while (boundary < messages.length && messages[boundary].role === 'tool') {
     boundary++;
+  }
+  // Walking forward runs off the end when the most recent turn made more tool
+  // calls than keepRecent: the tail is then entirely tool messages, the
+  // boundary lands at messages.length, and the compaction range covers the
+  // whole history — including the results that had just arrived, which the
+  // model then no longer has. Fall back to walking backwards to the assistant
+  // those trailing tools belong to, so that turn is preserved whole.
+  if (boundary >= messages.length) {
+    boundary = desired;
+    while (boundary > headerCount && messages[boundary].role === 'tool') {
+      boundary--;
+    }
   }
   if (boundary <= headerCount) return;
 

--- a/src/adapters/codexResponses.test.ts
+++ b/src/adapters/codexResponses.test.ts
@@ -497,3 +497,98 @@ describe('429 throttle vs spent quota (INT-2907)', () => {
     expect(fetchMock).toHaveBeenCalledTimes(4); // initial + 3 retries
   });
 });
+
+describe('401 refresh scope', () => {
+  const okStreamResponse = () =>
+    new Response(
+      [
+        'data: {"type":"response.output_text.delta","delta":"ok"}',
+        'data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}',
+        'data: [DONE]',
+        '',
+      ].join('\n'),
+      { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+    );
+
+  /** Duck-typed AuthProfileStore: refreshAndRetry only needs get/set. */
+  function fakeStore() {
+    let profile = {
+      type: 'oauth' as const,
+      provider: 'openai-gpt',
+      access: 'stale',
+      refresh: 'refresh-token',
+      expires: Date.now() + 3_600_000,
+      clientId: 'client',
+    };
+    return {
+      getProfile: () => profile,
+      setProfile: (_k: string, p: typeof profile) => { profile = p; },
+    };
+  }
+
+  // The regression: `retried` lived in createApiCaller's closure, so it was set
+  // once per run. The first 401 consumed the only refresh the whole run had,
+  // and a second token expiry — ordinary in a run measured in hours — then
+  // failed every remaining call without ever attempting the refresh.
+  it('refreshes again when the token expires a second time in the same run', async () => {
+    let responsesCalls = 0;
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      const target = String(url);
+      if (target.includes('oauth/token')) {
+        return new Response(JSON.stringify({ access_token: 'fresh', refresh_token: 'r2', expires_in: 3600 }), {
+          status: 200,
+        });
+      }
+      responsesCalls++;
+      // One 401 at the start of each of the two turns.
+      if (responsesCalls === 1 || responsesCalls === 3) {
+        return new Response('unauthorized', { status: 401 });
+      }
+      return okStreamResponse();
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    type CreateApiCaller = (
+      initialToken: string,
+      accountId: string,
+      store: unknown,
+      model: string,
+    ) => (messages: ChatMessage[], tools: ToolDefinition[]) => Promise<unknown>;
+    const adapter = new CodexResponsesAdapter() as unknown as { createApiCaller: CreateApiCaller };
+    const callApi = adapter.createApiCaller('token', 'account', fakeStore(), 'gpt-5.5');
+
+    await expect(callApi([{ role: 'user', content: 'first' }], [])).resolves.toBeDefined();
+    // The second turn must get its own retry budget.
+    await expect(callApi([{ role: 'user', content: 'second' }], [])).resolves.toBeDefined();
+    expect(responsesCalls).toBe(4);
+  });
+
+  // The retry stays once per call: a 401 that survives the refresh must fail
+  // rather than loop.
+  it('does not retry a second time within one call', async () => {
+    let responsesCalls = 0;
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      const target = String(url);
+      if (target.includes('oauth/token')) {
+        return new Response(JSON.stringify({ access_token: 'fresh', refresh_token: 'r2', expires_in: 3600 }), {
+          status: 200,
+        });
+      }
+      responsesCalls++;
+      return new Response('unauthorized', { status: 401 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    type CreateApiCaller = (
+      initialToken: string,
+      accountId: string,
+      store: unknown,
+      model: string,
+    ) => (messages: ChatMessage[], tools: ToolDefinition[]) => Promise<unknown>;
+    const adapter = new CodexResponsesAdapter() as unknown as { createApiCaller: CreateApiCaller };
+    const callApi = adapter.createApiCaller('token', 'account', fakeStore(), 'gpt-5.5');
+
+    await expect(callApi([{ role: 'user', content: 'hi' }], [])).rejects.toThrow();
+    expect(responsesCalls).toBe(2);
+  });
+});

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -424,7 +424,6 @@ export class CodexResponsesAdapter implements CliAdapter {
     cacheKey?: string,
   ) {
     let token = initialToken;
-    let retried = false;
     let modelRetried = false;
     let effectiveModel = model;
 
@@ -432,6 +431,12 @@ export class CodexResponsesAdapter implements CliAdapter {
       // Per-API-call throttle budget (a fresh one each turn — a wait that cleared
       // one turn's throttle must not count against the next). (INT-2907)
       const throttle: ThrottleState = { attempts: 0 };
+      // Per-API-call too, for the same reason. Held in the createApiCaller
+      // closure this was set once per run, so the first 401 refresh consumed
+      // the only retry the whole run had: a second token expiry — ordinary in a
+      // run measured in hours — then failed every remaining call with 401 and
+      // never attempted the refresh that would have fixed it.
+      let retried = false;
       const { instructions, input } = chatToResponsesInput(messages);
       const body: Record<string, unknown> = {
         model: effectiveModel,


### PR DESCRIPTION
## Summary

Two defects that only appear in long or wide runs — which is exactly when this tool is doing real work.

### 1. A wide tool fan-out compacted the turn that just happened

`compactPriorTurns` aligns its boundary *forward* past tool messages so no orphan tool is left behind. When the most recent turn issues more tool calls than `keepRecent`, the tail of the array is entirely tool messages and that walk runs off the end.

Measured on a 3-prior-round history with 9 parallel calls:

```
desired boundary: 6  -> T3-current
after alignment : 14 (length = 14)
compaction range: [2, 14) => A1, T1, A2-current, T2-current, … T10-current
preserved       : (nothing)
```

The model lost the reads it had just made and repeated them. The walk now falls back to going *backwards* to the assistant those trailing tools belong to, so that turn is preserved whole.

### 2. One 401 refresh per run, not per call

The `retried` flag lived in `createApiCaller`'s closure — created once per run, not once per call. The first refresh consumed the only retry the entire run had, so a second token expiry (ordinary in a run measured in hours) failed **every remaining call** with 401 without ever attempting the refresh that would have fixed it.

## Verification

| Mutation | Tests that went red |
|---|---|
| remove the backward-walk fallback | 4 (`keeps the turn whose results just arrived`, 9/12/30 parallel calls) |
| move `retried` back to the run closure | `refreshes again when the token expires a second time in the same run` |

The compaction tests needed their own orphan check: the existing helper assumes one tool per assistant, which cannot express the fan-out shape this bug lives in. The 401 tests also pin that the retry stays **once per call** — moving the flag must not turn it into an unbounded loop.

- Full suite: **253 files, 3378 passed, 1 skipped**
- `tsc --noEmit` clean, `oxlint` 0 warnings
- `openswarm review`: **APPROVE**, 0 issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent message history compaction and OAuth retry behavior on every Codex Responses call; regressions could drop context or mishandle auth, but scope is narrow and covered by new regression tests.
> 
> **Overview**
> Fixes two long-run agent bugs in the adapter layer.
> 
> **History compaction (`compactPriorTurns`)** — When the latest assistant turn issues more parallel tool calls than `keepRecent`, forward boundary alignment skips past a tail of only `tool` messages and can set the compaction boundary to the end of history. That compacts the turn whose results just arrived, so the model loses fresh reads and repeats them. The change **walks backward** from the desired boundary to the owning assistant so that whole turn stays intact while older rounds still collapse into `[Prior turns compacted]`.
> 
> **Codex OAuth (`createApiCaller`)** — The `retried` flag for 401 → token refresh lived in the **run-level** closure, so only the first 401 in a multi-hour run could refresh; later expirations failed every API call. **`retried` is reset per API call** (same pattern as per-call throttle state), with tests ensuring a second turn can refresh again and that a single call still retries at most once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7caa8c7b420659518a91f904fd53996a8174a70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->