### PR TITLE
fix: four severity findings from the src/adapters audit (INT-2961)

### DIFF
--- a/src/adapters/base.spawn.test.ts
+++ b/src/adapters/base.spawn.test.ts
@@ -17,7 +17,7 @@ describe('argv-safe adapter spawning', () => {
       pid: 123,
       stdout: new PassThrough(),
       stderr: new PassThrough(),
-      stdin: { end: vi.fn() },
+      stdin: Object.assign(new EventEmitter(), { end: vi.fn() }),
       kill: vi.fn(),
     });
     spawnMock.mockImplementationOnce(() => {
@@ -54,7 +54,7 @@ describe('argv-safe adapter spawning', () => {
       pid: 124,
       stdout: new PassThrough(),
       stderr: new PassThrough(),
-      stdin: { end: vi.fn() },
+      stdin: Object.assign(new EventEmitter(), { end: vi.fn() }),
       kill: vi.fn(),
     });
     spawnMock.mockImplementationOnce(() => {
@@ -114,5 +114,50 @@ describe('read-only fail-closed guard (INT-3189)', () => {
     await expect(
       spawnCli(stub(true), { prompt: 'p', cwd: process.cwd(), readOnly: true }),
     ).resolves.toMatchObject({ exitCode: 0 });
+  });
+});
+
+describe('stdin EPIPE must not take the process down (INT-2961)', () => {
+  it('handles an error on the child stdin stream', async () => {
+    // A CLI that exits before draining the pipe — a rejected flag, an auth
+    // failure, our own SIGKILL on timeout — makes the pending write emit EPIPE.
+    // An 'error' event with no listener is rethrown by Node as an uncaught
+    // exception; it arrives asynchronously, so neither the promise nor the
+    // caller's try/catch sees it and the daemon dies. `proc.on('error')` is a
+    // different emitter and does not cover this.
+    const stdinStream = Object.assign(new EventEmitter(), { end: vi.fn() });
+    const proc = Object.assign(new EventEmitter(), {
+      pid: 321,
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      stdin: stdinStream,
+      kill: vi.fn(),
+    });
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => {
+        stdinStream.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }));
+        proc.emit('close', 1);
+      });
+      return proc;
+    });
+
+    const logged: string[] = [];
+    const adapter = {
+      name: 'fixture',
+      capabilities: { supportsStreaming: false, supportsJsonOutput: false, supportsModelSelection: false, managedGit: false, supportedSkills: [] },
+      isAvailable: async () => true,
+      getDefaultModel: async () => 'fixture',
+      buildCommand: (o: { prompt: string }) => ({ command: 'fixture-cli', args: [], stdinFile: o.prompt }),
+      parseWorkerOutput: () => ({ success: true, summary: '', filesChanged: [], commands: [], output: '' }),
+      parseReviewerOutput: () => ({ decision: 'approve', feedback: '', issues: [], suggestions: [] }),
+    } as unknown as CliAdapter;
+
+    // Fails through the normal 'close' path with the child's real exit code,
+    // rather than throwing out of band where nothing can catch it.
+    await expect(
+      spawnCli(adapter, { prompt: 'p', cwd: process.cwd(), onLog: (l) => logged.push(l) }),
+    ).rejects.toThrow(/failed with code 1/);
+    expect(stdinStream.listenerCount('error')).toBeGreaterThan(0);
+    expect(logged.join('\n')).toContain('EPIPE');
   });
 });

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -82,6 +82,20 @@ export async function spawnCli(
         stdio: [stdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
       });
 
+      // The stdin 'error' listener is not optional, for the same reason it is
+      // not optional in github.ts: if the CLI exits before draining the pipe —
+      // a rejected flag, an auth failure, or our own SIGKILL on timeout — the
+      // pending write emits EPIPE on the stream, and an 'error' event with no
+      // listener is rethrown by Node as an uncaught exception. It arrives
+      // asynchronously, so neither the promise nor the caller's try/catch sees
+      // it, and `proc.on('error')` below is a different emitter. Every adapter
+      // that feeds a prompt file through stdin passes here, so without this one
+      // oversized prompt to a CLI that exits early kills the daemon. Reporting
+      // is left to 'close', which has the real exit code; this only has to keep
+      // the event handled.
+      proc.stdin?.on('error', (error) => {
+        if (options.onLog) options.onLog(`stdin closed before the prompt was written: ${error.message}`);
+      });
       if (stdin) proc.stdin?.end(stdin);
 
       // Register process for tracking if context provided

