### PR TITLE
feat(review): exit-code contract for CI — never exit 0 without a verdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,21 @@ openswarm annotate "funcName" --tag "needs-refactor"
 openswarm annotate "funcName" --warn "error/security: SQL injection"
 ```
 
+### `openswarm review` exit codes
+
+`review` is designed to work as a CI merge gate, and CI reads nothing but the
+exit code:
+
+| Exit | Meaning |
+|------|---------|
+| `0`  | The gate ran and did not reject (approve/revise), or there was nothing to review |
+| `1`  | The gate ran and the verdict is reject — with `--fix`, also when any area is left unresolved or deterministic verification did not pass |
+| `2`  | The gate did **not** run — no verdict was produced (provider usage limit, adapter failure, unparseable reviewer output). Never treat this as a pass |
+
+Treat any non-zero exit as a failed check. The `1`/`2` split lets a workflow
+retry or alert differently when the gate could not run at all (e.g. a quota
+window exhausted — stderr names the cause and, when known, the reset time).
+
 ### Deterministic verification
 
 Autonomous pipelines enable baseline-diff verification by default: OpenSwarm runs repository test/typecheck commands once, compares a failing head against the merge base, and gives the reviewer structured evidence so pre-existing failures do not block unrelated work. Add `.openswarm/verify.yaml` for repository-specific commands (see [`templates/verify.example.yaml`](templates/verify.example.yaml)), or let OpenSwarm discover standard Node, Python, Rust, and Go checks. Configure the behavior under `autonomous.verify`; the legacy `guards.qualityGate` whole-tree check is deprecated.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -339,15 +339,23 @@ program
           fixRounds: opts.fixRounds,
           learn: opts.learn,
         });
-        if (reviewMaxResultFailed(result, !!opts.fix)) process.exitCode = 1;
+        // Exit contract (INT-3100): 2 = the gate did not run at all (no area
+        // reviewed — quota/infra), 1 = it ran and failed. CI reads only this.
+        const { REVIEW_EXIT_GATE_NOT_RUN } = await import('./cli/reviewExit.js');
+        if (result && !result.gateRan) process.exitCode = REVIEW_EXIT_GATE_NOT_RUN;
+        else if (reviewMaxResultFailed(result, !!opts.fix)) process.exitCode = 1;
         return;
       }
       const { runReviewCommand } = await import('./cli/reviewCommand.js');
       const result = await runReviewCommand({ path: opts.path, base: opts.base, fileIssue: opts.issues ?? opts.file, adapter: opts.adapter, debug: opts.debug });
       if (result && result.decision === 'reject') process.exitCode = 1;
     } catch (e) {
-      console.error(e instanceof Error ? e.message : String(e));
-      process.exitCode = 1;
+      // A throw means no verdict was produced — the gate did NOT run. Exit 2,
+      // never 0/1, so CI can distinguish "couldn't review" from "reviewed and
+      // rejected" and neither reads as a pass. (INT-3100)
+      const { REVIEW_EXIT_GATE_NOT_RUN, describeReviewGateFailure } = await import('./cli/reviewExit.js');
+      console.error(describeReviewGateFailure(e));
+      process.exitCode = REVIEW_EXIT_GATE_NOT_RUN;
     }
   });
 

--- a/src/cli/reviewCommand.ts
+++ b/src/cli/reviewCommand.ts
@@ -327,59 +327,70 @@ export async function runReviewCommand(
   });
 
   const followups = result.recommendedActions?.length ?? 0;
-  if (opts.fileIssue && followups) {
-    // Resolve the parent issue: explicit id, else inferred from the git branch. (INT-1967)
-    let parent = typeof opts.fileIssue === 'string' ? opts.fileIssue : undefined;
-    if (!parent) {
-      const getBranch =
-        deps.getBranch ??
-        (async (c: string) => {
-          const { execFileSync } = await import('node:child_process');
-          return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
-            cwd: c,
-            stdio: ['ignore', 'pipe', 'ignore'],
-          })
-            .toString()
-            .trim();
-        });
-      const branch = await getBranch(cwd).catch(() => '');
-      parent = resolveIssueFromBranch(branch);
-      if (parent) log(`Filing follow-ups under ${parent} (inferred from branch "${branch}").`);
-    }
-    // No parent → create top-level (standalone) issues rather than refusing. (INT-1968)
-    // Before that, make sure this repo actually has a Linear project to land
-    // in — map it now (interactive) or bail rather than file an orphan. (INT-2599)
-    const mapping = await (deps.ensureProjectMapping ?? (async (c, p) => ensureProjectMapping(c, p, { log })))(cwd, parent);
-    if (mapping.abort) {
-      log('Skipped filing follow-ups — map this repo to a Linear project first (see above), then re-run.');
-    } else {
-      // Default path initializes a Linear task source itself (the daemon isn't
-      // running here), and files regardless of decision. (INT-1969)
-      const fileFollowups =
-        deps.fileFollowups ??
-        (async (p: string | undefined, r: ReviewResult) => {
-          const { fileReviewerFollowups } = await import('../automation/runnerExecution.js');
-          const source = await ensureTaskSource();
-          if (!source) return 0;
-          return fileReviewerFollowups(source, p, r, { autoFile: true, projectId: mapping.projectId, requireApprove: false });
-        });
-      const filed = await fileFollowups(parent, result);
-      if (filed > 0) {
-        log(
-          parent
-            ? `Filed ${filed} follow-up sub-issue(s) under ${parent}.`
-            : `Filed ${filed} standalone follow-up issue(s) (pass \`--issues <id>\` to nest them under an issue).`,
-        );
-      } else {
-        log(
-          `Could not file follow-ups (0 created). Is Linear connected? Run \`openswarm auth login --provider linear\` (or set linearApiKey in config).`,
-        );
-      }
-    }
-  } else if (followups) {
-    // Suggestions were made but nothing was filed — make the flag discoverable. (INT-1966/1967)
-    log(`\n${followups} follow-up(s) suggested. Re-run with \`--issues\` to create them as Linear sub-issues (parent inferred from the branch, or pass \`--issues <id>\`).`);
+  // Post-verdict side-effects must not change the exit code: a verdict exists,
+  // so a Linear/network failure here is a warning, not gate-not-run. A rethrow
+  // would turn a completed (even rejecting) review into exit 2. (INT-3100)
+  try {
+    await fileFollowupsBestEffort();
+  } catch (error) {
+    log(`Could not file follow-ups: ${error instanceof Error ? error.message : String(error)}`);
   }
 
   return result;
+
+  async function fileFollowupsBestEffort(): Promise<void> {
+    if (opts.fileIssue && followups) {
+      // Resolve the parent issue: explicit id, else inferred from the git branch. (INT-1967)
+      let parent = typeof opts.fileIssue === 'string' ? opts.fileIssue : undefined;
+      if (!parent) {
+        const getBranch =
+          deps.getBranch ??
+          (async (c: string) => {
+            const { execFileSync } = await import('node:child_process');
+            return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+              cwd: c,
+              stdio: ['ignore', 'pipe', 'ignore'],
+            })
+              .toString()
+              .trim();
+          });
+        const branch = await getBranch(cwd).catch(() => '');
+        parent = resolveIssueFromBranch(branch);
+        if (parent) log(`Filing follow-ups under ${parent} (inferred from branch "${branch}").`);
+      }
+      // No parent → create top-level (standalone) issues rather than refusing. (INT-1968)
+      // Before that, make sure this repo actually has a Linear project to land
+      // in — map it now (interactive) or bail rather than file an orphan. (INT-2599)
+      const mapping = await (deps.ensureProjectMapping ?? (async (c, p) => ensureProjectMapping(c, p, { log })))(cwd, parent);
+      if (mapping.abort) {
+        log('Skipped filing follow-ups — map this repo to a Linear project first (see above), then re-run.');
+      } else {
+        // Default path initializes a Linear task source itself (the daemon isn't
+        // running here), and files regardless of decision. (INT-1969)
+        const fileFollowups =
+          deps.fileFollowups ??
+          (async (p: string | undefined, r: ReviewResult) => {
+            const { fileReviewerFollowups } = await import('../automation/runnerExecution.js');
+            const source = await ensureTaskSource();
+            if (!source) return 0;
+            return fileReviewerFollowups(source, p, r, { autoFile: true, projectId: mapping.projectId, requireApprove: false });
+          });
+        const filed = await fileFollowups(parent, result);
+        if (filed > 0) {
+          log(
+            parent
+              ? `Filed ${filed} follow-up sub-issue(s) under ${parent}.`
+              : `Filed ${filed} standalone follow-up issue(s) (pass \`--issues <id>\` to nest them under an issue).`,
+          );
+        } else {
+          log(
+            `Could not file follow-ups (0 created). Is Linear connected? Run \`openswarm auth login --provider linear\` (or set linearApiKey in config).`,
+          );
+        }
+      }
+    } else if (followups) {
+      // Suggestions were made but nothing was filed — make the flag discoverable. (INT-1966/1967)
+      log(`\n${followups} follow-up(s) suggested. Re-run with \`--issues\` to create them as Linear sub-issues (parent inferred from the branch, or pass \`--issues <id>\`).`);
+    }
+  }
 }

