### PR TITLE
chore(release): v0.20.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.20.9 — 2026-08-07
+
+### Added
+
+- **`openswarm pr review --fresh`.** Runs a brand-new code review of the PR's current diff — the same reviewer `openswarm review` uses locally — instead of only reacting to feedback a reviewer already left, and posts the verdict as a PR comment naming the exact commit reviewed. Reviews inside a scratch `git worktree` at the PR/base merge-base, in read-only mode (the PR's contents are untrusted), so nothing under the caller's own checkout is ever touched.
+
 ## 0.20.8 — 2026-08-06
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.20.8",
+  "version": "0.20.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.20.8",
+      "version": "0.20.9",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.20.8",
+  "version": "0.20.9",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps `package.json`/`package-lock.json` to `0.20.9`.
- Adds the CHANGELOG entry for `openswarm pr review --fresh` (INT-3282, merged in #391).

Merging this triggers `release.yml`'s auto-publish to npm.

## Test plan
- [x] Version-only diff, no source changes.