### PR TITLE
fix: stop three transient failures from lasting the whole process

### DIFF
--- a/src/adapters/atlascloud.ts
+++ b/src/adapters/atlascloud.ts
@@ -11,6 +11,7 @@ import type {
   WorkerResult,
   ReviewResult,
 } from './types.js';
+import { abortSignalWithDeadline } from './requestDeadline.js';
 import {
   runAgenticLoop,
   loopResultToCliResult,
@@ -72,6 +73,7 @@ export class AtlasCloudCliAdapter implements CliAdapter {
     const callApi = createApiCaller(apiKey, model, {
       onToken: options.onToken,
       signal: options.signal,
+      timeoutMs: options.timeoutMs ?? 300000,
     });
 
     const mcpTools = await resolveMcpTools(options.mcpTools);
@@ -127,6 +129,15 @@ export class AtlasCloudCliAdapter implements CliAdapter {
 export interface AtlasCloudApiCallerOptions {
   onToken?: (delta: string) => void;
   signal?: AbortSignal;
+  /**
+   * Ceiling for one API call, including the streamed body.
+   *
+   * Without it the request was bounded only by the caller's signal, and the
+   * agentic loop checks its deadline between turns — so a connection that
+   * accepted the request and then went silent hung until something else
+   * intervened, which for a background worker is never.
+   */
+  timeoutMs?: number;
 }
 
 export function createApiCaller(apiKey: string, model: string, opts: AtlasCloudApiCallerOptions = {}) {
@@ -153,7 +164,8 @@ export function createApiCaller(apiKey: string, model: string, opts: AtlasCloudA
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(body),
-        signal: opts.signal,
+        // The caller's signal AND this call's own deadline. Either one aborts.
+        signal: abortSignalWithDeadline(opts.signal, opts.timeoutMs),
       });
 
       if (!res.ok) {

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -13,6 +13,7 @@ import type {
   WorkerResult,
   ReviewResult,
 } from './types.js';
+import { abortSignalWithDeadline } from './requestDeadline.js';
 import { AuthProfileStore, ensureValidToken } from '../auth/index.js';
 import { runAgenticLoop, loopResultToCliResult, type ChatMessage, type AgenticLoopOptions } from './agenticLoop.js';
 import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
@@ -360,6 +361,7 @@ export class CodexResponsesAdapter implements CliAdapter {
     const cacheKey = `osw-${options.processContext?.taskId ?? 'cli'}-${options.processContext?.stage ?? 'run'}-${model}`;
     const callApi = this.createApiCaller(
       accessToken, accountId, store, model, options.onToken, options.signal, onReasoning, options.disableReasoning, options.reasoningEffort, cacheKey,
+      options.timeoutMs ?? 300000,
     );
 
     const loopOptions: AgenticLoopOptions = {
@@ -422,6 +424,13 @@ export class CodexResponsesAdapter implements CliAdapter {
     disableReasoning?: boolean,
     reasoningEffort?: 'low' | 'medium' | 'high',
     cacheKey?: string,
+    /**
+     * Ceiling for one API call, including the streamed body. Without it the
+     * request was bounded only by the caller's signal, and the agentic loop
+     * checks its deadline between turns — so a connection that accepted the
+     * request and then went silent hung with nothing to interrupt it.
+     */
+    timeoutMs?: number,
   ) {
     let token = initialToken;
     let modelRetried = false;
@@ -468,7 +477,8 @@ export class CodexResponsesAdapter implements CliAdapter {
             'OpenAI-Beta': 'responses=experimental',
           },
           body: JSON.stringify(body),
-          signal,
+          // The caller's signal AND this call's own deadline. Either aborts.
+          signal: abortSignalWithDeadline(signal, timeoutMs),
         });
 
         if (!res.ok) {

--- a/src/adapters/errorClassification.test.ts
+++ b/src/adapters/errorClassification.test.ts
@@ -129,3 +129,28 @@ describe('codexMcpAuthHint (INT-2408)', () => {
     expect(codexMcpAuthHint('')).toBeNull();
   });
 });
+
+describe('a request that ran past its deadline', () => {
+  // AbortSignal.timeout() rejects with a DOMException named TimeoutError whose
+  // message is "The operation was aborted due to timeout" — which matches none
+  // of the message patterns ('timed out', 'timeout after'). Without an explicit
+  // check a provider that accepted a request and then went silent was reported
+  // as the task itself failing, which changes how the worker retries.
+  it('is infrastructure, not a task failure', () => {
+    const timeout = new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    expect(isInfraError(timeout)).toBe(true);
+    expect(isTimeoutError(timeout)).toBe(true);
+  });
+
+  // A user abort is a stop, not a fault — it must stay out of the infra bucket
+  // or a deliberate cancellation would be retried as though something broke.
+  it('is distinguished from a user abort', () => {
+    const aborted = new DOMException('This operation was aborted', 'AbortError');
+    expect(isInfraError(aborted)).toBe(false);
+  });
+
+  it('still classifies the message-based timeouts it always did', () => {
+    expect(isInfraError(new Error('connect ETIMEDOUT 1.2.3.4:443'))).toBe(true);
+    expect(isInfraError(new Error('claude timeout after 300000ms'))).toBe(true);
+  });
+});

--- a/src/adapters/errorClassification.ts
+++ b/src/adapters/errorClassification.ts
@@ -86,6 +86,14 @@ const INFRA_ERROR_REGEXES: readonly RegExp[] = [
  * instead). (INT-2010)
  */
 export function isInfraError(error: unknown): boolean {
+  // A request that ran past its deadline is infrastructure, not a verdict on
+  // the task. AbortSignal.timeout() rejects with a DOMException named
+  // TimeoutError whose message — "The operation was aborted due to timeout" —
+  // matches none of the patterns below ('timed out', 'timeout after'), so
+  // without this a provider that accepted a request and then went silent was
+  // reported as the task itself failing. A user abort is deliberately not
+  // included: that is a stop, not a fault.
+  if (error instanceof DOMException && error.name === 'TimeoutError') return true;
   const msg = (error instanceof Error ? error.message : String(error ?? '')).toLowerCase();
   // undici wraps connection failures as `TypeError: fetch failed` with the real
   // code (ECONNREFUSED / ECONNRESET / UND_ERR_*) on `error.cause.code` — the

--- a/src/adapters/requestDeadline.ts
+++ b/src/adapters/requestDeadline.ts
@@ -1,0 +1,29 @@
+// ============================================
+// OpenSwarm - outbound request deadlines
+// ============================================
+//
+// Provider requests were bounded only by the caller's AbortSignal, and the
+// agentic loop checks its own deadline between turns. A connection that
+// accepted the request and then went silent therefore hung with nothing to
+// interrupt it — for a background worker, indefinitely.
+
+/**
+ * Combine a caller's signal with a deadline for this request.
+ *
+ * Named for what it returns, not just what it does: mcpClient.ts already
+ * exports a `withDeadline` that wraps a Promise, and two functions of that name
+ * with different signatures is how a wrong import gets written later.
+ *
+ * Either one aborts. Returns the caller's signal unchanged when no deadline is
+ * given, and undefined when there is neither, so call sites stay unconditional.
+ *
+ * The deadline covers the streamed body, not just the response headers, which
+ * is the point: a stream that stops producing is the failure mode being bounded
+ * here. It is therefore the caller's per-call ceiling — not a short network
+ * timeout, which would cut off legitimate long generations.
+ */
+export function abortSignalWithDeadline(signal: AbortSignal | undefined, timeoutMs: number | undefined): AbortSignal | undefined {
+  if (!timeoutMs || !Number.isFinite(timeoutMs) || timeoutMs <= 0) return signal;
+  const deadline = AbortSignal.timeout(timeoutMs);
+  return signal ? AbortSignal.any([signal, deadline]) : deadline;
+}

--- a/src/adapters/transientBecomesPermanent.test.ts
+++ b/src/adapters/transientBecomesPermanent.test.ts
@@ -1,0 +1,101 @@
+// ============================================
+// OpenSwarm - transient failures that used to become permanent
+// ============================================
+//
+// Three places where a momentary problem was preserved for the life of the
+// process: a request with no deadline of its own, a tool discovery cached with
+// its failures, and a model lookup whose error was cached as an answer.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { abortSignalWithDeadline } from './requestDeadline.js';
+import { resolveAdapterDefaultModel } from '../agents/stageModelResolver.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('abortSignalWithDeadline', () => {
+  it('aborts on its own deadline when the caller never does', async () => {
+    const signal = abortSignalWithDeadline(undefined, 20)!;
+    expect(signal.aborted).toBe(false);
+    await new Promise((r) => setTimeout(r, 60));
+    expect(signal.aborted).toBe(true);
+  });
+
+  it('aborts when the caller aborts, before the deadline', () => {
+    const controller = new AbortController();
+    const signal = abortSignalWithDeadline(controller.signal, 60_000)!;
+
+    controller.abort();
+
+    expect(signal.aborted).toBe(true);
+  });
+
+  // A long generation is normal; the deadline must be the caller's ceiling and
+  // nothing shorter, or streaming answers get cut off mid-flight.
+  it('does not abort early while the deadline has not passed', async () => {
+    const signal = abortSignalWithDeadline(new AbortController().signal, 5_000)!;
+    await new Promise((r) => setTimeout(r, 50));
+    expect(signal.aborted).toBe(false);
+  });
+
+  it('passes the caller signal through when there is no deadline', () => {
+    const controller = new AbortController();
+    expect(abortSignalWithDeadline(controller.signal, undefined)).toBe(controller.signal);
+    expect(abortSignalWithDeadline(controller.signal, 0)).toBe(controller.signal);
+  });
+
+  it('is undefined when there is neither', () => {
+    expect(abortSignalWithDeadline(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe('resolveAdapterDefaultModel', () => {
+  // Caching the rejection meant one blip during startup left the adapter's
+  // displayed model blank for the whole process, unrecoverable short of a
+  // restart.
+  it('retries after a failed lookup instead of caching the failure', async () => {
+    const cache = new Map<string, Promise<string | undefined>>();
+    const adapters = await import('../adapters/index.js');
+    let calls = 0;
+    vi.spyOn(adapters, 'getAdapter').mockImplementation((() => ({
+      getDefaultModel: async () => {
+        calls++;
+        if (calls === 1) throw new Error('provider unreachable');
+        return 'gpt-5.5';
+      },
+    })) as never);
+
+    await expect(resolveAdapterDefaultModel('x', cache)).resolves.toBeUndefined();
+    await expect(resolveAdapterDefaultModel('x', cache)).resolves.toBe('gpt-5.5');
+    expect(calls).toBe(2);
+  });
+
+  // The cache still has to do its job: getDefaultModel is an OAuth + catalog
+  // round trip, so a success must not be repeated.
+  it('caches a successful lookup', async () => {
+    const cache = new Map<string, Promise<string | undefined>>();
+    const adapters = await import('../adapters/index.js');
+    let calls = 0;
+    vi.spyOn(adapters, 'getAdapter').mockImplementation((() => ({
+      getDefaultModel: async () => { calls++; return 'gpt-5.5'; },
+    })) as never);
+
+    await resolveAdapterDefaultModel('x', cache);
+    await resolveAdapterDefaultModel('x', cache);
+
+    expect(calls).toBe(1);
+  });
+
+  it('keeps adapters separate', async () => {
+    const cache = new Map<string, Promise<string | undefined>>();
+    const adapters = await import('../adapters/index.js');
+    vi.spyOn(adapters, 'getAdapter').mockImplementation(((name?: string) => ({
+      getDefaultModel: async () => `model-for-${name ?? 'default'}`,
+    })) as never);
+
+    await expect(resolveAdapterDefaultModel('a', cache)).resolves.toBe('model-for-a');
+    await expect(resolveAdapterDefaultModel('b', cache)).resolves.toBe('model-for-b');
+  });
+});

--- a/src/agents/stageModelResolver.ts
+++ b/src/agents/stageModelResolver.ts
@@ -19,7 +19,14 @@ export function resolveAdapterDefaultModel(
   if (!pending) {
     pending = Promise.resolve()
       .then(() => getAdapter(adapterName).getDefaultModel())
-      .catch(() => undefined);
+      .catch(() => {
+        // Drop the failure from the cache so a later call tries again. Storing
+        // it meant one transient lookup error — a provider blip during startup
+        // — left this adapter's displayed model blank for the whole process,
+        // with no way to recover short of a restart.
+        cache.delete(cacheKey);
+        return undefined;
+      });
     cache.set(cacheKey, pending);
   }
   return pending;

--- a/src/mcp/getMcpToolsCache.test.ts
+++ b/src/mcp/getMcpToolsCache.test.ts
@@ -1,0 +1,129 @@
+// ============================================
+// OpenSwarm - getMcpTools cache lifetime
+// ============================================
+//
+// getMcpTools cached its first result for the life of the process. If a server
+// was briefly unreachable during that call, its tools were absent from every
+// later call — no retry, no expiry, nothing short of a manual resetMcpTools().
+// A complete discovery should still be cached indefinitely; only an incomplete
+// one gets a short lease.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const clientMock = vi.hoisted(() => ({
+  connect: vi.fn(async () => {}),
+  close: vi.fn(async () => {}),
+  listTools: vi.fn(),
+  callTool: vi.fn(),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: vi.fn(function MockClient() {
+    return clientMock;
+  }),
+}));
+
+let home: string;
+
+/** Load mcpClient with ~/.openswarm/mcp.json pointing at a temp registry. */
+async function loadClient(servers: Record<string, unknown>) {
+  home = mkdtempSync(join(tmpdir(), 'mcp-cache-'));
+  mkdirSync(join(home, '.openswarm'), { recursive: true });
+  writeFileSync(join(home, '.openswarm', 'mcp.json'), JSON.stringify({ mcpServers: servers }));
+
+  vi.resetModules();
+  const mockOs = async (importOriginal: () => Promise<typeof import('node:os')>) => {
+    const actual = await importOriginal();
+    return { ...actual, default: { ...actual, homedir: () => home }, homedir: () => home };
+  };
+  vi.doMock('node:os', mockOs);
+  vi.doMock('os', mockOs);
+  return await import('./mcpClient.js');
+}
+
+const stdio = (name: string) => ({ transport: 'stdio', command: 'node', args: [`${name}.js`] });
+const oneTool = { tools: [{ name: 'ok', description: '', inputSchema: { type: 'object' } }] };
+
+beforeEach(() => {
+  clientMock.listTools.mockReset();
+  clientMock.connect.mockClear();
+});
+
+afterEach(() => {
+  if (home) rmSync(home, { recursive: true, force: true });
+  vi.doUnmock('node:os');
+  vi.doUnmock('os');
+  vi.useRealTimers();
+});
+
+describe('getMcpTools caching', () => {
+  it('does not re-discover after a complete discovery', async () => {
+    const { getMcpTools } = await loadClient({ good: stdio('good') });
+    clientMock.listTools.mockResolvedValue(oneTool);
+
+    const first = await getMcpTools();
+    const second = await getMcpTools();
+
+    expect(first).toHaveLength(1);
+    expect(second).toBe(first);
+    expect(clientMock.listTools).toHaveBeenCalledTimes(1);
+  });
+
+  // The regression: an incomplete result was kept forever. It should be reused
+  // briefly — so a repeated call does not hammer a dead server — and then tried
+  // again.
+  it('reuses an incomplete discovery only briefly', async () => {
+    const { getMcpTools } = await loadClient({ flaky: stdio('flaky') });
+    clientMock.listTools.mockRejectedValue(new Error('connection refused'));
+
+    await getMcpTools();
+    await getMcpTools();
+
+    expect(clientMock.listTools).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-discovers once the short lease expires, and the server can come back', async () => {
+    const { getMcpTools } = await loadClient({ flaky: stdio('flaky') });
+    clientMock.listTools.mockRejectedValueOnce(new Error('connection refused'));
+
+    const beforeRecovery = await getMcpTools();
+    expect(beforeRecovery).toHaveLength(0);
+
+    // The server recovers, and enough time passes for another attempt.
+    clientMock.listTools.mockResolvedValue(oneTool);
+    vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 120_000);
+
+    const afterRecovery = await getMcpTools();
+
+    expect(afterRecovery).toHaveLength(1);
+    expect(clientMock.listTools).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops re-discovering once a discovery finally completes', async () => {
+    const { getMcpTools } = await loadClient({ flaky: stdio('flaky') });
+    clientMock.listTools.mockRejectedValueOnce(new Error('down'));
+    await getMcpTools();
+
+    clientMock.listTools.mockResolvedValue(oneTool);
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 120_000);
+    await getMcpTools();          // recovers
+    nowSpy.mockReturnValue(Date.now() + 600_000);
+    await getMcpTools();          // must not discover again
+
+    expect(clientMock.listTools).toHaveBeenCalledTimes(2);
+  });
+
+  it('resetMcpTools forces a fresh discovery', async () => {
+    const { getMcpTools, resetMcpTools } = await loadClient({ good: stdio('good') });
+    clientMock.listTools.mockResolvedValue(oneTool);
+
+    await getMcpTools();
+    resetMcpTools();
+    await getMcpTools();
+
+    expect(clientMock.listTools).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/mcp/getMcpToolsCache.test.ts
+++ b/src/mcp/getMcpToolsCache.test.ts
@@ -139,6 +139,76 @@ describe('getMcpTools caching', () => {
     expect(clientMock.listTools).toHaveBeenCalledTimes(1);
   });
 
+  // Concurrent callers each starting their own discovery is how the fix
+  // defeated itself: the runs raced to publish the cache and the routing map,
+  // so a slower stale run could undo a newer successful one, and every
+  // unreachable server was hit once per caller.
+  it('runs one discovery for concurrent callers', async () => {
+    const { getMcpTools } = await loadClient({ good: stdio('good') });
+    let inFlight = 0;
+    let maxConcurrent = 0;
+    clientMock.listTools.mockImplementation(async () => {
+      maxConcurrent = Math.max(maxConcurrent, ++inFlight);
+      await new Promise((r) => setTimeout(r, 20));
+      inFlight--;
+      return oneTool;
+    });
+
+    const results = await Promise.all([getMcpTools(), getMcpTools(), getMcpTools(), getMcpTools()]);
+
+    expect(maxConcurrent).toBe(1);
+    expect(clientMock.listTools).toHaveBeenCalledTimes(1);
+    for (const r of results) expect(r).toBe(results[0]);
+  });
+
+  // Rediscovery used to clear the live routing map on entry, so an agent
+  // holding a tool definition from the previous result got "not registered"
+  // for a tool that was working a moment earlier.
+  it('keeps the previous routing usable until the new one is ready', async () => {
+    const { getMcpTools, resetMcpTools, callMcpTool } = await loadClient({ good: stdio('good') });
+    clientMock.listTools.mockResolvedValue(oneTool);
+    clientMock.callTool.mockResolvedValue({ content: [{ type: 'text', text: 'done' }] });
+    await getMcpTools();
+
+    // Start a slow rediscovery and call the existing tool while it runs.
+    resetMcpTools();
+    let release!: () => void;
+    clientMock.listTools.mockImplementation(async () => {
+      await new Promise<void>((r) => { release = r; });
+      return oneTool;
+    });
+    const pending = getMcpTools();
+    await new Promise((r) => setTimeout(r, 10));
+
+    const during = await callMcpTool('good__ok', {});
+    expect(JSON.stringify(during)).not.toMatch(/not registered/i);
+
+    release();
+    await pending;
+  });
+
+  // A discovery that started before a reset must not write its result back
+  // afterwards — it would silently reinstate the state the reset just cleared.
+  it('does not let a pre-reset discovery publish after the reset', async () => {
+    const { getMcpTools, resetMcpTools } = await loadClient({ good: stdio('good') });
+    let release!: () => void;
+    clientMock.listTools.mockImplementation(async () => {
+      await new Promise<void>((r) => { release = r; });
+      return oneTool;
+    });
+
+    const stale = getMcpTools();
+    await new Promise((r) => setTimeout(r, 10));
+    resetMcpTools();
+    release();
+    await stale;
+
+    // The reset must still be in force: the next call rediscovers.
+    clientMock.listTools.mockResolvedValue(oneTool);
+    await getMcpTools();
+    expect(clientMock.listTools).toHaveBeenCalledTimes(2);
+  });
+
   it('resetMcpTools forces a fresh discovery', async () => {
     const { getMcpTools, resetMcpTools } = await loadClient({ good: stdio('good') });
     clientMock.listTools.mockResolvedValue(oneTool);

--- a/src/mcp/getMcpToolsCache.test.ts
+++ b/src/mcp/getMcpToolsCache.test.ts
@@ -116,6 +116,29 @@ describe('getMcpTools caching', () => {
     expect(clientMock.listTools).toHaveBeenCalledTimes(2);
   });
 
+  // Unreachable servers are exactly the ones that take a long time to fail, so
+  // a discovery can outlast the lease it is about to set. Measuring the lease
+  // from when discovery *started* put the deadline in the past, and the next
+  // call rediscovered immediately — the lease failed in the very case it
+  // exists for.
+  it('gives a full lease even when discovery outlasted it', async () => {
+    const { getMcpTools } = await loadClient({ flaky: stdio('flaky') });
+    const start = Date.now();
+    let clock = start;
+    vi.spyOn(Date, 'now').mockImplementation(() => clock);
+
+    clientMock.listTools.mockImplementation(async () => {
+      // The discovery itself takes longer than INCOMPLETE_DISCOVERY_RETRY_MS.
+      clock = start + 120_000;
+      throw new Error('timed out');
+    });
+
+    await getMcpTools();
+    await getMcpTools();   // still inside the lease, must not rediscover
+
+    expect(clientMock.listTools).toHaveBeenCalledTimes(1);
+  });
+
   it('resetMcpTools forces a fresh discovery', async () => {
     const { getMcpTools, resetMcpTools } = await loadClient({ good: stdio('good') });
     clientMock.listTools.mockResolvedValue(oneTool);

--- a/src/mcp/mcpClient.ts
+++ b/src/mcp/mcpClient.ts
@@ -272,41 +272,68 @@ interface McpTool {
  * agentic-loop ToolDefinitions named `server__tool`. Unreachable servers are
  * skipped (logged). Call once before running the loop.
  */
-export async function initMcpTools(registry = loadRegistry()): Promise<ToolDefinition[]> {
-  serverByTool = {};
-  lastDiscoveryUnreachable = [];
+interface DiscoveryResult {
+  defs: ToolDefinition[];
+  routing: Record<string, { cfg: ServerConfig; toolName: string }>;
+  /** Servers skipped because they could not be reached. Empty when complete. */
+  unreachable: string[];
+}
+
+/**
+ * Probe every configured server and build the tool set.
+ *
+ * Everything it produces is local to the call. Recording failures on a module
+ * variable meant two overlapping discoveries shared one list, and each one
+ * cleared it on entry — so one run could erase the other's record and a partial
+ * result would be cached as if it were complete, which is precisely the
+ * process-lifetime tool loss this module is meant to avoid.
+ *
+ * The routing map is likewise built locally and published by the caller only
+ * once the run finishes. Clearing the live map on entry made every in-flight
+ * agent see "MCP tool not registered" for tools that were working a moment
+ * earlier, for as long as rediscovery took.
+ */
+async function discoverMcpTools(registry: Record<string, ServerConfig>): Promise<DiscoveryResult> {
   const defs: ToolDefinition[] = [];
+  const routing: Record<string, { cfg: ServerConfig; toolName: string }> = {};
+  const unreachable: string[] = [];
   const entries = Object.entries(registry);
   let next = 0;
-  const discover = async (): Promise<void> => {
+  const worker = async (): Promise<void> => {
     while (next < entries.length) {
       const [server, cfg] = entries[next++];
-    try {
-      const listed = (await withClient(cfg, (c) => c.listTools())) as { tools?: McpTool[] };
-      for (const tool of listed.tools ?? []) {
-        if (typeof tool.name !== 'string') continue;
-        const qualified = `${server}${SEP}${tool.name}`;
-        if (!isMcpTool(qualified)) {
-          console.warn(`[MCP] server "${server}" returned invalid tool name "${tool.name}" — skipped`);
-          continue;
+      try {
+        const listed = (await withClient(cfg, (c) => c.listTools())) as { tools?: McpTool[] };
+        for (const tool of listed.tools ?? []) {
+          if (typeof tool.name !== 'string') continue;
+          const qualified = `${server}${SEP}${tool.name}`;
+          if (!isMcpTool(qualified)) {
+            console.warn(`[MCP] server "${server}" returned invalid tool name "${tool.name}" — skipped`);
+            continue;
+          }
+          routing[qualified] = { cfg, toolName: tool.name };
+          defs.push({
+            type: 'function',
+            function: {
+              name: qualified,
+              description: (tool.description ?? '').slice(0, 1024),
+              parameters: sanitizeInputSchema(tool.inputSchema),
+            },
+          });
         }
-        serverByTool[qualified] = { cfg, toolName: tool.name };
-        defs.push({
-          type: 'function',
-          function: {
-            name: qualified,
-            description: (tool.description ?? '').slice(0, 1024),
-            parameters: sanitizeInputSchema(tool.inputSchema),
-          },
-        });
+      } catch (err) {
+        unreachable.push(server);
+        console.warn(`[MCP] server "${server}" unreachable — skipped: ${err instanceof Error ? err.message : String(err)}`);
       }
-    } catch (err) {
-      lastDiscoveryUnreachable.push(server);
-      console.warn(`[MCP] server "${server}" unreachable — skipped: ${err instanceof Error ? err.message : String(err)}`);
-    }
     }
   };
-  await Promise.all(Array.from({ length: Math.min(4, entries.length) }, () => discover()));
+  await Promise.all(Array.from({ length: Math.min(4, entries.length) }, () => worker()));
+  return { defs, routing, unreachable };
+}
+
+export async function initMcpTools(registry = loadRegistry()): Promise<ToolDefinition[]> {
+  const { defs, routing } = await discoverMcpTools(registry);
+  serverByTool = routing;
   return defs;
 }
 
@@ -314,8 +341,17 @@ export async function initMcpTools(registry = loadRegistry()): Promise<ToolDefin
 let cachedTools: ToolDefinition[] | null = null;
 /** When >0, the cached result was incomplete and may be re-attempted at this time. */
 let cachedToolsRetryAt = 0;
-/** Servers skipped by the most recent discovery because they were unreachable. */
-let lastDiscoveryUnreachable: string[] = [];
+/** The discovery currently running, shared by every concurrent caller. */
+let inFlightDiscovery: Promise<ToolDefinition[]> | null = null;
+/**
+ * Bumped by resetMcpTools. A discovery that started before a reset must not
+ * publish its result afterwards — it would silently reinstate the state the
+ * reset just cleared. Unreachable today (the only reset call site is a
+ * short-lived CLI process with no discovery in flight), but the guard costs
+ * one comparison and the alternative is a bug that only appears once reset
+ * moves into the daemon.
+ */
+let discoveryGeneration = 0;
 /** How long an incomplete discovery is reused before another attempt. */
 const INCOMPLETE_DISCOVERY_RETRY_MS = 60_000;
 
@@ -340,30 +376,45 @@ async function loadConfiguredRegistry(): Promise<Record<string, ServerConfig>> {
  * Empty when nothing is configured / no reachable servers. (INT-1951)
  */
 export async function getMcpTools(): Promise<ToolDefinition[]> {
-  const now = Date.now();
   // A complete discovery is cached until resetMcpTools(). An incomplete one —
   // some server was unreachable — is cached only briefly, so a server that was
   // down for a moment comes back on its own. Caching it for the process
   // lifetime meant a single blip removed those tools from every later call
   // until someone noticed and ran resetMcpTools() by hand.
-  if (cachedTools && (!cachedToolsRetryAt || now < cachedToolsRetryAt)) return cachedTools;
-  cachedTools = await initMcpTools(await loadConfiguredRegistry());
-  // Measured from when discovery finished, not when it started. Unreachable
-  // servers are precisely the ones that take a long time to fail, so a
-  // discovery that ran longer than the lease would set a deadline already in
-  // the past and the next call would rediscover immediately — the lease would
-  // apply least often in exactly the case it exists for.
-  cachedToolsRetryAt = lastDiscoveryUnreachable.length > 0
-    ? Date.now() + INCOMPLETE_DISCOVERY_RETRY_MS
-    : 0;
-  return cachedTools;
+  if (cachedTools && (!cachedToolsRetryAt || Date.now() < cachedToolsRetryAt)) return cachedTools;
+  // One discovery at a time. Without this, concurrent callers each start their
+  // own run; they race to publish the routing map and the cache, so a slower
+  // stale run can undo a newer successful one — and every unreachable server
+  // gets hit once per caller.
+  inFlightDiscovery ??= (async () => {
+    const generation = discoveryGeneration;
+    try {
+      const { defs, routing, unreachable } = await discoverMcpTools(await loadConfiguredRegistry());
+      // A reset landed while this ran: return the result to whoever asked, but
+      // do not write it back over the cleared state.
+      if (generation !== discoveryGeneration) return defs;
+      serverByTool = routing;
+      cachedTools = defs;
+      // Measured from when discovery finished, not when it started. Unreachable
+      // servers are precisely the ones that take a long time to fail, so a
+      // discovery that ran longer than the lease would set a deadline already
+      // in the past and the next call would rediscover immediately — the lease
+      // would apply least often in exactly the case it exists for.
+      cachedToolsRetryAt = unreachable.length > 0 ? Date.now() + INCOMPLETE_DISCOVERY_RETRY_MS : 0;
+      return defs;
+    } finally {
+      if (generation === discoveryGeneration) inFlightDiscovery = null;
+    }
+  })();
+  return inFlightDiscovery;
 }
-
 
 /** Drop the cache (after editing mcp.json). */
 export function resetMcpTools(): void {
+  discoveryGeneration++;
   cachedTools = null;
   cachedToolsRetryAt = 0;
+  inFlightDiscovery = null;
 }
 
 /**

--- a/src/mcp/mcpClient.ts
+++ b/src/mcp/mcpClient.ts
@@ -274,6 +274,7 @@ interface McpTool {
  */
 export async function initMcpTools(registry = loadRegistry()): Promise<ToolDefinition[]> {
   serverByTool = {};
+  lastDiscoveryUnreachable = [];
   const defs: ToolDefinition[] = [];
   const entries = Object.entries(registry);
   let next = 0;
@@ -300,6 +301,7 @@ export async function initMcpTools(registry = loadRegistry()): Promise<ToolDefin
         });
       }
     } catch (err) {
+      lastDiscoveryUnreachable.push(server);
       console.warn(`[MCP] server "${server}" unreachable — skipped: ${err instanceof Error ? err.message : String(err)}`);
     }
     }
@@ -310,6 +312,12 @@ export async function initMcpTools(registry = loadRegistry()): Promise<ToolDefin
 
 // Cache the discovered tools so chat doesn't re-list every message.
 let cachedTools: ToolDefinition[] | null = null;
+/** When >0, the cached result was incomplete and may be re-attempted at this time. */
+let cachedToolsRetryAt = 0;
+/** Servers skipped by the most recent discovery because they were unreachable. */
+let lastDiscoveryUnreachable: string[] = [];
+/** How long an incomplete discovery is reused before another attempt. */
+const INCOMPLETE_DISCOVERY_RETRY_MS = 60_000;
 
 /**
  * The effective registry for auto-discovery: mcp.json merged with the servers
@@ -332,14 +340,23 @@ async function loadConfiguredRegistry(): Promise<Record<string, ServerConfig>> {
  * Empty when nothing is configured / no reachable servers. (INT-1951)
  */
 export async function getMcpTools(): Promise<ToolDefinition[]> {
-  if (cachedTools) return cachedTools;
+  const now = Date.now();
+  // A complete discovery is cached until resetMcpTools(). An incomplete one —
+  // some server was unreachable — is cached only briefly, so a server that was
+  // down for a moment comes back on its own. Caching it for the process
+  // lifetime meant a single blip removed those tools from every later call
+  // until someone noticed and ran resetMcpTools() by hand.
+  if (cachedTools && (!cachedToolsRetryAt || now < cachedToolsRetryAt)) return cachedTools;
   cachedTools = await initMcpTools(await loadConfiguredRegistry());
+  cachedToolsRetryAt = lastDiscoveryUnreachable.length > 0 ? now + INCOMPLETE_DISCOVERY_RETRY_MS : 0;
   return cachedTools;
 }
+
 
 /** Drop the cache (after editing mcp.json). */
 export function resetMcpTools(): void {
   cachedTools = null;
+  cachedToolsRetryAt = 0;
 }
 
 /**

--- a/src/mcp/mcpClient.ts
+++ b/src/mcp/mcpClient.ts
@@ -348,7 +348,14 @@ export async function getMcpTools(): Promise<ToolDefinition[]> {
   // until someone noticed and ran resetMcpTools() by hand.
   if (cachedTools && (!cachedToolsRetryAt || now < cachedToolsRetryAt)) return cachedTools;
   cachedTools = await initMcpTools(await loadConfiguredRegistry());
-  cachedToolsRetryAt = lastDiscoveryUnreachable.length > 0 ? now + INCOMPLETE_DISCOVERY_RETRY_MS : 0;
+  // Measured from when discovery finished, not when it started. Unreachable
+  // servers are precisely the ones that take a long time to fail, so a
+  // discovery that ran longer than the lease would set a deadline already in
+  // the past and the next call would rediscover immediately — the lease would
+  // apply least often in exactly the case it exists for.
+  cachedToolsRetryAt = lastDiscoveryUnreachable.length > 0
+    ? Date.now() + INCOMPLETE_DISCOVERY_RETRY_MS
+    : 0;
   return cachedTools;
 }
 


### PR DESCRIPTION
## Summary

Three places where a momentary problem was preserved for the life of the process.

| | Transient cause | Permanent consequence |
|---|---|---|
| **Provider request** | connection accepts, then goes silent | hangs with nothing to interrupt it — the loop only checks its deadline between turns |
| **`getMcpTools`** | one server briefly unreachable at startup | its tools absent from **every later call**, no recovery short of a manual `resetMcpTools()` |
| **`resolveAdapterDefaultModel`** | one failed lookup | that adapter's displayed model blank for the whole process |

The request deadline is the caller's `timeoutMs`, **not a short network timeout**: it covers the streamed body, and anything shorter would cut off legitimate long generations. A complete MCP discovery is still cached indefinitely; only an incomplete one gets a 60s lease, so a blip heals itself without hammering a dead server. A successful model lookup is still cached, since `getDefaultModel` is an OAuth plus catalog round trip.

## Review found two gaps — both fixed here

- The helper exposing which servers were unreachable **had no production consumer**. It is private again. An exported function nothing calls is exactly what the previous PR deleted 962 lines over; adding one in the same session would be poor form.
- The tests exercised `initMcpTools`, leaving the actual cache decision in `getMcpTools` unverified. They now drive `getMcpTools` and go red when the TTL is removed.

## Verification

| Mutation | Tests that went red |
|---|---|
| cache the model lookup failure again | `retries after a failed lookup instead of caching the failure` |
| `getMcpTools` caches forever | `re-discovers once the short lease expires`, `stops re-discovering once a discovery finally completes` |
| deadline ignored | `aborts on its own deadline when the caller never does` |

The MCP tests also pin the **opposite** direction — a complete discovery must not be re-run, and a recovered server must stop being re-discovered — so "always re-discover" is not a way to make them pass.

- Full suite: **256 files, 3402 passed, 1 skipped**
- `tsc --noEmit` clean, `oxlint` 0 warnings
- `openswarm review`: **APPROVE**, 0 issues (after one REVISE round, addressed above)

Named `abortSignalWithDeadline` rather than `withDeadline`: `mcpClient.ts` already exports a `withDeadline` that wraps a Promise, and two functions of that name with different signatures is how a wrong import gets written later.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches long-running worker/provider paths (fetch abort, MCP routing cache, retry classification); behavior is well-tested but incorrect deadline or cache logic could affect all adapter runs and MCP tools in the daemon.
> 
> **Overview**
> Stops three **transient blips from sticking for the process lifetime**: silent provider streams, MCP discovery gaps, and failed default-model lookups.
> 
> **Provider requests** now use `abortSignalWithDeadline` on Atlas Cloud and Codex Responses `fetch` calls (default `timeoutMs` 300000), so a single turn—including a stalled stream—can abort instead of hanging until the agentic loop’s between-turn deadline. **`isInfraError`** treats `DOMException` `TimeoutError` as infrastructure (not a task failure); user `AbortError` stays excluded.
> 
> **`getMcpTools`** keeps complete discoveries cached forever but gives **incomplete** ones a 60s lease (from finish time), dedupes concurrent discovery, keeps prior routing during rediscovery, and ignores stale results after `resetMcpTools` via a generation counter. **`resolveAdapterDefaultModel`** removes failed lookups from the cache so a later call retries while successes stay cached.
> 
> Regression tests cover deadlines, model-cache behavior, and MCP cache/TTL/concurrency/routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 332cf707a18584ef4c9161ced9d958b330a41ad3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->