--- a/src/cli/reviewExit.test.ts
+++ b/src/cli/reviewExit.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { RateLimitError } from '../adapters/rateLimitError.js';
+import {
+  REVIEW_EXIT_GATE_NOT_RUN,
+  REVIEW_EXIT_OK,
+  REVIEW_EXIT_REJECT,
+  describeReviewGateFailure,
+} from './reviewExit.js';
+import { runReviewCommand } from './reviewCommand.js';
+
+describe('review exit-code contract (INT-3100)', () => {
+  it('keeps the three outcomes distinct', () => {
+    // CI reads only the exit code; 0 must be unreachable without a verdict.
+    expect(REVIEW_EXIT_OK).toBe(0);
+    expect(REVIEW_EXIT_REJECT).toBe(1);
+    expect(REVIEW_EXIT_GATE_NOT_RUN).toBe(2);
+    expect(new Set([REVIEW_EXIT_OK, REVIEW_EXIT_REJECT, REVIEW_EXIT_GATE_NOT_RUN]).size).toBe(3);
+  });
+
+  it('names the usage limit and its reset time in the gate-not-run message', () => {
+    const resetsAt = 1_800_000_000; // fixed timestamp; format is locale-dependent, presence is not
+    const message = describeReviewGateFailure(
+      new RateLimitError(resetsAt, 'Codex 100% used of 10080min window', 100, 10080),
+    );
+    expect(message).toContain('did NOT run');
+    expect(message).toContain('usage limit');
+    expect(message).toContain('Codex 100% used of 10080min window');
+    expect(message).toContain('Retry after');
+  });
+
+  it('reports a usage limit without a reset time without inventing one', () => {
+    const message = describeReviewGateFailure(new RateLimitError(undefined, 'claude: usage limit reached'));
+    expect(message).toContain('usage limit');
+    expect(message).not.toContain('Retry after');
+  });
+
+  it('describes a non-quota infrastructure failure plainly', () => {
+    const message = describeReviewGateFailure(new Error('claude cli failed: spawn ENOENT'));
+    expect(message).toContain('did NOT run');
+    expect(message).toContain('spawn ENOENT');
+  });
+});
+
+describe('--max gate-not-run detection (INT-3100)', () => {
+  it('a run where every area errored counts zero completed areas', async () => {
+    // runReviewMaxCommand derives gateRan from summary.completed > 0; the CLI
+    // maps gateRan=false to exit 2. Lock the aggregation invariant that feeds it.
+    const { aggregateAuditResults } = await import('./reviewAudit.js');
+    const summary = aggregateAuditResults([
+      { area: { label: 'src (1/2)', dir: 'src', files: ['src/a.ts'] }, error: 'skipped: codex usage limit already hit this run' },
+      { area: { label: 'src (2/2)', dir: 'src', files: ['src/b.ts'] }, error: 'usage limit reached' },
+    ]);
+    expect(summary.completed).toBe(0);
+    expect(summary.decision).toBe('reject'); // still fails closed even if a caller ignores gateRan
+  });
+
+  it('one real verdict among errors keeps the gate as ran', async () => {
+    const { aggregateAuditResults } = await import('./reviewAudit.js');
+    const summary = aggregateAuditResults([
+      { area: { label: 'src (1/2)', dir: 'src', files: ['src/a.ts'] }, review: { decision: 'approve', feedback: 'ok' } },
+      { area: { label: 'src (2/2)', dir: 'src', files: ['src/b.ts'] }, error: 'usage limit reached' },
+    ]);
+    expect(summary.completed).toBe(1);
+  });
+});
+
+describe('runReviewCommand post-verdict side-effects (INT-3100)', () => {
+  it('returns the verdict even when follow-up filing throws', async () => {
+    // A verdict exists — a Linear/network failure while filing must stay a
+    // warning, not become gate-not-run (exit 2) or mask a reject (exit 1).
+    const lines: string[] = [];
+    const result = await runReviewCommand(
+      { path: '/tmp', fileIssue: 'INT-1' },
+      {
+        getChangedFiles: async () => ['src/a.ts'],
+        review: async () => ({ decision: 'reject', feedback: 'bad', recommendedActions: [{ type: 'fix', title: 't' }] }),
+        ensureProjectMapping: async () => ({ projectId: undefined, abort: false }),
+        fileFollowups: async () => {
+          throw new Error('Linear API unreachable');
+        },
+        startProgress: () => null,
+        log: (l) => lines.push(l),
+      },
+    );
+    expect(result?.decision).toBe('reject');
+    expect(lines.join('\n')).toContain('Could not file follow-ups: Linear API unreachable');
+  });
+});
+
+describe('runReviewCommand propagates a quota abort (INT-3100)', () => {
+  it('rethrows RateLimitError instead of swallowing it into a fake verdict', async () => {
+    // The CLI catch converts a propagated throw into exit 2 (gate-not-run).
+    // If this were swallowed, a quota-exhausted run would print nothing and
+    // exit 0 — the silent pass this contract exists to prevent.
+    await expect(
+      runReviewCommand(
+        { path: '/tmp' },
+        {
+          getChangedFiles: async () => ['src/a.ts'],
+          review: async () => {
+            throw new RateLimitError(undefined, 'Codex 100% used of 10080min window');
+          },
+          startProgress: () => null,
+          log: () => {},
+        },
+      ),
+    ).rejects.toBeInstanceOf(RateLimitError);
+  });
+});

