### PR TITLE
fix(review): refuse a verdict the reviewer never substantiated

### DIFF
--- a/src/adapters/resultParsing.test.ts
+++ b/src/adapters/resultParsing.test.ts
@@ -72,3 +72,50 @@ describe('parseReviewerResult recommendedActions (INT-1954)', () => {
     ).toBeUndefined();
   });
 });
+
+describe('parseReviewerResult rejects unsubstantiated verdicts (INT-3182)', () => {
+  it('throws when the body is only a provider control token', () => {
+    // Measured: on a 35-file diff, deepseek-v4-pro read everything across 22 API
+    // calls and then emitted this as its entire final message. It is non-empty, so
+    // it cleared the empty-output guard and became REVISE with zero findings.
+    expect(() => parseReviewerResult('<｜｜DSML｜｜tool_calls>')).toThrow(/control tokens/);
+  });
+
+  it('throws for other providers\' sentinels too', () => {
+    expect(() => parseReviewerResult('<|im_start|>')).toThrow(/control tokens/);
+    expect(() => parseReviewerResult('  <|eot_id|>\n<|im_end|>  ')).toThrow(/control tokens/);
+  });
+
+  it('throws when a non-approving verdict carries no findings at all', () => {
+    // "Decision: revise" and nothing else sends the worker round the loop with
+    // no guidance — that is a failed review, not a verdict.
+    expect(() => parseReviewerResult('Decision: revise')).toThrow(/no findings/);
+    expect(() => parseReviewerResult('Decision: reject')).toThrow(/no findings/);
+  });
+
+  it('keeps a verdict that actually says something', () => {
+    const r = parseReviewerResult(
+      'Decision: revise\nThe session fixture depends on CSRF validation, which this diff removes.',
+    );
+    expect(r.decision).toBe('revise');
+  });
+
+  it('still allows approve with no findings — that is its correct shape', () => {
+    const r = parseReviewerResult('Decision: approve');
+    expect(r.decision).toBe('approve');
+  });
+
+  it('does not trip on review prose that merely mentions a control token', () => {
+    // Reviewing tokenizer code is a legitimate reason to write one out; substantial
+    // text remains after stripping, and only the residue is judged.
+    const r = parseReviewerResult(
+      'Decision: revise\nThe template emits <|im_start|> without a matching close, so the prompt is malformed.',
+    );
+    expect(r.decision).toBe('revise');
+  });
+
+  it('rejects a JSON verdict that is empty in every actionable field', () => {
+    expect(() => parseReviewerResult(wrap({ decision: 'revise', feedback: '', issues: [], suggestions: [] })))
+      .toThrow(/no findings/);
+  });
+});

--- a/src/adapters/resultParsing.ts
+++ b/src/adapters/resultParsing.ts
@@ -193,6 +193,23 @@ export function parseWorkerResult(text: string): WorkerResult {
 }
 
 /** JSON-first with text fallback — the canonical reviewer-output parse. */
