### PR TITLE
feat(ci): package the review gate as a GitHub Action

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -5,7 +5,14 @@ name: Review Gate
 # Deliberately manual (workflow_dispatch), not `on: pull_request`. The gate calls
 # a paid model on every run, so turning it on for every PR is a spending decision
 # the repository owner should make explicitly rather than inherit from a merge.
-# To enable it, add the `pull_request` trigger below.
+#
+# To automate it, the trigger you want is `pull_request_target`, not
+# `pull_request`: secrets are not exposed to a `pull_request` run from a fork, so
+# OPENROUTER_API_KEY would be empty and every fork PR would fail as gate-not-run.
+# `pull_request_target` runs with secrets — which is safe here only because the
+# two checkouts below keep the executed action code and the reviewed code apart,
+# and the reviewer itself runs read-only. The PR number resolves from either
+# trigger already.
 
 on:
   workflow_dispatch:
@@ -27,10 +34,45 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      # The action's own code comes from the default branch, never from the pull
+      # request. `uses: ./` against a PR checkout executes action.yml as the
+      # contributor wrote it, and this job hands that code OPENROUTER_API_KEY —
+      # so a PR that edits action.yml would be a credential handout. Two
+      # checkouts in two paths keep the executed code and the reviewed code
+      # apart.
+      #
+      # Consequence worth knowing: this workflow cannot run against the pull
+      # request that introduces action.yml, because the default branch does not
+      # have that file yet. The first real execution is necessarily after merge.
+      - name: Check out the trusted action code
+        uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ inputs.pr }}/head
-          # The gate diffs against the base branch, which a shallow single-ref
+          ref: ${{ github.event.repository.default_branch }}
+          path: action-src
+
+      - name: Resolve the pull request number
+        id: pr
+        env:
+          # From the event when a PR triggered this, from the dispatch input
+          # otherwise. Reading only `inputs.pr` would produce `refs/pull//head`
+          # the moment the `pull_request` trigger above is enabled.
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          INPUT_PR: ${{ inputs.pr }}
+        run: |
+          set -euo pipefail
+          NUMBER="${EVENT_PR:-$INPUT_PR}"
+          if [ -z "$NUMBER" ]; then
+            echo "::error::No pull request number from the event or the dispatch input"
+            exit 1
+          fi
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Check out the pull request
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
+          path: pr
+          # The gate diffs against the merge base, which a shallow single-ref
           # clone does not contain.
           fetch-depth: 0
 
@@ -38,19 +80,39 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Resolve the PR base branch
+      - name: Resolve the PR base
         id: base
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
-          BASE=$(gh pr view "${{ inputs.pr }}" --repo "$GITHUB_REPOSITORY" --json baseRefName --jq .baseRefName)
-          echo "ref=origin/$BASE" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          BASE=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json baseRefName --jq .baseRefName)
+          cd pr
+          git fetch --no-tags origin "+refs/heads/$BASE:refs/remotes/origin/$BASE"
+          # The merge base, not the tip: the base branch may have moved since the
+          # PR diverged, and a two-dot diff against its tip would list files the
+          # PR never touched.
+          #
+          # Assigned first, deliberately. `set -e` does not fire on a command
+          # substitution that fails inside an argument, so `echo "ref=$(git
+          # merge-base ...)"` would write an empty ref and let the step succeed —
+          # and an empty base makes the gate review a clean working tree, find
+          # nothing, and go green.
+          REF=$(git merge-base HEAD "refs/remotes/origin/$BASE")
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Review
         id: review
-        uses: ./
+        uses: ./action-src
         with:
+          path: pr
           base: ${{ steps.base.outputs.ref }}
