### PR TITLE
chore(release): v0.19.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.19.10 — 2026-07-26
+
+### Fixed
+
+- **A silent provider no longer hangs a worker indefinitely** — outbound requests were bounded only by the caller's AbortSignal, and the agentic loop checks its deadline between turns, so a connection that accepted a request and then stopped producing had nothing to interrupt it. Requests now carry the caller's own per-call ceiling, which covers the streamed body. A deadline abort is also classified as infrastructure rather than a task failure: `AbortSignal.timeout()` rejects with a `TimeoutError` whose message matched none of the existing patterns, so a hung provider was being reported as the task itself failing. (#345)
+- **A briefly unreachable MCP server no longer disappears for the process lifetime** — the first discovery result was cached forever, so one blip at startup removed that server's tools from every later call with no recovery short of a manual reset. A complete discovery is still cached indefinitely; an incomplete one gets a short lease, measured from when discovery finished. Discovery is also deduplicated and its routing map published atomically, so concurrent callers share one run and in-flight agents keep working tools while a rediscovery is under way. (#345)
+- **A failed adapter model lookup is retried** — the rejection was cached, so one lookup failure during startup left that adapter's displayed model blank for the whole process. (#345)
+
+### Removed
+
+- The unreferenced risk-on / CryptoQuant island: 962 lines nothing in the codebase imported, added four months ago and never wired in. Six of the standing audit findings lived there. (#344)
+
 ## 0.19.9 — 2026-07-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.9",
+  "version": "0.19.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.19.9",
+      "version": "0.19.10",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.19.9",
+  "version": "0.19.10",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Releases #345 and #344.

| | Transient cause | Permanent consequence, now fixed |
|---|---|---|
| Provider request | connection accepts, then goes silent | hung with nothing to interrupt it — and the abort was classified as a **task failure** rather than infrastructure |
| MCP discovery | one server briefly unreachable | its tools gone from **every later call** until a manual reset |
| Model lookup | one failed call | that adapter's displayed model blank for the whole process |
| — | — | plus 962 lines of unreferenced code removed, clearing six standing audit findings |

## Verification

- Full suite on merged main: **256 files, 3409 passed, 1 skipped**
- Every fix pinned by a mutation-verified test, including the opposite directions (a complete discovery must *not* be re-run; a user abort must *not* be treated as infrastructure)
- `openswarm review`: APPROVE on both
- Version bump touches only the three version lines

## Worth recording

Three of #345's four review findings were defects **the change itself introduced**. Making MCP rediscovery happen more often exposed hazards that were previously unreachable: shared failure state across concurrent runs, a routing map cleared while agents held tool definitions, and no in-flight deduplication.

There is also a correction to record. When review first said deadline aborts would be logged as user cancellation, I measured that `AbortSignal.timeout()` produces `TimeoutError` rather than `AbortError` and refuted it — correctly. But I stopped there. The next round found the real problem one layer down: `isInfraError` recognised neither, so a hung provider was reported as the task failing. Refuting a specific claim is not the same as clearing the path.

Merging this triggers the release workflow (npm publish → tag → GitHub release).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version and changelog updates with no runtime code in this diff; underlying fixes change provider timeouts, MCP caching, and error classification already covered by tests on main.
> 
> **Overview**
> **Release 0.19.10** — bumps `@intrect/openswarm` to **0.19.10** in `package.json` and `package-lock.json` and records shipped work in `CHANGELOG.md` (releases #345 and #344).
> 
> **#345 — transient failures no longer stick for the process lifetime:** outbound provider calls get a per-request deadline so a connection that goes silent cannot hang a worker indefinitely, and deadline aborts from `AbortSignal.timeout()` are treated as **infrastructure** (not task failure). MCP tool discovery keeps successful results cached forever but gives **incomplete** discoveries a short retry lease, with deduplicated discovery and atomic routing-map publish so concurrent callers share one run. Failed adapter default-model lookups are **retried** instead of caching the rejection.
> 
> **#344 — cleanup:** removes ~962 lines of unreferenced risk-on / CryptoQuant code that nothing imported.
> 
> The merge diff here is the version lines and changelog; implementation landed in the referenced PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f22fe8e4c1fe1e5ee2db780d9e4741bf120968f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->