### PR TITLE
feat(review): read-only reviewer mode, enforced or refused (INT-3189)

### DIFF
--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -246,8 +246,14 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
         ...(applyPatch && editFormat === 'json' && !readOnly ? [APPLY_PATCH_TOOL] : []),
         // Not in readOnly: it spawns compiler subprocesses, matching bash's exclusion.
         ...(diagnosticsTool && !readOnly ? [DIAGNOSTICS_TOOL] : []),
-        ...(webTools ? WEB_TOOL_DEFINITIONS : []),
-        ...(mcpTools ?? []),
+        // Both are withheld in readOnly. A read-only run exists because the
+        // material under inspection is untrusted, and a fetch is an outbound
+        // channel for anything the agent can read — the provider credential
+        // included. MCP servers are withheld for the mirror reason: OpenSwarm's
+        // own memory server exposes writes, so injected content could leave
+        // something behind for a later run. (INT-3189)
+        ...(webTools && !readOnly ? WEB_TOOL_DEFINITIONS : []),
+        ...(readOnly ? [] : mcpTools ?? []),
       ]
     : [];
   const readCache = createReadCache(); // 루프 단위 read 캐시 (중복 read 차단)

--- a/src/adapters/atlascloud.ts
+++ b/src/adapters/atlascloud.ts
@@ -80,6 +80,8 @@ export class AtlasCloudCliAdapter implements CliAdapter {
     supportsModelSelection: true,
     managedGit: false,
     supportedSkills: [],
+    // The agentic loop honours CliRunOptions.readOnly (see agenticLoop/tools). (INT-3189)
+    enforcesReadOnly: true,
   };
 
   async isAvailable(): Promise<boolean> {

--- a/src/adapters/base.spawn.test.ts
+++ b/src/adapters/base.spawn.test.ts
@@ -78,3 +78,41 @@ describe('argv-safe adapter spawning', () => {
     expect(existsSync(temporaryDir)).toBe(false);
   });
 });
+
+describe('read-only fail-closed guard (INT-3189)', () => {
+  const stub = (enforcesReadOnly?: boolean): CliAdapter => ({
+    name: 'fixture',
+    capabilities: {
+      supportsStreaming: false,
+      supportsJsonOutput: false,
+      supportsModelSelection: false,
+      managedGit: false,
+      supportedSkills: [],
+      ...(enforcesReadOnly === undefined ? {} : { enforcesReadOnly }),
+    },
+    isAvailable: async () => true,
+    getDefaultModel: async () => 'fixture',
+    buildCommand: () => ({ command: 'fixture-cli', args: [] }),
+    run: async () => ({ exitCode: 0, stdout: '', stderr: '', durationMs: 1 }),
+    parseWorkerOutput: () => ({ success: true, summary: '', filesChanged: [], commands: [], output: '' }),
+    parseReviewerOutput: () => ({ decision: 'approve', feedback: '', issues: [], suggestions: [] }),
+  });
+
+  it('refuses a read-only run on an adapter that cannot enforce it', async () => {
+    // The alternative is running with full tool access while the caller believes
+    // writes and shell are denied — the failure mode the flag exists to prevent.
+    await expect(
+      spawnCli(stub(), { prompt: 'p', cwd: process.cwd(), readOnly: true }),
+    ).rejects.toThrow(/cannot enforce read-only/);
+  });
+
+  it('lets the same adapter run when read-only was never asked for', async () => {
+    await expect(spawnCli(stub(), { prompt: 'p', cwd: process.cwd() })).resolves.toMatchObject({ exitCode: 0 });
+  });
+
+  it('runs read-only on an adapter that declares enforcement', async () => {
+    await expect(
+      spawnCli(stub(true), { prompt: 'p', cwd: process.cwd(), readOnly: true }),
+    ).resolves.toMatchObject({ exitCode: 0 });
+  });
+});

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -23,6 +23,17 @@ export async function spawnCli(
   adapter: CliAdapter,
   options: CliRunOptions,
 ): Promise<CliRunResult> {
+  // Fail closed before anything runs. `readOnly` is asked for when the input is
+  // untrusted, so an adapter that ignores it would hand a full toolset to an
+  // agent reading attacker-authored files. Refusing is loud; ignoring is not.
+  // (INT-3189)
+  if (options.readOnly && !adapter.capabilities.enforcesReadOnly) {
+    throw new Error(
+      `Adapter '${adapter.name}' cannot enforce read-only mode; refusing to run with full tool access. ` +
+        `Use an adapter that declares enforcesReadOnly, or drop the read-only requirement.`,
+    );
+  }
+
   // 어댑터가 직접 실행을 지원하면 shell spawn 대신 사용
   if (adapter.run) {
     return adapter.run(options);

--- a/src/adapters/claude.test.ts
+++ b/src/adapters/claude.test.ts
@@ -56,3 +56,42 @@ describe('ClaudeCliAdapter.buildCommand model pinning (INT-2509)', () => {
     expect(args[args.indexOf('--model') + 1]).toBe('sonnet; touch /tmp/pwned');
   });
 });
