### PR TITLE
feat(review): scale the reviewer's turn/timeout budget with diff size

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -322,6 +322,8 @@ program
   .option('--json', 'Emit the verdict as JSON on stdout instead of the human report (for CI)')
   .option('--sarif <file>', 'Write a SARIF 2.1.0 report for GitHub code scanning')
   .option('--read-only', 'Deny the reviewer all mutating tools including bash — required when reviewing an untrusted diff in CI')
+  .option('--max-turns <n>', 'Override the reviewer\'s agentic-loop turn ceiling (default: scaled by diff size)', parsePositiveIntegerOption)
+  .option('--timeout <ms>', 'Override the reviewer\'s wall-clock budget in ms (default: scaled by diff size)', parsePositiveIntegerOption)
   .option('--debug', 'Verbose logging')
   // --max: full-codebase multi-agent audit (INT-2006)
   .option('--max', 'Audit the whole codebase: fan reviewer subagents out over directory-shaped areas')
@@ -339,6 +341,7 @@ program
   .option('--no-learn', 'For --max: do not record the audit findings into the repo knowledge memory')
   .action(async (opts: {
     path?: string; base?: string; issues?: string | boolean; issuesPerArea?: string | boolean; file?: string | boolean; adapter?: string; debug?: boolean; json?: boolean; sarif?: string; readOnly?: boolean;
+    maxTurns?: number; timeout?: number;
     max?: boolean; concurrency?: number; maxFilesPerArea?: number; yes?: boolean; dryRun?: boolean;
     out?: string; linear?: boolean; fallback?: string | boolean; fix?: boolean; inPlace?: boolean; fixRounds?: number; learn?: boolean;
   }) => {
@@ -390,7 +393,7 @@ program
         return;
       }
       const { runReviewCommand } = await import('./cli/reviewCommand.js');
-      const result = await runReviewCommand({ path: opts.path, base: opts.base, fileIssue: opts.issues ?? opts.file, adapter: opts.adapter, debug: opts.debug, json: opts.json, sarif: opts.sarif, readOnly: opts.readOnly });
+      const result = await runReviewCommand({ path: opts.path, base: opts.base, fileIssue: opts.issues ?? opts.file, adapter: opts.adapter, debug: opts.debug, json: opts.json, sarif: opts.sarif, readOnly: opts.readOnly, maxTurns: opts.maxTurns, timeoutMs: opts.timeout });
       if (result && result.decision === 'reject') process.exitCode = 1;
     } catch (e) {
       // A throw means no verdict was produced — the gate did NOT run. Exit 2,

--- a/src/cli/reviewCommand.test.ts
+++ b/src/cli/reviewCommand.test.ts
@@ -5,6 +5,8 @@ import {
   runReviewCommand,
   resolveIssueFromBranch,
   ensureProjectMapping,
+  scaledReviewMaxTurns,
+  scaledReviewTimeoutMs,
 } from './reviewCommand.js';
 import type { ReviewResult } from '../agents/agentPair.js';
 
@@ -44,6 +46,34 @@ describe('formatReviewOutput (INT-1955)', () => {
     expect(colored).toContain('\x1b['); // has ANSI codes
     expect(colored).toContain('Decision: REJECT'); // substring still intact
     expect(formatReviewOutput(review, false)).not.toContain('\x1b['); // plain by default
+  });
+});
+
+// Regression: `openswarm review` had no way to raise the reviewer's turn/time
+// budget, so a large diff (29 files/+2200 lines) hit the agentic loop's
+// hardcoded 20-turn ceiling deterministically on two separate runs and got a
+// truncated/empty verdict, while a third run was cut by the 5-minute wall
+// clock mid-analysis having already found real defects.
+describe('scaledReviewMaxTurns / scaledReviewTimeoutMs', () => {
+  it('leaves small diffs at the original defaults', () => {
+    expect(scaledReviewMaxTurns(1)).toBe(20);
+    expect(scaledReviewMaxTurns(10)).toBe(20);
+    expect(scaledReviewTimeoutMs(1)).toBe(300_000);
+    expect(scaledReviewTimeoutMs(10)).toBe(300_000);
+  });
+
+  it('scales up past the free-file threshold, capped', () => {
+    expect(scaledReviewMaxTurns(29)).toBe(30); // the diff that triggered this fix
+    expect(scaledReviewMaxTurns(200)).toBe(60); // cap
+    expect(scaledReviewTimeoutMs(29)).toBe(585_000);
+    expect(scaledReviewTimeoutMs(200)).toBe(900_000); // cap
+  });
+
+  it('is monotonically non-decreasing', () => {
+    for (let n = 1; n < 100; n++) {
+      expect(scaledReviewMaxTurns(n + 1)).toBeGreaterThanOrEqual(scaledReviewMaxTurns(n));
+      expect(scaledReviewTimeoutMs(n + 1)).toBeGreaterThanOrEqual(scaledReviewTimeoutMs(n));
+    }
   });
 });
 

