### PR TITLE
chore(release): v0.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.20.2 — 2026-08-01
+
+Three fixes to the CI review gate, all found by running it rather than reading it. Each is the same failure in a different place: the gate produced a confident verdict while something it needed was missing.
+
+### Fixed
+
+- **The reviewer is given the diff.** `buildReviewerPrompt` handed direct mode only a list of changed filenames — its own comment said direct mode "reviews a Git diff supplied by a user/CI checkout", but no diff was ever supplied. In working-tree mode an agent can recover the rest with `bash`; under `--read-only` it cannot, and in `--base` mode there is nothing in the working tree to recover, because reading a file shows the result of a change and never the change. Those two flags together are what the GitHub Action passes, so the flagship CI path was reviewing blind — a real run said so in its own feedback ("I cannot determine the actual diff… the .git directory is not accessible") and returned a verdict anyway. The diff now travels in the prompt, bounded at 200KB and explicit when it truncates. (#375)
+- **`search_files` no longer loses its capability silently.** It shells out to ripgrep, which a hosted runner may not have; every search then failed with ENOENT, the agent stopped searching, and it reviewed the diff without reading the code around it — while still returning `approve`. It falls back to `git grep` now, and when neither is available it says the search was unavailable and that this is not "no matches", because the quiet failure is the one that gets read as evidence of absence. The bundled action installs ripgrep so the fast path is used. (#373)
+- **A failing gate says why.** `--json` suppresses the human report by design and SARIF carries only findings that have a file and line, so a `revise` reached the job log as a single word with its reasoning nowhere. The action now renders decision, feedback, issues, suggestions and follow-ups into the step log and the GitHub job summary. That text comes from a model that just read an untrusted diff, so it is written inside a `::stop-commands::` fence with an unpredictable token — otherwise injected prose could forge annotations or silence the rest of the step. (#374)
+
 ## 0.20.1 — 2026-08-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.20.1",
+      "version": "0.20.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Three fixes to the CI review gate, all found by **running** it rather than reading it. Each is the same failure in a different place: the gate produced a confident verdict while something it needed was missing.

- **The reviewer is given the diff** (#375). Direct mode received only a list of filenames. Under `--read-only --base` — what the Action passes — it had no way to see the change at all, and a real run said so in its own feedback before returning a verdict anyway.
- **`search_files` falls back to `git grep`** (#373). ripgrep was absent on the runner, so every search failed, the agent stopped searching, and it reviewed without reading the surrounding code — returning `approve`.
- **A failing gate says why** (#374). A `revise` reached the log as one word. Decision, feedback, issues, suggestions and follow-ups now render into the log and job summary, fenced with `::stop-commands::` so injected prose cannot forge workflow commands.

Needed as a release because the first two are CLI-side: the Action installs `@intrect/openswarm` from npm, so it keeps reviewing blind until this publishes.