+
+describe('ClaudeCliAdapter read-only mode (INT-3189)', () => {
+  it('drops bypassPermissions for an allowlist of inspection tools', () => {
+    // bypassPermissions is what grants Write and Bash, so a read-only run that
+    // kept it would deny nothing. `-p` has no one to prompt, so anything outside
+    // --allowedTools is refused outright.
+    const { args } = new ClaudeCliAdapter().buildCommand({
+      prompt: '/tmp/prompt.txt',
+      cwd: '/tmp/project',
+      model: 'claude-sonnet-4',
+      readOnly: true,
+    });
+
+    expect(args).not.toContain('bypassPermissions');
+    expect(args.slice(args.indexOf('--permission-mode'), args.indexOf('--permission-mode') + 2))
+      .toEqual(['--permission-mode', 'default']);
+    const allowed = args.slice(args.indexOf('--allowedTools') + 1, args.indexOf('--model'));
+    expect(allowed).toEqual(['Read', 'Grep', 'Glob']);
+    // Task would spawn a subagent whose toolset this flag never reaches.
+    expect(allowed).not.toContain('Task');
+    expect(allowed.some((tool) => /Write|Edit|Bash|Web/.test(tool))).toBe(false);
+  });
+
+  it('does not register the memory MCP server in a read-only run', () => {
+    // It exposes writes, and every call would be denied by the allowlist anyway.
+    const { args } = new ClaudeCliAdapter().buildCommand({
+      prompt: '/tmp/prompt.txt',
+      cwd: '/tmp/project',
+      model: 'claude-sonnet-4',
+      readOnly: true,
+    });
+
+    expect(args).not.toContain('--mcp-config');
+  });
+
+  it('declares that it enforces read-only, so spawnCli does not refuse it', () => {
+    expect(new ClaudeCliAdapter().capabilities.enforcesReadOnly).toBe(true);
+  });
+});

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -30,6 +30,18 @@ const execFileAsync = promisify(execFile);
  */
 const CLAUDE_DEFAULT_MODEL = 'sonnet';
 
