### PR TITLE
chore(release): v0.19.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.19.9 — 2026-07-26
+
+### Fixed
+
+- **Schedule updates stop overwriting each other** — `schedules.json` was written atomically but updated non-atomically: four sites did load → mutate → save with no lock, so two jobs finishing near the same moment each read before the other wrote and the last writer discarded the other's update. A lost `lastRun` is cosmetic; a lost auto-pause leaves a failing job running on schedule, which is what auto-pause exists to prevent. All four now share one locked read-modify-write, and `addSchedule`'s duplicate-name check moved inside the lock. Job ids use a UUID instead of `Date.now()`, which two adds in the same millisecond shared. (#342)
+- **A plan whose description quotes code is no longer discarded** — the planner found the end of its JSON by counting braces, including the ones inside string values, so a subtask description containing an unmatched `{` or `}` moved the end offset and the parse failed. The whole plan then fell through to a lossy text heuristic with no error. Measured: `remove the trailing } here` ended two characters early; `{ here` never closed at all. (#341)
+
+### Removed
+
+- `createLinearSubIssues`, which returned `{ success: true }` after doing nothing. It had no callers. (#341)
+
 ## 0.19.8 — 2026-07-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.8",
+  "version": "0.19.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.19.8",
+      "version": "0.19.9",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.8",
+  "version": "0.19.9",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Releases #342 and #341.

| | Symptom |
|---|---|
| Schedule read-modify-write | Concurrent job completions discarded each other's state — **including auto-pause**, leaving a failing job running on schedule |
| Job id from `Date.now()` | Two adds in the same millisecond shared an id that remove/toggle look up |
| Planner brace counting | A description quoting code made the JSON parse fail, and the plan silently fell through to a lossy heuristic |
| `createLinearSubIssues` | Returned `success: true` after doing nothing; no callers, removed |

## Verification

- Full suite on merged main: **254 files, 3389 passed, 1 skipped**
- Every fix pinned by a mutation-verified test
- `openswarm review`: APPROVE on both, 0 issues
- Version bump touches only the three version lines

## Worth recording

Two test fixtures in this pair were **green against the unfixed code** and had to be rewritten:

- The id-uniqueness test passed with `Date.now()` because the new lock serializes adds and each takes over a millisecond. Freezing the clock is what makes it test the actual property — that uniqueness does not depend on clock resolution.
- The brace-parsing test set includes a *balanced* `{ y }` case that passes either way. It is kept deliberately: the naive implementation is not obviously broken, which is why this survived several audit rounds.

Merging this triggers the release workflow (npm publish → tag → GitHub release).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only in this PR; underlying fixes are already on main with tests—the version bump has no runtime effect beyond publishing 0.19.9.
> 
> **Overview**
> **Release v0.19.9** — bumps `package.json` / lockfile to **0.19.9** and documents fixes from #341 and #342 in `CHANGELOG.md` (no additional source changes in this diff).
> 
> **Schedule persistence (#342):** concurrent load→mutate→save on `schedules.json` could drop another job’s update (notably **auto-pause** after failures). Updates now use a single locked read-modify-write; duplicate-name checks run under that lock; new job ids use **UUID** instead of `Date.now()`.
> 
> **Planner JSON (#341):** brace-counting for plan boundaries treated `{`/`}` inside string values as structure, breaking parse and silently falling back to a lossy heuristic. Descriptions that quote code are handled correctly.
> 
> **Cleanup (#341):** removes unused `createLinearSubIssues` (no-op success stub).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4865e63907cf24d1ea70d47a5dc184c81ba0fe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->