### PR TITLE
chore(release): v0.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.20.3 — 2026-08-04
+
+### Fixed
+
+- **Switching provider to `atlascloud` no longer 400s on every review and worker call.** `mapModelForProvider` special-cased `codex`/`codex-responses` and `claude`, but every other adapter — including `atlascloud` — fell into the generic "any `vendor/model`-shaped id survives" branch it shares with openrouter/gpt/local/lmstudio. OpenRouter and Atlas Cloud both name models `vendor/model`, but with different catalogs (OpenRouter's `z-ai/glm-5.2` vs Atlas's own `zai-org/GLM-4.6`), so a role configured for OpenRouter kept its model id verbatim on a switch to `atlascloud` and every call to `api.atlascloud.ai` 400'd `"not found"` — confirmed live against the real API. It now checks membership against Atlas's curated model list and live catalog cache, in both directions, so a switch away from `atlascloud` can't leak its ids into OpenRouter either. (INT-3246)
+
 ## 0.20.2 — 2026-08-01
 
 Three fixes to the CI review gate, all found by running it rather than reading it. Each is the same failure in a different place: the gate produced a confident verdict while something it needed was missing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.20.2",
+      "version": "0.20.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Release the atlascloud model-id-leak fix (87bcd0c, INT-3246) to npm — the fix landed directly on `main` before branch protection was set up, but the globally-installed `openswarm` CLI is a separate npm package and never picked it up.
- Version bump 0.20.2 → 0.20.3 + CHANGELOG entry. `release.yml` publishes to npm automatically on merge (paths: `package.json`).

## Test plan
- [x] `npm run build` clean, `npx tsc --noEmit -p .` clean (already verified for the underlying fix in INT-3246)
- [x] Version-bump-only diff — no source changes in this PR
- [ ] Confirm `release.yml` runs and publishes 0.20.3 after merge
- [ ] `npm install -g @intrect/openswarm@latest` picks up the fix