+/**
+ * The only tools a read-only run may use. Inspection and search, nothing that
+ * writes and nothing that shells out.
+ *
+ * `Task` is absent deliberately: a subagent is a second agent whose toolset this
+ * flag does not reach, which would turn the allowlist into a suggestion. Web
+ * tools are absent for the same reason the sandbox exists — the diff under
+ * review is attacker-authored, and a fetch is an outbound channel for whatever
+ * the agent can read, including the provider credential.
+ */
+const READ_ONLY_CLAUDE_TOOLS = ['Read', 'Grep', 'Glob'];
+
 // Claude CLI Adapter
 
 export class ClaudeCliAdapter implements CliAdapter {
@@ -41,6 +53,7 @@ export class ClaudeCliAdapter implements CliAdapter {
     supportsModelSelection: true,
     managedGit: false,
     supportedSkills: ['/audit', '/documents', '/refactor'],
+    enforcesReadOnly: true,
   };
 
   async isAvailable(): Promise<boolean> {
@@ -62,8 +75,21 @@ export class ClaudeCliAdapter implements CliAdapter {
     if (!model.trim() || model.includes('\0')) throw new Error('Invalid Claude model');
     // Register OpenSwarm's memory MCP server unless the caller needs an isolated run.
     // bypassPermissions auto-allows its tool when present.
-    const args = ['-p', '--output-format', 'stream-json', '--verbose', '--permission-mode', 'bypassPermissions'];
-    const mcpConfig = options.memoryTools !== false ? writeClaudeMcpConfig() : undefined;
+    //
+    // Read-only runs must not use bypassPermissions — it is what grants Write and
+    // Bash in the first place. `--permission-mode default` in `-p` has no one to
+    // prompt, so anything outside the allowlist is denied outright (verified:
+    // Write refused twice, no file created). An allowlist rather than a denylist,
+    // so a tool added to the CLI later is denied by default. (INT-3189)
+    const args = options.readOnly
+      ? ['-p', '--output-format', 'stream-json', '--verbose', '--permission-mode', 'default',
+         '--allowedTools', ...READ_ONLY_CLAUDE_TOOLS]
+      : ['-p', '--output-format', 'stream-json', '--verbose', '--permission-mode', 'bypassPermissions'];
+    // Not registered in a read-only run: the memory tools are outside the
+    // allowlist, so every call would be denied anyway, and the server exposes
+    // writes — memory is the one place a prompt-injected review could leave
+    // something behind for the next run.
+    const mcpConfig = options.memoryTools !== false && !options.readOnly ? writeClaudeMcpConfig() : undefined;
     if (mcpConfig) args.push('--mcp-config', mcpConfig);
     args.push('--model', model);
     if (options.maxTurns) args.push('--max-turns', String(options.maxTurns));

--- a/src/adapters/codex.test.ts
+++ b/src/adapters/codex.test.ts
@@ -179,3 +179,25 @@ describe('CodexCliAdapter', () => {
     expect(logs).toEqual(['Hello world']);
   });
 });
+
+describe('CodexCliAdapter read-only mode (INT-3189)', () => {
+  const adapter = new CodexCliAdapter();
+
+  it('drops to the read-only sandbox policy and unregisters memory', () => {
+    const { args } = adapter.buildCommand({
+      prompt: '/tmp/prompt.txt',
+      cwd: '/tmp/project',
+      model: 'gpt-5-codex',
+      readOnly: true,
+    });
+
+    expect(args.slice(args.indexOf('--sandbox'), args.indexOf('--sandbox') + 2))
+      .toEqual(['--sandbox', 'read-only']);
+    expect(args).not.toContain('workspace-write');
+    expect(args.join(' ')).not.toContain('openswarm_memory');
+  });
+
+  it('declares that it enforces read-only, so spawnCli does not refuse it', () => {
+    expect(adapter.capabilities.enforcesReadOnly).toBe(true);
+  });
+});

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -35,6 +35,7 @@ export class CodexCliAdapter implements CliAdapter {
     supportsModelSelection: true,
     managedGit: true,
     supportedSkills: [],
+    enforcesReadOnly: true,
   };
 
   async isAvailable(): Promise<boolean> {
@@ -77,9 +78,16 @@ export class CodexCliAdapter implements CliAdapter {
     // replacement is `--sandbox workspace-write`: same low-friction policy (writes
     // confined to the workspace, no approval prompts in non-interactive `exec`). (INT-1699)
     // Register OpenSwarm's memory MCP server unless the caller needs an isolated run.
-    const args = ['exec', '--json', '--sandbox', 'workspace-write', '--skip-git-repo-check'];
+    // A read-only run drops to codex's own `read-only` sandbox policy. Stronger
+    // than a tool denylist: shell commands still run, but the filesystem is
+    // read-only and the sandbox denies network, so a prompt-injected reviewer
+    // has nothing to write to and nowhere to send what it read. (INT-3189)
+    const sandbox = options.readOnly ? 'read-only' : 'workspace-write';
+    const args = ['exec', '--json', '--sandbox', sandbox, '--skip-git-repo-check'];
     if (resolvedModel) args.push('-m', resolvedModel);
-    if (options.memoryTools !== false) args.push(...codexMcpConfigArgs());
+    // See the claude adapter: the memory server exposes writes, and a read-only
+    // review is exactly where injected content must not reach them.
+    if (options.memoryTools !== false && !options.readOnly) args.push(...codexMcpConfigArgs());
     return { command: 'codex', args, stdinFile: promptFile };
   }
 

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -290,6 +290,8 @@ export class CodexResponsesAdapter implements CliAdapter {
     supportsModelSelection: true,
     managedGit: false,
     supportedSkills: [],
+    // The agentic loop honours CliRunOptions.readOnly (see agenticLoop/tools). (INT-3189)
+    enforcesReadOnly: true,
   };
 
   async isAvailable(): Promise<boolean> {

--- a/src/adapters/gpt.ts
+++ b/src/adapters/gpt.ts
@@ -75,6 +75,8 @@ export class GptCliAdapter implements CliAdapter {
     supportsModelSelection: true,
     managedGit: false,
     supportedSkills: [],
+    // The agentic loop honours CliRunOptions.readOnly (see agenticLoop/tools). (INT-3189)
+    enforcesReadOnly: true,
   };
 
   async isAvailable(): Promise<boolean> {

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -49,6 +49,8 @@ export class LocalModelAdapter implements CliAdapter {
     supportsModelSelection: true,
     managedGit: false,
     supportedSkills: [],
+    // The agentic loop honours CliRunOptions.readOnly (see agenticLoop/tools). (INT-3189)
+    enforcesReadOnly: true,
   };
 
   // 활성 서버 URL (isAvailable에서 감지, run에서 사용)

--- a/src/adapters/openrouter.ts
+++ b/src/adapters/openrouter.ts
@@ -102,6 +102,8 @@ export class OpenRouterCliAdapter implements CliAdapter {
     supportsModelSelection: true,
     managedGit: false,
     supportedSkills: [],
+    // The agentic loop honours CliRunOptions.readOnly (see agenticLoop/tools). (INT-3189)
+    enforcesReadOnly: true,
   };
 
   async isAvailable(): Promise<boolean> {

--- a/src/adapters/tools.test.ts
+++ b/src/adapters/tools.test.ts
@@ -352,6 +352,30 @@ describe('Safety guards (isCommandBlocked via bash)', () => {
     expect(bash.content).toContain('READ_ONLY');
     await expect(fs.readFile(filePath, 'utf-8')).resolves.toBe('keep');
   });
+
+  it('refuses the web tools too, since a fetch is an outbound channel', async () => {
+    // Read-only runs exist because the material under inspection is untrusted.
+    // A fetch would carry out whatever the agent can read, credentials included.
+    // The tool list already withholds these; this is the enforcement behind it,
+    // for a model that calls a tool it was never shown. (INT-3189)
+    const fetched = await executeTool(
+      makeCall('web_fetch', { url: 'https://example.com/' }),
+      TMP_DIR,
+      undefined,
+      { readOnly: true },
+    );
+    const searched = await executeTool(
+      makeCall('web_search', { query: 'anything' }),
+      TMP_DIR,
+      undefined,
+      { readOnly: true },
+    );
+
+    expect(fetched.is_error).toBe(true);
+    expect(fetched.content).toContain('READ_ONLY');
+    expect(searched.is_error).toBe(true);
+    expect(searched.content).toContain('READ_ONLY');
+  });
 });
 
 // ──────────────────────────────────────────────

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -398,7 +398,11 @@ export async function executeTool(
 
   try {
     const args = JSON.parse(argsJson);
-    if (execOptions?.readOnly && ['write_file', 'edit_file', 'apply_patch', 'bash'].includes(name)) {
+    // `web_fetch`/`web_search` are withheld from the tool list in readOnly, but
+    // the denial lives here too: a model can emit a call for a tool it was never
+    // shown, and an outbound request is the exfiltration path the mode exists to
+    // close. Withholding is the hint; this is the enforcement. (INT-3189)
+    if (execOptions?.readOnly && ['write_file', 'edit_file', 'apply_patch', 'bash', 'web_fetch', 'web_search'].includes(name)) {
       return {
         tool_call_id: callId,
         content: `READ_ONLY: ${name} is disabled for this run. Use read_file/search_files/search_memory only.`,

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -128,6 +128,15 @@ export interface AdapterCapabilities {
   supportsModelSelection: boolean;
   managedGit: boolean;
   supportedSkills: string[];
+  /**
+   * This adapter actually denies mutating tools when `CliRunOptions.readOnly` is
+   * set. Optional, and absent means "cannot enforce": `spawnCli` refuses a
+   * read-only run on such an adapter rather than executing it with full tool
+   * access. A caller asking for read-only is usually doing so because the input
+   * is untrusted, and a flag that quietly does nothing there is worse than no
+   * flag at all. (INT-3189)
+   */
+  enforcesReadOnly?: boolean;
 }
 
 export interface CliCommandSpec {

--- a/src/agents/reviewer.test.ts
+++ b/src/agents/reviewer.test.ts
@@ -499,3 +499,44 @@ describe('reviewer', () => {
     });
   });
 });
+
+describe('reviewer read-only mode (INT-3189)', () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  const mockAdapter = () =>
+    vi.spyOn(adapters, 'getAdapter').mockReturnValue({
+      name: 'mock',
+      getDefaultModel: async () => 'm',
+      parseReviewerOutput: () => ({ decision: 'approve', feedback: 'ok' }),
+    } as never);
+
+  const wr: WorkerResult = { success: true, summary: 's', filesChanged: ['a.ts'], commands: [], output: '' };
+
+  it('passes readOnly through so mutating tools are denied', async () => {
+    // Without this the reviewer keeps bash. In CI that is an agent with shell
+    // access on attacker-controlled files while the provider credential is in
+    // the environment — prompt injection becomes command execution.
+    const spawn = vi.spyOn(adapters, 'spawnCli').mockResolvedValue({ exitCode: 0, stdout: '{}', stderr: '', durationMs: 1 } as never);
+    // The `reviewer` block above never restores its spies, so spyOn hands back an
+    // existing mock carrying that block's calls. Without the clear, calls[0] is
+    // someone else's call and the assertion reads a stale argument.
+    spawn.mockClear();
+    mockAdapter();
+
+    await runReviewer({ taskTitle: 't', taskDescription: 'd', workerResult: wr, projectPath: '/tmp', readOnly: true });
+
+    expect(spawn.mock.calls[0][1]).toMatchObject({ readOnly: true });
+  });
+
+  it('leaves the local path unrestricted when readOnly is not set', async () => {
+    // `openswarm review` reviews the operator's own working tree, where running
+    // a command is how the reviewer substantiates a claim.
+    const spawn = vi.spyOn(adapters, 'spawnCli').mockResolvedValue({ exitCode: 0, stdout: '{}', stderr: '', durationMs: 1 } as never);
+    spawn.mockClear();
+    mockAdapter();
+
+    await runReviewer({ taskTitle: 't', taskDescription: 'd', workerResult: wr, projectPath: '/tmp' });
+
+    expect(spawn.mock.calls[0][1].readOnly).toBeUndefined();
+  });
+});

--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -53,6 +53,21 @@ export interface ReviewerOptions {
   onToken?: (delta: string) => void;
   /** Abort the run + in-flight adapter call (pipeline cancel / project disable). */
   signal?: AbortSignal;
+  /**
+   * Deny the reviewer every mutating tool — write_file, edit_file, apply_patch
+   * and bash — leaving read_file/search_files/search_memory.
+   *
+   * Mandatory whenever the diff under review is not trusted. Reviewing a pull
+   * request in CI puts an agent with shell access on attacker-controlled files
+   * while the provider credential sits in the environment, which turns prompt
+   * injection into command execution. A review is a judgement, not an
+   * execution, so nothing legitimate is lost.
+   *
+   * Off by default: the local `openswarm review` path reviews the operator's own
+   * working tree, and running commands there is how the reviewer substantiates a
+   * claim. (INT-3189)
+   */
+  readOnly?: boolean;
 }
 
 export interface PreCheckResult {
@@ -187,6 +202,7 @@ export async function runPreCheck(options: ReviewerOptions): Promise<PreCheckRes
       processContext: options.processContext,
       onLog: options.onLog,
       signal: options.signal,
+      readOnly: options.readOnly,
     });
 
     // DEBUG: Log raw Haiku output for troubleshooting
@@ -267,6 +283,7 @@ export async function runReviewer(options: ReviewerOptions): Promise<ReviewResul
       onLog: options.onLog,
       onToken: options.onToken,
       signal: options.signal,
+      readOnly: options.readOnly,
     });
 
     // Parse result via adapter

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -298,6 +298,7 @@ program
   .option('--adapter <name>', 'Adapter override for the reviewer')
   .option('--json', 'Emit the verdict as JSON on stdout instead of the human report (for CI)')
   .option('--sarif <file>', 'Write a SARIF 2.1.0 report for GitHub code scanning')
+  .option('--read-only', 'Deny the reviewer all mutating tools including bash — required when reviewing an untrusted diff in CI')
   .option('--debug', 'Verbose logging')
   // --max: full-codebase multi-agent audit (INT-2006)
   .option('--max', 'Audit the whole codebase: fan reviewer subagents out over directory-shaped areas')
@@ -314,7 +315,7 @@ program
   .option('--fix-rounds <n>', 'For --max --fix: optional round cap (default: until clean, with a two-hour safety budget)', parsePositiveIntegerOption)
   .option('--no-learn', 'For --max: do not record the audit findings into the repo knowledge memory')
   .action(async (opts: {
-    path?: string; base?: string; issues?: string | boolean; issuesPerArea?: string | boolean; file?: string | boolean; adapter?: string; debug?: boolean; json?: boolean; sarif?: string;
+    path?: string; base?: string; issues?: string | boolean; issuesPerArea?: string | boolean; file?: string | boolean; adapter?: string; debug?: boolean; json?: boolean; sarif?: string; readOnly?: boolean;
     max?: boolean; concurrency?: number; maxFilesPerArea?: number; yes?: boolean; dryRun?: boolean;
     out?: string; linear?: boolean; fallback?: string | boolean; fix?: boolean; inPlace?: boolean; fixRounds?: number; learn?: boolean;
   }) => {
@@ -325,6 +326,14 @@ program
       // read an absent SARIF as "no findings".
       if (opts.max && (opts.json || opts.sarif)) {
         console.error('--json and --sarif are not supported with --max yet; use --out for the audit report.');
+        process.exitCode = 2;
+        return;
+      }
+      // Same refusal, and it matters more here: silently ignoring --read-only
+      // would leave the caller believing bash was denied when the audit
+      // subagents still have it. (INT-3189)
+      if (opts.max && opts.readOnly) {
+        console.error('--read-only is not supported with --max yet; the audit fan-out still grants the reviewer its full toolset.');
         process.exitCode = 2;
         return;
       }
@@ -358,7 +367,7 @@ program
         return;
       }
       const { runReviewCommand } = await import('./cli/reviewCommand.js');
-      const result = await runReviewCommand({ path: opts.path, base: opts.base, fileIssue: opts.issues ?? opts.file, adapter: opts.adapter, debug: opts.debug, json: opts.json, sarif: opts.sarif });
+      const result = await runReviewCommand({ path: opts.path, base: opts.base, fileIssue: opts.issues ?? opts.file, adapter: opts.adapter, debug: opts.debug, json: opts.json, sarif: opts.sarif, readOnly: opts.readOnly });
       if (result && result.decision === 'reject') process.exitCode = 1;
     } catch (e) {
       // A throw means no verdict was produced — the gate did NOT run. Exit 2,

--- a/src/cli/reviewCommand.coverage.test.ts
+++ b/src/cli/reviewCommand.coverage.test.ts
@@ -311,6 +311,27 @@ describe('runReviewCommand default deps (no injected review/getBranch/log/fileFo
     );
   });
 
