### PR TITLE
fix(verify): name the reason the Linux sandbox is unavailable

### DIFF
--- a/src/verify/runner.ts
+++ b/src/verify/runner.ts
@@ -1,11 +1,12 @@
 import { execFile, spawn } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
 import { access, cp, lstat, mkdir, mkdtemp, readFile, readdir, readlink, realpath, rm } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { promisify } from 'node:util';
 import { isInfraError } from '../adapters/errorClassification.js';
+import { describeLinuxSandbox, formatSandboxUnavailable } from './sandboxDiagnostics.js';
 import { copyIsolatedPath } from '../support/isolatedPath.js';
 import { loadRepoMetadata } from '../support/repoMetadata.js';
 import { resolveSharedPaths } from '../support/worktreeManager.js';
@@ -197,9 +198,23 @@ async function runCommand(command: VerifyCommand, root: string, env: NodeJS.Proc
     executable = '/usr/bin/sandbox-exec';
     invocationArgs = ['-p', profile, shell, '-lc', command.run];
   } else if (process.platform === 'linux') {
-    const bubblewrap = ['/usr/bin/bwrap', '/usr/local/bin/bwrap'].find(existsSync);
-    if (!bubblewrap) return { status: 'fail', output: '[security] OS verification sandbox is unavailable (bubblewrap not installed)' };
-    executable = bubblewrap;
+    // Still fails closed — running a worker's code unsandboxed to decide whether
+    // to trust it defeats the point. What changed is that the message now names
+    // which of the two causes applies and how to fix it, instead of reporting
+    // "unavailable" for a missing binary and dying at exec time with an opaque
+    // error for a blocked user namespace. (INT-3103)
+    const sandbox = describeLinuxSandbox({
+      exists: existsSync,
+      readSysctl: (path) => {
+        try {
+          return readFileSync(path, 'utf8');
+        } catch {
+          return undefined;
+        }
+      },
+    });
+    if (!sandbox.available) return { status: 'fail', output: formatSandboxUnavailable(sandbox) };
+    executable = sandbox.executable;
     const writableRoot = dirname(root);
     invocationArgs = ['--ro-bind', '/', '/', '--bind', writableRoot, writableRoot, '--unshare-net', '--dev', '/dev', '--proc', '/proc', '--', shell, '-lc', command.run];
   } else if (process.platform === 'win32') {

--- a/src/verify/sandboxDiagnostics.test.ts
+++ b/src/verify/sandboxDiagnostics.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  describeLinuxSandbox,
+  formatSandboxUnavailable,
+  type SandboxProbe,
+} from './sandboxDiagnostics.js';
+
+function probe(over: Partial<{ paths: string[]; sysctl: Record<string, string> }> = {}): SandboxProbe {
+  const paths = over.paths ?? ['/usr/bin/bwrap'];
+  const sysctl = over.sysctl ?? {};
+  return {
+    exists: (p) => paths.includes(p),
+    readSysctl: (p) => sysctl[p],
+  };
+}
+
+describe('describeLinuxSandbox', () => {
+  it('accepts a host with bwrap and no userns restriction', () => {
+    expect(describeLinuxSandbox(probe())).toEqual({ available: true, executable: '/usr/bin/bwrap' });
+  });
+
+  it('finds bwrap at the alternate prefix', () => {
+    const result = describeLinuxSandbox(probe({ paths: ['/usr/local/bin/bwrap'] }));
+    expect(result).toMatchObject({ available: true, executable: '/usr/local/bin/bwrap' });
+  });
+
+  it('names the install step when bwrap is missing', () => {
+    const result = describeLinuxSandbox(probe({ paths: [] }));
+    expect(result.available).toBe(false);
+    if (result.available) return;
+    expect(result.reason).toContain('not installed');
+    expect(result.remedy.join('\n')).toContain('apt-get install -y bubblewrap');
+  });
+
+  it('separates a blocked user namespace from a missing binary', () => {
+    // The case that used to surface as an opaque bwrap exec failure: the binary
+    // is present, so the old existence check passed, and the run died later.
+    const result = describeLinuxSandbox(
+      probe({ sysctl: { '/proc/sys/kernel/unprivileged_userns_clone': '0' } }),
+    );
+    expect(result.available).toBe(false);
+    if (result.available) return;
+    expect(result.reason).toContain('unprivileged user namespaces are disabled');
+    expect(result.remedy.join('\n')).toContain('seccomp=unconfined');
+  });
+
+  it('reports the AppArmor restriction Ubuntu 24.04 enables by default', () => {
+    const result = describeLinuxSandbox(
+      probe({ sysctl: { '/proc/sys/kernel/apparmor_restrict_unprivileged_userns': '1' } }),
+    );
+    expect(result.available).toBe(false);
+    if (result.available) return;
+    expect(result.reason).toContain('AppArmor');
+    expect(result.remedy.join('\n')).toContain('apparmor_restrict_unprivileged_userns=0');
+  });
+
+  it('treats an absent sysctl as unrestricted rather than blocked', () => {
+    // Most kernels do not expose these files. Refusing to run on a missing file
+    // would break every healthy host to guard against a rarer failure.
+    expect(describeLinuxSandbox(probe({ sysctl: {} })).available).toBe(true);
+  });
+
+  it('treats a permissive sysctl value as unrestricted', () => {
+    const result = describeLinuxSandbox(
+      probe({
+        sysctl: {
+          '/proc/sys/kernel/unprivileged_userns_clone': '1\n',
+          '/proc/sys/kernel/apparmor_restrict_unprivileged_userns': '0\n',
+        },
+      }),
+    );
+    expect(result.available).toBe(true);
+  });
+});
+
+describe('formatSandboxUnavailable', () => {
+  it('states the cause, the fixes, and that the gate failed closed', () => {
+    const result = describeLinuxSandbox(probe({ paths: [] }));
+    if (result.available) throw new Error('expected unavailable');
+    const text = formatSandboxUnavailable(result);
+
+    expect(text).toContain('[security] OS verification sandbox is unavailable');
+    expect(text).toContain('fix: ');
+    expect(text).toContain('fails closed');
+  });
+});

