### PR TITLE
fix(tools): search_files must not silently lose its capability

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,24 @@ runs:
       shell: bash
       run: npm install -g "@intrect/openswarm@${{ inputs.version }}"
 
+    - name: Ensure ripgrep
+      shell: bash
+      # The reviewer's search tool prefers ripgrep. It falls back to git grep
+      # when that is missing, but the fallback is the safety net, not the plan:
+      # a hosted runner without rg was observed making every search fail, and an
+      # agent whose search errors stops searching and reviews the diff without
+      # reading the code around it — while still returning a confident verdict.
+      run: |
+        set -euo pipefail
+        if command -v rg >/dev/null; then exit 0; fi
+        if command -v apt-get >/dev/null; then
+          sudo apt-get update && sudo apt-get install -y ripgrep
+        elif command -v apk >/dev/null; then
+          apk add --no-cache ripgrep
+        else
+          echo "::warning::ripgrep is unavailable and could not be installed; searches will use the git grep fallback"
+        fi
+
     - name: Run review gate
       id: review
       shell: bash

--- a/src/adapters/tools.test.ts
+++ b/src/adapters/tools.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
+import * as os from 'node:os';
 import { TOOL_DEFINITIONS, executeTool, createReadCache, ToolCall, buildBashToolEnv, validatePath } from './tools.js';
 import { homedir } from 'node:os';
 
@@ -616,5 +617,55 @@ describe('ToolExecOptions', () => {
     const env = buildBashToolEnv({ PATH: `${path.join(homedir(), '.cargo', 'bin')}:/usr/bin` });
     const cargo = path.join(homedir(), '.cargo', 'bin');
     expect((env.PATH ?? '').split(':').filter((p) => p === cargo)).toHaveLength(1);
+  });
+});
+
+describe('search_files without ripgrep', () => {
+  // Observed on a real GitHub Actions run of the review gate: five consecutive
+  // `spawn rg ENOENT`, and the reviewer still returned `approve`. An agent whose
+  // search always errors stops searching and reviews the diff without ever
+  // looking at the surrounding code, while the verdict reads exactly like one
+  // produced with working tools.
+  it('falls back to git grep when rg is not installed', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'openswarm-nogrep-'));
+    execFileSync('git', ['init', '-q'], { cwd: repo });
+    await fs.writeFile(path.join(repo, 'a.ts'), 'const needle = 1;\nconst other = 2;\n');
+    execFileSync('git', ['add', '-A'], { cwd: repo });
+
+    // A PATH with no rg on it, which is what the hosted runner effectively had.
+    const savedPath = process.env.PATH;
+    const emptyBin = await fs.mkdtemp(path.join(os.tmpdir(), 'openswarm-bin-'));
+    process.env.PATH = `${emptyBin}:/usr/bin:/bin`;
+    try {
+      const result = await executeTool(
+        makeCall('search_files', { pattern: 'needle', path: repo }),
+        repo,
+      );
+      expect(result.is_error).toBeFalsy();
+      expect(result.content).toContain('needle');
+      expect(result.content).toContain('a.ts');
+    } finally {
+      process.env.PATH = savedPath;
+    }
+  });
+
+  it('says the search failed rather than reporting no matches', async () => {
+    // The dangerous failure is the quiet one: "(no matches)" from a search that
+    // never ran reads as evidence of absence.
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'openswarm-nogit-'));
+    const savedPath = process.env.PATH;
+    const emptyBin = await fs.mkdtemp(path.join(os.tmpdir(), 'openswarm-bin2-'));
+    process.env.PATH = `${emptyBin}:/usr/bin:/bin`;
+    try {
+      const result = await executeTool(
+        makeCall('search_files', { pattern: 'needle', path: outside }),
+        outside,
+      );
+      expect(result.is_error).toBe(true);
+      expect(result.content).toContain('unavailable');
+      expect(result.content).not.toBe('(no matches)');
+    } finally {
+      process.env.PATH = savedPath;
+    }
   });
 });

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -217,6 +217,48 @@ const READ_ONLY_DENIED_TOOLS = new Set([
   'diagnostics',
 ]);
 
