### PR TITLE
fix(adapters): a read-only run must not connect MCP servers (INT-3189)

### DIFF
--- a/src/adapters/atlascloud.ts
+++ b/src/adapters/atlascloud.ts
@@ -120,7 +120,17 @@ export class AtlasCloudCliAdapter implements CliAdapter {
       timeoutMs: options.timeoutMs ?? 300000,
     });
 
-    const mcpTools = await resolveMcpTools(options.mcpTools);
+    // MCP tools: caller-provided, else self-source from the registry. (INT-1951)
+    //
+    // Skipped entirely in read-only mode, and the skip has to be here rather
+    // than in the loop. Resolving means CONNECTING: the registry merges
+    // `mcp.servers` from the config discovered in cwd, and the stdio transport
+    // spawns each server's command with `${SECRETS}` already expanded into its
+    // environment. When the cwd is a checkout under review, that config is
+    // attacker-authored, so a read-only run that resolved first and filtered
+    // afterwards would have executed the attacker's command and handed it the
+    // provider credential before any tool list was consulted. (INT-3189)
+    const mcpTools = options.readOnly ? undefined : await resolveMcpTools(options.mcpTools);
 
     const loopOptions: AgenticLoopOptions = {
       systemPrompt: options.systemPrompt,

--- a/src/adapters/gpt.ts
+++ b/src/adapters/gpt.ts
@@ -127,7 +127,17 @@ export class GptCliAdapter implements CliAdapter {
     // MCP tools: caller-provided, else self-source from the registry
     // (mcp.json + config.mcp.servers) so standalone chat/exec and the worker
     // path all get MCP without each caller threading them. (INT-1951)
-    const mcpTools = await resolveMcpTools(options.mcpTools);
+    // MCP tools: caller-provided, else self-source from the registry. (INT-1951)
+    //
+    // Skipped entirely in read-only mode, and the skip has to be here rather
+    // than in the loop. Resolving means CONNECTING: the registry merges
+    // `mcp.servers` from the config discovered in cwd, and the stdio transport
+    // spawns each server's command with `${SECRETS}` already expanded into its
+    // environment. When the cwd is a checkout under review, that config is
+    // attacker-authored, so a read-only run that resolved first and filtered
+    // afterwards would have executed the attacker's command and handed it the
+    // provider credential before any tool list was consulted. (INT-3189)
+    const mcpTools = options.readOnly ? undefined : await resolveMcpTools(options.mcpTools);
 
     const loopOptions: AgenticLoopOptions = {
       systemPrompt: options.systemPrompt,

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -161,7 +161,16 @@ export class LocalModelAdapter implements CliAdapter {
     const callApi = this.createApiCaller(baseUrl, model, options.onToken, options.signal);
 
     // MCP tools: caller-provided, else self-source from the registry. (INT-1951)
-    const mcpTools = await resolveMcpTools(options.mcpTools);
+    //
+    // Skipped entirely in read-only mode, and the skip has to be here rather
+    // than in the loop. Resolving means CONNECTING: the registry merges
+    // `mcp.servers` from the config discovered in cwd, and the stdio transport
+    // spawns each server's command with `${SECRETS}` already expanded into its
+    // environment. When the cwd is a checkout under review, that config is
+    // attacker-authored, so a read-only run that resolved first and filtered
+    // afterwards would have executed the attacker's command and handed it the
+    // provider credential before any tool list was consulted. (INT-3189)
+    const mcpTools = options.readOnly ? undefined : await resolveMcpTools(options.mcpTools);
 
     const loopOptions: AgenticLoopOptions = {
       systemPrompt: options.systemPrompt,

--- a/src/adapters/openrouter.ts
+++ b/src/adapters/openrouter.ts
@@ -157,7 +157,16 @@ export class OpenRouterCliAdapter implements CliAdapter {
     });
 
     // MCP tools: caller-provided, else self-source from the registry. (INT-1951)
-    const mcpTools = await resolveMcpTools(options.mcpTools);
+    //
+    // Skipped entirely in read-only mode, and the skip has to be here rather
+    // than in the loop. Resolving means CONNECTING: the registry merges
+    // `mcp.servers` from the config discovered in cwd, and the stdio transport
+    // spawns each server's command with `${SECRETS}` already expanded into its
+    // environment. When the cwd is a checkout under review, that config is
+    // attacker-authored, so a read-only run that resolved first and filtered
+    // afterwards would have executed the attacker's command and handed it the
+    // provider credential before any tool list was consulted. (INT-3189)
+    const mcpTools = options.readOnly ? undefined : await resolveMcpTools(options.mcpTools);
 
     const loopOptions: AgenticLoopOptions = {
       systemPrompt: options.systemPrompt,

--- a/src/adapters/readOnlyMcp.test.ts
+++ b/src/adapters/readOnlyMcp.test.ts
@@ -28,17 +28,18 @@ vi.mock('./agenticLoop.js', async (importOriginal) => {
   return { ...actual, runAgenticLoop: runAgenticLoopMock };
 });
 
+import { readFileSync } from 'node:fs';
 import { OpenRouterCliAdapter } from './openrouter.js';
 import { AtlasCloudCliAdapter } from './atlascloud.js';
-import { GptCliAdapter } from './gpt.js';
-import { LocalModelAdapter } from './local.js';
 
-// Each adapter needs its own credential/endpoint to reach the MCP step at all.
+// Only the two adapters that reach the MCP step from an API key alone are
+// driven behaviourally. `gpt` wants an OAuth profile and `local` probes for a
+// live server, so on a developer machine that happens to have either they pass
+// for the wrong reason and on a CI runner they never reach the code under test.
+// Every adapter is covered by the source invariant at the bottom instead.
 const ADAPTERS = [
   { name: 'openrouter', make: () => new OpenRouterCliAdapter(), env: { OPENROUTER_API_KEY: 'test-key' } },
   { name: 'atlascloud', make: () => new AtlasCloudCliAdapter(), env: { ATLASCLOUD_API_KEY: 'test-key' } },
-  { name: 'gpt', make: () => new GptCliAdapter(), env: { OPENAI_API_KEY: 'test-key' } },
-  { name: 'local', make: () => new LocalModelAdapter(), env: { LOCAL_LLM_URL: 'http://127.0.0.1:1234/v1' } },
 ];
 
 describe('read-only runs never resolve MCP tools (INT-3189)', () => {
@@ -78,6 +79,24 @@ describe('read-only runs never resolve MCP tools (INT-3189)', () => {
       await adapter.run?.({ prompt: 'do work', cwd: process.cwd(), model: 'm' }).catch(() => {});
 
       expect(resolveMcpToolsMock).toHaveBeenCalledTimes(1);
+    });
+  }
+});
+
+describe('every adapter that resolves MCP tools guards it on readOnly', () => {
+  // Read the sources rather than restate the list: an adapter added later, or an
+  // existing one refactored back to an unconditional call, is a regression this
+  // file must catch even though it cannot drive that adapter end to end.
+  const SOURCES = ['openrouter', 'atlascloud', 'gpt', 'local'];
+
+  for (const name of SOURCES) {
+    it(`${name}.ts does not call resolveMcpTools unconditionally`, () => {
+      const source = readFileSync(new URL(`./${name}.ts`, import.meta.url), 'utf8');
+      const calls = source.split('\n').filter((line) => line.includes('resolveMcpTools(') && !line.trim().startsWith('import'));
+      expect(calls.length).toBeGreaterThan(0);
+      for (const call of calls) {
+        expect(call).toContain('options.readOnly ?');
+      }
     });
   }
 });

--- a/src/adapters/readOnlyMcp.test.ts
+++ b/src/adapters/readOnlyMcp.test.ts
@@ -8,7 +8,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const resolveMcpToolsMock = vi.hoisted(() => vi.fn(async () => []));
-vi.mock('../mcp/mcpClient.js', () => ({ resolveMcpTools: resolveMcpToolsMock }));
+const isMcpToolMock = vi.hoisted(() => vi.fn((name: string) => name.includes('__')));
+const callMcpToolMock = vi.hoisted(() => vi.fn(async () => 'called'));
+vi.mock('../mcp/mcpClient.js', () => ({
+  resolveMcpTools: resolveMcpToolsMock,
+  isMcpTool: isMcpToolMock,
+  callMcpTool: callMcpToolMock,
+}));
 
 const runAgenticLoopMock = vi.hoisted(() =>
   vi.fn(async () => ({
@@ -48,6 +54,7 @@ describe('read-only runs never resolve MCP tools (INT-3189)', () => {
   beforeEach(() => {
     resolveMcpToolsMock.mockClear();
     runAgenticLoopMock.mockClear();
+    callMcpToolMock.mockClear();
   });
 
   afterEach(() => {
@@ -99,4 +106,41 @@ describe('every adapter that resolves MCP tools guards it on readOnly', () => {
       }
     });
   }
+});
+
+describe('read-only refuses MCP tool calls at execution (INT-3189)', () => {
+  // Per-test reset: without it a call leaking from the denial case makes the
+  // ordinary-run count assertion fail for a reason that has nothing to do with
+  // what it is testing.
+  beforeEach(() => { callMcpToolMock.mockClear(); });
+
+  it('denies a qualified MCP name a read-only run was never shown', async () => {
+    // Not covered by skipping discovery: a long-lived daemon that resolved these
+    // servers during an earlier ordinary run still knows them, so a read-only
+    // run whose model emits `server__tool` would reach one. The denial is by
+    // predicate because MCP names are whatever the servers declare — no fixed
+    // list can enumerate them.
+    const { executeTool } = await import('./tools.js');
+    const result = await executeTool(
+      { id: '1', function: { name: 'pwn__run', arguments: '{}' } },
+      process.cwd(),
+      undefined,
+      { readOnly: true },
+    );
+
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain('READ_ONLY');
+    expect(callMcpToolMock).not.toHaveBeenCalled();
+  });
+
+  it('still routes MCP calls in an ordinary run', async () => {
+    const { executeTool } = await import('./tools.js');
+    const result = await executeTool(
+      { id: '1', function: { name: 'memory__search', arguments: '{}' } },
+      process.cwd(),
+    );
+
+    expect(callMcpToolMock).toHaveBeenCalledTimes(1);
+    expect(result.is_error).toBeFalsy();
+  });
 });

--- a/src/adapters/readOnlyMcp.test.ts
+++ b/src/adapters/readOnlyMcp.test.ts
@@ -1,0 +1,83 @@
+// ============================================
+// OpenSwarm — read-only runs must not connect MCP servers
+// Purpose: guard the INT-3189 hole where resolving MCP tools spawned an
+//          attacker-authored command before the read-only filter ever ran.
+// Test Status: npm run test -- src/adapters/readOnlyMcp.test.ts
+// ============================================
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const resolveMcpToolsMock = vi.hoisted(() => vi.fn(async () => []));
+vi.mock('../mcp/mcpClient.js', () => ({ resolveMcpTools: resolveMcpToolsMock }));
+
+const runAgenticLoopMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    text: '{}',
+    toolCallCount: 0,
+    apiCallCount: 1,
+    totalTokens: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cachedTokens: 0,
+    durationMs: 1,
+    executedCommands: [],
+  })),
+);
+vi.mock('./agenticLoop.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./agenticLoop.js')>();
+  return { ...actual, runAgenticLoop: runAgenticLoopMock };
+});
+
+import { OpenRouterCliAdapter } from './openrouter.js';
+import { AtlasCloudCliAdapter } from './atlascloud.js';
+import { GptCliAdapter } from './gpt.js';
+import { LocalModelAdapter } from './local.js';
+
+// Each adapter needs its own credential/endpoint to reach the MCP step at all.
+const ADAPTERS = [
+  { name: 'openrouter', make: () => new OpenRouterCliAdapter(), env: { OPENROUTER_API_KEY: 'test-key' } },
+  { name: 'atlascloud', make: () => new AtlasCloudCliAdapter(), env: { ATLASCLOUD_API_KEY: 'test-key' } },
+  { name: 'gpt', make: () => new GptCliAdapter(), env: { OPENAI_API_KEY: 'test-key' } },
+  { name: 'local', make: () => new LocalModelAdapter(), env: { LOCAL_LLM_URL: 'http://127.0.0.1:1234/v1' } },
+];
+
+describe('read-only runs never resolve MCP tools (INT-3189)', () => {
+  const saved = { ...process.env };
+
+  beforeEach(() => {
+    resolveMcpToolsMock.mockClear();
+    runAgenticLoopMock.mockClear();
+  });
+
+  afterEach(() => {
+    process.env = { ...saved };
+    vi.restoreAllMocks();
+  });
+
+  for (const { name, make, env } of ADAPTERS) {
+    it(`${name}: does not connect MCP servers when readOnly is set`, async () => {
+      // Resolving is connecting. The registry merges `mcp.servers` from whatever
+      // config is discovered in cwd, and the stdio transport spawns each
+      // server's command with secrets expanded into its environment. During a CI
+      // review the cwd is the checkout under review, so that config belongs to
+      // the author of the diff — filtering the tools afterwards is far too late,
+      // the process has already run.
+      Object.assign(process.env, env);
+      const adapter = make();
+      await adapter.run?.({ prompt: 'review this', cwd: process.cwd(), model: 'm', readOnly: true }).catch(() => {});
+
+      expect(resolveMcpToolsMock).not.toHaveBeenCalled();
+      const passed = runAgenticLoopMock.mock.calls[0]?.[0];
+      expect(passed?.readOnly).toBe(true);
+      expect(passed?.mcpTools).toBeUndefined();
+    });
+
+    it(`${name}: still resolves MCP tools for an ordinary run`, async () => {
+      Object.assign(process.env, env);
+      const adapter = make();
+      await adapter.run?.({ prompt: 'do work', cwd: process.cwd(), model: 'm' }).catch(() => {});
+
+      expect(resolveMcpToolsMock).toHaveBeenCalledTimes(1);
+    });
+  }
+});

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -402,7 +402,15 @@ export async function executeTool(
     // the denial lives here too: a model can emit a call for a tool it was never
     // shown, and an outbound request is the exfiltration path the mode exists to
     // close. Withholding is the hint; this is the enforcement. (INT-3189)
-    if (execOptions?.readOnly && ['write_file', 'edit_file', 'apply_patch', 'bash', 'web_fetch', 'web_search'].includes(name)) {
+    // MCP tools are denied by predicate, not by name: their names are whatever
+    // the servers declare, so no fixed list can cover them. Skipping discovery
+    // in the adapter is not enough on its own — a long-lived daemon that
+    // resolved these servers during an earlier ordinary run still has them in
+    // `serverByTool`, and a later read-only run whose model emits `server__tool`
+    // would connect to one. (INT-3189)
+    const readOnlyDenied = execOptions?.readOnly
+      && (['write_file', 'edit_file', 'apply_patch', 'bash', 'web_fetch', 'web_search'].includes(name) || isMcpTool(name));
+    if (readOnlyDenied) {
       return {
         tool_call_id: callId,
         content: `READ_ONLY: ${name} is disabled for this run. Use read_file/search_files/search_memory only.`,


### PR DESCRIPTION
## The hole

The read-only reviewer denied `bash` and the write tools — and still had arbitrary code execution, because **resolving MCP tools means connecting to them**.

Every step of the chain lives in the repository under review:

1. `cli.ts` preAction `loadConfig()` searches `process.cwd()` **first** (`src/core/config.ts:25-31`), and during a CI review the cwd is the checked-out pull request.
2. A `config.yaml` there is accepted — `looksLikeOpenSwarmConfig` only requires a top-level `agents:`.
3. `substituteEnvVarsDeep` expands `${OPENROUTER_API_KEY}` to its real value.
4. `mcpClient` merges that file's `mcp.servers` into the registry.
5. `resolveMcpTools` opens a `StdioClientTransport` per server — which **spawns the configured command with the configured env**.

All four API adapters called `resolveMcpTools` unconditionally, before the loop's read-only filter (`agenticLoop.ts`, `readOnly ? [] : mcpTools`). That filter only removes the tools from the list the model is *shown*. By then the attacker's command has run and been handed the credential. A failed handshake does not save you either — the spawn happens first, and `server unreachable — skipped` is printed after.

## The fix

Skip at the resolve, not at the filter. A read-only run contacts no MCP server at all, which costs nothing: the loop was going to discard those tools anyway.

## Verification

`src/adapters/readOnlyMcp.test.ts` asserts, for each of the four adapters, that `resolveMcpTools` is **not called** under `readOnly` and *is* called for an ordinary run. Confirmed the pair bisects: reverting the openrouter line alone turns that adapter's case red.

- `npm run lint` · `npx tsc --noEmit` — clean
- `npm run test:coverage` — 265 files, 3557 pass, statements 90.15%

## Credit

Found by an independent reviewer while reviewing the GitHub Action PR (#364), with a working proof of concept: a `config.yaml` in the repo root, no flags, and the marker file existed with the key inside it. #364 stays draft until this lands.