+          # A hosted runner has no OpenSwarm config, so the CLI would fall back
+          # to its `codex` default and never reach OpenRouter no matter which key
+          # is exported.
+          adapter: openrouter
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           # Pin routing to the sponsor's capacity. Without it the account's own
@@ -64,3 +126,11 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.review.outputs.sarif-file }}
+          # Locations in the report are relative to the reviewed checkout, not
+          # the workspace root.
+          checkout_path: ${{ github.workspace }}/pr
+          # Without these the upload is attributed to whatever ref dispatched the
+          # workflow — the default branch — instead of the pull request that was
+          # actually analysed.
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
+          sha: ${{ steps.base.outputs.sha }}

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -1,0 +1,66 @@
+name: Review Gate
+
+# Dogfoods action.yml against this repository's own pull requests.
+#
+# Deliberately manual (workflow_dispatch), not `on: pull_request`. The gate calls
+# a paid model on every run, so turning it on for every PR is a spending decision
+# the repository owner should make explicitly rather than inherit from a merge.
+# To enable it, add the `pull_request` trigger below.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'Pull request number to review'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  # Required by upload-sarif. Without it the review still runs; only the
+  # code-scanning upload fails.
+  security-events: write
+
+jobs:
+  review:
+    name: OpenSwarm review
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ inputs.pr }}/head
+          # The gate diffs against the base branch, which a shallow single-ref
+          # clone does not contain.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Resolve the PR base branch
+        id: base
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BASE=$(gh pr view "${{ inputs.pr }}" --repo "$GITHUB_REPOSITORY" --json baseRefName --jq .baseRefName)
+          echo "ref=origin/$BASE" >> "$GITHUB_OUTPUT"
+
+      - name: Review
+        id: review
+        uses: ./
+        with:
+          base: ${{ steps.base.outputs.ref }}
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Pin routing to the sponsor's capacity. Without it the account's own
+          # credit is spent, and it has none.
+          OPENROUTER_PROVIDER_ONLY: atlas-cloud
+
+      - name: Upload SARIF
+        # Runs even when the gate rejected — the findings are most useful exactly
+        # then. Skipped only if no report was produced.
+        if: always() && steps.review.outputs.sarif-file != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.review.outputs.sarif-file }}

--- a/README.md
+++ b/README.md
@@ -132,6 +132,46 @@ Treat any non-zero exit as a failed check. The `1`/`2` split lets a workflow
 retry or alert differently when the gate could not run at all (e.g. a quota
 window exhausted — stderr names the cause and, when known, the reset time).
 
+### Running the gate in CI
+
+A composite action wraps the whole flow — install, diff against the PR base,
+review, and map the exit code onto the job result:
+
+```yaml
+permissions:
+  contents: read
+  security-events: write   # only needed for the SARIF upload
+
+steps:
+  - uses: actions/checkout@v4
+    with: { fetch-depth: 0 }   # the base branch has to be present to diff against
+  - uses: actions/setup-node@v4
+    with: { node-version: '22' }
+  - id: review
+    uses: unohee/OpenSwarm@main
+    env:
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+  - if: always() && steps.review.outputs.sarif-file != ''
+    uses: github/codeql-action/upload-sarif@v3
+    with: { sarif_file: ${{ steps.review.outputs.sarif-file }} }
+```
+
+Inputs: `base` (defaults to the PR base branch), `adapter`, `version`,
+`sarif-file`, and `fail-on-gate-not-run` — the last defaults to `true` because a
+review that did not happen must not read as a pass.
+
+Outputs: `decision`, `gate-ran`, `sarif-file`.
+
+For scripting without the action, `--json` prints the verdict on stdout under a
+versioned schema (the human report is suppressed so `openswarm review --json |
+jq` works), and `--sarif <file>` writes SARIF 2.1.0 for code scanning. Findings
+are reported at `warning`: the verdict is what blocks, while individual
+follow-ups are advisory and some accompany an approve.
+
+`.github/workflows/review-gate.yml` in this repository dogfoods the action. It is
+`workflow_dispatch` only — the gate calls a paid model on every run, so enabling
+it for every pull request is left as an explicit choice.
+
 ### Deterministic verification
 
 Autonomous pipelines enable baseline-diff verification by default: OpenSwarm runs repository test/typecheck commands once, compares a failing head against the merge base, and gives the reviewer structured evidence so pre-existing failures do not block unrelated work. Add `.openswarm/verify.yaml` for repository-specific commands (see [`templates/verify.example.yaml`](templates/verify.example.yaml)), or let OpenSwarm discover standard Node, Python, Rust, and Go checks. Configure the behavior under `autonomous.verify`; the legacy `guards.qualityGate` whole-tree check is deprecated.

--- a/README.md
+++ b/README.md
@@ -144,11 +144,14 @@ permissions:
 
 steps:
   - uses: actions/checkout@v4
-    with: { fetch-depth: 0 }   # the base branch has to be present to diff against
+    with: { fetch-depth: 0 }   # the merge base has to be present to diff against
   - uses: actions/setup-node@v4
     with: { node-version: '22' }
   - id: review
     uses: unohee/OpenSwarm@main