+
+/** Did this spawn fail because the binary is not installed? */
+function isMissingExecutable(error: unknown): boolean {
+  return !!error && typeof error === 'object' && 'code' in error && (error as { code: unknown }).code === 'ENOENT';
+}
+
+/**
+ * `git grep` stand-in for ripgrep.
+ *
+ * Deliberately not a full reimplementation: it covers the case that matters —
+ * searching a repository — and says so plainly when it cannot, rather than
+ * returning an error the agent reads as "no matches". Line numbers and the
+ * 50-match cap match the ripgrep invocation so the output shape is the same.
+ */
+async function searchWithGitGrep(
+  pattern: string,
+  searchPath: string,
+  glob: string | undefined,
+  callId: string,
+  cwd: string,
+): Promise<ToolResult> {
+  const args = ['grep', '--no-color', '-n', '-I', '-E', '-e', pattern, '--'];
+  args.push(glob ? `${searchPath}/${glob}` : searchPath);
+  try {
+    const { stdout } = await execFileAsync('git', args, { cwd, timeout: 10000, maxBuffer: 1024 * 256 });
+    const lines = stdout.split('\n').filter(Boolean).slice(0, 50);
+    return { tool_call_id: callId, content: lines.length ? lines.join('\n') : '(no matches)', is_error: false };
+  } catch (error) {
+    // git grep also exits 1 for no matches.
+    if (error && typeof error === 'object' && 'code' in error && (error as { code: number }).code === 1) {
+      return { tool_call_id: callId, content: '(no matches)', is_error: false };
+    }
+    return {
+      tool_call_id: callId,
+      content:
+        'search_files is unavailable: ripgrep is not installed and git grep failed. ' +
+        'Install ripgrep, or run this inside a git repository. Do not treat this as "no matches".',
+      is_error: true,
+    };
+  }
+}
+
 function isCommandBlocked(command: string): boolean {
   return BLOCKED_COMMANDS.some(pattern => pattern.test(command));
 }
@@ -599,6 +641,16 @@ export async function executeTool(
           // rg exit code 1 = no matches
           if (err && typeof err === 'object' && 'code' in err && (err as { code: number }).code === 1) {
             return { tool_call_id: callId, content: '(no matches)', is_error: false };
+          }
+          // ripgrep is not everywhere. On a hosted CI runner it can be absent
+          // entirely, and then every search returns ENOENT: the agent learns
+          // that searching does not work, stops trying, and reviews the diff
+          // without ever looking at the surrounding code — while still emitting
+          // a confident verdict. Observed on a real GitHub Actions run: five
+          // consecutive `spawn rg ENOENT`, verdict `approve`. Falling back to
+          // git grep keeps the capability instead of silently losing it.
+          if (isMissingExecutable(err)) {
+            return searchWithGitGrep(args.pattern, searchPath, args.glob, callId, cwd);
           }
           throw err;
         }


### PR DESCRIPTION
The first real GitHub Actions run of the review gate returned **`approve`** — after five consecutive `spawn rg ENOENT`.

ripgrep was not on the runner. Every search the reviewer attempted errored, so it stopped attempting them and reviewed the diff without ever reading the code around it. The verdict was indistinguishable from one produced with working tools.

That is the failure this sprint has been about, arriving through the tools instead of the exit code: a gate that looks like it ran.

## Fix

`search_files` falls back to `git grep` when `rg` is missing — same line numbers, same 50-match cap, so the output shape the agent sees does not change.

When neither is available it says **the search was unavailable, and that this is not "no matches"**. The quiet failure is the dangerous one: absence of evidence reads as evidence of absence to whatever consumes the result.

The action also installs ripgrep (apt/apk, warning if neither). The fallback is the safety net, not the plan.

## Verification

Both tests bisect — removing the fallback branch turns exactly these two red. They run against a real git repo with a `PATH` that has no `rg` on it, which is what the runner effectively had.

- `npm run lint` · `npx tsc --noEmit` — clean
- `npm run test:coverage` — 266 files, 3571 pass, statements 90.14%