--- a/src/cli/reviewExit.ts
+++ b/src/cli/reviewExit.ts
@@ -1,0 +1,39 @@
+// ============================================
+// OpenSwarm - `openswarm review` exit-code contract (INT-3100)
+// ============================================
+//
+// `review` is used as a CI merge gate, and CI reads nothing but the exit code.
+// The dangerous failure mode is a quota-exhausted or infra-broken run that
+// reviews nothing and still exits 0 — a silent pass. The contract below makes
+// "the gate did not run" its own outcome, distinct from "the gate ran and
+// rejected":
+//
+//   0  the gate ran and did not reject (approve/revise), or there was nothing
+//      to review
+//   1  the gate ran and the verdict is reject (or --fix left areas
+//      unresolved/unverified)
+//   2  the gate did NOT run — no verdict was produced (usage limit, adapter
+//      infra failure, unparseable reviewer output, bad invocation)
+//
+// CI must treat any non-zero as a failed check; the 1/2 split exists so a
+// workflow can retry or alert differently on "gate didn't run".
+
+import { RateLimitError } from '../adapters/rateLimitError.js';
+
+export const REVIEW_EXIT_OK = 0;
+export const REVIEW_EXIT_REJECT = 1;
+export const REVIEW_EXIT_GATE_NOT_RUN = 2;
+
+/**
+ * Describe a thrown review-command error for stderr. Every throw means no
+ * verdict was produced, so the caller pairs this with REVIEW_EXIT_GATE_NOT_RUN;
+ * a usage-limit error additionally carries its reset time.
+ */
+export function describeReviewGateFailure(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (error instanceof RateLimitError) {
+    const resetsAt = error.resetsAt ? ` Retry after ${new Date(error.resetsAt * 1000).toLocaleString()}.` : '';
+    return `Review gate did NOT run — usage limit: ${message}.${resetsAt}`;
+  }
+  return `Review gate did NOT run: ${message}`;
+}