+    with:
+      adapter: openrouter   # a hosted runner has no config; without this the CLI
+                            # falls back to its `codex` default
     env:
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
   - if: always() && steps.review.outputs.sarif-file != ''
@@ -156,11 +159,48 @@ steps:
     with: { sarif_file: ${{ steps.review.outputs.sarif-file }} }
 ```
 
-Inputs: `base` (defaults to the PR base branch), `adapter`, `version`,
+Inputs: `path` (which checkout to review), `base` (defaults to the merge base of
+the PR head and its base branch), `adapter`, `read-only`, `version`,
 `sarif-file`, and `fail-on-gate-not-run` — the last defaults to `true` because a
 review that did not happen must not read as a pass.
 
 Outputs: `decision`, `gate-ran`, `sarif-file`.
+
+#### Reviewing pull requests safely
+
+The reviewer reads attacker-authored files with your provider credential in the
+environment. Two properties keep that from becoming code execution:
+
+**`read-only` defaults to `true`**, which denies the reviewer every mutating tool
+including `bash`. It is enforced per adapter, and an adapter that cannot enforce
+it refuses to run rather than quietly ignoring the flag:
+
+| Adapter | How read-only is enforced |
+| --- | --- |
+| `openrouter`, `atlascloud`, `gpt`, `codex-responses`, `local`/`lmstudio` | The agentic loop withholds the mutating, web, and MCP tools, and the executor refuses them if called anyway |
+| `claude` | `--permission-mode default` with an allowlist of `Read`/`Grep`/`Glob`, instead of `bypassPermissions` |
+| `codex` | `--sandbox read-only` instead of `workspace-write` |
+| anything else | Refused — `spawnCli` will not start a read-only run on an adapter that has not declared enforcement |
+
+**The reviewed checkout never becomes the working directory.** OpenSwarm looks
+for its own `config.yaml` in the current directory first, so a config committed
+to the pull request would otherwise choose the run's adapter, model, and MCP
+servers. The action runs from the runner temp and points `--path` at the
+checkout instead.
+
+**Run the action's code from a trusted ref.** `uses: unohee/OpenSwarm@main`
+already does this — the action code comes from this repository, not from the
+pull request. It is only `uses: ./` that is unsafe, because after checking out a
+pull request that path holds `action.yml` as the contributor wrote it, with your
+secrets in scope. If you self-host the action, check it out from your default
+branch into its own path and the pull request into another, then point `path` at
+the latter — see
+[`.github/workflows/review-gate.yml`](.github/workflows/review-gate.yml), which
+does exactly that to dogfood this repository.
+
+**To run it automatically, the trigger is `pull_request_target`.** A
+`pull_request` run from a fork gets no secrets, so the provider key would be
+empty and every fork PR would fail as gate-not-run.
 
 For scripting without the action, `--json` prints the verdict on stdout under a
 versioned schema (the human report is suppressed so `openswarm review --json |

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,114 @@
+name: 'OpenSwarm Review'
+description: 'Run the OpenSwarm agentic review gate over a pull request diff'
+author: 'Heewon Oh'
+
+branding:
+  icon: 'check-circle'
+  color: 'purple'
+
+inputs:
+  base:
+    description: >-
+      Git ref to diff against. Defaults to the PR base branch. A checked-out PR
+      branch has no dirty working tree, only commits ahead of its base, so the
+      gate must review the committed diff rather than working-tree changes.
+    required: false
+    default: ''
+  adapter:
+    description: 'Adapter override (openrouter, atlascloud, codex-responses, ...). Defaults to the configured provider.'
+    required: false
+    default: ''
+  version:
+    description: 'Version of @intrect/openswarm to install.'
+    required: false
+    default: 'latest'
+  sarif-file:
+    description: >-
+      Where to write the SARIF report. Uploading it is left to the caller —
+      that step needs `security-events: write`, which a composite action cannot
+      grant itself.
+    required: false
+    default: 'openswarm-review.sarif'
+  fail-on-gate-not-run:
+    description: >-
+      Whether a gate that never produced a verdict (quota exhausted, adapter
+      down) fails the job. Default true: a review that did not happen must not
+      read as a pass. Set false only if a separate alert covers it.
+    required: false
+    default: 'true'
+
+outputs:
+  decision:
+    description: 'approve | revise | reject — empty when the gate did not run.'
+    value: ${{ steps.review.outputs.decision }}
+  gate-ran:
+    description: 'true when a verdict was produced, false when the gate could not run.'
+    value: ${{ steps.review.outputs.gate-ran }}
+  sarif-file:
+    description: 'Path to the SARIF report, when one was written.'
+    value: ${{ steps.review.outputs.sarif-file }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install OpenSwarm
+      shell: bash
+      run: npm install -g "@intrect/openswarm@${{ inputs.version }}"
+
+    - name: Run review gate
+      id: review
+      shell: bash
+      env:
+        # `review` reads provider credentials from the environment; the caller
+        # passes whichever secrets its configured adapter needs.
+        OPENSWARM_BASE: ${{ inputs.base }}
+        OPENSWARM_ADAPTER: ${{ inputs.adapter }}
+        SARIF_FILE: ${{ inputs.sarif-file }}
+        FAIL_ON_GATE_NOT_RUN: ${{ inputs.fail-on-gate-not-run }}
+        GITHUB_BASE_REF: ${{ github.base_ref }}
+      run: |
+        set -uo pipefail
+
+        BASE="${OPENSWARM_BASE:-}"
+        if [ -z "$BASE" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+          # actions/checkout fetches only the PR head by default, so the base
+          # branch has to be fetched before it can be diffed against.
+          git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF" || true
+          BASE="origin/$GITHUB_BASE_REF"
+        fi
+
+        ARGS=(review --json --sarif "$SARIF_FILE")
+        [ -n "$BASE" ] && ARGS+=(--base "$BASE")
+        [ -n "${OPENSWARM_ADAPTER:-}" ] && ARGS+=(--adapter "$OPENSWARM_ADAPTER")
+
+        # stdout is the JSON document; diagnostics go to stderr and stay on the
+        # job log.
+        set +e
+        openswarm "${ARGS[@]}" > review.json
+        STATUS=$?
+        set -e
+
+        DECISION=""
+        GATE_RAN="false"
+        if [ -s review.json ]; then
+          DECISION=$(node -e 'try{process.stdout.write(String(JSON.parse(require("fs").readFileSync("review.json","utf8")).decision??""))}catch{}')
+          GATE_RAN=$(node -e 'try{process.stdout.write(String(JSON.parse(require("fs").readFileSync("review.json","utf8")).gateRan??false))}catch{process.stdout.write("false")}')
+        fi
+
+        echo "decision=$DECISION" >> "$GITHUB_OUTPUT"
+        echo "gate-ran=$GATE_RAN" >> "$GITHUB_OUTPUT"
+        [ -f "$SARIF_FILE" ] && echo "sarif-file=$SARIF_FILE" >> "$GITHUB_OUTPUT"
+
+        # Exit contract (INT-3100): 0 ran and did not reject · 1 ran and rejected
+        # · 2 never ran. The 1/2 split is preserved so a workflow can alert
+        # differently, but both are failures by default — a review that did not
+        # happen is not a pass.
+        case "$STATUS" in
+          0) echo "::notice::OpenSwarm review: ${DECISION:-no changes}" ;;
+          1) echo "::error::OpenSwarm review rejected this change"; exit 1 ;;
+          2)
+            echo "::error::OpenSwarm review gate did not run — no verdict was produced"
+            if [ "$FAIL_ON_GATE_NOT_RUN" = "true" ]; then exit 2; fi
+            ;;
+          *) echo "::error::OpenSwarm exited with unexpected status $STATUS"; exit "$STATUS" ;;
+        esac

