### PR TITLE
fix(scheduler): serialize schedule-file updates instead of losing them

### DIFF
--- a/src/automation/scheduler.ts
+++ b/src/automation/scheduler.ts
@@ -11,10 +11,13 @@ import * as fs from 'fs/promises';
 import { checkWorkAllowed } from '../support/timeWindow.js';
 import { extractCostFromStreamJson, formatCost } from '../support/costTracker.js';
 import { t, getDateLocale } from '../locale/index.js';
+import { randomUUID } from 'crypto';
+import { withFileLock } from '../support/fileLock.js';
 
 // Schedule storage path
 const SCHEDULE_DIR = resolve(homedir(), '.openswarm');
 const SCHEDULE_FILE = resolve(SCHEDULE_DIR, 'schedules.json');
+const SCHEDULE_LOCK_FILE = resolve(SCHEDULE_DIR, 'schedules.json.lock');
 
 // Scheduled job interface
 export interface ScheduledJob {
@@ -131,9 +134,33 @@ function isScheduledJob(value: unknown): value is ScheduledJob {
  */
 async function saveSchedules(schedules: ScheduledJob[]): Promise<void> {
   await fs.mkdir(SCHEDULE_DIR, { recursive: true });
-  const tempFile = `${SCHEDULE_FILE}.${process.pid}.${Date.now()}.tmp`;
+  const tempFile = `${SCHEDULE_FILE}.${process.pid}.${randomUUID()}.tmp`;
   await fs.writeFile(tempFile, JSON.stringify(schedules, null, 2), { mode: 0o600 });
   await fs.rename(tempFile, SCHEDULE_FILE);
+}
+
+/**
+ * Read the schedule file, transform it and write it back, all under one lock.
+ *
+ * The write was already atomic, but load → mutate → save was not: two jobs
+ * finishing near the same moment each read the file before the other wrote, so
+ * one job's lastRun, consecutiveFailures and auto-pause were discarded by
+ * whichever saved last. An auto-pause lost that way leaves a failing job
+ * running on schedule.
+ *
+ * The callback receives the state as it is *inside* the lock, so callers must
+ * not decide anything from a read taken before calling this. Returning a null
+ * `next` skips the write, for the cases that decide there is nothing to do.
+ */
+async function mutateSchedules<T>(
+  mutate: (schedules: ScheduledJob[]) => Promise<{ next: ScheduledJob[] | null; result: T }>,
+): Promise<T> {
+  return withFileLock(SCHEDULE_LOCK_FILE, async () => {
+    const current = await loadSchedules();
+    const { next, result } = await mutate(current);
+    if (next) await saveSchedules(next);
+    return result;
+  });
 }
 
 /**
@@ -324,24 +351,30 @@ async function runScheduledJob(
     }
 
     // Update last run + consecutive-failure tracking; auto-pause on repeated failure.
-    const schedules = await loadSchedules();
-    const latest = schedules.find((schedule) => schedule.id === job.id);
-    if (!latest) {
-      console.log(`[Scheduler] Job "${job.name}" was removed while running; skipping state update`);
-      return success;
-    }
-    const failureState = nextFailureState(latest.consecutiveFailures ?? 0, success);
-    const updated = schedules.map((s) =>
-      s.id === job.id
-        ? {
-            ...s,
-            lastRun: Date.now(),
-            consecutiveFailures: failureState.consecutiveFailures,
-            enabled: failureState.autoPause ? false : s.enabled,
-          }
-        : s
-    );
-    await saveSchedules(updated);
+    // Read and write under one lock: several jobs finish near the same moment,
+    // and an unlocked read-modify-write let the last writer discard another
+    // job's failure count — including an auto-pause, which would leave a
+    // failing job running on schedule.
+    const failureState = await mutateSchedules(async (schedules) => {
+      const latest = schedules.find((schedule) => schedule.id === job.id);
+      if (!latest) {
+        console.log(`[Scheduler] Job "${job.name}" was removed while running; skipping state update`);
+        return { next: null, result: null };
+      }
+      const state = nextFailureState(latest.consecutiveFailures ?? 0, success);
+      const updated = schedules.map((s) =>
+        s.id === job.id
+          ? {
+              ...s,
+              lastRun: Date.now(),
+              consecutiveFailures: state.consecutiveFailures,
+              enabled: state.autoPause ? false : s.enabled,
+            }
+          : s
+      );
+      return { next: updated, result: state };
+    });
+    if (!failureState) return success;
 
     if (failureState.autoPause) {
       activeJobs.get(job.id)?.stop();
@@ -372,27 +405,28 @@ export async function addSchedule(
   createdBy?: string
 ): Promise<ScheduledJob> {
   validateScheduleExpression(schedule);
-  const schedules = await loadSchedules();
 
-  // Check for duplicates
-  const existing = schedules.find((s) => s.name === name);
-  if (existing) {
-    throw new Error(`Schedule "${name}" already exists`);
-  }
-
-  const job: ScheduledJob = {
-    id: `job-${Date.now()}`,
-    name,
-    projectPath,
-    prompt,
-    schedule,
-    enabled: true,
-    createdAt: Date.now(),
-    createdBy,
-  };
-
-  schedules.push(job);
-  await saveSchedules(schedules);
+  // The duplicate-name check and the append have to be one atomic step, or two
+  // concurrent adds of the same name both see "no duplicate" and one is lost.
+  const job = await mutateSchedules<ScheduledJob>(async (schedules) => {
+    if (schedules.some((s) => s.name === name)) {
+      throw new Error(`Schedule "${name}" already exists`);
+    }
+    const created: ScheduledJob = {
+      // randomUUID, not Date.now(): ids are looked up by removeSchedule and
+      // toggleSchedule, and two schedules added in the same millisecond would
+      // otherwise share one.
+      id: `job-${randomUUID()}`,
+      name,
+      projectPath,
+      prompt,
+      schedule,
+      enabled: true,
+      createdAt: Date.now(),
+      createdBy,
+    };
+    return { next: [...schedules, created], result: created };
+  });
 
   // Start cron job
   await startCronJob(job);
@@ -405,14 +439,14 @@ export async function addSchedule(
  * Remove a scheduled job
  */
 export async function removeSchedule(nameOrId: string): Promise<boolean> {
-  const schedules = await loadSchedules();
-  const index = schedules.findIndex(
-    (s) => s.name === nameOrId || s.id === nameOrId
-  );
+  const job = await mutateSchedules<ScheduledJob | null>(async (schedules) => {
+    const index = schedules.findIndex((s) => s.name === nameOrId || s.id === nameOrId);
+    if (index === -1) return { next: null, result: null };
+    const removed = schedules[index];
+    return { next: schedules.filter((_, i) => i !== index), result: removed };
+  });
 
-  if (index === -1) return false;
-
-  const job = schedules[index];
+  if (!job) return false;
 
   // Stop cron job
   const cron = activeJobs.get(job.id);
@@ -428,10 +462,6 @@ export async function removeSchedule(nameOrId: string): Promise<boolean> {
     runningProcesses.delete(job.id);
   }
 
-  // Save
-  schedules.splice(index, 1);
-  await saveSchedules(schedules);
-
   console.log(`[Scheduler] Removed schedule: ${job.name}`);
   return true;
 }
@@ -442,14 +472,18 @@ export async function removeSchedule(nameOrId: string): Promise<boolean> {
 export async function toggleSchedule(
   nameOrId: string
 ): Promise<ScheduledJob | null> {
-  const schedules = await loadSchedules();
-  const job = schedules.find((s) => s.name === nameOrId || s.id === nameOrId);
+  const job = await mutateSchedules<ScheduledJob | null>(async (schedules) => {
+    const found = schedules.find((s) => s.name === nameOrId || s.id === nameOrId);
+    if (!found) return { next: null, result: null };
+    const toggled = { ...found, enabled: !found.enabled };
+    if (toggled.enabled) validateScheduleExpression(toggled.schedule);
+    return {
+      next: schedules.map((s) => (s.id === found.id ? toggled : s)),
+      result: toggled,
+    };
+  });
 
   if (!job) return null;
-
-  job.enabled = !job.enabled;
-  if (job.enabled) validateScheduleExpression(job.schedule);
-  await saveSchedules(schedules);
 
   // Toggle cron job
   const cron = activeJobs.get(job.id);

--- a/src/automation/schedulerState.test.ts
+++ b/src/automation/schedulerState.test.ts
@@ -1,0 +1,112 @@
+// ============================================
+// OpenSwarm - schedule file update races
+// ============================================
+//
+// The write to schedules.json was already atomic, but load → mutate → save was
+// not. Several jobs finish near the same moment, and each read the file before
+// the other wrote — so the last writer discarded the other's update. Losing a
+// lastRun is cosmetic; losing an auto-pause leaves a failing job running on
+// schedule.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let home: string;
+
+/** Load the scheduler with ~/.openswarm pointed at a temp directory. */
+async function loadScheduler() {
+  vi.resetModules();
+  const mockOs = async (importOriginal: () => Promise<typeof import('node:os')>) => {
+    const actual = await importOriginal();
+    return { ...actual, default: { ...actual, homedir: () => home }, homedir: () => home };
+  };
+  vi.doMock('node:os', mockOs);
+  vi.doMock('os', mockOs);
+  return await import('./scheduler.js');
+}
+
+const scheduleFile = () => join(home, '.openswarm', 'schedules.json');
+const readSchedules = () => JSON.parse(readFileSync(scheduleFile(), 'utf-8')) as Array<Record<string, unknown>>;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'openswarm-sched-'));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  vi.doUnmock('node:os');
+  vi.doUnmock('os');
+});
+
+describe('concurrent schedule updates', () => {
+  // Adds racing each other: without a lock both read the same file and the
+  // second write drops the first job entirely.
+  it('keeps every schedule when adds run concurrently', async () => {
+    const { addSchedule } = await loadScheduler();
+
+    await Promise.all(
+      Array.from({ length: 6 }, (_, i) =>
+        addSchedule(`job-${i}`, '/repo', 'do something', '30m'),
+      ),
+    );
+
+    const names = readSchedules().map((s) => s.name).sort();
+    expect(names).toEqual(['job-0', 'job-1', 'job-2', 'job-3', 'job-4', 'job-5']);
+  }, 30_000);
+
+  // The clock is frozen deliberately. With the lock in place each add takes
+  // more than a millisecond anyway, so a Date.now()-based id would look fine
+  // here — the property worth pinning is that uniqueness does not depend on
+  // clock resolution at all.
+  it('gives each schedule a distinct id even when the clock does not move', async () => {
+    const { addSchedule } = await loadScheduler();
+    const frozen = 1_785_050_644_884;
+    const now = vi.spyOn(Date, 'now').mockReturnValue(frozen);
+    try {
+      await Promise.all(
+        Array.from({ length: 6 }, (_, i) => addSchedule(`job-${i}`, '/repo', 'p', '30m')),
+      );
+    } finally {
+      now.mockRestore();
+    }
+
+    const ids = readSchedules().map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  }, 30_000);
+
+  it('rejects a duplicate name even when both adds race', async () => {
+    const { addSchedule } = await loadScheduler();
+
+    const results = await Promise.allSettled([
+      addSchedule('same', '/repo', 'p', '30m'),
+      addSchedule('same', '/repo', 'p', '30m'),
+    ]);
+
+    expect(results.filter((r) => r.status === 'fulfilled')).toHaveLength(1);
+    expect(readSchedules()).toHaveLength(1);
+  }, 30_000);
+
+  // A toggle and a remove touching different jobs must both survive.
+  it('does not lose a toggle to a concurrent remove', async () => {
+    const { addSchedule, toggleSchedule, removeSchedule } = await loadScheduler();
+    await addSchedule('keeper', '/repo', 'p', '30m');
+    await addSchedule('goner', '/repo', 'p', '30m');
+
+    await Promise.all([toggleSchedule('keeper'), removeSchedule('goner')]);
+
+    const rows = readSchedules();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ name: 'keeper', enabled: false });
+  }, 30_000);
+
+  it('leaves no temp files behind', async () => {
+    const { addSchedule } = await loadScheduler();
+    await Promise.all(Array.from({ length: 4 }, (_, i) => addSchedule(`j${i}`, '/repo', 'p', '30m')));
+
+    const { readdirSync } = await import('node:fs');
+    const stray = readdirSync(join(home, '.openswarm')).filter((f) => f.endsWith('.tmp'));
+    expect(stray).toEqual([]);
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

`schedules.json` was written atomically but **updated non-atomically**. Four sites did load → mutate → save with no lock — the post-run state update, `addSchedule`, `removeSchedule`, `toggleSchedule` — so two jobs finishing near the same moment each read the file before the other wrote, and the last writer discarded the other's update.

Losing a `lastRun` is cosmetic. **Losing an auto-pause leaves a failing job running on schedule**, which is the thing auto-pause exists to prevent.

All four now go through `mutateSchedules`, which reads, transforms and writes inside one `withFileLock` — the primitive the repo already uses elsewhere. `addSchedule`'s duplicate-name check moved inside the lock too: checking outside it let two concurrent adds of the same name both see "no duplicate".

Job ids move from `job-${Date.now()}` to `randomUUID`. Ids are looked up by remove and toggle, and two adds in the same millisecond shared one.

## Verification

| Mutation | Result |
|---|---|
| drop the lock, keep the atomic write | **3 of 5 tests red, 3 runs out of 3** |
| id back to `Date.now()` | `gives each schedule a distinct id even when the clock does not move` red |

**The id test freezes the clock deliberately, and that mattered.** With the lock in place each add takes more than a millisecond anyway, so a `Date.now()` id passed the naive concurrency test — the first version of that test was green against the unfixed code. The property worth pinning is that uniqueness does not depend on clock resolution at all.

- Full suite: **254 files, 3389 passed, 1 skipped**
- `tsc --noEmit` clean, `oxlint` 0 warnings
- `openswarm review`: **APPROVE**, 0 issues — also confirmed no other site writes `schedules.json`, and the remaining `loadSchedules` callers (`listSchedules`, `runNow`, `startAllSchedules`) are read-only and need no lock

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistence and auto-pause behavior for scheduled jobs; incorrect locking could still wedge or corrupt schedule state, but the change reuses an existing lock primitive and adds targeted concurrency tests.
> 
> **Overview**
> Fixes a race where concurrent updates to `schedules.json` could overwrite each other even though each write was atomic. **Post-run state** (including **auto-pause** after consecutive failures), **add**, **remove**, and **toggle** now go through **`mutateSchedules`**, which load → mutate → save inside **`withFileLock`** on `schedules.json.lock`.
> 
> **`addSchedule`** moves the duplicate-name check inside the lock so two concurrent adds of the same name can’t both succeed. New schedule **ids** use **`randomUUID`** instead of `Date.now()` so concurrent creates don’t collide.
> 
> Adds **`schedulerState.test.ts`** covering concurrent adds, duplicate-name races, toggle vs remove, distinct ids with a frozen clock, and no stray `.tmp` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21c22af1bcbcba9d55ce5d1e715939390b949b8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->