--- a/src/cli/reviewCommand.ts
+++ b/src/cli/reviewCommand.ts
@@ -20,6 +20,32 @@ import {
   type ReviewHistoryRecord,
 } from './reviewHistory.js';
 
+/**
+ * `openswarm review` had no way to raise the reviewer's turn/time budget, so it
+ * inherited the agentic loop's hardcoded defaults (20 turns, 5 min) regardless
+ * of diff size — a 29-file/+2200-line diff hit the turn ceiling deterministically
+ * on two separate runs, salvaged an empty or truncated verdict, and a third run
+ * (raised nothing, same defaults) got cut by the 5-minute wall clock mid-analysis,
+ * having already found the real defects. Small diffs are unaffected (thresholds
+ * below the current defaults are no-ops); large ones now get proportionally more
+ * room, and `--max-turns`/`--timeout` remain available to override either.
+ * Unvalidated heuristic, not a measured optimum — widen the caps if it's still
+ * not enough for some diff shape.
+ */
+const REVIEW_BUDGET_FREE_FILES = 10;
+const REVIEW_BUDGET_MAX_TURNS_CAP = 60;
+const REVIEW_BUDGET_TIMEOUT_CAP_MS = 900_000; // 15 min
+
+export function scaledReviewMaxTurns(changedFileCount: number, base = 20): number {
+  if (changedFileCount <= REVIEW_BUDGET_FREE_FILES) return base;
+  return Math.min(REVIEW_BUDGET_MAX_TURNS_CAP, base + Math.ceil((changedFileCount - REVIEW_BUDGET_FREE_FILES) / 2));
+}
+
+export function scaledReviewTimeoutMs(changedFileCount: number, base = 300_000): number {
+  if (changedFileCount <= REVIEW_BUDGET_FREE_FILES) return base;
+  return Math.min(REVIEW_BUDGET_TIMEOUT_CAP_MS, base + (changedFileCount - REVIEW_BUDGET_FREE_FILES) * 15_000);
+}
+
 /** Synthesize a WorkerResult describing the working-tree changes for the reviewer. */
 /**
  * The diff the reviewer will read, when git can produce one.
@@ -242,6 +268,10 @@ export interface ReviewCommandOptions {
    * credential in the environment. (INT-3189)
    */
   readOnly?: boolean;
+  /** Override the reviewer's agentic-loop turn ceiling (default: scaled by diff size). */
+  maxTurns?: number;
+  /** Override the reviewer's wall-clock budget in ms (default: scaled by diff size). */
+  timeoutMs?: number;
 }
 
 /**
@@ -325,6 +355,8 @@ export async function runReviewCommand(
         mode: 'direct',
         priorReviewContext: history.context,
         readOnly: opts.readOnly,
+        maxTurns: opts.maxTurns ?? scaledReviewMaxTurns(changed.length),
+        timeoutMs: opts.timeoutMs ?? scaledReviewTimeoutMs(changed.length),
         diff: await deps.getDiff?.(c, opts.base) ?? await defaultGetDiff(c, opts.base),
         onLog,
       });


### PR DESCRIPTION
## Summary
- `openswarm review` never passed `maxTurns`/`timeoutMs` to the reviewer, so every run was stuck at the agentic loop's hardcoded 20-turn/5-min defaults regardless of diff size — a 29-file/+2200-line diff hit the turn ceiling deterministically on two runs and got cut by the timeout on a third, mid-analysis, having already found real defects.
- Added `scaledReviewMaxTurns()`/`scaledReviewTimeoutMs()`: diffs ≤10 files keep the original defaults untouched; larger ones scale up, capped at 60 turns / 15 min.
- Added `--max-turns <n>` / `--timeout <ms>` CLI flags as an explicit override.
- `--max` (audit mode) untouched — separate per-area budget handling.

INT-3263.

## Test plan
- [x] New tests in `reviewCommand.test.ts` — defaults preserved ≤10 files, scaling/caps verified, monotonicity
- [x] `npx tsc --noEmit -p .` clean, oxlint clean
- [x] Full `src/cli/` suite: 509 passed
- [x] `openswarm review` on this diff itself: APPROVE in 95s (no timeout/truncation)