--- a/action.yml
+++ b/action.yml
@@ -7,26 +7,50 @@ branding:
   color: 'purple'
 
 inputs:
+  path:
+    description: >-
+      Directory holding the checkout to review, relative to the workspace.
+      Defaults to the workspace root. Set this when the reviewed code and the
+      action's own code are checked out to separate paths — which is the safe
+      arrangement for reviewing pull requests.
+    required: false
+    default: ''
   base:
     description: >-
-      Git ref to diff against. Defaults to the PR base branch. A checked-out PR
-      branch has no dirty working tree, only commits ahead of its base, so the
-      gate must review the committed diff rather than working-tree changes.
+      Git ref or commit to diff against. Defaults to the merge base of the PR
+      head and its base branch. A checked-out PR branch has no dirty working
+      tree, only commits ahead of its base, so the gate must review the
+      committed diff rather than working-tree changes.
     required: false
     default: ''
   adapter:
-    description: 'Adapter override (openrouter, atlascloud, codex-responses, ...). Defaults to the configured provider.'
+    description: >-
+      Adapter override (openrouter, atlascloud, codex-responses, ...). Pass one
+      explicitly on a hosted runner: with no OpenSwarm config present the CLI
+      falls back to its `codex` default, so exporting another provider's key is
+      not by itself enough to select that provider.
     required: false
     default: ''