+  it('forwards --read-only to the reviewer so CI reviews cannot mutate or shell out', async () => {
+    // The CI gate reviews an attacker-authored diff. If the flag stopped at the
+    // CLI boundary the reviewer would keep bash with the provider credential in
+    // the environment. (INT-3189)
+    runReviewerMock.mockResolvedValueOnce({ decision: 'approve', feedback: 'ok' } as ReviewResult);
+    await runReviewCommand(
+      { base: 'origin/main', readOnly: true },
+      { getChangedFiles: async () => ['a.ts'], startProgress: () => null, log: () => {} },
+    );
+    expect(runReviewerMock).toHaveBeenCalledWith(expect.objectContaining({ readOnly: true }));
+  });
+
+  it('leaves the local review unrestricted when --read-only is absent', async () => {
+    runReviewerMock.mockResolvedValueOnce({ decision: 'approve', feedback: 'ok' } as ReviewResult);
+    await runReviewCommand(
+      {},
+      { getChangedFiles: async () => ['a.ts'], startProgress: () => null, log: () => {} },
+    );
+    expect(runReviewerMock.mock.calls.at(-1)?.[0].readOnly).toBeUndefined();
+  });
+
   it('builds the reviewer call itself (committed-diff mode) when `opts.base` is set', async () => {
     runReviewerMock.mockResolvedValueOnce({ decision: 'approve', feedback: 'ok' } as ReviewResult);
     await runReviewCommand(

--- a/src/cli/reviewCommand.ts
+++ b/src/cli/reviewCommand.ts
@@ -221,6 +221,13 @@ export interface ReviewCommandOptions {
   json?: boolean;
   /** Write a SARIF 2.1.0 report here for GitHub code scanning. (INT-3102) */
   sarif?: string;
+  /**
+   * Deny the reviewer every mutating tool, including bash. Required when the
+   * diff under review is untrusted — a CI review of a pull request otherwise
+   * hands an agent shell access on attacker-authored files with the provider
+   * credential in the environment. (INT-3189)
+   */
+  readOnly?: boolean;
 }
 
 /**
@@ -301,6 +308,7 @@ export async function runReviewCommand(
         adapterName: opts.adapter as never,
         mode: 'direct',
         priorReviewContext: history.context,
+        readOnly: opts.readOnly,
         onLog,
       });
     });


### PR DESCRIPTION
## Why

Reviewing an untrusted diff gave the reviewer a worker's toolset — `write_file`, `edit_file`, `apply_patch`, `bash` — with the provider credential in the environment. In CI that turns prompt injection in an attacker-authored file into command execution. A review is a judgement, not an execution, so nothing legitimate is lost by taking those away.

This blocks INT-3101: the GitHub Action gate cannot ship until the reviewer it invokes can be told not to write.

## What

`openswarm review --read-only` denies the mutating tools. The flag is typed through CLI → `reviewCommand` → `runReviewer` → `spawnCli`.

The part worth reviewing is that it **cannot silently do nothing**:

| Layer | Enforcement |
|---|---|
| `spawnCli` | Refuses when the adapter does not declare `capabilities.enforcesReadOnly`. The field is optional, so absent = cannot enforce → a new adapter is fail-closed by default. |
| `claude` | Drops `--permission-mode bypassPermissions` (the thing that grants Write and Bash) for `default` + `--allowedTools Read Grep Glob`. |
| `codex` | `--sandbox read-only` instead of `workspace-write`. |
| API adapters | Already forwarded `readOnly` into the agentic loop. |
| `agenticLoop` | Withholds web tools and MCP servers from the tool list. |
| `tools.ts` | Denies `write_file`/`edit_file`/`apply_patch`/`bash`/`web_fetch`/`web_search` at execution, for a model that calls a tool it was never shown. |

Verified against the installed claude CLI rather than assumed: `claude -p --allowedTools Read --permission-mode default` asked to write a file refused twice and created nothing.

Two deliberate exclusions:
- **`Task`** is not allowlisted — a subagent is a second agent whose toolset this flag never reaches, which would make the allowlist a suggestion.
- **Web tools** are withheld because a fetch is an outbound channel for whatever the agent can read, credentials included. The **memory MCP server** is not registered either: it exposes writes, and memory is where an injected review could leave something behind for the next run.

`--max` **refuses** `--read-only` (exit 2) rather than ignoring it — its audit fan-out still grants subagents a full toolset, and silently accepting the flag there would be the exact failure this PR is about.

Default is off: local `openswarm review` inspects the operator's own working tree, where running a command is how the reviewer substantiates a claim.

## Verification

- `npm run lint` · `npm run typecheck` · `npm run build` — clean
- `npm run test:coverage` — 264 files, 3536 passed, statements 90.04% (threshold 90%)
- `openswarm review` on this diff — APPROVE