### PR TITLE
chore(typecheck): put benchmarks/ under the type gate · bench(review): more clean fixtures

### DIFF
--- a/benchmarks/tasks/reviewLensFixtures.ts
+++ b/benchmarks/tasks/reviewLensFixtures.ts
@@ -270,4 +270,95 @@ export const LENS_FIXTURES: LensFixture[] = [
     expectDefect: false,
     detectionKeywords: [],
   },
+  {
+    // A rename is the change most likely to be wrongly flagged: the reviewer sees a
+    // symbol disappear and has to check every call site before concluding anything.
+    key: 'clean-rename-all-callers',
+    category: 'clean',
+    taskTitle: 'Rename fetchUser() to loadUser() across the module',
+    taskDescription:
+      'Rename fetchUser to loadUser. Every caller must be updated; no behavior change.',
+    committed: {
+      'src/user.ts':
+        `export function fetchUser(id: string): string {\n` +
+        `  return 'user:' + id;\n` +
+        `}\n`,
+      'src/profile.ts':
+        `import { fetchUser } from './user.js';\n` +
+        `export function profile(id: string): string {\n` +
+        `  return fetchUser(id).toUpperCase();\n` +
+        `}\n`,
+    },
+    changed: {
+      'src/user.ts':
+        `export function loadUser(id: string): string {\n` +
+        `  return 'user:' + id;\n` +
+        `}\n`,
+      'src/profile.ts':
+        `import { loadUser } from './user.js';\n` +
+        `export function profile(id: string): string {\n` +
+        `  return loadUser(id).toUpperCase();\n` +
+        `}\n`,
+    },
+    summary: 'Renamed fetchUser to loadUser and updated the only caller in profile.ts.',
+    commands: ['npx tsc --noEmit'],
+    expectDefect: false,
+    detectionKeywords: [],
+  },
+  {
+    // Tests-only diffs invite "where is the implementation change?" objections even
+    // though adding coverage for existing behavior is complete on its own.
+    key: 'clean-tests-only',
+    category: 'clean',
+    taskTitle: 'Add test coverage for parsePort()',
+    taskDescription:
+      'parsePort() is untested. Add tests for the valid, out-of-range and non-numeric cases. Do not change the implementation.',
+    committed: {
+      'src/port.ts':
+        `export function parsePort(raw: string): number | undefined {\n` +
+        `  const n = Number(raw);\n` +
+        `  if (!Number.isInteger(n) || n < 1 || n > 65535) return undefined;\n` +
+        `  return n;\n` +
+        `}\n`,
+    },
+    changed: {
+      'src/port.test.ts':
+        `import { describe, it, expect } from 'vitest';\n` +
+        `import { parsePort } from './port.js';\n` +
+        `\n` +
+        `describe('parsePort', () => {\n` +
+        `  it('accepts a valid port', () => expect(parsePort('8080')).toBe(8080));\n` +
+        `  it('rejects out-of-range', () => expect(parsePort('70000')).toBeUndefined());\n` +
+        `  it('rejects non-numeric', () => expect(parsePort('http')).toBeUndefined());\n` +
+        `});\n`,
+    },
+    summary: 'Added port.test.ts covering valid, out-of-range and non-numeric input. Implementation untouched.',
+    commands: ['npx vitest run src/port.test.ts'],
+    expectDefect: false,
+    detectionKeywords: [],
+  },
+  {
+    // Widening a type is safe for every existing caller, but reads as an API change.
+    key: 'clean-widen-parameter-type',
+    category: 'clean',
+    taskTitle: 'Accept Iterable<string> in joinLines()',
+    taskDescription:
+      'joinLines() only takes string[]. Widen it to Iterable<string> so Sets and generators work. Existing callers must keep compiling.',
+    committed: {
+      'src/lines.ts':
+        `export function joinLines(lines: string[]): string {\n` +
+        `  return Array.from(lines).join('\\n');\n` +
+        `}\n`,
+    },
+    changed: {
+      'src/lines.ts':
+        `export function joinLines(lines: Iterable<string>): string {\n` +
+        `  return Array.from(lines).join('\\n');\n` +
+        `}\n`,
+    },
+    summary: 'Widened joinLines to Iterable<string>. string[] satisfies Iterable<string>, so all callers still compile.',
+    commands: ['npx tsc --noEmit'],
+    expectDefect: false,
+    detectionKeywords: [],
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "node --env-file=.env dist/index.js",
     "stop": "pkill -f 'node --env-file=.env.*openswarm' 2>/dev/null || echo 'No process running'",
     "lint": "oxlint src/",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.check.json",
     "test": "node --experimental-vm-modules node_modules/vitest/vitest.mjs run",
     "test:coverage": "node --experimental-vm-modules node_modules/vitest/vitest.mjs run --coverage",
     "test:watch": "node --experimental-vm-modules node_modules/vitest/vitest.mjs",

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,0 +1,19 @@
+{
+  // Typecheck-only project. The build config roots at src/ so it can emit to
+  // dist/, which left benchmarks/ checked by nothing: `tsc --noEmit` reported
+  // clean on a fixture file with a hard syntax error, and the break only surfaced
+  // when the benchmark was actually run.
+  //
+  // scripts/ is still outside this net — it carries pre-existing errors that are
+  // their own cleanup, not this file's job.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*", "benchmarks/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.test.tsx"]
+}


### PR DESCRIPTION
Two small gate/measurement fixes found while working on INT-3182.

## chore(typecheck): benchmarks/ was checked by nothing

The build config roots at `src/` so it can emit to `dist/`, so `benchmarks/` fell outside every gate. Found the hard way: `tsc --noEmit` reported **clean** on a fixture file containing a syntax error (a template literal nested inside another, terminating the outer string). The break only surfaced when the benchmark was actually run — after the change already looked verified.

Adds `tsconfig.check.json` (extends the build config, `rootDir: "."`, `noEmit`) and points `npm run typecheck` — and therefore CI — at it. **The build path is untouched**: `npm run build` still compiles src/ → dist/.

`benchmarks/` typechecks at **zero errors** today, so this closes the gap with no cleanup backlog. `scripts/` stays outside the net — it carries two pre-existing errors that are their own piece of work.

## bench(review): three more clean fixtures

The reviewer sweep had **two** clean fixtures, so a model's false-reject rate was measured over four runs and moved in 25-point steps. That is too coarse to separate the two candidates that tied at 0%, and repeating the same two diffs would only measure consistency on those diffs — the metric needs breadth, not depth.

Adds three legitimate changes of the kind a jumpy reviewer is most likely to flag:

| fixture | why it invites a false reject |
|---|---|
| `clean-rename-all-callers` | a symbol disappears; the reviewer must check every call site before concluding |
| `clean-tests-only` | invites "where is the implementation change?" |
| `clean-widen-parameter-type` | safe for every existing caller, but reads as an API change |

Clean fixtures: 2 → 5. At `--repeat 3` that is 15 runs per model instead of 4.

## Gates

`lint` ✅ · `typecheck` (now including benchmarks) ✅ · `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)