--- a/src/adapters/codexResponses.test.ts
+++ b/src/adapters/codexResponses.test.ts
@@ -523,6 +523,9 @@ describe('401 refresh scope', () => {
     return {
       getProfile: () => profile,
       setProfile: (_k: string, p: typeof profile) => { profile = p; },
+      // refreshAndRetry expires the token through the store rather than writing
+      // a snapshot back, so the fake has to offer the same door. (INT-2961)
+      expireProfile: (_k: string) => { profile = { ...profile, expires: 0 }; return true; },
     };
   }
 

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -560,9 +560,10 @@ export class CodexResponsesAdapter implements CliAdapter {
 }
 
 async function refreshAndRetry(store: AuthProfileStore): Promise<string> {
-  const profile = store.getProfile(PROFILE_KEY);
-  if (!profile) throw new Error('No auth profile found');
-  profile.expires = 0; // force refresh
-  store.setProfile(PROFILE_KEY, profile);
+  // expireProfile, not getProfile + setProfile. `store` was built when run()
+  // started and this 401 can arrive hours later, so writing its snapshot back
+  // would restore whatever the refresh token was then — dead, if another
+  // process rotated it in between. Only `expires` is ours to change.
+  if (!store.expireProfile(PROFILE_KEY)) throw new Error('No auth profile found');
   return ensureValidToken(store, PROFILE_KEY);
 }

--- a/src/adapters/tools.test.ts
+++ b/src/adapters/tools.test.ts
@@ -353,6 +353,24 @@ describe('Safety guards (isCommandBlocked via bash)', () => {
     await expect(fs.readFile(filePath, 'utf-8')).resolves.toBe('keep');
   });
 
+  it('refuses diagnostics, which runs a binary found in the tree under review', async () => {
+    // The loop withholds this tool in readOnly ("it spawns compiler
+    // subprocesses, matching bash's exclusion") but the executor did not deny
+    // it, and withholding is only a hint — the comment above exists because a
+    // model calls tools it was never shown. runTsc walks up from the reviewed
+    // tree for node_modules/.bin/tsc and runs it with the full environment, so
+    // this was `bash` by another name. (INT-2961)
+    const result = await executeTool(
+      makeCall('diagnostics', { path: TMP_DIR }),
+      TMP_DIR,
+      undefined,
+      { readOnly: true },
+    );
+
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain('READ_ONLY');
+  });
+
   it('refuses the web tools too, since a fetch is an outbound channel', async () => {
     // Read-only runs exist because the material under inspection is untrusted.
     // A fetch would carry out whatever the agent can read, credentials included.
@@ -518,6 +536,30 @@ describe('ToolExecOptions', () => {
       undefined,
       { protectedFiles: ['run_tests.sh'] },
     );
+    expect(res.is_error).toBe(true);
+    expect(res.content).toContain('PROTECTED');
+    expect(await fs.readFile(filePath, 'utf-8')).toContain('echo ok');
+  });
+
+  it('apply_patch refuses a protected file whose header is indented', async () => {
+    // parseV4A trims each line before matching a header; this guard used to
+    // match the raw line. One leading space therefore hid the header from the
+    // guard while the parser still applied the patch — and applyV4APatch has no
+    // protection of its own, so this scan is the only thing standing there.
+    // Blast radius today is benchmark integrity: a worker could neuter
+    // run_tests.sh and manufacture a RESOLVED. (INT-2961)
+    const filePath = path.join(TMP_DIR, 'run_tests.sh');
+    await fs.writeFile(filePath, 'echo ok\n');
+
+    const res = await executeTool(
+      makeCall('apply_patch', {
+        input: '*** Begin Patch\n *** Update File: run_tests.sh\n@@\n-echo ok\n+exit 0\n*** End Patch',
+      }),
+      TMP_DIR,
+      undefined,
+      { protectedFiles: ['run_tests.sh'] },
+    );
+
     expect(res.is_error).toBe(true);
     expect(res.content).toContain('PROTECTED');
     expect(await fs.readFile(filePath, 'utf-8')).toContain('echo ok');

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -197,6 +197,26 @@ const BLOCKED_COMMANDS = [
   /\bkill\s+-9\b/,
 ];
 
+/**
+ * Tools a read-only run refuses to execute.
+ *
+ * Kept beside the loop's tool-list filter rather than inline, because the two
+ * drifted apart once already: `diagnostics` was withheld from the list but
+ * missing here, and the loop's own comment explains why that is not enough — a
+ * model calls tools it was never shown. `diagnostics` matters as much as `bash`
+ * does, since it runs a `tsc`/`ruff` binary found by walking up from the tree
+ * under review, with the full environment. (INT-3189, INT-2961)
+ */
+const READ_ONLY_DENIED_TOOLS = new Set([
+  'write_file',
+  'edit_file',
+  'apply_patch',
+  'bash',
+  'web_fetch',
+  'web_search',
+  'diagnostics',
+]);
+
 function isCommandBlocked(command: string): boolean {
   return BLOCKED_COMMANDS.some(pattern => pattern.test(command));
 }
@@ -409,7 +429,7 @@ export async function executeTool(
     // `serverByTool`, and a later read-only run whose model emits `server__tool`
     // would connect to one. (INT-3189)
     const readOnlyDenied = execOptions?.readOnly
-      && (['write_file', 'edit_file', 'apply_patch', 'bash', 'web_fetch', 'web_search'].includes(name) || isMcpTool(name));
+      && (READ_ONLY_DENIED_TOOLS.has(name) || isMcpTool(name));
     if (readOnlyDenied) {
       return {
         tool_call_id: callId,
@@ -530,8 +550,13 @@ export async function executeTool(
         }
         // Scan BOTH the source headers and `*** Move to:` targets — a rename can
         // overwrite a protected harness path that no Update/Add/Delete header names. (INT-1928)
+        // `.trim()` on the line, because that is what parseV4A does before it
+        // matches a header. Scanning the raw line while the parser trims meant
+        // one leading space hid a header from this guard and still applied it —
+        // the guard is the only protection, applyV4APatch has none of its own.
         const protectedHit = patchText
           .split('\n')
+          .map((raw) => raw.trim())
           .map((l) =>
             l.match(/^\*\*\* (?:Update|Add|Delete) File: (.+)$/)?.[1]?.trim()
             ?? l.match(/^\*\*\* Move to: (.+)$/)?.[1]?.trim(),

--- a/src/auth/oauthStore.test.ts
+++ b/src/auth/oauthStore.test.ts
@@ -152,6 +152,32 @@ describe('AuthProfileStore.save concurrency', () => {
     expect(onDisk['linear:default'].refresh).toBe('rotated-by-second');
   });
 
+  it('expireProfile keeps the same-key rotation another writer just made', async () => {
+    // The case setProfile could not cover, and the one that actually bites: an
+    // adapter builds a store when a run starts and hits a 401 hours later. It
+    // only wants to force a refresh, but writing its snapshot back restores the
+    // pre-rotation refresh token, and a dead refresh token fails every later
+    // run with invalid_grant until the user logs in again. (INT-2961)
+    writeStore({ 'gpt:default': validProfile({ refresh: 'original' }) });
+    const { AuthProfileStore } = await loadModule();
+
+    const stale = new AuthProfileStore();           // snapshot: refresh=original
+    const other = new AuthProfileStore();
+    other.setProfile('gpt:default', validProfile({ refresh: 'rotated-by-other' }) as never);
+
+    expect(stale.expireProfile('gpt:default')).toBe(true);
+
+    const onDisk = readStore().profiles['gpt:default'];
+    expect(onDisk.refresh).toBe('rotated-by-other');
+    expect(onDisk.expires).toBe(0);
+  });
+
+  it('expireProfile reports an absent key rather than inventing one', async () => {
+    writeStore({});
+    const { AuthProfileStore } = await loadModule();
+    expect(new AuthProfileStore().expireProfile('gpt:default')).toBe(false);
+  });
+
   it('still applies a delete against the current file', async () => {
     writeStore({ 'gpt:default': validProfile(), 'linear:default': validProfile({ provider: 'linear' }) });
     const { AuthProfileStore } = await loadModule();

--- a/src/auth/oauthStore.ts
+++ b/src/auth/oauthStore.ts
@@ -194,6 +194,27 @@ export class AuthProfileStore {
     this.save();
   }
 
+  /**
+   * Mark a key's token expired, based on the current on-disk profile rather
+   * than this instance's snapshot.
+   *
+   * A caller holding a long-lived store — the adapters build one when a run
+   * starts and can hit a 401 hours later — would otherwise write its whole
+   * stale profile back through `setProfile`, and `save()` puts the touched key
+   * over the disk value. If another process refreshed in the meantime and the
+   * provider rotated the refresh token, that write restores the dead one and
+   * every later run fails with invalid_grant until the user logs in again. Only
+   * `expires` is ours to change here.
+   */
+  expireProfile(key: string): boolean {
+    const current = this.readProfilesQuietly()[key] ?? this.data.profiles[key];
+    if (!current) return false;
+    this.data.profiles[key] = { ...current, expires: 0 };
+    this.touched.add(key);
+    this.save();
+    return true;
+  }
+
   deleteProfile(key: string): boolean {
     if (!(key in this.data.profiles)) return false;
     delete this.data.profiles[key];


### PR DESCRIPTION
`src/adapters (1/3)` was the one area of the 43-area codebase audit whose reviewer subagent crashed — the only part of the codebase with no coverage. Re-audited under the narrowed close criterion (security · data loss · crash). **It was not clean.** Three of the four were reproduced by actually running them.

## CRASH — an EPIPE on child stdin takes the daemon down

`src/adapters/base.ts` had no `'error'` listener on `proc.stdin`. When a CLI exits before draining the pipe — a flag it rejects, an auth failure, or **our own SIGKILL on timeout** — the pending write emits EPIPE. An `'error'` event with no listener is rethrown by Node as an uncaught exception, it arrives asynchronously so neither the promise nor the caller's `try/catch` sees it, and `proc.on('error')` is a different emitter.

Every adapter that feeds a prompt file through stdin passes through here. Prompts exceeding the 64KB pipe buffer are ordinary.

The telling part: **this exact class was already fixed in `src/github/github.ts:646`**, with a comment that says "takes the daemon down" and a regression test. The shared path never got it.

## SECURITY — `diagnostics` escaped the read-only denial

The loop withholds `DIAGNOSTICS_TOOL` in read-only mode ("it spawns compiler subprocesses, matching bash's exclusion"), but the executor's denial set did not include it — and that set exists *because* withholding is only a hint; its own comment says a model calls tools it was never shown.

`runTsc` executes a `tsc` binary found by walking up from the tree under review, with `{...process.env}`. That is `bash` by another name. The reviewer reproduced it: `bash` denied, `diagnostics` allowed, marker file written during a read-only run.

The denied set now lives beside the loop's filter, since the two drifted apart once already.

## INTEGRITY — an indented V4A header bypassed the protected-file guard

`parseV4A` trims each line before matching a header; the guard matched the **raw** line. One leading space hid the header from the guard while the parser still applied the patch, and `applyV4APatch` has no protection of its own — this scan is the only thing standing there.

Reach today is bounded: only `benchmarks/sweBench.ts` sets `protectedFiles`. So this is benchmark integrity rather than production security — a worker could neuter `run_tests.sh` and manufacture a RESOLVED. Those numbers decide model routing, so it is not harmless.

## DATA LOSS — a stale snapshot written back over a rotated refresh token

`refreshAndRetry` read a profile, set `expires = 0`, and wrote the whole thing back. The store is constructed when a run starts and the 401 can arrive hours later, so that write restores whatever the refresh token was *then* — dead, if another process rotated it meanwhile — and every later run fails `invalid_grant` until the user logs in again. The store's own comment already admits this residual same-key race.

Now `AuthProfileStore.expireProfile(key)`: reads the current file, changes only `expires`. Kept on the store rather than in the adapter so the injected test store still works — my first attempt constructed a new store inside the adapter, which would have reached the real `~/.openswarm/auth-profiles.json` from tests.

## Verification

Each fix was checked to bisect — reverting the one line turns exactly its own test red. The `stdin` mocks in `base.spawn.test.ts` were `{ end }`, which a real `ChildProcess.stdin` never is; they emit now, which is what makes the regression test possible.

- `npm run lint` · `npx tsc --noEmit` — clean
- `npm run test:coverage` — 266 files, 3569 pass, statements 90.16%