### PR TITLE
fix(dev): contain !dev repository names to ~/dev

### DIFF
--- a/src/support/dev.ts
+++ b/src/support/dev.ts
@@ -3,8 +3,8 @@
 // ============================================
 
 import { spawn, type ChildProcess } from 'node:child_process';
-import { existsSync, readdirSync, statSync, writeFileSync, appendFileSync, mkdirSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, readdirSync, statSync, writeFileSync, appendFileSync, mkdirSync, realpathSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
 import { checkWorkAllowed, getTimeWindowSummary } from './timeWindow.js';
 import { extractCostFromStreamJson, formatCost } from './costTracker.js';
 import { expandPath } from '../core/config.js';
@@ -61,12 +61,33 @@ export function resolveRepoPath(repo: string): string | null {
   }
 
   // 3. Relative path (assumed under ~/dev/)
-  const devPath = expandPath(`~/dev/${repo}`);
-  if (existsSync(devPath)) {
-    return devPath;
+  //
+  // Contained deliberately. This name arrives from a Discord message via
+  // `!dev <repo> "<task>"`, and the path it resolves to becomes the cwd of a
+  // `claude --permission-mode bypassPermissions` process. Without the check,
+  // `../.ssh` resolved to ~/.ssh and `..` to the home directory — measured —
+  // so a repo name alone chose where an unsandboxed agent would run.
+  //
+  // realpath, not just resolve: a symlink inside ~/dev pointing outside it
+  // would otherwise pass a purely lexical check.
+  const devRoot = realpathIfPossible(expandPath('~/dev'));
+  const devPath = resolve(expandPath(`~/dev/${repo}`));
+  if (!existsSync(devPath)) return null;
+  const real = realpathIfPossible(devPath);
+  if (real !== devRoot && !real.startsWith(devRoot + sep)) {
+    console.warn(`[Dev] Refusing "${repo}": resolves outside ~/dev (${real})`);
+    return null;
   }
+  return devPath;
+}
 
-  return null;
+/** realpath when the path exists, the lexical form otherwise. */
+function realpathIfPossible(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
 }
 
 /**

--- a/src/support/repoPathContainment.test.ts
+++ b/src/support/repoPathContainment.test.ts
@@ -1,0 +1,103 @@
+// ============================================
+// OpenSwarm - !dev repo path containment
+// ============================================
+//
+// The repo name in `!dev <repo> "<task>"` comes from a Discord message, and the
+// path it resolves to becomes the cwd of a
+// `claude --permission-mode bypassPermissions` process. The relative branch
+// joined the name onto ~/dev without filtering, so `../.ssh` resolved to
+// ~/.ssh and `..` to the home directory — a repo name alone chose where an
+// unsandboxed agent would run.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let home: string;
+
+/** Load dev.ts with HOME pointed at a temp tree containing ~/dev. */
+async function loadDev() {
+  vi.resetModules();
+  const mockOs = async (importOriginal: () => Promise<typeof import('node:os')>) => {
+    const actual = await importOriginal();
+    return { ...actual, default: { ...actual, homedir: () => home }, homedir: () => home };
+  };
+  vi.doMock('node:os', mockOs);
+  vi.doMock('os', mockOs);
+  return await import('./dev.js');
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'openswarm-home-'));
+  mkdirSync(join(home, 'dev', 'RealRepo'), { recursive: true });
+  mkdirSync(join(home, 'dev', 'nested', 'inner'), { recursive: true });
+  // Things that must stay unreachable through a repo name.
+  mkdirSync(join(home, '.ssh'), { recursive: true });
+  writeFileSync(join(home, '.ssh', 'id_rsa'), 'secret\n');
+  mkdirSync(join(home, 'elsewhere'), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  vi.doUnmock('node:os');
+  vi.doUnmock('os');
+  vi.restoreAllMocks();
+});
+
+describe('resolveRepoPath', () => {
+  it('resolves a repository inside ~/dev', async () => {
+    const { resolveRepoPath } = await loadDev();
+    expect(resolveRepoPath('RealRepo')).toBe(join(home, 'dev', 'RealRepo'));
+  });
+
+  it('resolves a nested path inside ~/dev', async () => {
+    const { resolveRepoPath } = await loadDev();
+    expect(resolveRepoPath('nested/inner')).toBe(join(home, 'dev', 'nested', 'inner'));
+  });
+
+  // The defect. Each of these existed and was returned, so the agent ran there.
+  it.each([
+    ['a parent escape', '../.ssh'],
+    ['the home directory', '..'],
+    ['a deeper escape', '../../'],
+    ['an escape after a real segment', 'RealRepo/../../.ssh'],
+    ['an escape to a sibling of dev', '../elsewhere'],
+  ])('refuses %s', async (_label, repo) => {
+    const { resolveRepoPath } = await loadDev();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(resolveRepoPath(repo)).toBeNull();
+  });
+
+  // A lexical check alone would pass this: the path string stays under ~/dev
+  // while the directory it names does not.
+  it('refuses a symlink inside ~/dev that points outside it', async () => {
+    symlinkSync(join(home, '.ssh'), join(home, 'dev', 'looks-normal'));
+    const { resolveRepoPath } = await loadDev();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(resolveRepoPath('looks-normal')).toBeNull();
+  });
+
+  it('says why it refused', async () => {
+    const { resolveRepoPath } = await loadDev();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    resolveRepoPath('../.ssh');
+
+    expect(String(warn.mock.calls[0]?.[0])).toMatch(/outside ~\/dev/);
+  });
+
+  it('returns null for a name that does not exist', async () => {
+    const { resolveRepoPath } = await loadDev();
+    expect(resolveRepoPath('NoSuchRepo')).toBeNull();
+  });
+
+  // An explicitly absolute path is a separate, deliberate branch — the
+  // containment rule is about a bare name being joined onto ~/dev.
+  it('still allows an explicit absolute path', async () => {
+    const { resolveRepoPath } = await loadDev();
+    expect(resolveRepoPath(join(home, 'elsewhere'))).toBe(join(home, 'elsewhere'));
+  });
+});