--- a/src/verify/sandboxDiagnostics.ts
+++ b/src/verify/sandboxDiagnostics.ts
@@ -1,0 +1,90 @@
+// ============================================
+// OpenSwarm — Linux verification sandbox diagnostics
+// ============================================
+//
+// Deterministic verify refuses to run without an OS sandbox, which is correct:
+// executing a worker's code unsandboxed to decide whether to trust it defeats
+// the point. But "unavailable" was a single message covering two very different
+// situations, and neither said what to do about it.
+//
+// CI containers hit both. `bwrap` is frequently not installed, and even when it
+// is, unprivileged user namespaces are commonly blocked — Docker's default
+// seccomp profile denies the syscall, and Ubuntu 24.04+ restricts it through
+// AppArmor. A bwrap that cannot unshare fails at exec time with a message that
+// does not name either cause. (INT-3103)
+
+export interface SandboxProbe {
+  /** Does this path exist? */
+  exists: (path: string) => boolean;
+  /** Read a sysctl-style file, or undefined when it is absent/unreadable. */
+  readSysctl: (path: string) => string | undefined;
+}
+
+export type SandboxAvailability =
+  | { available: true; executable: string }
+  | { available: false; reason: string; remedy: string[] };
+
+const BWRAP_PATHS = ['/usr/bin/bwrap', '/usr/local/bin/bwrap'];
+
+/** Debian/Ubuntu toggle: 0 means unprivileged userns creation is off. */
+const USERNS_CLONE = '/proc/sys/kernel/unprivileged_userns_clone';
+/** Ubuntu 24.04+: 1 means AppArmor confines unprivileged userns. */
+const APPARMOR_USERNS = '/proc/sys/kernel/apparmor_restrict_unprivileged_userns';
+
+/**
+ * Why can't we sandbox here, and what would fix it?
+ *
+ * Absent sysctls are treated as "no restriction" rather than "blocked": most
+ * kernels do not expose them at all, and refusing to run on a missing file would
+ * turn a healthy host into a broken one. A wrong guess in that direction costs a
+ * confusing failure at exec time; the other direction costs every run.
+ */
+export function describeLinuxSandbox(probe: SandboxProbe): SandboxAvailability {
+  const executable = BWRAP_PATHS.find(probe.exists);
+  if (!executable) {
+    return {
+      available: false,
+      reason: 'bubblewrap (bwrap) is not installed',
+      remedy: [
+        'Debian/Ubuntu: apt-get install -y bubblewrap',
+        'Alpine: apk add bubblewrap',
+        'GitHub Actions (ubuntu-latest): add the apt-get step above before running the gate',
+      ],
+    };
+  }
+
+  const clone = probe.readSysctl(USERNS_CLONE)?.trim();
+  if (clone === '0') {
+    return {
+      available: false,
+      reason: 'unprivileged user namespaces are disabled (kernel.unprivileged_userns_clone=0)',
+      remedy: [
+        'Host: sysctl -w kernel.unprivileged_userns_clone=1',
+        'Docker: run with --security-opt seccomp=unconfined (the default profile denies the syscall)',
+      ],
+    };
+  }
+
+  const apparmor = probe.readSysctl(APPARMOR_USERNS)?.trim();
+  if (apparmor === '1') {
+    return {
+      available: false,
+      reason: 'AppArmor restricts unprivileged user namespaces (Ubuntu 24.04+ default)',
+      remedy: [
+        'Host: sysctl -w kernel.apparmor_restrict_unprivileged_userns=0',
+        'Docker: run with --security-opt seccomp=unconfined',
+      ],
+    };
+  }
+
+  return { available: true, executable };
+}
+
+/** One-line reason plus indented remedies, for the evidence tail. */
+export function formatSandboxUnavailable(result: Extract<SandboxAvailability, { available: false }>): string {
+  return [
+    `[security] OS verification sandbox is unavailable: ${result.reason}`,
+    ...result.remedy.map((line) => `  fix: ${line}`),
+    '  Verification fails closed rather than running unsandboxed code.',
+  ].join('\n');
+}


