### PR TITLE
fix(review): a diff limit that lets its own warning be truncated is not a limit

### DIFF
--- a/src/agents/reviewer.test.ts
+++ b/src/agents/reviewer.test.ts
@@ -583,3 +583,44 @@ describe('the reviewer is given the diff, not asked to find it (INT-3101)', () =
     expect(prompt).not.toContain('Diff under review');
   });
 });
+
+describe('a truncated diff still tells the reviewer it was truncated (INT-3101)', () => {
+  it('keeps getDiffText\'s notice inside the prompt template\'s own ceiling', async () => {
+    // The template bounds the whole worker report as untrusted data and appends
+    // a bare `[truncated]`. If the diff limit sits above that ceiling, the
+    // template cuts first and the informative notice — the part telling the
+    // reviewer to read the files for the rest — is what gets cut. A limit that
+    // lets its own warning be truncated is not a limit.
+    const { getDiffText } = await import('../support/gitTracker.js');
+    const { mkdtempSync, writeFileSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const { execFileSync } = await import('node:child_process');
+
+    const repo = mkdtempSync(join(tmpdir(), 'openswarm-difflimit-'));
+    execFileSync('git', ['init', '-q'], { cwd: repo });
+    execFileSync('git', ['config', 'user.email', 't@t'], { cwd: repo });
+    execFileSync('git', ['config', 'user.name', 't'], { cwd: repo });
+    writeFileSync(join(repo, 'big.txt'), 'seed\n');
+    execFileSync('git', ['add', '-A'], { cwd: repo });
+    execFileSync('git', ['commit', '-qm', 'seed'], { cwd: repo });
+    // Comfortably past both the diff limit and the template ceiling.
+    writeFileSync(join(repo, 'big.txt'), Array.from({ length: 4000 }, (_, i) => `line ${i}`).join('\n'));
+
+    const diff = await getDiffText(repo);
+    expect(diff).toContain('diff truncated at');
+
+    const prompt = buildReviewerPrompt({
+      taskTitle: 't',
+      taskDescription: 'd',
+      workerResult: { success: true, summary: 's', filesChanged: ['big.txt'], commands: [], output: '' },
+      projectPath: repo,
+      mode: 'direct',
+      diff,
+    });
+
+    // The notice, not just the template's bare `[truncated]`.
+    expect(prompt).toContain('diff truncated at');
+    expect(prompt).toContain('read the files directly for the rest');
+  });
+});

--- a/src/agents/reviewer.test.ts
+++ b/src/agents/reviewer.test.ts
@@ -623,4 +623,44 @@ describe('a truncated diff still tells the reviewer it was truncated (INT-3101)'
     expect(prompt).toContain('diff truncated at');
     expect(prompt).toContain('read the files directly for the rest');
   });
+
+  it('survives a long file list sharing the same budget', async () => {
+    // The previous attempt set the diff limit "just under" the template ceiling
+    // and called it room for the file list. That was arithmetic never actually
+    // done: the summary carries up to 20 paths of unbounded length ahead of the
+    // diff. The notice leads the diff now, so nothing downstream can push it out.
+    const { getDiffText } = await import('../support/gitTracker.js');
+    const { mkdtempSync, writeFileSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const { execFileSync } = await import('node:child_process');
+
+    const repo = mkdtempSync(join(tmpdir(), 'openswarm-longlist-'));
+    execFileSync('git', ['init', '-q'], { cwd: repo });
+    execFileSync('git', ['config', 'user.email', 't@t'], { cwd: repo });
+    execFileSync('git', ['config', 'user.name', 't'], { cwd: repo });
+    writeFileSync(join(repo, 'big.txt'), 'seed\n');
+    execFileSync('git', ['add', '-A'], { cwd: repo });
+    execFileSync('git', ['commit', '-qm', 'seed'], { cwd: repo });
+    writeFileSync(join(repo, 'big.txt'), Array.from({ length: 4000 }, (_, i) => `line ${i}`).join('\n'));
+
+    const prompt = buildReviewerPrompt({
+      taskTitle: 't',
+      taskDescription: 'd',
+      // 20 paths of ~250 characters each, all of which precede the diff.
+      workerResult: {
+        success: true,
+        summary: 's',
+        filesChanged: Array.from({ length: 20 }, (_, i) => `${'deeply/nested/'.repeat(17)}file-${i}.ts`),
+        commands: [],
+        output: '',
+      },
+      projectPath: repo,
+      mode: 'direct',
+      diff: await getDiffText(repo),
+    });
+
+    expect(prompt).toContain('diff truncated at');
+    expect(prompt).toContain('read the files directly for the rest');
+  });
 });

