### PR TITLE
fix(telemetry): stop losing the events that answer the question (INT-3190)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,8 @@ function loadTelemetryEnabledQuietly(quiet: boolean): boolean | undefined {
 // DO_NOT_TRACK / CI. One event per command invocation (command name only — never
 // arguments). Fire-and-forget: not awaited, and track() never throws.
 initTelemetry({ version: VERSION });
+/** Start times, so the completion event can report how long the command ran. */
+const commandStartedAt = new WeakMap<object, number>();
 program.hook('preAction', (_thisCommand, actionCommand) => {
   // Honor config telemetry.enabled when a config exists (best-effort — `run`/`init`
   // may have none, in which case the env opt-out still applies).
@@ -64,7 +66,28 @@ program.hook('preAction', (_thisCommand, actionCommand) => {
   } catch {
     /* no/invalid config — keep the built-in default */
   }
+  commandStartedAt.set(actionCommand, Date.now());
   void track({ command: actionCommand.name() });
+});
+
+// The other half of the pair. `invoke` alone says a command started and nothing
+// else — a run that crashed, hung, or was killed looked exactly like one that
+// finished. That gap mattered: 11 of 18 external installs ended on the TUI and
+// the data could not say whether it failed or they simply quit.
+//
+// An `invoke` with no matching `complete` is now itself the signal, so this hook
+// does not need to catch every abnormal exit to be useful — it only has to be
+// honest about the ones it does see. Commands that report failure by setting
+// process.exitCode are the common case here; a thrown error skips postAction and
+// leaves the absent-completion signal instead, which is the correct reading.
+program.hook('postAction', (_thisCommand, actionCommand) => {
+  const startedAt = commandStartedAt.get(actionCommand);
+  void track({
+    event: 'complete',
+    command: actionCommand.name(),
+    isError: !!process.exitCode,
+    ...(startedAt ? { durationMs: Date.now() - startedAt } : {}),
+  });
 });
 
 program

--- a/src/cli/doctorHandler.ts
+++ b/src/cli/doctorHandler.ts
@@ -11,12 +11,41 @@ import { listAvailableAdapters } from '../adapters/index.js';
 import { findConfigFile } from '../core/config.js';
 import { banner } from '../support/banner.js';
 import { c } from '../support/colors.js';
+import { track } from '../telemetry/telemetry.js';
 
 const execFileAsync = promisify(execFile);
 
 type Status = 'ok' | 'warn' | 'fail';
 
+/**
+ * Which checks came back not-ok, as stable names.
+ *
+ * Names, never the accompanying message: the message contains versions, paths
+ * and port numbers, and this set is reported by telemetry. `check` is derived
+ * from the label rather than passed separately so a new `line()` call cannot
+ * forget it — an unrecognised label simply contributes nothing.
+ */
+const failedChecks = new Set<string>();
+
+/** Label → stable check name. Labels carry variable parts; these do not. */
+function checkName(label: string): string | undefined {
+  if (label === 'Node.js') return 'node';
+  if (label.startsWith('native:')) return 'native-deps';
+  if (label === 'providers') return 'providers';
+  if (label === 'config') return 'config';
+  if (label === 'linear') return 'linear';
+  if (label.startsWith('port ')) return 'ports';
+  if (label === 'codex' || label === 'claude') return 'providers';
+  if (label === 'git') return 'git';
+  if (label === 'gh') return 'gh';
+  return undefined;
+}
+
 function line(status: Status, label: string, detail = ''): void {
+  if (status !== 'ok') {
+    const name = checkName(label);
+    if (name) failedChecks.add(name);
+  }
   const icon = status === 'ok' ? c.green('✓') : status === 'warn' ? c.yellow('⚠') : c.red('✗');
   console.log(`${icon} ${c.bold(label)}${detail ? ` ${c.dim('—')} ${c.dim(detail)}` : ''}`);
 }
@@ -111,6 +140,18 @@ export async function handleDoctor(): Promise<void> {
   else line('warn', 'linear', 'not configured — local SQLite issue store will be used');
 
   console.log('');
+  // Which checks failed, by name. Twelve external installs ran `doctor` and only
+  // four ever reached `start`; without this the data says they diagnosed
+  // something and stops there. Awaited rather than fire-and-forget because the
+  // fatal branch calls process.exit, which would drop an in-flight request —
+  // track() has its own timeout, so this cannot hang the command.
+  await track({
+    event: 'complete',
+    command: 'doctor',
+    isError: fatal,
+    detail: [...failedChecks],
+  });
+
   if (fatal) {
     console.log(c.red(c.bold('✗ Critical issues found — fix the ✗ items above.')));
     process.exit(1);

--- a/src/telemetry/telemetry.test.ts
+++ b/src/telemetry/telemetry.test.ts
@@ -158,3 +158,63 @@ describe('privacy contract (payload shape)', () => {
     expect(JSON.stringify(p)).not.toMatch(/Users|secret prompt|tmp\/path/);
   });
 });
+
+describe('the allowlist must not silently discard real commands (INT-3190)', () => {
+  it('accepts every command cli.ts registers', () => {
+    // Read the registrations rather than restate them. This list dropped
+    // `openswarm` — the bare TUI launch, the most-used entry point and the last
+    // thing 11 of 18 external installs ever did — and nothing failed: the event
+    // still arrived, with a NULL command. Nine days of the drop-off signal went
+    // unlabelled before anyone looked. A new command is now a red test.
+    const { readFileSync } = require('node:fs') as typeof import('node:fs');
+    const cli = readFileSync(new URL('../cli.ts', import.meta.url), 'utf8');
+    const registered = [...cli.matchAll(/\.command\('([a-z-]+)'/g)].map((m) => m[1]);
+
+    expect(registered.length).toBeGreaterThan(5);
+    const dropped = registered.filter((name) => buildPayload({ command: name }, 'i').command !== name);
+    expect(dropped).toEqual([]);
+  });
+
+  it('accepts the bare TUI launch, which is not a registered subcommand', () => {
+    expect(buildPayload({ command: 'openswarm' }, 'i').command).toBe('openswarm');
+  });
+});
+
+describe('completion events (INT-3190)', () => {
+  it('carries the outcome and how long the command ran', () => {
+    const p = buildPayload({ event: 'complete', command: 'doctor', isError: true, durationMs: 1234.6 }, 'i');
+    expect(p).toMatchObject({ event: 'complete', command: 'doctor', isError: 1, durationMs: 1235 });
+  });
+
+  it('omits a duration that is missing or nonsensical rather than storing a lie', () => {
+    for (const durationMs of [undefined, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(buildPayload({ event: 'complete', durationMs }, 'i')).not.toHaveProperty('durationMs');
+    }
+  });
+});
+
+describe('doctor detail is names, never messages (INT-3190)', () => {
+  it('keeps recognised check names', () => {
+    expect(buildPayload({ detail: ['node', 'providers'] }, 'i').detail).toBe('node,providers');
+  });
+
+  it('drops anything not on the list, including messages that mention a real check', () => {
+    // The doctor lines that produce these names also contain versions, paths and
+    // port numbers. Only the name may travel.
+    const p = buildPayload({
+      detail: ['providers', 'node v22 at /Users/unohee/.nvm/versions/node', '/home/x/config.yaml', 'port 3000 in use'],
+    }, 'i');
+    expect(p.detail).toBe('providers');
+    expect(JSON.stringify(p)).not.toMatch(/\/Users\/|\/home\/|nvm|3000/);
+  });
+
+  it('omits the field entirely when nothing survives, rather than sending an empty string', () => {
+    expect(buildPayload({ detail: ['not-a-check'] }, 'i')).not.toHaveProperty('detail');
+    expect(buildPayload({}, 'i')).not.toHaveProperty('detail');
+  });
+
+  it('bounds the list so a caller cannot pad the row', () => {
+    const p = buildPayload({ detail: Array.from({ length: 50 }, () => 'node') }, 'i');
+    expect((p.detail ?? '').split(',').length).toBeLessThanOrEqual(8);
+  });
+});

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -152,6 +152,13 @@ export interface TrackOptions {
   isError?: boolean;
   /** Event kind; defaults to 'invoke'. */
   event?: string;
+  /**
+   * Names of failed diagnostic checks — from ALLOWED_DETAILS and nothing else.
+   * Never a message, a path, or a value.
+   */
+  detail?: string[];
+  /** How long the command ran, for completion events. */
+  durationMs?: number;
 }
 
 /** The exact wire payload — kept flat and asserted by tests so PII can't creep in. */
@@ -165,13 +172,42 @@ export interface TelemetryPayload {
   command?: string;
   adapter?: string;
   isError: 0 | 1;
+  detail?: string;
+  durationMs?: number;
 }
 
-const ALLOWED_EVENTS = new Set(['invoke', 'complete', 'error', 'start', 'stop']);
+const ALLOWED_EVENTS = new Set(['invoke', 'complete', 'error', 'start', 'stop', 'engage']);
+
+/**
+ * Commands whose names may be recorded.
+ *
+ * This list silently discarded real usage once already. `allowTelemetryLabel`
+ * returns undefined for anything absent, so the event still arrives with a NULL
+ * command — the row survives and the fact it describes does not. When it landed
+ * (2026-07-23) it was missing `openswarm`, the bare TUI launch, which was the
+ * single most-used entry point and the last thing 11 of 18 external installs
+ * ever did. That signal went unlabelled for nine days before anyone looked.
+ *
+ * `telemetry.test.ts` reads the commands registered in cli.ts and requires every
+ * one of them to be here, so adding a command without adding it here is a
+ * failing test rather than a blind spot discovered months later.
+ */
 const ALLOWED_COMMANDS = new Set([
-  'add', 'auth', 'chat', 'dash', 'doctor', 'init', 'mcp', 'projects', 'remove',
-  'review', 'run', 'start', 'status', 'stop', 'upgrade', 'version',
+  'add', 'annotate', 'auth', 'chat', 'check', 'dash', 'design-pipeline', 'doctor',
+  'exec', 'fix', 'init', 'login', 'logout', 'mcp', 'memory', 'models', 'openswarm',
+  'projects', 'provider', 'remove', 'resume', 'review', 'run', 'schedule', 'start',
+  'status', 'stop', 'upgrade', 'validate', 'version',
 ]);
+
+/**
+ * The only free-form-looking field, and it is not free-form: a fixed set of
+ * check names. Anything else is dropped rather than truncated, because a value
+ * we did not anticipate is exactly what a privacy contract has to refuse.
+ */
+const ALLOWED_DETAILS = new Set([
+  'node', 'native-deps', 'providers', 'config', 'linear', 'ports', 'git', 'gh',
+]);
+const MAX_DETAIL_ITEMS = 8;
 const ALLOWED_ADAPTERS = new Set([
   'atlascloud', 'claude', 'codex', 'codex-responses', 'gpt', 'lmstudio', 'local', 'openrouter',
 ]);
@@ -188,6 +224,11 @@ function allowTelemetryLabel(
 
 /** Build the payload (pure — used directly by tests to assert the privacy contract). */
 export function buildPayload(opts: TrackOptions, installId: string): TelemetryPayload {
+  const detail = (opts.detail ?? [])
+    .map((name) => allowTelemetryLabel(name, ALLOWED_DETAILS))
+    .filter((name): name is string => !!name)
+    .slice(0, MAX_DETAIL_ITEMS)
+    .join(',');
   return {
     installId,
     event: allowTelemetryLabel(opts.event, ALLOWED_EVENTS, 'invoke') ?? 'invoke',
@@ -198,6 +239,10 @@ export function buildPayload(opts: TrackOptions, installId: string): TelemetryPa
     command: allowTelemetryLabel(opts.command, ALLOWED_COMMANDS),
     adapter: allowTelemetryLabel(opts.adapter, ALLOWED_ADAPTERS),
     isError: opts.isError ? 1 : 0,
+    ...(detail ? { detail } : {}),
+    ...(Number.isFinite(opts.durationMs) && (opts.durationMs as number) >= 0
+      ? { durationMs: Math.round(opts.durationMs as number) }
+      : {}),
   };
 }
 

--- a/src/tui/panels/ChatPanel.tsx
+++ b/src/tui/panels/ChatPanel.tsx
@@ -30,6 +30,7 @@ import { getDefaultChatModel, listChatModels } from '../../support/chatBackend.j
 import { runPlanCommand, type PlanIO } from '../../support/planCommand.js';
 import { runGoalCommand, buildGoalPursuitPrompt, GOAL_PURSUIT_MAX_TURNS } from '../../support/goalCommand.js';
 import type { AdapterName } from '../../adapters/types.js';
+import { track } from '../../telemetry/telemetry.js';
 
 function buildConversationPrompt(messages: Message[]): string {
   if (messages.length <= 1) return messages[0]?.content ?? '';
@@ -53,6 +54,9 @@ export interface ChatPanelProps {
   /** Session goal restored from a resumed session — keeps it "in pursuit". (INT-2014) */
   goal?: string;
 }
+
+/** Process-scoped: the signal is "did this session engage at all", not a counter. */
+let engagementReported = false;
 
 export function ChatPanel({ active, provider: providerProp, model: modelProp, projectPath, sessionId: sessionIdProp, initialHistory, goal: goalProp }: ChatPanelProps) {
   const [state, dispatch] = useReducer(
@@ -360,6 +364,14 @@ export function ChatPanel({ active, provider: providerProp, model: modelProp, pr
 
   const submit = useCallback(
     async (raw: string) => {
+      // One bit, once per process: this session got as far as a submitted line.
+      // Launching the TUI and submitting nothing were indistinguishable, and
+      // that is precisely the difference between someone who bounced off the
+      // first screen and someone who tried and was let down. (INT-3190)
+      if (!engagementReported) {
+        engagementReported = true;
+        void track({ event: 'engage', command: 'openswarm' });
+      }
       setInput('');
       const parsed = parseInput(raw);
       // A pending /plan confirm/edit consumes the next line verbatim.

--- a/workers/telemetry/worker.ts
+++ b/workers/telemetry/worker.ts
@@ -20,6 +20,32 @@ function str(v: unknown, max: number): string | null {
   return s ? s.slice(0, max) : null;
 }
 
+/**
+ * Failed-check names, re-whitelisted here.
+ *
+ * The client already filters this, and that is not a reason to trust it: this
+ * endpoint is public, so anything accepted here is something an arbitrary
+ * caller can write into the table. The list is duplicated rather than shared
+ * because the two sides are deployed independently — a client rollout must not
+ * be able to widen what the collector stores.
+ */
+const ALLOWED_DETAILS = new Set([
+  'node', 'native-deps', 'providers', 'config', 'linear', 'ports', 'git', 'gh',
+]);
+
+function detail(v: unknown): string | null {
+  const raw = str(v, 200);
+  if (!raw) return null;
+  const names = raw.split(',').map((n) => n.trim().toLowerCase()).filter((n) => ALLOWED_DETAILS.has(n));
+  return names.length ? [...new Set(names)].slice(0, 8).join(',') : null;
+}
+
+/** Milliseconds, bounded — a day is already far beyond any real command. */
+function duration(v: unknown): number | null {
+  if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) return null;
+  return Math.min(Math.round(v), 86_400_000);
+}
+
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     if (req.method === 'OPTIONS') return new Response(null, { status: 204 });
@@ -41,8 +67,8 @@ export default {
     try {
       await env.DB.prepare(
         `INSERT INTO openswarm_events
-           (install_id, event, version, platform, arch, node_version, command, adapter, is_error, country)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+           (install_id, event, version, platform, arch, node_version, command, adapter, is_error, country, detail, duration_ms)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
         .bind(
           installId,
@@ -55,6 +81,8 @@ export default {
           str(body.adapter, 32),
           body.isError ? 1 : 0,
           country && country !== 'XX' ? country.slice(0, 2) : null,
+          detail(body.detail),
+          duration(body.durationMs),
         )
         .run();
     } catch {


### PR DESCRIPTION
Analysing a month of real usage for the first time showed the instrument was blind at exactly the moment worth measuring: **11 of 18 external installs ended on the TUI**, and nothing recorded said whether it failed or they simply left.

Three independent causes, each verified against the live D1 table.

## The allowlist silently discarded real commands

`allowTelemetryLabel` returns `undefined` for anything absent, so **the event still arrives and the fact it describes does not** — the row lands with a NULL command.

When the list shipped (676ac5e, 2026-07-23 13:48) it was missing `openswarm`, the bare TUI launch — the most-used entry point and the exact drop-off point. Measured:

| | |
| --- | --- |
| last `command='openswarm'` row | **2026-07-23 15:29**, none since |
| NULL-command rows after that commit | 6 |
| labelled rows after that commit | 480 |

Also missing: `exec`, `validate`, `login`, `models`, `fix`.

The test now **reads the commands registered in `cli.ts`** and requires every one to be in the list. Running it immediately found six more nobody had spotted: `annotate`, `check`, `design-pipeline`, `logout`, `memory`, `schedule`. A list nobody can check drifts; this one is checked.

## `isError` was never set

Not by anything — `track({ command })` was the only call site. All **1,952 rows read `is_error = 0`**. That was not a measurement, and I had already misread it as a zero error rate before I checked.

## Events fired only before execution

`track()` runs in the `preAction` hook, so a run that crashed looked identical to one that finished.

There is a completion event now with the outcome and duration. An `invoke` with no matching `complete` becomes its own signal, so this does not have to catch every abnormal exit to be useful — only be honest about what it does see.

## Two additions

- **`doctor` reports which checks failed**, by name. "Twelve ran doctor, four reached `start`" stops being the end of the story.
- **The TUI reports one bit** for whether anything was ever submitted — separating bouncing off the first screen from trying and being let down.

## Privacy

`detail` is names from a fixed set. The doctor lines they come from carry versions, paths and port numbers, and none of that may travel. The worker **re-whitelists independently** rather than importing the client's list: the endpoint is public, so a client rollout must not be able to widen what the collector stores.

Verified against the deployed worker — a payload containing a home path and a SQL fragment stored `providers,node` and nothing else; a duration of 10¹² ms clamped to one day. E2E rows deleted afterwards (7 removed, 0 remaining).

## Verification

- D1 migrated (`detail`, `duration_ms`); all 1,952 existing rows intact
- Worker deployed; custom domain confirmed 3/3 after edge propagation
- `npm run lint` · `npx tsc --noEmit` — clean
- `npm run test:coverage` — 266 files, 3588 pass, statements 90.15%