+  read-only:
+    description: >-
+      Deny the reviewer every mutating tool, including bash. Default true, and
+      it should stay true for anything triggered by a pull request: the reviewer
+      reads attacker-authored files with the provider credential in the
+      environment, so a shell is an exfiltration path. Adapters that cannot
+      enforce read-only refuse to run rather than silently ignoring this.
+    required: false
+    default: 'true'
   version:
     description: 'Version of @intrect/openswarm to install.'
     required: false
     default: 'latest'
   sarif-file:
     description: >-
-      Where to write the SARIF report. Uploading it is left to the caller —
-      that step needs `security-events: write`, which a composite action cannot
-      grant itself.
+      Where to write the SARIF report. Relative paths are resolved against the
+      runner temp directory, not the checkout — a report written inside the
+      reviewed tree would itself show up as a changed file. Uploading it is left
+      to the caller: that step needs `security-events: write`, which a composite
+      action cannot grant itself.
     required: false
     default: 'openswarm-review.sarif'
   fail-on-gate-not-run:
@@ -45,7 +69,7 @@ outputs:
     description: 'true when a verdict was produced, false when the gate could not run.'
     value: ${{ steps.review.outputs.gate-ran }}
   sarif-file:
-    description: 'Path to the SARIF report, when one was written.'
+    description: 'Absolute path to the SARIF report, when one was written.'
     value: ${{ steps.review.outputs.sarif-file }}
 
 runs:
@@ -61,48 +85,138 @@ runs:
       env:
         # `review` reads provider credentials from the environment; the caller
         # passes whichever secrets its configured adapter needs.
+        REVIEW_PATH: ${{ inputs.path }}
         OPENSWARM_BASE: ${{ inputs.base }}
         OPENSWARM_ADAPTER: ${{ inputs.adapter }}
+        READ_ONLY: ${{ inputs.read-only }}
         SARIF_FILE: ${{ inputs.sarif-file }}
         FAIL_ON_GATE_NOT_RUN: ${{ inputs.fail-on-gate-not-run }}
         GITHUB_BASE_REF: ${{ github.base_ref }}
       run: |
