### PR TITLE
chore(release): v0.20.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.20.8 — 2026-08-06
+
+### Added
+
+- **`openswarm pr review`.** A new PR autopilot action that re-applies outstanding review feedback on demand — including comments left by Codex-based review actions, which formal CHANGES_REQUESTED-only detection previously missed entirely alongside Claude's. Sits next to `status`/`fix`/`watch`/`create`; skips conflict handling and CI waits, so it's safe to run as a lightweight "did a reviewer leave feedback I haven't addressed yet?" check.
+
 ## 0.20.7 — 2026-08-06
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.20.7",
+  "version": "0.20.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.20.7",
+      "version": "0.20.8",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.20.7",
+  "version": "0.20.8",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps `package.json`/`package-lock.json` to `0.20.8`.
- Adds the CHANGELOG entry for `openswarm pr review` (INT-3282, merged in #387).

Merging this triggers `release.yml`'s auto-publish to npm.

## Test plan
- [x] Version-only diff, no source changes — `npm run typecheck`/tests unaffected.