### PR TITLE
fix(review --max --fix): stream the fix baseline patch instead of buffering it

### DIFF
--- a/src/agents/workerFanout.test.ts
+++ b/src/agents/workerFanout.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { WorkerOptions } from './worker.js';
@@ -39,10 +39,83 @@ describe('captureBaselinePatch', () => {
       await writeFile(path.join(repo, 'README.md'), 'base\ndirty\n', 'utf8');
 
       const { captureBaselinePatch } = await import('./workerFanout.js');
-      const patch = await captureBaselinePatch(repo);
+      const dest = path.join(repo, '..', `baseline-${path.basename(repo)}.patch`);
+      const baseline = await captureBaselinePatch(repo, dest);
+      const patch = await readFile(baseline.path, 'utf8');
 
       expect(patch).toContain('README.md');
       expect(patch).not.toContain('node_modules');
+      await rm(dest, { force: true });
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('reports a clean worktree as no patch at all', async () => {
+    const repo = await mkdtemp(path.join(tmpdir(), 'osw-fanout-clean-'));
+    try {
+      await writeFile(path.join(repo, 'README.md'), 'base\n', 'utf8');
+      initRepo(repo);
+
+      const { captureBaselinePatch } = await import('./workerFanout.js');
+      const dest = path.join(repo, '..', `baseline-clean-${path.basename(repo)}.patch`);
+      const baseline = await captureBaselinePatch(repo, dest);
+
+      expect(baseline.path).toBe('');
+      expect(existsSync(dest)).toBe(false);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('streams a patch far larger than the exec stdout buffer instead of failing', async () => {
+    // Production failure (enzyme, `review --max --fix`): a dirty tree carrying
+    // ~271MB of uncommitted files made `git diff --cached --binary` overflow the
+    // 20MB execFile buffer, and "stdout maxBuffer length exceeded" killed the
+    // whole audit after every reviewer had already run. (INT-3098)
+    const repo = await mkdtemp(path.join(tmpdir(), 'osw-fanout-huge-'));
+    try {
+      await writeFile(path.join(repo, 'big.txt'), 'seed\n', 'utf8');
+      initRepo(repo);
+      // Tracked (so the size limit for untracked artifacts does not apply) and
+      // well past the old 20MB ceiling.
+      await writeFile(path.join(repo, 'big.txt'), `${'x'.repeat(1024)}\n`.repeat(25 * 1024), 'utf8');
+
+      const { captureBaselinePatch } = await import('./workerFanout.js');
+      const dest = path.join(repo, '..', `baseline-huge-${path.basename(repo)}.patch`);
+      const baseline = await captureBaselinePatch(repo, dest);
+
+      expect(baseline.path).toBe(dest);
+      expect((await stat(dest)).size).toBeGreaterThan(24 * 1024 * 1024);
+      await rm(dest, { force: true });
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  it('leaves oversized untracked artifacts out of the baseline but keeps source edits', async () => {
+    const repo = await mkdtemp(path.join(tmpdir(), 'osw-fanout-artifact-'));
+    try {
+      await writeFile(path.join(repo, 'src.ts'), 'export const a = 1;\n', 'utf8');
+      initRepo(repo);
+      await writeFile(path.join(repo, 'src.ts'), 'export const a = 2;\n', 'utf8');
+      await writeFile(path.join(repo, 'new-source.ts'), 'export const b = 3;\n', 'utf8');
+      await mkdir(path.join(repo, 'trash'), { recursive: true });
+      await writeFile(path.join(repo, 'trash', 'bundle.bin'), 'z'.repeat(3 * 1024 * 1024), 'utf8');
+
+      const { captureBaselinePatch } = await import('./workerFanout.js');
+      const dest = path.join(repo, '..', `baseline-artifact-${path.basename(repo)}.patch`);
+      const baseline = await captureBaselinePatch(repo, dest);
+      const patch = await readFile(baseline.path, 'utf8');
+
+      // git reports repository-relative paths with forward slashes on every platform.
+      expect(baseline.skippedUntracked).toEqual(['trash/bundle.bin']);
+      expect(patch).toContain('src.ts');
+      expect(patch).toContain('new-source.ts');
+      expect(patch).not.toContain('bundle.bin');
+      // The project keeps the file — only the temporary index dropped it.
+      expect(existsSync(path.join(repo, 'trash', 'bundle.bin'))).toBe(true);
+      await rm(dest, { force: true });
     } finally {
       await rm(repo, { recursive: true, force: true });
     }

--- a/src/agents/workerFanout.ts
+++ b/src/agents/workerFanout.ts
@@ -5,12 +5,13 @@
 // Runs candidate workers in isolated temporary git clones and promotes only the
 // selected winner's diff back into the real project path.
 
-import { execFile } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync } from 'node:fs';
-import { chmod, copyFile, cp, lstat, mkdir, mkdtemp, readlink, rm, symlink, writeFile } from 'node:fs/promises';
+import { createWriteStream, existsSync } from 'node:fs';
+import { chmod, copyFile, cp, lstat, mkdir, mkdtemp, readlink, rm, stat, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { pipeline as streamPipeline } from 'node:stream/promises';
 import { promisify } from 'node:util';
 import type { WorkerFanoutCandidateConfig, PipelineGuardsConfig } from '../core/types.js';
 import { runPool } from '../support/concurrencyPool.js';
@@ -85,13 +86,95 @@ async function git(cwd: string, args: string[], opts?: { env?: NodeJS.ProcessEnv
   return String(stdout);
 }
 
+/**
+ * Untracked files above this size are artifacts (build output, media, vendored
+ * bundles, trashed copies), not in-flight source edits. Seeding them copies the
+ * same bytes into every sandbox for no fix value, so they stay out of the
+ * baseline. Tracked modifications are always seeded, whatever their size.
+ */
+export const BASELINE_UNTRACKED_FILE_LIMIT_BYTES = 2 * 1024 * 1024;
+
+/** Where the captured baseline lives, plus what it deliberately left out. */
+export interface BaselinePatch {
+  /** Patch file path, or '' when there is nothing uncommitted to seed. */
+  path: string;
+  /** Untracked files excluded by BASELINE_UNTRACKED_FILE_LIMIT_BYTES. */
+  skippedUntracked: string[];
+}
+
+/** A baseline that seeds nothing — clean worktree, or capture failed. */
+export function emptyBaselinePatch(): BaselinePatch {
+  return { path: '', skippedUntracked: [] };
+}
+
+/**
+ * Run git with stdout streamed straight to a file. `git diff --binary` over a
+ * dirty tree carrying large untracked artifacts reaches hundreds of MB; buffering
+ * that through execFile dies with "stdout maxBuffer length exceeded" and takes
+ * the whole fix/fan-out run down with it. (INT-3098)
+ */
+async function gitToFile(
+  cwd: string,
+  args: string[],
+  destPath: string,
+  opts?: { env?: NodeJS.ProcessEnv },
+): Promise<void> {
+  const child = spawn('git', args, {
+    cwd,
+    env: opts?.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: FANOUT_GIT_TIMEOUT_MS,
+  });
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk: string) => {
+    if (stderr.length < 8_192) stderr += chunk;
+  });
+  const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolveExit, rejectExit) => {
+    child.once('error', rejectExit);
+    child.once('close', (code, signal) => resolveExit({ code, signal }));
+  });
+  try {
+    await streamPipeline(child.stdout, createWriteStream(destPath));
+  } catch (error) {
+    child.kill('SIGKILL');
+    await exited.catch(() => undefined);
+    throw error;
+  }
+  const { code, signal } = await exited;
+  if (code !== 0) {
+    throw new Error(`git ${args.join(' ')} failed${signal ? ` (${signal})` : ''}: ${stderr.trim()}`.trim());
+  }
+}
+
+/**
+ * Unstage untracked additions that are too big to be worth seeding, and report
+ * them. They stay untouched on disk in the project — only the temporary index
+ * (and therefore the baseline patch) drops them.
+ */
+async function dropOversizedUntracked(projectPath: string, env: NodeJS.ProcessEnv): Promise<string[]> {
+  const added = await git(projectPath, ['diff', '--cached', '--name-only', '--diff-filter=A', '-z', 'HEAD'], { env })
+    .catch(() => '');
+  const oversized: string[] = [];
+  for (const rel of added.split('\0').filter(Boolean)) {
+    const info = await stat(resolve(projectPath, rel)).catch(() => null);
+    if (info?.isFile() && info.size > BASELINE_UNTRACKED_FILE_LIMIT_BYTES) oversized.push(rel);
+  }
+  // Chunked: a repository can hold thousands of these, and one argv has a limit.
+  for (let i = 0; i < oversized.length; i += 100) {
+    await git(projectPath, ['rm', '--cached', '--quiet', '-r', '--ignore-unmatch', '--', ...oversized.slice(i, i + 100)], { env });
+  }
+  return oversized;
+}
+
 // Capture ALL uncommitted work in the project (tracked edits, deletions, and
 // untracked new files) as a binary patch vs HEAD, WITHOUT mutating the project's
 // real index or worktree — everything is staged into a throwaway temporary index
-// selected via GIT_INDEX_FILE. Returns '' when the worktree is clean. This lets
-// fan-out run on a dirty tree (e.g. a self-repair retry that still holds the
-// previous iteration's edits) by seeding that state into each sandbox.
-export async function captureBaselinePatch(projectPath: string): Promise<string> {
+// selected via GIT_INDEX_FILE. The patch is written to `destPath`; a clean
+// worktree yields no file and `{ path: '' }`. This lets fan-out run on a dirty
+// tree (e.g. a self-repair retry that still holds the previous iteration's
+// edits) by seeding that state into each sandbox.
+export async function captureBaselinePatch(projectPath: string, destPath: string): Promise<BaselinePatch> {
   const idxDir = await mkdtemp(join(tmpdir(), 'openswarm-fanout-idx-'));
   const env = { ...process.env, GIT_INDEX_FILE: join(idxDir, 'index') };
   try {
@@ -118,7 +201,14 @@ export async function captureBaselinePatch(projectPath: string): Promise<string>
       // symlink/directory while treating the normal absent case as a no-op.
       await git(projectPath, ['rm', '--cached', '--quiet', '-r', '--ignore-unmatch', '--', ...injectedUntracked], { env });
     }
-    return await git(projectPath, ['diff', '--cached', '--binary', 'HEAD'], { env });
+    const skippedUntracked = await dropOversizedUntracked(projectPath, env);
+    await gitToFile(projectPath, ['diff', '--cached', '--binary', 'HEAD'], destPath, { env });
+    const written = await stat(destPath).catch(() => null);
+    if (!written || written.size === 0) {
+      await rm(destPath, { force: true });
+      return { path: '', skippedUntracked };
+    }
+    return { path: destPath, skippedUntracked };
   } finally {
     await rm(idxDir, { recursive: true, force: true });
   }
@@ -598,12 +688,12 @@ function scoreCandidate(input: {
 // sandbox and commit it, so the candidate continues from the dirty base and the
 // winner's promoted diff is the incremental delta (not base+delta, which would
 // double-apply onto the already-dirty project).
-export async function seedBaseline(sandbox: string, root: string, id: string, baseline: string): Promise<void> {
-  if (!baseline.trim()) return;
-  const patchPath = join(root, `${id}-base.patch`);
-  await writeFile(patchPath, baseline, 'utf8');
-  await git(sandbox, ['apply', '--whitespace=nowarn', patchPath]);
-  await rm(patchPath, { force: true });
+// The patch file is shared read-only by every sandbox in the batch (each used to
+// rewrite its own copy, which meant holding the whole patch in memory per worker);
+// the batch owner deletes it with the sandbox root.
+export async function seedBaseline(sandbox: string, baseline: BaselinePatch): Promise<void> {
+  if (!baseline.path) return;
+  await git(sandbox, ['apply', '--whitespace=nowarn', baseline.path]);
   await git(sandbox, ['add', '-A']);
   await git(sandbox, [
     '-c', 'user.email=fanout@openswarm.local',
@@ -617,7 +707,7 @@ async function runCandidate(
   candidate: WorkerFanoutCandidateConfig,
   index: number,
   root: string,
-  baseline: string,
+  baseline: BaselinePatch,
   sharedPathSnapshot?: SharedPathSnapshot,
 ): Promise<WorkerFanoutCandidateRun> {
   const id = safeCandidateId(candidate.id, index);
@@ -633,7 +723,7 @@ async function runCandidate(
       sharedPathModeFor(options.linkSharedPaths),
       sharedPathSnapshot,
     ));
-    await seedBaseline(sandbox, root, id, baseline);
+    await seedBaseline(sandbox, baseline);
     const result = await runWorker({
       ...options.baseWorkerOptions,
       projectPath: sandbox,
@@ -694,14 +784,21 @@ export async function runWorkerFanout(options: RunWorkerFanoutOptions): Promise<
     return { candidates: [], fallbackReason: 'fan-out needs at least two candidates' };
   }
 
-  // A dirty worktree is expected on self-repair retries (the gate scores fan-out
-  // mainly on retry signals). Rather than bail, snapshot the uncommitted state
-  // and seed it into each sandbox so candidates continue from it and only the
-  // incremental winner diff is promoted back. Falls back to '' (clean) on error.
-  const baseline = await captureBaselinePatch(options.projectPath).catch(() => '');
-
   const root = await mkdtemp(join(tmpdir(), 'openswarm-worker-fanout-'));
   try {
+    // A dirty worktree is expected on self-repair retries (the gate scores fan-out
+    // mainly on retry signals). Rather than bail, snapshot the uncommitted state
+    // and seed it into each sandbox so candidates continue from it and only the
+    // incremental winner diff is promoted back. Falls back to clean on error.
+    const baseline = await captureBaselinePatch(options.projectPath, join(root, 'baseline.patch'))
+      .catch(() => emptyBaselinePatch());
+    if (baseline.skippedUntracked.length > 0) {
+      options.onLog?.(
+        `[fanout] baseline skipped ${baseline.skippedUntracked.length} untracked file(s) over ` +
+          `${Math.round(BASELINE_UNTRACKED_FILE_LIMIT_BYTES / (1024 * 1024))}MB: ${baseline.skippedUntracked.slice(0, 3).join(', ')}` +
+          `${baseline.skippedUntracked.length > 3 ? ', …' : ''}`,
+      );
+    }
     let sharedPathSnapshot: SharedPathSnapshot | undefined;
     if (sharedPathModeFor(options.linkSharedPaths) === 'copy') {
       try {
@@ -716,7 +813,7 @@ export async function runWorkerFanout(options: RunWorkerFanoutOptions): Promise<
         };
       }
     }
-    options.onLog?.(`[fanout] launching ${options.candidates.length} candidate worker(s)${baseline.trim() ? ' (seeded from dirty worktree)' : ''}`);
+    options.onLog?.(`[fanout] launching ${options.candidates.length} candidate worker(s)${baseline.path ? ' (seeded from dirty worktree)' : ''}`);
     const settled = await runPool(
       options.candidates,
       options.concurrency,

--- a/src/cli/fixSandbox.ts
+++ b/src/cli/fixSandbox.ts
@@ -6,6 +6,7 @@ import { mkdtemp, readdir, rm, rmdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 import {
+  BASELINE_UNTRACKED_FILE_LIMIT_BYTES,
   captureBaselinePatch,
   cloneSandbox,
   createSharedPathSnapshot,
@@ -63,15 +64,29 @@ export async function runIsolatedFixBatch<T extends IsolatedFixItem>(options: {
   signal?: AbortSignal;
   run: (item: T, sandbox: string, onLog: (line: string) => void) => Promise<{ success: boolean; error?: string }>;
   onLog?: (item: T, line: string) => void;
+  /** Batch-level notices (not tied to one unit), e.g. what the baseline left out. */
+  onNotice?: (line: string) => void;
 }): Promise<Array<IsolatedFixResult<T>>> {
   if (options.items.length === 0) return [];
   options.signal?.throwIfAborted();
-  // Every sandbox starts from the exact same dirty candidate state. A failed
-  // snapshot must abort rather than silently run against stale HEAD.
-  const baseline = await captureBaselinePatch(options.projectPath);
   const root = await mkdtemp(join(tmpdir(), 'openswarm-fix-units-'));
   const knownEntries = new Set<string>();
   try {
+    // Every sandbox starts from the exact same dirty candidate state. A failed
+    // snapshot must abort rather than silently run against stale HEAD. The patch
+    // is streamed to disk and shared by all sandboxes — a dirty tree carrying
+    // large artifacts used to blow the exec stdout buffer here. (INT-3098)
+    const baselineEntry = 'baseline.patch';
+    knownEntries.add(baselineEntry);
+    const baseline = await captureBaselinePatch(options.projectPath, join(root, baselineEntry));
+    if (baseline.skippedUntracked.length > 0) {
+      const limitMb = Math.round(BASELINE_UNTRACKED_FILE_LIMIT_BYTES / (1024 * 1024));
+      options.onNotice?.(
+        `Baseline left out ${baseline.skippedUntracked.length} untracked file(s) over ${limitMb}MB ` +
+          `(artifacts, not source): ${baseline.skippedUntracked.slice(0, 3).join(', ')}` +
+          `${baseline.skippedUntracked.length > 3 ? ', …' : ''}`,
+      );
+    }
     // Build one sanitized dependency/data snapshot for the whole batch. Each
     // worker still receives an independent filesystem clone, but large trees
     // are scanned for external symlinks only once instead of once per worker.
@@ -88,7 +103,6 @@ export async function runIsolatedFixBatch<T extends IsolatedFixItem>(options: {
       async (item, index): Promise<SandboxRun<T>> => {
         const id = `${String(index + 1).padStart(3, '0')}-${safeId(item.label, index)}`;
         knownEntries.add(id);
-        knownEntries.add(`${id}-base.patch`);
         let sandbox = '';
         let linkedSharedPaths: string[] = [];
         try {
@@ -103,7 +117,7 @@ export async function runIsolatedFixBatch<T extends IsolatedFixItem>(options: {
             'copy',
             sharedPathSnapshot,
           ));
-          await seedBaseline(sandbox, root, id, baseline);
+          await seedBaseline(sandbox, baseline);
           options.signal?.throwIfAborted();
           const worker = await options.run(item, sandbox, (line) => options.onLog?.(item, line));
           options.signal?.throwIfAborted();

--- a/src/cli/reviewAudit.ts
+++ b/src/cli/reviewAudit.ts
@@ -525,6 +525,8 @@ export interface FixAreaResult {
 export type FixProgress =
   | { type: 'start'; label: string; done: number; total: number }
   | { type: 'log'; label: string; line: string }
+  /** Batch-level note that belongs to no single area (e.g. baseline exclusions). */
+  | { type: 'notice'; line: string }
   | { type: 'done'; label: string; filesChanged: number; done: number; total: number }
   | { type: 'error'; label: string; error: string; done: number; total: number };
 
@@ -681,6 +683,7 @@ export async function runAreaFixes(
         : defaultFixUnit(unit, context, sandbox, opts, onLog);
     },
     onLog: (unit, line) => deps.onProgress?.({ type: 'log', label: unit.label, line }),
+    onNotice: (line) => deps.onProgress?.({ type: 'notice', line }),
   });
   return isolated.map((result) => {
     onResult(result.item, result);

--- a/src/cli/reviewMaxCommand.tsx
+++ b/src/cli/reviewMaxCommand.tsx
@@ -544,7 +544,7 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
   if (opts.fix) {
     const targets = fixTargets(run);
     if (!targets.length) console.log('\n--fix: no reviewer edits requested; running the deterministic publication gate.');
-    {
+    try {
       const maxRounds = opts.fixRounds === undefined
         ? undefined
         : positiveIntegerOption(opts.fixRounds, opts.fixRounds, '--fix-rounds');
@@ -603,6 +603,7 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
           onFixProgress: (e) => {
             if (e.type === 'done') console.log(`  ${status.ok(`${e.label} — ${e.filesChanged} file(s) changed`)}`);
             else if (e.type === 'error') console.log(`  ${status.err(`${e.label} — ${e.error}`)}`);
+            else if (e.type === 'notice') console.log(`  ${c.dim(e.line)}`);
           },
           onReviewProgress: (e) => {
             if (e.type === 'done') console.log(`  ${status.info(`re-review ${e.label} — ${e.decision}`)}`);
@@ -648,6 +649,13 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
             : 'Changes are in the working tree — review the diff before committing.',
         ),
       );
+    } catch (error) {
+      // Infrastructure failure in the fix phase (sandbox, git, adapter) must not
+      // throw away a completed audit. Fall through with the pre-fix verdicts so
+      // the report, review history and follow-ups below are still persisted;
+      // fixResult stays undefined, which keeps the publication gate closed.
+      console.warn(`\n${status.err(`--fix aborted: ${error instanceof Error ? error.message : String(error)}`)}`);
+      console.warn(status.warn('Review findings kept — nothing was fixed or published.'));
     }
   }
 

--- a/src/tui/components/AuditBoard.tsx
+++ b/src/tui/components/AuditBoard.tsx
@@ -37,6 +37,8 @@ export function AuditBoard({ areas, concurrency, events, mode = 'audit' }: Audit
 
   useEffect(() => {
     const onProgress = (e: AuditProgress | FixProgress) => {
+      // Batch-level notices belong to no area row — the CLI prints them instead.
+      if (!('label' in e)) return;
       setStatuses((prev) => {
         const cur = prev[e.label] ?? { status: 'pending' as const };
         let next: AreaStatus;


### PR DESCRIPTION
## Problem

`openswarm review --max --fix` dies immediately after the fix loop starts:

```
Round 1 — fixing 1 area(s)...
stdout maxBuffer length exceeded
```

`captureBaselinePatch` returns the whole `git diff --cached --binary HEAD` as a
string through `execFile`, whose buffer is capped at 20MB. On a dirty worktree
the patch is far bigger than that — measured on the reporting repository:
**271,583,806 bytes**, 98% of it untracked build/media artifacts (`trash/`
plugin bundles, `.png`, `.wav`).

Two things made the failure worse than it had to be:

- The baseline string was re-written to disk once per sandbox, so the same
  hundreds of MB were held and copied N times.
- Report writing, review-history persistence and Linear filing all happen
  *after* the fix loop (`reviewMaxCommand.tsx`), so this one exception threw
  away a completed 11-area audit.

## Fix

- **Stream, don't buffer.** `gitToFile` spawns git and pipes stdout straight to
  a file. `captureBaselinePatch(projectPath, destPath)` now returns
  `{ path, skippedUntracked }`, and `seedBaseline(sandbox, baseline)` applies
  that single file read-only from every sandbox.
- **Skip untracked artifacts.** Untracked files over 2MB stay out of the
  baseline (they are build output, not in-flight source edits) and the skipped
  set is surfaced through a new `notice` fix-progress event. Tracked
  modifications are still always seeded, whatever their size.
- **Keep the audit when the fix phase crashes.** The loop is wrapped so the
  report, review history and follow-ups are still persisted; `fixResult` stays
  unset, so the publication gate remains closed and the run still exits non-zero.

## Verification

- New tests: a patch larger than the old 20MB ceiling is captured successfully,
  a clean worktree yields no patch, oversized untracked artifacts are excluded
  while source edits survive.
- Real repository that reproduced the crash: 271MB → 27.4MB in 2.6s, 68
  artifacts skipped, no buffer failure.
- Full suite: 256 files / 3414 tests green; typecheck and lint clean.

INT-3098