--- a/src/cli/reviewMaxCommand.test.ts
+++ b/src/cli/reviewMaxCommand.test.ts
@@ -100,14 +100,14 @@ describe('loadVerifyConfigBestEffort (INT-2762)', () => {
 
 describe('reviewMaxResultFailed', () => {
   it('fails closed when --fix leaves a revise verdict unresolved', () => {
-    expect(reviewMaxResultFailed({ decision: 'revise', resolved: false }, true)).toBe(true);
-    expect(reviewMaxResultFailed({ decision: 'approve', resolved: true, verified: false }, true)).toBe(true);
-    expect(reviewMaxResultFailed({ decision: 'approve', resolved: true, verified: true }, true)).toBe(false);
+    expect(reviewMaxResultFailed({ decision: 'revise', gateRan: true, resolved: false }, true)).toBe(true);
+    expect(reviewMaxResultFailed({ decision: 'approve', gateRan: true, resolved: true, verified: false }, true)).toBe(true);
+    expect(reviewMaxResultFailed({ decision: 'approve', gateRan: true, resolved: true, verified: true }, true)).toBe(false);
   });
 
   it('preserves report-only review semantics without --fix', () => {
-    expect(reviewMaxResultFailed({ decision: 'revise' }, false)).toBe(false);
-    expect(reviewMaxResultFailed({ decision: 'reject' }, false)).toBe(true);
+    expect(reviewMaxResultFailed({ decision: 'revise', gateRan: true }, false)).toBe(false);
+    expect(reviewMaxResultFailed({ decision: 'reject', gateRan: true }, false)).toBe(true);
   });
 });
 

--- a/src/cli/reviewMaxCommand.tsx
+++ b/src/cli/reviewMaxCommand.tsx
@@ -105,6 +105,12 @@ export interface ReviewMaxOptions {
 
 export interface ReviewMaxCommandResult {
   decision: string;
+  /**
+   * True when at least one area produced a real reviewer verdict. False means
+   * the gate did not run at all (quota exhausted, adapter down) — the caller
+   * must exit gate-not-run, never pass. (INT-3100)
+   */
+  gateRan: boolean;
   /** For --fix, true only when every area has a fresh approve verdict. */
   resolved?: boolean;
   /** For --fix, true only when trusted deterministic verification passed. */
@@ -371,9 +377,11 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
   let files: string[];
   try {
     files = listSourceFiles(cwd);
-  } catch {
-    console.error(`Not a git repository (or git unavailable): ${cwd}`);
-    return null;
+  } catch (cause) {
+    // Not a "nothing to audit" no-op: in CI this is a wrong path or a missing
+    // checkout step, and returning null would exit 0 — a silent pass. Throw so
+    // the CLI reports gate-not-run (exit 2). (INT-3100)
+    throw new Error(`Not a git repository (or git unavailable): ${cwd}`, { cause });
   }
   if (!files.length) {
     console.log('No production source files to audit.');
@@ -693,12 +701,18 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
   //     `--issues-per-area` keeps the legacy per-area fan-out; `--no-linear`
   //     skips Linear entirely (report only). (INT-2022 / INT-2225)
   let parent: AuditIssueParent = {};
-  if (opts.issuesPerArea) {
-    await filePerAreaFollowups(cwd, opts.issuesPerArea, run);
-  } else if (!opts.noLinear && run.summary.recommendedActions.length) {
-    parent = await filePmSynthesizedIssues(cwd, opts, run.summary, report, ts);
-  } else if (run.summary.recommendedActions.length) {
-    console.log(`\n${run.summary.recommendedActions.length} follow-up(s) — captured in the report (--no-linear).`);
+  // Post-verdict side-effect: a Linear/network failure here must not change the
+  // exit code — the verdict exists, so this is a warning, not gate-not-run. (INT-3100)
+  try {
+    if (opts.issuesPerArea) {
+      await filePerAreaFollowups(cwd, opts.issuesPerArea, run);
+    } else if (!opts.noLinear && run.summary.recommendedActions.length) {
+      parent = await filePmSynthesizedIssues(cwd, opts, run.summary, report, ts);
+    } else if (run.summary.recommendedActions.length) {
+      console.log(`\n${run.summary.recommendedActions.length} follow-up(s) — captured in the report (--no-linear).`);
+    }
+  } catch (error) {
+    console.warn(`Could not file follow-ups (report saved to file): ${error instanceof Error ? error.message : String(error)}`);
   }
 
   // (4.5) Ship the isolated worktree: commit → push → PR, linked to the audit
@@ -727,6 +741,7 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
 
   return {
     decision: run.summary.decision,
+    gateRan: run.summary.completed > 0,
     resolved: opts.fix ? fixResolved ?? run.results.every((result) => result.review?.decision === 'approve') : undefined,
     verified: opts.fix ? fixVerified ?? fixVerificationStatus === 'passed' : undefined,
   };


### PR DESCRIPTION
## Problem

`openswarm review` is designed to work as a CI merge gate, and CI reads nothing but the exit code. Two silent-pass holes:

- A quota-exhausted run (measured 2026-07-23: `Codex 100% used of 10080min window`) could produce **no verdict** and still not be distinguishable from "reviewed and clean".
- `review --max` on a non-git / wrong path printed an error and exited **0** — in CI that is a mis-checked-out workspace reading as a pass.

## Contract

| Exit | Meaning |
|------|---------|
| 0 | Gate ran, verdict approve/revise (or nothing to review) |
| 1 | Gate ran, verdict reject (`--fix`: also unresolved/unverified) |
| 2 | Gate did **not** run — no verdict produced (usage limit, adapter failure, non-git path) |

- All review-path throws now exit 2 with a `Review gate did NOT run: …` stderr line; a `RateLimitError` includes its quota reset time.
- `--max` returns `gateRan` (≥1 area produced a real verdict). All-areas-errored → exit 2 instead of blending into reject. Partial runs keep the existing fail-closed reject.
- Post-verdict side-effects (Linear follow-up filing on both paths) are isolated so a network failure after a verdict cannot reclassify a completed review as gate-not-run — found by the self-review gate during this change.
- README documents the contract.

## Verification

- Built CLI, real runs: adapter 429 → `exit=2` + reset message; non-git `--max` path → `exit=2`; this branch's own review gate (APPROVE) → `exit=0`.
- New tests: contract constants, quota message formatting, RateLimitError propagation out of `runReviewCommand`, all-errored aggregation (`completed=0` + decision still reject), verdict surviving a filing failure.
- Full suite 257 files / 3422 green; typecheck/lint clean; `openswarm review` gate: APPROVE.

INT-3100 (epic INT-3099)