+/**
+ * Chat-template sentinels that leaked into a final message instead of being
+ * consumed by the provider's parser — `<|im_start|>`, `<|eot_id|>`, and DeepSeek's
+ * fullwidth `<｜｜DSML｜｜tool_calls>`. Matched by the angle-bracket-plus-pipe shape
+ * rather than a fixed list, because every provider spells its own differently.
+ *
+ * Deliberately narrow: real review prose can *mention* such a token when reviewing
+ * tokenizer code, but then substantial text remains after stripping, and only the
+ * residue is judged.
+ */
+const CONTROL_TOKEN = /<[｜|][^>]*>|<\/?[｜|][^>]*>/g;
+
+/** Does anything survive that a human could act on? */
+function hasSubstance(text: string): boolean {
+  return /[\p{L}\p{N}]/u.test(text.replace(CONTROL_TOKEN, ''));
+}
+
 export function parseReviewerResult(text: string): ReviewResult {
   // An empty reviewer result is a harness failure, not a quality verdict. Falling
   // through to the safe text default would fabricate REVISE with no findings and
@@ -200,5 +217,50 @@ export function parseReviewerResult(text: string): ReviewResult {
   if (!text.trim()) {
     throw new Error('Reviewer output was empty: no final message or verdict');
   }
-  return extractReviewerResultJson(text) ?? extractReviewerFromText(text);
+  // Same failure wearing a disguise: a body consisting only of control tokens is
+  // non-empty, so it cleared the check above and became REVISE with zero findings.
+  // Measured on a 35-file diff: deepseek-v4-pro read the whole diff across 22 API
+  // calls and then emitted `<｜｜DSML｜｜tool_calls>` as its entire final message.
+  // (INT-3182)
+  if (!hasSubstance(text)) {
+    throw new Error('Reviewer output contained no verdict: only provider control tokens');
+  }
+
+  const json = extractReviewerResultJson(text);
+  const result = json ?? extractReviewerFromText(text);
+
+  // A non-approving verdict with nothing to act on is not a verdict — it is a
+  // failed review that would send the worker round the loop with no guidance.
+  // `approve` is exempt: having no findings is the correct shape for it.
+  if (result.decision !== 'approve' && !isSubstantiated(result, json !== null, text)) {
+    throw new Error(
+      `Reviewer returned "${result.decision}" with no findings, feedback or suggestions — treating as a failed review`,
+    );
+  }
+
+  return result;
+}
+
+/** The decision declaration itself, which carries no information beyond the verdict. */
+const DECISION_PHRASE =
+  /\bdecision\b\s*[:=-]?\s*["'`]?\s*(?:approve[d]?|reject(?:ed)?|revis(?:e|ion)|request[- ]?changes)["'`]?/gi;
+
+/**
+ * Did the reviewer say anything beyond the verdict?
+ *
+ * The two parse paths need different evidence. A JSON verdict carries its findings
+ * in dedicated fields, so those are authoritative. The text fallback does not: its
+ * `feedback` comes from extractSummary, which quotes the first substantial line —
+ * usually the "Decision: revise" line itself — so a populated feedback field there
+ * proves nothing. For that path the question is whether the message holds anything
+ * once the control tokens and the verdict declaration are removed.
+ */
+function isSubstantiated(result: ReviewResult, fromJson: boolean, sourceText: string): boolean {
+  if ((result.issues ?? []).some(hasSubstance) || (result.suggestions ?? []).some(hasSubstance)) {
+    return true;
+  }
+  if (fromJson) {
+    return hasSubstance(result.feedback ?? '');
+  }
+  return hasSubstance(sourceText.replace(DECISION_PHRASE, ''));
 }


### PR DESCRIPTION
Closes INT-3182.

## The gap

INT-2879 already rejects an empty reviewer output — falling through to the safe text default fabricates `REVISE` with no findings. The same failure gets past that guard wearing a disguise: **a body consisting only of a provider's chat-template sentinel is non-empty.**

Measured on a 35-file diff, `deepseek-v4-pro` read everything across 22 API calls and then emitted this as its entire final message:

```
· ▸ Final answer turn (no tools) — loop ended without a final message
✎ Decision: REVISE
  <｜｜DSML｜｜tool_calls>
```

That is worse than the empty case, which at least reports honestly that the gate did not run. INT-3100 built an exit-code contract on exactly that distinction (exit 2 = gate did not run), and this path bypassed it — claiming "I reviewed, and there are problems" while citing nothing.

## The fix

Two checks, both `throw` so the existing "gate did NOT run" handling applies unchanged:

1. **Body is only control tokens.** Matched by the angle-bracket-plus-pipe shape rather than a fixed list, since every provider spells its own differently (`<|im_start|>`, `<|eot_id|>`, DeepSeek's fullwidth variant). Only the *residue* is judged, so a review that legitimately mentions such a token while reviewing tokenizer code still parses.
2. **Non-approving verdict with nothing to act on.** `approve` is exempt — no findings is its correct shape.

The two parse paths need different evidence for check 2. A JSON verdict carries findings in dedicated fields, so those are authoritative. The text fallback does not: its `feedback` comes from `extractSummary`, which quotes the first substantial line — **usually the "Decision: revise" line itself** — so a populated feedback field there proves nothing. For that path the question is whether anything survives removing the control tokens and the verdict declaration.

(That subtlety was found by the tests: a first attempt checked the parsed `feedback` field and was silently dead code.)

## Behaviour

| input | before | after |
|---|---|---|
| `<｜｜DSML｜｜tool_calls>` | REVISE, 0 findings | throws → gate did NOT run |
| `<\|im_start\|>` | REVISE, 0 findings | throws → gate did NOT run |
| `Decision: revise` (alone) | REVISE, 0 findings | throws → gate did NOT run |
| `Decision: revise` + prose | REVISE | REVISE (unchanged) |
| `Decision: approve` | approve | approve (unchanged) |
| prose mentioning `<\|im_start\|>` | REVISE | REVISE (unchanged) |

## Gates

`lint` ✅ · `typecheck` ✅ · `test` **3487 passed / 1 skipped (262 files)** ✅ · `test:coverage` **90.04%** ✅ · 7 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)