### PR TITLE
fix(daemon): admit isolated worktree fanout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.20.7 — 2026-08-06
+
+### Fixed
+
+- **Worktree fan-out now survives durable admission.** `0.20.6` intentionally omitted `conflictScope` when isolated worktrees should use capacity-only admission, but the ledger interpreted the omitted value as an unknown scope and failed closed as soon as one worker was active. The scheduler briefly started eight issues and the ledger immediately superseded seven, making the dashboard look single-threaded. Omitted scope now bypasses scope serialization while an explicitly supplied empty or unknown scope still fails closed. Verified live with eight KYTE-Portal issues simultaneously in `EXECUTING` state.
+
 ## 0.20.6 — 2026-08-06
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.20.6",
+      "version": "0.20.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",

--- a/src/automation/runLedger.test.ts
+++ b/src/automation/runLedger.test.ts
@@ -185,7 +185,7 @@ describe('RunLedger claim and fencing races', () => {
     ledger.close();
   });
 
-  it('fails closed when either side of a parallel repository claim has unknown scope', () => {
+  it('bypasses scope serialization only when the caller explicitly omits conflictScope', () => {
     const ledger = new RunLedger(createDbPath());
     register(ledger, 'KNOWN', '/same-repo', ['src/known.ts']);
     register(ledger, 'UNKNOWN', '/same-repo');
@@ -197,6 +197,21 @@ describe('RunLedger claim and fencing races', () => {
     expect(ledger.claimRun('UNKNOWN', {
       ownerInstanceId: 'unknown', leaseMs: 1_000, now: 2_001,
       maxActiveForProject: 2,
+    })).not.toBeNull();
+    ledger.close();
+  });
+
+  it('fails closed when a parallel claim explicitly supplies an unknown scope', () => {
+    const ledger = new RunLedger(createDbPath());
+    register(ledger, 'KNOWN', '/same-repo', ['src/known.ts']);
+    register(ledger, 'UNKNOWN', '/same-repo');
+    expect(ledger.claimRun('KNOWN', {
+      ownerInstanceId: 'known', leaseMs: 1_000, now: 2_000,
+      maxActiveForProject: 2, conflictScope: ['src/known.ts'],
+    })).not.toBeNull();
+    expect(ledger.claimRun('UNKNOWN', {
+      ownerInstanceId: 'unknown', leaseMs: 1_000, now: 2_001,
+      maxActiveForProject: 2, conflictScope: [],
     })).toBeNull();
     ledger.close();
   });

--- a/src/automation/runLedger.ts
+++ b/src/automation/runLedger.ts
@@ -502,7 +502,10 @@ export class RunLedger {
       // The cap controls capacity; the write scope controls safety inside that
       // capacity. Both checks happen in the same SQLite transaction as the
       // claim, so two daemon instances cannot race disjoint scheduler views.
-      if (maxActive > 1) {
+      // An omitted conflictScope explicitly means the caller relies on isolated
+      // worktrees and wants capacity-only admission. An explicitly supplied but
+      // empty/unknown scope still fails closed inside admitsConflictScope().
+      if (maxActive > 1 && options.conflictScope !== undefined) {
         const activeScopes = activeRows
           .filter(active => ACTIVE_LEASE_STATES.includes(active.state as RunState))
           .map(active => parseJson(active.metadata_json));


### PR DESCRIPTION
## What changed

- treat an omitted durable `conflictScope` as capacity-only admission for isolated worktree fan-out
- preserve fail-closed behavior when a caller explicitly supplies an empty or unknown scope
- release as `0.20.7`

## Root cause

`0.20.6` intentionally omitted `conflictScope` in worktree fan-out mode, but `admitsConflictScope(undefined, activeScopes)` interpreted omission as unknown scope. The scheduler started eight tasks, then durable admission superseded seven as soon as one worker was active.

## Proof

- live daemon: eight KYTE-Portal issues simultaneously `EXECUTING`
- full suite: 269 files, 3635 passed, 1 skipped
- lint, typecheck, build passed
- targeted ledger/coordinator tests: 121 passed
- OpenSwarm review confirmed the omitted-scope bypass is correctly wired and the regression test distinguishes omission from explicit empty scope; it returned REVISE only for an unspecified historical defect with no issue, file, line, suggestion, or action.