### PR DESCRIPTION
## Summary

**A Discord message could choose where an unsandboxed agent runs.**

The repo name in `!dev <repo> "<task>"` comes from a chat message. `resolveRepoPath` joined it onto `~/dev` with no filtering, and the result becomes the `cwd` of a `claude --permission-mode bypassPermissions` process.

Measured before fixing:

```
../.ssh     -> /Users/unohee/.ssh
..          -> /Users/unohee
a/../../..  -> /Users
```

Each of those exists, so the function returned it and the agent ran there.

## The fix

Containment is checked by **realpath**, not lexically: a symlink inside `~/dev` pointing outside it keeps a path string that looks contained, and a purely textual check would pass it. The test covers that case explicitly.

The explicit absolute-path branch (`~/...` or `/...`) is untouched — that is a deliberate choice by the operator, whereas this is a bare name being joined onto a fixed root.

## Verification

Restoring the unchecked join turns **7 of 11** tests red — every escape case plus the symlink one — while the 4 legitimate cases stay green:

```
× refuses the home directory
× refuses a deeper escape
× refuses an escape after a real segment
× refuses an escape to a sibling of dev
× refuses a symlink inside ~/dev that points outside it
× says why it refused
✓ resolves a repository inside ~/dev
✓ still allows an explicit absolute path
```

Tests run against a temp `HOME` containing a real `~/dev`, a real `.ssh`, and a real symlink, so the escape is exercised on the filesystem rather than asserted about string handling.

- Full suite: **256 files, 3410 passed, 1 skipped**
- `tsc --noEmit` clean, `oxlint` 0 warnings
- `openswarm review`: **APPROVE** — also confirmed all three existing callers already treat a `null` return as "not found", so refusing introduces no new path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive change to where bypass-permission agents run; behavior is narrow (relative names only) and covered by filesystem tests, but mis-containment could still block legit repos or leave an edge case open.
> 
> **Overview**
> **Closes a path-traversal hole** where a Discord-supplied repo name in `!dev` could set the working directory for an unsandboxed Claude agent outside `~/dev` (e.g. `../.ssh` → `~/.ssh`).
> 
> For the relative-name branch only, `resolveRepoPath` now resolves the candidate path and **`realpath`**-compares it against the real `~/dev` root (so symlinks under `~/dev` that point outside are rejected). Escapes log a warning and return `null`, which existing callers already treat as “repo not found.” **Explicit `~/` or `/` paths are unchanged.**
> 
> Adds **`repoPathContainment.test.ts`** with a temp `HOME` tree covering traversal variants, symlink escape, nested valid paths, and the absolute-path branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2513b6286b4f8cba903b0c00e2f96e6d6f2b4a09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->