### PR TITLE
chore(release): v0.20.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.20.10 — 2026-08-07
+
+### Added
+
+- **`openswarm pr review --all`.** Reviews every open PR in the repo sequentially instead of just the current branch's PR / `--number`, combinable with `--fresh`. Fork PRs are skipped (with a per-PR note) under feedback re-application since that path can only fetch same-repo branches — use `--fresh`, which works for forks too. A `--repo` that doesn't match the checkout's own `origin` refuses upfront rather than fetching from the wrong remote.
+
 ## 0.20.9 — 2026-08-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.20.9",
+  "version": "0.20.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.20.9",
+      "version": "0.20.10",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.20.9",
+  "version": "0.20.10",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps `package.json`/`package-lock.json` to `0.20.10`.
- Adds the CHANGELOG entry for `openswarm pr review --all` (INT-3282, merged in #393).

Merging this triggers `release.yml`'s auto-publish to npm.

## Test plan
- [x] Version-only diff, no source changes.