### PR TITLE
chore(release): v0.19.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.19.8 — 2026-07-26
+
+### Fixed
+
+- **A wide tool fan-out no longer compacts the turn that just happened** — `compactPriorTurns` aligns its boundary forward past tool messages to avoid orphans, but when the most recent turn issues more tool calls than `keepRecent` the tail is entirely tool messages and that walk runs off the end. Measured on a 3-round history with 9 parallel calls, nothing at all was preserved: the model lost the reads it had just made and repeated them. The walk now falls back to going backwards to the assistant those tools belong to. (#339)
+- **A second token expiry mid-run refreshes instead of failing** — the 401 retry flag lived in the per-run caller closure, so the first refresh consumed the only retry the entire run had. A second expiry, ordinary in a run measured in hours, then failed every remaining call with 401 without attempting the refresh that would have fixed it. (#339)
+
 ## 0.19.7 — 2026-07-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.19.7",
+      "version": "0.19.8",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Releases #339 — two defects that only appear in long or wide runs, which is when this tool is doing real work.

| | Symptom |
|---|---|
| Compaction boundary | A turn with more parallel tool calls than `keepRecent` had **its own results compacted away** — measured: nothing preserved at all, so the model repeated the reads it had just made |
| 401 retry scope | The first token refresh consumed the only retry the whole run had; a second expiry failed **every remaining call** without attempting a refresh |

## Verification

- Full suite on merged main: **253 files, 3378 passed, 1 skipped**
- Both pinned by mutation-verified tests, including a case confirming the 401 retry stays *once per call* rather than becoming a loop
- `openswarm review`: APPROVE, 0 issues
- Version bump touches only the three version lines

Merging this triggers the release workflow (npm publish → tag → GitHub release).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2c53d7439163fa19f239ad2bef6183707ae6de4d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->