### PR DESCRIPTION
Part of INT-3103.

Deterministic verify refuses to run without an OS sandbox, which is right — executing a worker's code unsandboxed to decide whether to trust it defeats the point. But `"unavailable"` was **one message covering two very different situations**, and neither said what to do about it.

## The gap

CI containers hit both causes:

| cause | old behaviour |
|---|---|
| `bwrap` not installed | "sandbox is unavailable (bubblewrap not installed)" — no remedy |
| unprivileged userns blocked | **passed preflight**, then died at exec time with an error naming neither cause |

The second is common and invisible: Docker's default seccomp profile denies the syscall, and Ubuntu 24.04+ restricts it through AppArmor. The old check only tested whether the binary existed.

## Now

Each cause is detected separately and carries its fix:

```
[security] OS verification sandbox is unavailable: unprivileged user namespaces are
disabled (kernel.unprivileged_userns_clone=0)
  fix: Host: sysctl -w kernel.unprivileged_userns_clone=1
  fix: Docker: run with --security-opt seccomp=unconfined (the default profile denies the syscall)
  Verification fails closed rather than running unsandboxed code.
```

**Fail-closed behaviour is unchanged** — an unavailable sandbox still fails. The message now says so explicitly rather than leaving it to be inferred.

An absent sysctl is read as *unrestricted*, not blocked: most kernels do not expose these files at all, and refusing to run on a missing file would break every healthy host to guard against a rarer one.

## Testability

The diagnosis is a pure function over an injected probe, so the Linux-only paths are covered from any host — which mattered here: the Linux box this would otherwise need went offline mid-session.

## Not in this PR

The remaining INT-3103 items — measuring on `ubuntu-latest` and the documented `verify.sandbox` opt-out — depend on the GitHub Action (INT-3101) for a real environment to measure in.

## Gates

`lint` ✅ · `typecheck` ✅ · `test` **3510 passed / 1 skipped (264 files)** ✅ · 8 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)