### PR TITLE
fix(planner): stop discarding plans whose descriptions contain braces

### DIFF
--- a/src/support/planner.test.ts
+++ b/src/support/planner.test.ts
@@ -103,3 +103,53 @@ describe('runPlanner — agentic loop migration', () => {
     ).rejects.toBeInstanceOf(RateLimitError);
   });
 });
+
+describe('plan JSON containing braces inside string values', () => {
+  const planWith = (description: string) =>
+    JSON.stringify({
+      needsDecomposition: true,
+      subTasks: [{ title: 'A', description, estimatedMinutes: 20, priority: 2 }],
+      totalEstimatedMinutes: 20,
+    });
+
+  // Brace counting that ignores string literals ends the JSON at the wrong
+  // offset, JSON.parse fails, and the whole plan falls through to a lossy text
+  // heuristic — the model's actual decomposition is discarded. Descriptions
+  // quoting code are ordinary, so this is not an exotic input.
+  it.each([
+    ['an unmatched closing brace', 'remove the trailing } here'],
+    ['an unmatched opening brace', 'starts a block with { here'],
+    ['a balanced pair', 'replace if (x) { y } with a switch'],
+    ['several braces', '} then { then } again'],
+  ])('keeps the plan intact with %s', async (_label, description) => {
+    mockedSpawnCli.mockResolvedValue(cliResult(planWith(description)) as never);
+
+    const res = await runPlanner({ taskTitle: 'big task', taskDescription: 'do it', projectPath: '/tmp/x' });
+
+    expect(res.success).toBe(true);
+    expect(res.needsDecomposition).toBe(true);
+    expect(res.subTasks).toHaveLength(1);
+    expect(res.subTasks[0].description).toBe(description);
+  });
+
+  it('keeps a plan whose description contains an escaped quote before a brace', async () => {
+    const description = 'the \\"guard\\" closes with }';
+    mockedSpawnCli.mockResolvedValue(cliResult(planWith(description)) as never);
+
+    const res = await runPlanner({ taskTitle: 'big task', taskDescription: 'do it', projectPath: '/tmp/x' });
+
+    expect(res.success).toBe(true);
+    expect(res.subTasks[0].description).toBe(description);
+  });
+
+  it('still stops at the end of the first JSON object when trailing prose follows', async () => {
+    mockedSpawnCli.mockResolvedValue(
+      cliResult(`${planWith('plain')}\n\nThat is the plan. Let me know if } looks wrong.`) as never,
+    );
+
+    const res = await runPlanner({ taskTitle: 'big task', taskDescription: 'do it', projectPath: '/tmp/x' });
+
+    expect(res.success).toBe(true);
+    expect(res.subTasks).toHaveLength(1);
+  });
+});

--- a/src/support/planner.ts
+++ b/src/support/planner.ts
@@ -288,10 +288,25 @@ function parsePlanResult(resultText: string, originalTitle: string): PlannerResu
 function parseDirectJson(text: string, startIdx: number, originalTitle: string): PlannerResult {
   let depth = 0;
   let endIdx = startIdx;
+  // Braces inside string values are not structure. Counting them made a plan
+  // whose description mentioned an unmatched `{` or `}` — a code snippet, a
+  // shell fragment — end at the wrong offset, so JSON.parse failed and the
+  // whole plan fell through to the lossy text heuristic below. Measured: a
+  // description containing "remove the trailing } here" ended two characters
+  // early; one containing "{ here" never closed at all.
+  let inString = false;
+  let escaped = false;
 
   for (let i = startIdx; i < text.length; i++) {
-    if (text[i] === '{') depth++;
-    if (text[i] === '}') {
+    const ch = text[i];
+
+    if (escaped) { escaped = false; continue; }
+    if (ch === '\\') { escaped = true; continue; }
+    if (ch === '"') { inString = !inString; continue; }
+    if (inString) continue;
+
+    if (ch === '{') depth++;
+    if (ch === '}') {
       depth--;
       if (depth === 0) {
         endIdx = i + 1;
@@ -344,26 +359,6 @@ function extractFromText(text: string, originalTitle: string): PlannerResult {
 
 // Linear Integration
 
-/**
- * Create sub-tasks as Linear sub-issues
- */
-export async function createLinearSubIssues(
-  parentIssueId: string,
-  subTasks: SubTask[],
-  _teamId: string,
-  _projectId?: string
-): Promise<{ success: boolean; createdIds: string[]; error?: string }> {
-  // This function needs to call Linear MCP directly,
-  // so autonomousRunner uses mcp__linear-server__create_issue
-  // Here we only prepare data
-
-  const createdIds: string[] = [];
-
-  // Note: actual Linear API calls are made in autonomousRunner
-  console.log(`[Planner] Prepared ${subTasks.length} sub-issues for ${parentIssueId}`);
-
-  return { success: true, createdIds };
-}
 
 /**
  * Estimate issue duration (heuristic)


### PR DESCRIPTION
## Summary

Two findings from the audit backlog, both in `src/support/planner.ts`.

### 1. A plan whose description quoted code was thrown away

`parseDirectJson` located the end of the plan object by counting braces — **including the ones inside string values**. A subtask description containing an unmatched `{` or `}` (a code snippet, a shell fragment) moved the end offset, `JSON.parse` failed, and the whole plan fell through to `extractFromText`, a lossy heuristic. The model's actual decomposition was discarded with no error.

Measured before fixing:

| description contains | result |
|---|---|
| `remove the trailing } here` | ended **2 chars early** → parse failed |
| `starts a block with { here` | **never closed** → parse failed |
| `if (x) { y }` (balanced) | fine |

The balanced case working is why this survived: the obvious test passes either way. String literals are now skipped, with escape handling so a `\"` inside a description does not flip the parser out of the string.

### 2. A function that reported success for work it never did

`createLinearSubIssues` returned `{ success: true, createdIds: [] }` after logging one line and doing nothing — a caller checking `success` would believe sub-issues existed. It had **no callers repo-wide**, so it is removed rather than left for someone to find and trust.

## Verification

| Mutation | Tests that went red |
|---|---|
| restore the string-blind brace counting | 4 (unmatched open, several braces, escaped quote, and one of the `it.each` cases) |

The test set deliberately includes the **balanced-pair** case, which passes with or without the fix — it is there to document that the naive version is not obviously broken, which is what let this sit through several audits.

- Full suite: **253 files, 3384 passed, 1 skipped**
- `tsc --noEmit` clean, `oxlint` 0 warnings
- `openswarm review`: **APPROVE**, 0 issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted parser fix with new tests plus removal of an uncalled stub; no auth, data, or runtime integration changes.
> 
> **Overview**
> **`parseDirectJson`** now finds the end of a planner JSON object by counting braces only **outside** string literals, with escape handling so `\"` does not break string tracking. Before, `{`/`}` inside subtask descriptions (code snippets, shell fragments) skewed the slice boundary, **`JSON.parse` failed**, and the run fell through to the lossy **`extractFromText`** path—discarding the model’s decomposition without a clear error.
> 
> Adds regression tests for unmatched braces, balanced pairs, escaped quotes before braces, and trailing prose after the first object (prose braces must not extend the slice).
> 
> Removes unused **`createLinearSubIssues`**, which logged and returned **`{ success: true, createdIds: [] }`** without creating issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1df77a83c0d89a9e146d6300ceca043db44b98a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->