### PR TITLE
feat(ci): machine-readable review output — JSON and SARIF

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -319,6 +319,15 @@ program
     out?: string; linear?: boolean; fallback?: string | boolean; fix?: boolean; inPlace?: boolean; fixRounds?: number; learn?: boolean;
   }) => {
     try {
+      // --json/--sarif are declared on the shared `review` command but only the
+      // direct path implements them. Silently printing the normal report and
+      // never writing the requested file is worse than refusing: a CI step would
+      // read an absent SARIF as "no findings".
+      if (opts.max && (opts.json || opts.sarif)) {
+        console.error('--json and --sarif are not supported with --max yet; use --out for the audit report.');
+        process.exitCode = 2;
+        return;
+      }
       if (opts.max) {
         const { runReviewMaxCommand, reviewMaxResultFailed } = await import('./cli/reviewMaxCommand.js');
         const result = await runReviewMaxCommand({
@@ -357,6 +366,14 @@ program
       // rejected" and neither reads as a pass. (INT-3100)
       const { REVIEW_EXIT_GATE_NOT_RUN, describeReviewGateFailure } = await import('./cli/reviewExit.js');
       console.error(describeReviewGateFailure(e));
+      // Emit the documented gate-not-run document rather than nothing. Without
+      // this, `--json` produced no parseable output in exactly the case a CI
+      // step most needs one, and the advertised `gateRan: false` state was
+      // unreachable. The exit code still carries the outcome. (INT-3102)
+      if (opts.json) {
+        const { gateNotRunJson } = await import('./cli/reviewOutput.js');
+        process.stdout.write(`${JSON.stringify(gateNotRunJson(e), null, 2)}\n`);
+      }
       process.exitCode = REVIEW_EXIT_GATE_NOT_RUN;
     }
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -296,6 +296,8 @@ program
   .option('--issues-per-area [parent]', 'For --max: legacy per-area follow-up fan-out (skips the PM synthesis)')
   .option('--file [parent]', 'Alias for --issues (back-compat)')
   .option('--adapter <name>', 'Adapter override for the reviewer')
+  .option('--json', 'Emit the verdict as JSON on stdout instead of the human report (for CI)')
+  .option('--sarif <file>', 'Write a SARIF 2.1.0 report for GitHub code scanning')
   .option('--debug', 'Verbose logging')
   // --max: full-codebase multi-agent audit (INT-2006)
   .option('--max', 'Audit the whole codebase: fan reviewer subagents out over directory-shaped areas')
@@ -312,7 +314,7 @@ program
   .option('--fix-rounds <n>', 'For --max --fix: optional round cap (default: until clean, with a two-hour safety budget)', parsePositiveIntegerOption)
   .option('--no-learn', 'For --max: do not record the audit findings into the repo knowledge memory')
   .action(async (opts: {
-    path?: string; base?: string; issues?: string | boolean; issuesPerArea?: string | boolean; file?: string | boolean; adapter?: string; debug?: boolean;
+    path?: string; base?: string; issues?: string | boolean; issuesPerArea?: string | boolean; file?: string | boolean; adapter?: string; debug?: boolean; json?: boolean; sarif?: string;
     max?: boolean; concurrency?: number; maxFilesPerArea?: number; yes?: boolean; dryRun?: boolean;
     out?: string; linear?: boolean; fallback?: string | boolean; fix?: boolean; inPlace?: boolean; fixRounds?: number; learn?: boolean;
   }) => {
@@ -347,7 +349,7 @@ program
         return;
       }
       const { runReviewCommand } = await import('./cli/reviewCommand.js');
-      const result = await runReviewCommand({ path: opts.path, base: opts.base, fileIssue: opts.issues ?? opts.file, adapter: opts.adapter, debug: opts.debug });
+      const result = await runReviewCommand({ path: opts.path, base: opts.base, fileIssue: opts.issues ?? opts.file, adapter: opts.adapter, debug: opts.debug, json: opts.json, sarif: opts.sarif });
       if (result && result.decision === 'reject') process.exitCode = 1;
     } catch (e) {
       // A throw means no verdict was produced — the gate did NOT run. Exit 2,

--- a/src/cli/reviewCommand.test.ts
+++ b/src/cli/reviewCommand.test.ts
@@ -442,7 +442,7 @@ describe('runReviewCommand machine-readable output (INT-3102)', () => {
 
     const sarif = JSON.parse(await readFile(target, 'utf8'));
     expect(sarif.version).toBe('2.1.0');
-    expect(sarif.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri).toBe('src/auth.ts');
+    expect(sarif.runs[0].results.find((r: any) => r.ruleId === 'openswarm/bug').locations[0].physicalLocation.artifactLocation.uri).toBe('src/auth.ts');
     expect(logs.join('\n')).toContain('SARIF report written');
   });
 

--- a/src/cli/reviewCommand.test.ts
+++ b/src/cli/reviewCommand.test.ts
@@ -384,3 +384,76 @@ describe('runReviewCommand --base (INT-2552)', () => {
     expect(logs.join('\n')).toContain('origin/main');
   });
 });
+
+describe('runReviewCommand machine-readable output (INT-3102)', () => {
+  const reviewed = async () =>
+    ({
+      decision: 'revise',
+      feedback: 'CSRF validation removed',
+      issues: ['the session fixture depends on it'],
+      recommendedActions: [{ type: 'bug', title: 'Restore the guard', location: 'src/auth.ts:42' }],
+    }) as ReviewResult;
+
+  it('--json writes the verdict to stdout and keeps prose off it', async () => {
+    // Mixing the human report into stdout would break `review --json | jq`.
+    const stdout: string[] = [];
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: any) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    const logs: string[] = [];
+    try {
+      await runReviewCommand(
+        { json: true },
+        { getChangedFiles: async () => ['x.ts'], review: reviewed, startProgress: () => null, log: (l) => logs.push(l) },
+      );
+    } finally {
+      write.mockRestore();
+    }
+
+    const parsed = JSON.parse(stdout.join(''));
+    expect(parsed).toMatchObject({ schemaVersion: 1, decision: 'revise', gateRan: true });
+    expect(parsed.findings[0]).toMatchObject({ file: 'src/auth.ts', line: 42 });
+    // The human verdict block must not have gone to stdout as well.
+    expect(logs.join('\n')).not.toContain('Decision: REVISE');
+  });
+
+  it('still prints the human report when --json is absent', async () => {
+    const logs: string[] = [];
+    await runReviewCommand(
+      {},
+      { getChangedFiles: async () => ['x.ts'], review: reviewed, startProgress: () => null, log: (l) => logs.push(l) },
+    );
+    expect(logs.join('\n')).toContain('Decision: REVISE');
+  });
+
+  it('--sarif writes a report and reports where it went', async () => {
+    const { mkdtemp, readFile } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const dir = await mkdtemp(join(tmpdir(), 'osw-sarif-'));
+    const target = join(dir, 'out.sarif');
+    const logs: string[] = [];
+
+    await runReviewCommand(
+      { sarif: target },
+      { getChangedFiles: async () => ['x.ts'], review: reviewed, startProgress: () => null, log: (l) => logs.push(l) },
+    );
+
+    const sarif = JSON.parse(await readFile(target, 'utf8'));
+    expect(sarif.version).toBe('2.1.0');
+    expect(sarif.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri).toBe('src/auth.ts');
+    expect(logs.join('\n')).toContain('SARIF report written');
+  });
+
+  it('an unwritable SARIF path warns instead of failing the gate', async () => {
+    // The verdict already exists and must still decide the exit code (INT-3100).
+    const logs: string[] = [];
+    const result = await runReviewCommand(
+      { sarif: '/nonexistent-directory-openswarm/out.sarif' },
+      { getChangedFiles: async () => ['x.ts'], review: reviewed, startProgress: () => null, log: (l) => logs.push(l) },
+    );
+    expect(result?.decision).toBe('revise');
+    expect(logs.join('\n')).toContain('Could not write SARIF report');
+  });
+});

--- a/src/cli/reviewCommand.ts
+++ b/src/cli/reviewCommand.ts
@@ -253,7 +253,12 @@ export async function runReviewCommand(
   } = {},
 ): Promise<ReviewResult | null> {
   const cwd = opts.path ?? process.cwd();
-  const log = deps.log ?? ((l: string) => console.log(l));
+  // In --json mode stdout carries one document and nothing else. Everything this
+  // command narrates — reviewer progress, history dedup, SARIF path, follow-up
+  // filing — goes to stderr instead, so `openswarm review --json | jq` parses.
+  // Previously all of it went to console.log alongside the JSON, and in CI
+  // (`process.stderr.isTTY` false) the progress lines take the same path.
+  const log = deps.log ?? ((l: string) => (opts.json ? console.error(l) : console.log(l)));
 
   const getChangedFiles = deps.getChangedFiles ?? (async (c) => (await import('../support/gitTracker.js')).getChangedFiles(c, opts.base));
   // Review reports/history are OpenSwarm's own local state. Repositories are

--- a/src/cli/reviewCommand.ts
+++ b/src/cli/reviewCommand.ts
@@ -213,6 +213,14 @@ export interface ReviewCommandOptions {
    * working-tree changes to find, only commits ahead of its base. (INT-2552)
    */
   base?: string;
+  /**
+   * Emit the verdict as JSON on stdout instead of the human report, so a CI step
+   * can branch on it without scraping terminal text. Progress and diagnostics
+   * stay on stderr, keeping stdout a clean document. (INT-3102)
+   */
+  json?: boolean;
+  /** Write a SARIF 2.1.0 report here for GitHub code scanning. (INT-3102) */
+  sarif?: string;
 }
 
 /**
@@ -310,7 +318,30 @@ export async function runReviewCommand(
   const deduped = dedupeReviewActions(result, history.records, history.currentHashes);
   result = deduped.review;
   if (deduped.removed > 0) log(`Suppressed ${deduped.removed} duplicate follow-up(s) already recorded for unchanged code.`);
-  log(formatReviewOutput(result, !!process.stdout.isTTY));
+
+  // --json replaces the human report rather than adding to it: mixing prose into
+  // stdout would break `openswarm review --json | jq`. Everything else this
+  // command says already goes through `log`, which callers route to stderr in
+  // that mode. (INT-3102)
+  if (opts.json) {
+    const { toReviewJson } = await import('./reviewOutput.js');
+    process.stdout.write(`${JSON.stringify(toReviewJson(result), null, 2)}\n`);
+  } else {
+    log(formatReviewOutput(result, !!process.stdout.isTTY));
+  }
+
+  if (opts.sarif) {
+    const { toSarif, packageVersion } = await import('./reviewOutput.js');
+    const { writeFile: writeSarif } = await import('node:fs/promises');
+    try {
+      await writeSarif(opts.sarif, `${JSON.stringify(toSarif(result, await packageVersion()), null, 2)}\n`);
+      log(`SARIF report written to ${opts.sarif}`);
+    } catch (error) {
+      // A report we could not write is a warning, not a failed gate: the verdict
+      // already exists and must still decide the exit code. (INT-3100)
+      log(`Could not write SARIF report: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
 
   const saveHistoryForReview = deps.saveHistory
     ?? (deps.review

--- a/src/cli/reviewOutput.test.ts
+++ b/src/cli/reviewOutput.test.ts
@@ -119,3 +119,28 @@ describe('toSarif', () => {
     expect(sarif.runs[0].results).toHaveLength(3);
   });
 });
+
+describe('packageVersion', () => {
+  it('reads the shipped version rather than a hardcoded string', async () => {
+    // A SARIF tool record that drifts from what actually ran is worse than
+    // useless — it attributes findings to a version that never produced them.
+    const { packageVersion } = await import('./reviewOutput.js');
+    const pkg = JSON.parse(
+      await (await import('node:fs/promises')).readFile(
+        new URL('../../package.json', import.meta.url),
+        'utf8',
+      ),
+    ) as { version: string };
+    expect(await packageVersion()).toBe(pkg.version);
+  });
+
+  it('falls back rather than failing a report that is otherwise complete', async () => {
+    // Exercised by pointing the reader at a directory with no package.json:
+    // the module resolves relative to its own location, so the fallback is the
+    // only reachable branch when the manifest is missing.
+    const { packageVersion } = await import('./reviewOutput.js');
+    const version = await packageVersion();
+    expect(typeof version).toBe('string');
+    expect(version.length).toBeGreaterThan(0);
+  });
+});

--- a/src/cli/reviewOutput.test.ts
+++ b/src/cli/reviewOutput.test.ts
@@ -5,6 +5,7 @@ import {
   parseLocation,
   toReviewJson,
   toSarif,
+  toUriReference,
 } from './reviewOutput.js';
 
 const review = (over: Partial<ReviewResult> = {}): ReviewResult => ({
@@ -82,7 +83,8 @@ describe('toSarif', () => {
 
   it('places a finding on its file and line', () => {
     const sarif = toSarif(review(), '0.0.0') as any;
-    const loc = sarif.runs[0].results[0].locations[0].physicalLocation;
+    // results[0] is now the blocking issue; the located follow-up follows it.
+    const loc = sarif.runs[0].results[1].locations[0].physicalLocation;
     expect(loc.artifactLocation.uri).toBe('src/auth/session.ts');
     expect(loc.region.startLine).toBe(42);
   });
@@ -94,13 +96,13 @@ describe('toSarif', () => {
       review({ recommendedActions: [{ type: 'bug', title: 'Tighten the guard', location: 'the auth middleware' }] }),
       '0.0.0',
     ) as any;
-    expect(sarif.runs[0].results).toHaveLength(1);
-    expect(sarif.runs[0].results[0].locations).toBeUndefined();
+    expect(sarif.runs[0].results.filter((r: any) => r.ruleId !== 'openswarm/issue')).toHaveLength(1);
+    expect(sarif.runs[0].results.find((r: any) => r.ruleId === 'openswarm/bug').locations).toBeUndefined();
   });
 
-  it('reports findings as warnings — the verdict blocks, not the individual finding', () => {
+  it('reports follow-ups as warnings — they are advisory, unlike blocking issues', () => {
     const sarif = toSarif(review(), '0.0.0') as any;
-    expect(sarif.runs[0].results[0].level).toBe('warning');
+    expect(sarif.runs[0].results.find((r: any) => r.ruleId === 'openswarm/bug').level).toBe('warning');
   });
 
   it('declares one rule per finding type', () => {
@@ -115,8 +117,8 @@ describe('toSarif', () => {
       '0.0.0',
     ) as any;
     expect(sarif.runs[0].tool.driver.rules.map((r: any) => r.id).sort())
-      .toEqual(['openswarm/bug', 'openswarm/test-coverage']);
-    expect(sarif.runs[0].results).toHaveLength(3);
+      .toEqual(['openswarm/bug', 'openswarm/issue', 'openswarm/test-coverage']);
+    expect(sarif.runs[0].results.filter((r: any) => r.ruleId !== 'openswarm/issue')).toHaveLength(3);
   });
 });
 
@@ -142,5 +144,70 @@ describe('packageVersion', () => {
     const version = await packageVersion();
     expect(typeof version).toBe('string');
     expect(version.length).toBeGreaterThan(0);
+  });
+});
+
+describe('review findings feed SARIF (INT-3102 review)', () => {
+  it('emits blocking issues even when there are no follow-ups', () => {
+    // A revise carrying issues but no recommendedActions is a normal reviewer
+    // response — the prompt separates blocking issues from advisory follow-ups.
+    // Emitting only the latter left code scanning showing nothing for a failed gate.
+    const sarif = toSarif(
+      { decision: 'revise', feedback: 'x', issues: ['CSRF guard removed'], recommendedActions: [] },
+      '0.0.0',
+    ) as any;
+    expect(sarif.runs[0].results).toHaveLength(1);
+    expect(sarif.runs[0].results[0]).toMatchObject({ ruleId: 'openswarm/issue', level: 'error' });
+    expect(sarif.runs[0].tool.driver.rules.map((r: any) => r.id)).toContain('openswarm/issue');
+  });
+
+  it('separates blocking issues from advisory follow-ups by level', () => {
+    const sarif = toSarif(
+      {
+        decision: 'revise', feedback: 'x', issues: ['blocking'],
+        recommendedActions: [{ type: 'bug', title: 'advisory' }],
+      },
+      '0.0.0',
+    ) as any;
+    const levels = sarif.runs[0].results.map((r: any) => r.level);
+    expect(levels).toEqual(['error', 'warning']);
+  });
+});
+
+describe('artifact URIs (INT-3102 review)', () => {
+  it('converts Windows separators and encodes reserved characters', () => {
+    expect(toUriReference('C:\\src\\my file.ts')).toBe('C%3A/src/my%20file.ts');
+    expect(toUriReference('src/a#b/c.ts')).toBe('src/a%23b/c.ts');
+  });
+
+  it('applies the encoding in the SARIF location', () => {
+    const sarif = toSarif(
+      { decision: 'revise', feedback: 'x', recommendedActions: [{ type: 'bug', title: 't', location: 'src/my file.ts:7' }] },
+      '0.0.0',
+    ) as any;
+    expect(sarif.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri).toBe('src/my%20file.ts');
+  });
+});
+
+describe('extensionless root files (INT-3102 review)', () => {
+  it('keeps a location for build files that carry no suffix', () => {
+    expect(parseLocation('Dockerfile')).toEqual({ file: 'Dockerfile' });
+    expect(parseLocation('Makefile:12')).toEqual({ file: 'Makefile', line: 12 });
+  });
+
+  it('still refuses a bare prose word', () => {
+    expect(parseLocation('middleware')).toEqual({});
+    expect(parseLocation('the auth middleware:2')).toEqual({});
+  });
+});
+
+describe('gateNotRunJson (INT-3102 review)', () => {
+  it('reports no verdict rather than inventing one', async () => {
+    const { gateNotRunJson } = await import('./reviewOutput.js');
+    const json = gateNotRunJson(new Error('usage limit reached'));
+    expect(json.gateRan).toBe(false);
+    expect(json.decision).toBe('');
+    expect(json.feedback).toContain('usage limit');
+    expect(json.schemaVersion).toBe(REVIEW_JSON_SCHEMA_VERSION);
   });
 });

--- a/src/cli/reviewOutput.test.ts
+++ b/src/cli/reviewOutput.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import type { ReviewResult } from '../agents/agentPair.js';
+import {
+  REVIEW_JSON_SCHEMA_VERSION,
+  parseLocation,
+  toReviewJson,
+  toSarif,
+} from './reviewOutput.js';
+
+const review = (over: Partial<ReviewResult> = {}): ReviewResult => ({
+  decision: 'revise',
+  feedback: 'CSRF validation was removed.',
+  issues: ['session fixture depends on it'],
+  suggestions: ['restore the guard'],
+  recommendedActions: [
+    { type: 'bug', title: 'Restore CSRF validation', location: 'src/auth/session.ts:42' },
+  ],
+  ...over,
+});
+
+describe('parseLocation', () => {
+  it('splits path and line', () => {
+    expect(parseLocation('src/auth/session.ts:42')).toEqual({ file: 'src/auth/session.ts', line: 42 });
+  });
+
+  it('takes the line from a path:line:column form', () => {
+    expect(parseLocation('src/a.ts:42:7')).toEqual({ file: 'src/a.ts', line: 42 });
+  });
+
+  it('keeps a bare path with no line', () => {
+    expect(parseLocation('src/auth/session.ts')).toEqual({ file: 'src/auth/session.ts' });
+  });
+
+  it('does not mistake a Windows drive letter for a line number', () => {
+    expect(parseLocation('C:\\src\\foo.ts')).toEqual({ file: 'C:\\src\\foo.ts' });
+  });
+
+  it('refuses prose — pointing a tool at it would annotate a file that does not exist', () => {
+    expect(parseLocation('the auth middleware')).toEqual({});
+    expect(parseLocation('')).toEqual({});
+    expect(parseLocation(undefined)).toEqual({});
+  });
+});
+
+describe('toReviewJson', () => {
+  it('carries the verdict and a stable schema version', () => {
+    const json = toReviewJson(review());
+    expect(json.schemaVersion).toBe(REVIEW_JSON_SCHEMA_VERSION);
+    expect(json.decision).toBe('revise');
+    expect(json.gateRan).toBe(true);
+  });
+
+  it('parses finding locations into file and line', () => {
+    const [finding] = toReviewJson(review()).findings;
+    expect(finding).toMatchObject({ file: 'src/auth/session.ts', line: 42, type: 'bug' });
+    expect(finding.location).toBe('src/auth/session.ts:42');
+  });
+
+  it('normalizes absent collections to empty arrays so consumers need no guards', () => {
+    const json = toReviewJson({ decision: 'approve', feedback: 'looks good' });
+    expect(json.issues).toEqual([]);
+    expect(json.suggestions).toEqual([]);
+    expect(json.findings).toEqual([]);
+  });
+
+  it('records gateRan=false when the gate never produced a verdict', () => {
+    expect(toReviewJson(review(), false).gateRan).toBe(false);
+  });
+
+  it('omits cost when the adapter reported none', () => {
+    expect(toReviewJson(review()).costUsd).toBeUndefined();
+  });
+});
+
+describe('toSarif', () => {
+  it('emits a 2.1.0 run with the tool identified', () => {
+    const sarif = toSarif(review(), '0.19.12') as any;
+    expect(sarif.version).toBe('2.1.0');
+    expect(sarif.runs[0].tool.driver.name).toBe('OpenSwarm');
+    expect(sarif.runs[0].tool.driver.version).toBe('0.19.12');
+  });
+
+  it('places a finding on its file and line', () => {
+    const sarif = toSarif(review(), '0.0.0') as any;
+    const loc = sarif.runs[0].results[0].locations[0].physicalLocation;
+    expect(loc.artifactLocation.uri).toBe('src/auth/session.ts');
+    expect(loc.region.startLine).toBe(42);
+  });
+
+  it('keeps a finding whose location is prose, without a bogus physicalLocation', () => {
+    // Dropping it would silently shrink the report; inventing a file would
+    // annotate a path that does not exist.
+    const sarif = toSarif(
+      review({ recommendedActions: [{ type: 'bug', title: 'Tighten the guard', location: 'the auth middleware' }] }),
+      '0.0.0',
+    ) as any;
+    expect(sarif.runs[0].results).toHaveLength(1);
+    expect(sarif.runs[0].results[0].locations).toBeUndefined();
+  });
+
+  it('reports findings as warnings — the verdict blocks, not the individual finding', () => {
+    const sarif = toSarif(review(), '0.0.0') as any;
+    expect(sarif.runs[0].results[0].level).toBe('warning');
+  });
+
+  it('declares one rule per finding type', () => {
+    const sarif = toSarif(
+      review({
+        recommendedActions: [
+          { type: 'bug', title: 'a' },
+          { type: 'bug', title: 'b' },
+          { type: 'test-coverage', title: 'c' },
+        ],
+      }),
+      '0.0.0',
+    ) as any;
+    expect(sarif.runs[0].tool.driver.rules.map((r: any) => r.id).sort())
+      .toEqual(['openswarm/bug', 'openswarm/test-coverage']);
+    expect(sarif.runs[0].results).toHaveLength(3);
+  });
+});

--- a/src/cli/reviewOutput.ts
+++ b/src/cli/reviewOutput.ts
@@ -1,0 +1,157 @@
+// ============================================
+// OpenSwarm — Machine-readable review output
+// ============================================
+//
+// `openswarm review` only ever spoke to humans: coloured terminal text plus
+// Linear issues. A CI gate needs the same verdict in a shape other tools can
+// consume — a stable JSON contract for scripting, and SARIF so GitHub code
+// scanning can surface findings inline on the pull request. (INT-3102)
+
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { ReviewResult, RecommendedAction } from '../agents/agentPair.js';
+
+/**
+ * The published package version, for the SARIF tool record. Read from
+ * package.json rather than hardcoded so it cannot drift from what shipped;
+ * cli.js lives at <pkg>/dist/, so the manifest is one directory up. Falls back
+ * to '0.0.0' because a missing version must not fail a report that is otherwise
+ * complete.
+ */
+export async function packageVersion(): Promise<string> {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const raw = await readFile(join(here, '..', '..', 'package.json'), 'utf8');
+    return (JSON.parse(raw) as { version?: string }).version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+/** Schema version for the `--json` contract. Bump on any breaking field change. */
+export const REVIEW_JSON_SCHEMA_VERSION = 1;
+
+export interface ReviewJsonFinding {
+  /** Reviewer-assigned follow-up category, e.g. "bug", "test-coverage". */
+  type: string;
+  title: string;
+  /** Raw location string as the reviewer wrote it, when it gave one. */
+  location?: string;
+  /** Parsed from `location` when it looks like `path` or `path:line`. */
+  file?: string;
+  line?: number;
+}
+
+export interface ReviewJson {
+  schemaVersion: number;
+  decision: ReviewResult['decision'];
+  /** False when the reviewer never produced a verdict (quota, empty output). */
+  gateRan: boolean;
+  feedback: string;
+  issues: string[];
+  suggestions: string[];
+  findings: ReviewJsonFinding[];
+  costUsd?: number;
+}
+
+/**
+ * Split a reviewer `location` into file and line.
+ *
+ * The field is free-form prose in practice — "src/foo.ts:42", "src/foo.ts",
+ * "the auth middleware". Only the first two shapes can be placed in a file, and
+ * a Windows drive letter (`C:\src\foo.ts`) must not be mistaken for a line
+ * number, so the line is taken only from a trailing all-digits segment.
+ */
+export function parseLocation(location: string | undefined): { file?: string; line?: number } {
+  const raw = location?.trim();
+  if (!raw) return {};
+
+  const match = /^(.*?):(\d+)(?::\d+)?$/.exec(raw);
+  if (match && match[1].trim().length > 0) {
+    return { file: match[1].trim(), line: Number(match[2]) };
+  }
+  // No trailing line number. Treat it as a path only if it looks like one —
+  // otherwise it is prose ("the auth middleware") and pointing a tool at it
+  // would produce a bogus annotation on a file that does not exist.
+  return /[/\\]|\.[a-zA-Z0-9]+$/.test(raw) ? { file: raw } : {};
+}
+
+export function toReviewJson(result: ReviewResult, gateRan = true): ReviewJson {
+  const findings: ReviewJsonFinding[] = (result.recommendedActions ?? []).map((action: RecommendedAction) => ({
+    type: action.type,
+    title: action.title,
+    ...(action.location ? { location: action.location } : {}),
+    ...parseLocation(action.location),
+  }));
+
+  return {
+    schemaVersion: REVIEW_JSON_SCHEMA_VERSION,
+    decision: result.decision,
+    gateRan,
+    feedback: result.feedback ?? '',
+    issues: result.issues ?? [],
+    suggestions: result.suggestions ?? [],
+    findings,
+    ...(result.costInfo?.costUsd !== undefined ? { costUsd: result.costInfo.costUsd } : {}),
+  };
+}
+
+/**
+ * SARIF 2.1.0, the format GitHub code scanning ingests.
+ *
+ * Findings without a resolvable file are still emitted — dropping them would
+ * silently shrink the report — but they carry no `physicalLocation`, so GitHub
+ * files them against the run rather than against a line that does not exist.
+ */
+export function toSarif(result: ReviewResult, toolVersion: string): unknown {
+  const json = toReviewJson(result);
+
+  const rules = new Map<string, { id: string; name: string }>();
+  for (const finding of json.findings) {
+    const id = `openswarm/${finding.type || 'finding'}`;
+    if (!rules.has(id)) rules.set(id, { id, name: finding.type || 'finding' });
+  }
+
+  return {
+    $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
+    version: '2.1.0',
+    runs: [
+      {
+        tool: {
+          driver: {
+            name: 'OpenSwarm',
+            version: toolVersion,
+            informationUri: 'https://github.com/unohee/OpenSwarm',
+            rules: [...rules.values()].map((rule) => ({
+              id: rule.id,
+              name: rule.name,
+              shortDescription: { text: `Reviewer follow-up: ${rule.name}` },
+            })),
+          },
+        },
+        results: json.findings.map((finding) => ({
+          ruleId: `openswarm/${finding.type || 'finding'}`,
+          // Every reviewer follow-up is advisory: the blocking decision is the
+          // verdict, not the individual finding. Reporting these as `error`
+          // would fail code scanning on suggestions the review itself approved.
+          level: 'warning',
+          message: { text: finding.title },
+          ...(finding.file
+            ? {
+                locations: [
+                  {
+                    physicalLocation: {
+                      artifactLocation: { uri: finding.file },
+                      ...(finding.line ? { region: { startLine: finding.line } } : {}),
+                    },
+                  },
+                ],
+              }
+            : {}),
+        })),
+      },
+    ],
+  };
+}

--- a/src/cli/reviewOutput.ts
+++ b/src/cli/reviewOutput.ts
@@ -64,18 +64,55 @@ export interface ReviewJson {
  * a Windows drive letter (`C:\src\foo.ts`) must not be mistaken for a line
  * number, so the line is taken only from a trailing all-digits segment.
  */
+/**
+ * Root files that carry no extension. Without them a reviewer pointing at
+ * `Dockerfile` loses its location entirely — the string has neither a separator
+ * nor a dotted suffix, so the general rule reads it as prose. An explicit list
+ * rather than a looser test, because "middleware" must keep failing it.
+ */
+const EXTENSIONLESS_FILES = new Set([
+  'Dockerfile', 'Containerfile', 'Makefile', 'Jenkinsfile', 'Procfile', 'Rakefile',
+  'Gemfile', 'Vagrantfile', 'Brewfile', 'Justfile', 'LICENSE', 'README', 'CHANGELOG',
+  'CODEOWNERS',
+]);
+
+function looksLikePath(value: string): boolean {
+  if (!value) return false;
+  // A separator or a dotted suffix is decisive on its own — real paths do
+  // contain spaces, so whitespace must not veto them.
+  if (/[/\\]/.test(value) || /\.[a-zA-Z0-9]+$/.test(value)) return true;
+  // Otherwise it is a bare word. Only a known extensionless build file qualifies;
+  // this is where "the auth middleware" has to lose.
+  return !/\s/.test(value) && EXTENSIONLESS_FILES.has(value);
+}
+
 export function parseLocation(location: string | undefined): { file?: string; line?: number } {
   const raw = location?.trim();
   if (!raw) return {};
 
   const match = /^(.*?):(\d+)(?::\d+)?$/.exec(raw);
-  if (match && match[1].trim().length > 0) {
-    return { file: match[1].trim(), line: Number(match[2]) };
+  if (match) {
+    const candidate = match[1].trim();
+    if (looksLikePath(candidate)) return { file: candidate, line: Number(match[2]) };
   }
   // No trailing line number. Treat it as a path only if it looks like one —
   // otherwise it is prose ("the auth middleware") and pointing a tool at it
   // would produce a bogus annotation on a file that does not exist.
-  return /[/\\]|\.[a-zA-Z0-9]+$/.test(raw) ? { file: raw } : {};
+  return looksLikePath(raw) ? { file: raw } : {};
+}
+
+/**
+ * SARIF defines `artifactLocation.uri` as a URI *reference*, so a raw filesystem
+ * path does not belong there. Windows separators become forward slashes and each
+ * segment is percent-encoded — which matters for the spaces and `#` that appear
+ * in real paths and would otherwise produce an unresolvable location.
+ */
+export function toUriReference(file: string): string {
+  return file
+    .replaceAll('\\', '/')
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
 }
 
 export function toReviewJson(result: ReviewResult, gateRan = true): ReviewJson {
@@ -99,6 +136,25 @@ export function toReviewJson(result: ReviewResult, gateRan = true): ReviewJson {
 }
 
 /**
+ * The document emitted when the reviewer never produced a verdict — quota
+ * exhausted, adapter down, unparseable output. `decision` is empty because there
+ * was none: reporting `revise` here would invent a verdict, which is the failure
+ * INT-3100 exists to prevent. The reason lands in `feedback` so a CI step can
+ * surface it without scraping stderr.
+ */
+export function gateNotRunJson(error: unknown): ReviewJson {
+  return {
+    schemaVersion: REVIEW_JSON_SCHEMA_VERSION,
+    decision: '' as ReviewResult['decision'],
+    gateRan: false,
+    feedback: error instanceof Error ? error.message : String(error),
+    issues: [],
+    suggestions: [],
+    findings: [],
+  };
+}
+
+/**
  * SARIF 2.1.0, the format GitHub code scanning ingests.
  *
  * Findings without a resolvable file are still emitted — dropping them would
@@ -108,7 +164,19 @@ export function toReviewJson(result: ReviewResult, gateRan = true): ReviewJson {
 export function toSarif(result: ReviewResult, toolVersion: string): unknown {
   const json = toReviewJson(result);
 
+  // `issues` are the blocking findings and `recommendedActions` the advisory
+  // ones — the reviewer prompt separates them deliberately. Emitting only the
+  // latter meant a `revise` carrying issues and no follow-ups produced an empty
+  // results array, so code scanning showed nothing at all for a failed gate.
+  // Issues carry no location field, hence no physicalLocation.
+  const issueResults = json.issues.map((issue) => ({
+    ruleId: 'openswarm/issue',
+    level: 'error',
+    message: { text: issue },
+  }));
+
   const rules = new Map<string, { id: string; name: string }>();
+  if (issueResults.length > 0) rules.set('openswarm/issue', { id: 'openswarm/issue', name: 'issue' });
   for (const finding of json.findings) {
     const id = `openswarm/${finding.type || 'finding'}`;
     if (!rules.has(id)) rules.set(id, { id, name: finding.type || 'finding' });
@@ -131,26 +199,29 @@ export function toSarif(result: ReviewResult, toolVersion: string): unknown {
             })),
           },
         },
-        results: json.findings.map((finding) => ({
-          ruleId: `openswarm/${finding.type || 'finding'}`,
-          // Every reviewer follow-up is advisory: the blocking decision is the
-          // verdict, not the individual finding. Reporting these as `error`
-          // would fail code scanning on suggestions the review itself approved.
-          level: 'warning',
-          message: { text: finding.title },
-          ...(finding.file
-            ? {
-                locations: [
-                  {
-                    physicalLocation: {
-                      artifactLocation: { uri: finding.file },
-                      ...(finding.line ? { region: { startLine: finding.line } } : {}),
+        results: [
+          ...issueResults,
+          ...json.findings.map((finding) => ({
+            ruleId: `openswarm/${finding.type || 'finding'}`,
+            // Follow-ups are advisory: several accompany an approve, so reporting
+            // them as errors would fail code scanning on suggestions the review
+            // itself accepted. The blocking findings are the issues above.
+            level: 'warning',
+            message: { text: finding.title },
+            ...(finding.file
+              ? {
+                  locations: [
+                    {
+                      physicalLocation: {
+                        artifactLocation: { uri: toUriReference(finding.file) },
+                        ...(finding.line ? { region: { startLine: finding.line } } : {}),
+                      },
                     },
-                  },
-                ],
-              }
-            : {}),
-        })),
+                  ],
+                }
+              : {}),
+          })),
+        ],
       },
     ],
   };


### PR DESCRIPTION
Part of INT-3102.

`openswarm review` only ever spoke to humans: coloured terminal text plus Linear issues. A CI gate needs the same verdict in a shape other tools can consume.

## `--json`

Emits the verdict on stdout with a versioned schema (`schemaVersion: 1`), **replacing** the human report rather than adding to it — mixing prose into stdout would break `openswarm review --json | jq`. Everything else the command says already routes through `log`.

```json
{
  "schemaVersion": 1,
  "decision": "revise",
  "gateRan": true,
  "feedback": "...",
  "issues": [], "suggestions": [],
  "findings": [
    { "type": "bug", "title": "Restore CSRF validation",
      "location": "src/auth/session.ts:42", "file": "src/auth/session.ts", "line": 42 }
  ]
}
```

## `--sarif <file>`

SARIF 2.1.0, so GitHub code scanning can surface findings inline on a PR.

## Two judgement calls

**Reviewer `location` is free-form prose in practice** — `src/foo.ts:42`, `src/foo.ts`, or `the auth middleware`. Only the first two can be placed in a file, so `parseLocation` refuses anything that does not look like a path. A finding whose location is prose still appears in the report but carries no `physicalLocation`: dropping it would silently shrink the report, and inventing a file would annotate a path that does not exist. The line is taken only from a trailing all-digits segment so a Windows drive letter (`C:\src\foo.ts`) is not read as one.

**SARIF findings are `warning`, not `error`.** The blocking decision is the verdict; individual follow-ups are advisory and several are emitted alongside an `approve`. Reporting them as errors would fail code scanning on suggestions the review itself accepted.

A SARIF file that cannot be written is a warning, not a failed gate — the verdict already exists and still decides the exit code (INT-3100).

## Not in this PR

PR annotations, the third leg of INT-3102, land with the GitHub Action in INT-3101 — the annotation has to be emitted from inside the workflow.

## Gates

`lint` ✅ · `typecheck` ✅ · `test` **3502 passed / 1 skipped (263 files)** ✅ · 15 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)