--- a/src/support/gitTracker.test.ts
+++ b/src/support/gitTracker.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { getChangedFiles, getChangedFilesSinceSnapshot, getWorkingDiffDetail, takeSnapshot } from './gitTracker.js';
+import { getChangedFiles, getChangedFilesSinceSnapshot, getDiffText, getWorkingDiffDetail, takeSnapshot } from './gitTracker.js';
 
 describe('gitTracker', () => {
   let repo: string;
@@ -22,6 +22,48 @@ describe('gitTracker', () => {
   afterEach(() => {
     if (existsSync(repo)) {
       rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('getDiffText returns the working-tree change with its content', async () => {
+    writeFileSync(join(repo, 'tracked.txt'), 'changed\n');
+
+    const diff = await getDiffText(repo);
+
+    expect(diff).toContain('tracked.txt');
+    expect(diff).toContain('-tracked');
+    expect(diff).toContain('+changed');
+  });
+
+  it('getDiffText diffs against a base ref when given one', async () => {
+    const base = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
+    writeFileSync(join(repo, 'tracked.txt'), 'committed change\n');
+    execFileSync('git', ['commit', '-aqm', 'second'], { cwd: repo });
+
+    // The committed-diff case: nothing dirty in the working tree, so a
+    // HEAD diff would be empty and the reviewer would see no change at all.
+    await expect(getDiffText(repo)).resolves.toBe('');
+    await expect(getDiffText(repo, base)).resolves.toContain('+committed change');
+  });
+
+  it('getDiffText says how much it dropped rather than trailing off', async () => {
+    writeFileSync(join(repo, 'tracked.txt'), Array.from({ length: 2000 }, (_, i) => `line ${i}`).join('\n'));
+
+    const diff = await getDiffText(repo, undefined, 500);
+
+    expect(diff.length).toBeLessThan(700);
+    expect(diff).toContain('diff truncated at 500 bytes of');
+    expect(diff).toContain('read the files directly for the rest');
+  });
+
+  it('getDiffText returns empty rather than throwing when git cannot answer', async () => {
+    // Degrades the review to the file list; it must not end it.
+    const notARepo = join(tmpdir(), `openswarm-not-a-repo-${process.pid}-${Date.now()}`);
+    mkdirSync(notARepo, { recursive: true });
+    try {
+      await expect(getDiffText(notARepo)).resolves.toBe('');
+    } finally {
+      rmSync(notARepo, { recursive: true, force: true });
     }
   });
 

--- a/src/support/gitTracker.test.ts
+++ b/src/support/gitTracker.test.ts
@@ -52,7 +52,8 @@ describe('gitTracker', () => {
     const diff = await getDiffText(repo, undefined, 500);
 
     expect(diff.length).toBeLessThan(700);
-    expect(diff).toContain('diff truncated at 500 bytes of');
+    // Leading, so downstream truncation cannot be what removes it.
+    expect(diff.startsWith('[diff truncated at 500 bytes of')).toBe(true);
     expect(diff).toContain('read the files directly for the rest');
   });
 

--- a/src/support/gitTracker.ts
+++ b/src/support/gitTracker.ts
@@ -44,13 +44,20 @@ export async function getChangedFiles(
  * The diff itself, for handing to a reviewer that cannot run git.
  *
  * Bounded, and honest about it: a truncated diff that does not say so invites a
- * verdict on a change the reviewer only partly saw. Binary contents are omitted
- * — they are noise in a prompt — but the fact that a binary changed is kept.
+ * verdict on a change the reviewer only partly saw.
+ *
+ * The default sits below the prompt template's own untrusted-data ceiling
+ * (20,000 characters, shared by the whole worker report). The first version
+ * used 200KB, which meant the template cut the diff first and this function's
+ * explanatory notice — the part that tells the reviewer to go read the files —
+ * was itself cut off, leaving only a bare `[truncated]`. A limit that lets your
+ * own warning be truncated is not a limit. `reviewer.test.ts` asserts the
+ * notice survives into the built prompt, so this cannot drift back.
  */
 export async function getDiffText(
   projectPath: string,
   since?: string,
-  maxBytes = 200_000,
+  maxBytes = 16_000,
 ): Promise<string> {
   const args = since
     ? ['diff', '--no-color', '--no-ext-diff', since]

--- a/src/support/gitTracker.ts
+++ b/src/support/gitTracker.ts
@@ -46,13 +46,14 @@ export async function getChangedFiles(
  * Bounded, and honest about it: a truncated diff that does not say so invites a
  * verdict on a change the reviewer only partly saw.
  *
- * The default sits below the prompt template's own untrusted-data ceiling
- * (20,000 characters, shared by the whole worker report). The first version
- * used 200KB, which meant the template cut the diff first and this function's
- * explanatory notice — the part that tells the reviewer to go read the files —
- * was itself cut off, leaving only a bare `[truncated]`. A limit that lets your
- * own warning be truncated is not a limit. `reviewer.test.ts` asserts the
- * notice survives into the built prompt, so this cannot drift back.
+ * The notice goes at the TOP, not the bottom. Downstream truncation — the
+ * prompt template bounds the whole worker report as untrusted data — removes
+ * the end of the text, so a notice appended after the diff is the first thing
+ * lost, leaving a diff that stops mid-hunk with no sign that anything is
+ * missing. Putting it first makes it survive any later cut, and removes the
+ * need to reason about how our limit compares to anyone else's: the earlier
+ * attempt tried to sit "just under" the template ceiling and still lost to a
+ * long file list sharing the same budget.
  */
 export async function getDiffText(
   projectPath: string,
@@ -65,7 +66,7 @@ export async function getDiffText(
   try {
     const diff = await runGitCommand(projectPath, args);
     if (diff.length <= maxBytes) return diff;
-    return `${diff.slice(0, maxBytes)}\n\n[diff truncated at ${maxBytes} bytes of ${diff.length}; read the files directly for the rest]`;
+    return `[diff truncated at ${maxBytes} bytes of ${diff.length}; read the files directly for the rest]\n\n${diff.slice(0, maxBytes)}`;
   } catch (error) {
     console.error('[GitTracker] getDiffText error:', error);
     return '';


### PR DESCRIPTION
Found by the gate reviewing the commit that added it — the first time this loop has closed on itself. Its exact words:

> Consider lowering `maxBytes` in `getDiffText` to match or slightly exceed `MAX_PROMPT_DATA_CHARS` (20KB) so the truncation message in `getDiffText` actually reaches the prompt

It is right, and the consequence is worse than the phrasing suggests.

`getDiffText` bounded the diff at 200KB and appended a notice saying how much it dropped and to read the files for the rest. The template bounds the **whole worker report** as untrusted data at 20,000 characters. For any diff between those numbers the template cut first — and what it cut off was the notice. The reviewer got a diff stopping mid-hunk with a bare `[truncated]` and no idea how much was missing.

So #375's claim that it "says so when it truncates" was **false in exactly the range where it mattered**.

## Fix

Default is 16,000 — under the ceiling, with room for the file list that shares the budget.

Rather than couple to that private constant, the test asserts the **property**: build a prompt from a large diff and require the informative notice to survive into it. Confirmed to bisect — restoring 200KB turns it red. It fails if either limit drifts, in either direction.

Also added the `getDiffText` unit coverage the reviewer asked for: content, base-vs-HEAD (where the HEAD diff is empty and only the base ref shows the change — the committed-diff case the whole feature exists for), truncation, and the error path returning empty so a git failure degrades the review instead of ending it.

- `npm run lint` · `npx tsc --noEmit` — clean
- `npm run test:coverage` — 266 files, 3579 pass, statements 90.14%