-        set -uo pipefail
+        set -euo pipefail
+
+        # Booleans are parsed, not string-compared. `[ "$X" = "true" ]` turns a
+        # typo — `True`, `yes`, a trailing space — into a silently disabled
+        # security control, which for `read-only` means reviewing attacker code
+        # with a shell. Anything that is not exactly true or false is refused.
+        parse_bool() {
+          case "$2" in
+            true|false) printf '%s' "$2" ;;
+            *) echo "::error::Input '$1' must be exactly 'true' or 'false' (got '$2')" >&2; exit 2 ;;
+          esac
+        }
+        READ_ONLY=$(parse_bool read-only "${READ_ONLY:-true}")
+        FAIL_ON_GATE_NOT_RUN=$(parse_bool fail-on-gate-not-run "${FAIL_ON_GATE_NOT_RUN:-true}")
+
+        # Written as if-statements rather than `test && action` one-liners on
+        # purpose: under `set -e` a one-liner whose test is false returns 1 and
+        # kills the step, so the optional paths would abort the run.
+        REPO_DIR="$GITHUB_WORKSPACE"
+        if [ -n "${REVIEW_PATH:-}" ]; then
+          case "$REVIEW_PATH" in
+            /*) echo "::error::Input 'path' must be relative to the workspace (got '$REVIEW_PATH')" >&2; exit 2 ;;
+          esac
+          REPO_DIR="$GITHUB_WORKSPACE/$REVIEW_PATH"
+        fi
+        if [ ! -d "$REPO_DIR" ]; then
+          echo "::error::No checkout at '$REPO_DIR'" >&2
+          exit 2
+        fi
+        cd "$RUNNER_TEMP"
+
+        # The installed CLI has to actually support what this action passes it.
+        # Commander exits 1 on an unknown option, and 1 is the reject code — so
+        # an older @intrect/openswarm would report every run as "rejected"
+        # without ever reviewing anything. Fail as gate-not-run instead.
+        HELP=$(openswarm review --help 2>&1 || true)
+        for required in --json --sarif $( [ "$READ_ONLY" = "true" ] && echo --read-only ); do
+          case "$HELP" in
+            *"$required"*) ;;
+            *)
+              echo "::error::The installed @intrect/openswarm does not support 'review $required'. Pin a newer 'version' input." >&2
+              exit 2
+              ;;
+          esac
+        done
 
         BASE="${OPENSWARM_BASE:-}"
         if [ -z "$BASE" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
           # actions/checkout fetches only the PR head by default, so the base
-          # branch has to be fetched before it can be diffed against.
-          git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF" || true
-          BASE="origin/$GITHUB_BASE_REF"
+          # branch has to be fetched before it can be diffed against. No
+          # `|| true` here: continuing with a ref that was never fetched makes
+          # the gate pass in exactly the case where it could not establish a
+          # base, and a stale remote-tracking ref is no better — it produces a
+          # confident verdict about the wrong diff.
+          if ! git -C "$REPO_DIR" fetch --no-tags origin \
+            "+refs/heads/$GITHUB_BASE_REF:refs/remotes/origin/$GITHUB_BASE_REF"; then
+            echo "::error::Could not fetch base branch '$GITHUB_BASE_REF' — refusing to review against an unknown base"
+            exit 2
+          fi
+
+          # The merge base, not the base tip. `--base <ref>` becomes a two-dot
+          # `git diff`, so passing the current tip of a base branch that moved
+          # after the PR diverged lists files the PR never touched, and the
+          # reviewer rejects a change over someone else's commits.
+          if ! BASE=$(git -C "$REPO_DIR" merge-base HEAD "refs/remotes/origin/$GITHUB_BASE_REF"); then
+            echo "::error::Could not resolve a merge base with '$GITHUB_BASE_REF' — a shallow checkout cannot; use fetch-depth: 0"
+            exit 2
+          fi
+          echo "Reviewing against merge base $BASE"
         fi
 
-        ARGS=(review --json --sarif "$SARIF_FILE")
-        [ -n "$BASE" ] && ARGS+=(--base "$BASE")
-        [ -n "${OPENSWARM_ADAPTER:-}" ] && ARGS+=(--adapter "$OPENSWARM_ADAPTER")
+        # Scratch files live in the runner temp, never in the checkout: an
+        # untracked file inside the tree is picked up by the changed-file scan
+        # and reviewed as part of the diff, so even a base with no real changes
+        # would invoke the paid reviewer.
+        case "$SARIF_FILE" in
+          /*) SARIF_PATH="$SARIF_FILE" ;;
+          *)  SARIF_PATH="$RUNNER_TEMP/$SARIF_FILE" ;;
+        esac
+        REVIEW_JSON="$RUNNER_TEMP/openswarm-review.json"
+
+        # `--path` rather than running from inside the checkout. OpenSwarm looks
+        # for its own config in the current directory first, and a config.yaml
+        # authored by whoever opened the pull request would otherwise choose this
+        # run's adapter, model and MCP servers. Reviewing from the runner temp
+        # keeps that discovery away from the reviewed tree.
+        ARGS=(review --path "$REPO_DIR" --json --sarif "$SARIF_PATH")
+        if [ -n "$BASE" ]; then ARGS+=(--base "$BASE"); fi
+        if [ -n "${OPENSWARM_ADAPTER:-}" ]; then ARGS+=(--adapter "$OPENSWARM_ADAPTER"); fi
+        if [ "${READ_ONLY:-true}" = "true" ]; then ARGS+=(--read-only); fi
 
         # stdout is the JSON document; diagnostics go to stderr and stay on the
         # job log.
         set +e
-        openswarm "${ARGS[@]}" > review.json
+        openswarm "${ARGS[@]}" > "$REVIEW_JSON"
         STATUS=$?
         set -e
 
         DECISION=""
         GATE_RAN="false"
-        if [ -s review.json ]; then
-          DECISION=$(node -e 'try{process.stdout.write(String(JSON.parse(require("fs").readFileSync("review.json","utf8")).decision??""))}catch{}')
-          GATE_RAN=$(node -e 'try{process.stdout.write(String(JSON.parse(require("fs").readFileSync("review.json","utf8")).gateRan??false))}catch{process.stdout.write("false")}')
+        if [ -s "$REVIEW_JSON" ]; then
+          DECISION=$(REVIEW_JSON="$REVIEW_JSON" node -e 'try{process.stdout.write(String(JSON.parse(require("fs").readFileSync(process.env.REVIEW_JSON,"utf8")).decision??""))}catch{}')
+          GATE_RAN=$(REVIEW_JSON="$REVIEW_JSON" node -e 'try{process.stdout.write(String(JSON.parse(require("fs").readFileSync(process.env.REVIEW_JSON,"utf8")).gateRan??false))}catch{process.stdout.write("false")}')
         fi
 
         echo "decision=$DECISION" >> "$GITHUB_OUTPUT"
         echo "gate-ran=$GATE_RAN" >> "$GITHUB_OUTPUT"
-        [ -f "$SARIF_FILE" ] && echo "sarif-file=$SARIF_FILE" >> "$GITHUB_OUTPUT"
+        if [ -f "$SARIF_PATH" ]; then echo "sarif-file=$SARIF_PATH" >> "$GITHUB_OUTPUT"; fi
 
         # Exit contract (INT-3100): 0 ran and did not reject · 1 ran and rejected
         # · 2 never ran. The 1/2 split is preserved so a workflow can alert
         # differently, but both are failures by default — a review that did not
         # happen is not a pass.
+        # An exit status is only trusted to mean "rejected" when a verdict was
+        # actually parsed. Anything that exits non-zero before producing one —
+        # an unknown option, a crash, output that is not the JSON document — is
+        # a gate that did not run, and calling that a reject both misreports the
+        # change and hides the real failure.
+        if [ "$STATUS" != "0" ] && [ "$GATE_RAN" != "true" ]; then
+          echo "::error::OpenSwarm exited $STATUS without producing a verdict — the gate did not run"
+          if [ "$FAIL_ON_GATE_NOT_RUN" = "true" ]; then exit 2; fi
+          exit 0
+        fi
+
         case "$STATUS" in
           0) echo "::notice::OpenSwarm review: ${DECISION:-no changes}" ;;
           1) echo "::error::OpenSwarm review rejected this change"; exit 1 ;;


### PR DESCRIPTION
Part of INT-3101.

`openswarm review` already had the exit-code contract a merge gate needs (INT-3100) and, since #362, machine-readable output. What was missing was the wrapper: every consumer had to hand-write the install, the base fetch, the flag set, and the exit-code mapping.

## Two details a hand-rolled step usually gets wrong

**The base branch isn't there.** `actions/checkout` fetches only the PR head, so `git diff` against the base finds nothing and **the gate passes vacuously** — the worst possible failure for a merge gate. The action fetches the base ref first.

**`exit 2` must fail.** That is the entire point of INT-3100's 1/2 split: a review that did not happen must not read as a pass. Default is to fail the job; `fail-on-gate-not-run: false` exists for callers with a separate alert, and it is opt-in.

## Usage

```yaml
permissions:
  contents: read
  security-events: write   # only for the SARIF upload

steps:
  - uses: actions/checkout@v4
    with: { fetch-depth: 0 }
  - uses: actions/setup-node@v4
    with: { node-version: '22' }
  - id: review
    uses: unohee/OpenSwarm@main
    env:
      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
  - if: always() && steps.review.outputs.sarif-file != ''
    uses: github/codeql-action/upload-sarif@v3
    with: { sarif_file: ${{ steps.review.outputs.sarif-file }} }
```

Inputs: `base`, `adapter`, `version`, `sarif-file`, `fail-on-gate-not-run`.
Outputs: `decision`, `gate-ran`, `sarif-file`.

SARIF upload stays with the caller because it needs `security-events: write`, which a composite action cannot grant itself.

## The dogfood workflow is manual on purpose

`.github/workflows/review-gate.yml` is `workflow_dispatch`, **not** `on: pull_request`. The gate calls a paid model on every run, so enabling it for every PR is a spending decision the repository owner should make deliberately rather than inherit from a merge. It pins routing to the sponsor's capacity — without that the account's own credit is spent, and it has none.

## Verification

Both YAML files parse, and the composite step's shell script passes `bash -n`. **The action itself has not been executed** — that needs a dispatch on a real PR with the secrets configured, which is the natural next step once this is on `main`.

## Remaining on INT-3101

Token-only auth for Linear (adapter keys already read from env) and the CLI-install path for `codex`/`claude` adapters in a container. Neither blocks the action for API-direct adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)