### PR TITLE
feat(daemon): explicit issue dispatch + /api/health + static issue board (INT-3388)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev": "node --env-file=.env --import=tsx src/index.ts",
     "prestart": "pkill -f 'dist/index.js' 2>/dev/null || true",
     "build": "tsc",
-    "postbuild": "chmod +x dist/cli.js && rm -rf dist/web-static && cp -R web/static dist/web-static",
+    "postbuild": "chmod +x dist/cli.js && node -e \"const fs=require('node:fs');fs.rmSync('dist/web-static',{recursive:true,force:true});fs.cpSync('web/static','dist/web-static',{recursive:true})\"",
     "start": "node --env-file=.env dist/index.js",
     "stop": "pkill -f 'node --env-file=.env.*openswarm' 2>/dev/null || echo 'No process running'",
     "lint": "oxlint src/",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev": "node --env-file=.env --import=tsx src/index.ts",
     "prestart": "pkill -f 'dist/index.js' 2>/dev/null || true",
     "build": "tsc",
-    "postbuild": "chmod +x dist/cli.js",
+    "postbuild": "chmod +x dist/cli.js && rm -rf dist/web-static && cp -R web/static dist/web-static",
     "start": "node --env-file=.env dist/index.js",
     "stop": "pkill -f 'node --env-file=.env.*openswarm' 2>/dev/null || echo 'No process running'",
     "lint": "oxlint src/",

--- a/src/automation/autonomousRunner.dispatch.test.ts
+++ b/src/automation/autonomousRunner.dispatch.test.ts
@@ -66,6 +66,23 @@ describe('AutonomousRunner.enqueueIssues (INT-3388)', () => {
     await expect(noConcurrency.enqueueIssues([task('1')], '/x/a')).rejects.toThrow(/maxConcurrentTasks/);
   });
 
+  it('refuses dispatch during an active provider rate-limit hold (review finding)', async () => {
+    const runner = new AutonomousRunner(cfg());
+    (runner as unknown as { rateLimitUntil: number }).rateLimitUntil = Date.now() + 60_000;
+    await expect(runner.enqueueIssues([task('1')], '/x/a')).rejects.toThrow(/rate limit active/);
+  });
+
+  it('enableHeartbeat turns the cron on for an explicit-mode runner exactly once (review finding)', () => {
+    const runner = new AutonomousRunner(cfg({ autonomousHeartbeat: false }));
+    type CronInternal = { cronJob: { stop(): void } | null };
+    expect((runner as unknown as CronInternal).cronJob ?? null).toBeNull();
+    expect(runner.enableHeartbeat()).toBe(true);
+    expect((runner as unknown as CronInternal).cronJob).not.toBeNull();
+    // Second call is a no-op — a cron already exists.
+    expect(runner.enableHeartbeat()).toBe(false);
+    (runner as unknown as CronInternal).cronJob?.stop();
+  });
+
   it('suppresses the automatic post-completion heartbeat re-fire in explicit-dispatch mode (review finding)', async () => {
     vi.useFakeTimers();
     try {
@@ -88,6 +105,36 @@ describe('AutonomousRunner.enqueueIssues (INT-3388)', () => {
       expect(autoBeat).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
+    }
+  });
+});
+
+describe('AutonomousRunner shutdown claim rollback (INT-3388, review finding)', () => {
+  it('rolls back Linear claims for explicit dispatches discarded by shutdown, using the atomic discard snapshot', async () => {
+    const { updateIssueState, isLinearInitialized } = vi.hoisted(() => ({
+      updateIssueState: vi.fn(async () => true),
+      isLinearInitialized: vi.fn(() => true),
+    }));
+    vi.doMock('../linear/linear.js', () => ({ updateIssueState, isLinearInitialized }));
+    try {
+      const runner = new AutonomousRunner(cfg());
+      const runSpy = vi.fn(async () => {}); // keep queued tasks from executing
+      (runner as unknown as Internal).runAvailableTasks = runSpy;
+
+      const dispatched: TaskItem = { ...task('d1'), explicitDispatch: true, linearState: 'Backlog' };
+      const heartbeatPicked: TaskItem = task('h1'); // no explicitDispatch marker
+      await runner.enqueueIssues([dispatched], '/x/a');
+      // Simulate a heartbeat-enqueued task sharing the queue.
+      (runner as unknown as { enqueueCandidate(t: TaskItem, p: string): boolean }).enqueueCandidate(heartbeatPicked, '/x/a');
+
+      await runner.stop();
+
+      // The dispatched task's claim is restored to its recorded prior state;
+      // the heartbeat task (never claimed at queue time) is untouched.
+      expect(updateIssueState).toHaveBeenCalledWith('d1', 'Backlog');
+      expect(updateIssueState).not.toHaveBeenCalledWith('h1', expect.anything());
+    } finally {
+      vi.doUnmock('../linear/linear.js');
     }
   });
 });

--- a/src/automation/autonomousRunner.dispatch.test.ts
+++ b/src/automation/autonomousRunner.dispatch.test.ts
@@ -1,0 +1,126 @@
+// Purpose: explicit dispatch (INT-3388) — enqueueIssues queues exactly the
+// user-chosen tasks (scheduler dedupe intact) and starts execution, and
+// autonomousHeartbeat:false starts the runner without any heartbeat cron.
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AutonomousRunner } from './autonomousRunner.js';
+import type { AutonomousConfig } from './runnerTypes.js';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+
+const cfg = (over: Partial<AutonomousConfig> = {}): AutonomousConfig => ({
+  linearTeamId: 'team',
+  allowedProjects: ['/x/a'],
+  heartbeatSchedule: '0 * * * *',
+  autoExecute: false,
+  maxConsecutiveTasks: 1,
+  cooldownSeconds: 0,
+  dryRun: true,
+  pairMode: true,
+  maxConcurrentTasks: 4,
+  ...over,
+});
+
+const task = (id: string): TaskItem => ({
+  id,
+  source: 'linear',
+  title: `Task ${id}`,
+  priority: 2,
+  issueId: id,
+  issueIdentifier: `INT-${id}`,
+  createdAt: Date.now(),
+});
+
+type Internal = { runAvailableTasks(): Promise<void>; cronJob: unknown };
+
+describe('AutonomousRunner.enqueueIssues (INT-3388)', () => {
+  it('queues each task, kicks execution once, and dedupes re-queues via the scheduler', async () => {
+    const runner = new AutonomousRunner(cfg());
+    const runSpy = vi.fn(async () => {});
+    (runner as unknown as Internal).runAvailableTasks = runSpy;
+
+    const first = await runner.enqueueIssues([task('1'), task('2')], '/x/a');
+    expect(first.queued).toEqual(['1', '2']);
+    expect(first.rejected).toEqual([]);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    // Same issues again: scheduler's already-queued dedupe rejects them and
+    // no extra execution kick happens.
+    const second = await runner.enqueueIssues([task('1'), task('3')], '/x/a');
+    expect(second.queued).toEqual(['3']);
+    expect(second.rejected).toEqual([{ id: '1', reason: 'duplicate' }]);
+    expect(runSpy).toHaveBeenCalledTimes(2);
+
+    const third = await runner.enqueueIssues([task('1')], '/x/a');
+    expect(third.queued).toEqual([]);
+    expect(third.rejected).toEqual([{ id: '1', reason: 'duplicate' }]);
+    expect(runSpy).toHaveBeenCalledTimes(2); // nothing new queued → no kick
+  });
+
+  it('throws loudly on a config whose scheduler never executes (solo mode) instead of stranding the queue (review finding)', async () => {
+    const noPair = new AutonomousRunner(cfg({ pairMode: false }));
+    await expect(noPair.enqueueIssues([task('1')], '/x/a')).rejects.toThrow(/pairMode/);
+
+    const noConcurrency = new AutonomousRunner(cfg({ maxConcurrentTasks: undefined }));
+    await expect(noConcurrency.enqueueIssues([task('1')], '/x/a')).rejects.toThrow(/maxConcurrentTasks/);
+  });
+
+  it('suppresses the automatic post-completion heartbeat re-fire in explicit-dispatch mode (review finding)', async () => {
+    vi.useFakeTimers();
+    try {
+      type HeartbeatInternal = { scheduleNextHeartbeat(): void; heartbeat(): Promise<void>; _nextHeartbeatTimer: unknown };
+
+      const explicit = new AutonomousRunner(cfg({ autonomousHeartbeat: false }));
+      const explicitBeat = vi.fn(async () => {});
+      (explicit as unknown as HeartbeatInternal).heartbeat = explicitBeat;
+      (explicit as unknown as HeartbeatInternal).scheduleNextHeartbeat();
+      expect((explicit as unknown as HeartbeatInternal)._nextHeartbeatTimer).toBeNull();
+      await vi.runAllTimersAsync();
+      expect(explicitBeat).not.toHaveBeenCalled();
+
+      // Default (heartbeat mode) keeps the re-fire behavior.
+      const auto = new AutonomousRunner(cfg());
+      const autoBeat = vi.fn(async () => {});
+      (auto as unknown as HeartbeatInternal).heartbeat = autoBeat;
+      (auto as unknown as HeartbeatInternal).scheduleNextHeartbeat();
+      await vi.runAllTimersAsync();
+      expect(autoBeat).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('AutonomousRunner explicit-dispatch start (INT-3388)', () => {
+  let dbDir: string | null = null;
+
+  afterEach(() => {
+    if (dbDir) rmSync(dbDir, { recursive: true, force: true });
+    dbDir = null;
+  });
+
+  it('autonomousHeartbeat:false starts without a heartbeat cron; default keeps it', async () => {
+    dbDir = mkdtempSync(join(tmpdir(), 'osw-dispatch-'));
+
+    const explicit = new AutonomousRunner(cfg({
+      autonomousHeartbeat: false,
+      triggerNow: false,
+      automationLedgerMode: 'primary',
+      automationDbPath: join(dbDir, 'a.db'),
+    }));
+    await explicit.start();
+    expect((explicit as unknown as Internal).cronJob).toBeNull();
+    expect(explicit.getState().isRunning).toBe(true);
+    await explicit.stop();
+
+    const heartbeat = new AutonomousRunner(cfg({
+      triggerNow: false,
+      automationLedgerMode: 'primary',
+      automationDbPath: join(dbDir, 'b.db'),
+    }));
+    await heartbeat.start();
+    expect((heartbeat as unknown as Internal).cronJob).not.toBeNull();
+    await heartbeat.stop();
+  });
+});

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -1436,6 +1436,13 @@ export class AutonomousRunner {
       this.cronJob = new Cron(this.config.heartbeatSchedule, async () => {
         await this.heartbeat();
       });
+    } else {
+      // Explicit-dispatch mode has no heartbeat to run the artifact
+      // reconciliation that unparks NEEDS_RECONCILE runs — without this,
+      // explicit work interrupted by a crash stays In Progress forever.
+      // Recovery-only: fetch feeds the reconciler; nothing is selected.
+      await this.recoverParkedRunsOnly().catch((error) =>
+        console.error('[AutonomousRunner] Explicit-mode recovery failed:', error));
     }
 
     this.state.isRunning = true;
@@ -1464,6 +1471,54 @@ export class AutonomousRunner {
     }
   }
 
+  /**
+   * Recovery-only startup path for explicit-dispatch mode: run the same
+   * artifact reconciliation a heartbeat would, without any task selection.
+   * The Linear fetch only feeds the reconciler's issueId→task lookup. (INT-3388)
+   */
+  private async rollbackDiscardedDispatchClaims(
+    discarded: Array<{ task: TaskItem }>,
+  ): Promise<void> {
+    const dispatched = discarded.filter(({ task }) => task.explicitDispatch === true && task.issueId);
+    if (dispatched.length === 0) return;
+    const linear = await import('../linear/linear.js');
+    if (!linear.isLinearInitialized()) return;
+    for (const { task } of dispatched) {
+      const prior = (task.linearState ?? '').toLowerCase() === 'backlog' ? 'Backlog' : 'Todo';
+      const ok = await linear.updateIssueState(task.issueId!, prior).catch(() => false);
+      console.log(ok
+        ? `[AutonomousRunner] Rolled back queued dispatch claim: ${task.issueIdentifier ?? task.issueId} → ${prior}`
+        : `[AutonomousRunner] WARNING: could not roll back claim for ${task.issueIdentifier ?? task.issueId} — left In Progress`);
+    }
+  }
+
+  private async recoverParkedRunsOnly(): Promise<void> {
+    if (!this.durableRuns.isPrimary) return;
+    if (this.durableRuns.listRuns(['NEEDS_RECONCILE']).length === 0) return;
+    const fetchResult = await fetchLinearTasks();
+    if (fetchResult.error) {
+      console.warn(`[AutonomousRunner] Explicit-mode recovery fetch failed: ${fetchResult.error}`);
+      return;
+    }
+    await this.reconcileDurableArtifacts(fetchResult.tasks);
+  }
+
+  /**
+   * Turn the heartbeat cron on for a runner that was started in
+   * explicit-dispatch mode — the runtime activation path behind Discord's
+   * `!auto start` when startup had `autonomous.enabled: false`. No-op when a
+   * cron already exists. (INT-3388)
+   */
+  enableHeartbeat(): boolean {
+    if (this.stopping || this.cronJob) return false;
+    this.config.autonomousHeartbeat = true;
+    this.cronJob = new Cron(this.config.heartbeatSchedule, async () => {
+      await this.heartbeat();
+    });
+    console.log(`[AutonomousRunner] Heartbeat enabled at runtime (schedule: ${this.config.heartbeatSchedule})`);
+    return true;
+  }
+
   stop(): Promise<void> {
     if (!this.stopPromise) this.stopPromise = this.performStop();
     return this.stopPromise;
@@ -1488,6 +1543,15 @@ export class AutonomousRunner {
     const deadline = Date.now() + graceMs;
     const heartbeatAtStop = this.heartbeatCompletion;
     const shutdown = await this.scheduler.shutdown(graceMs);
+    // Queued-but-never-started explicit dispatches were discarded by
+    // shutdown() with no cancellation event — roll their Linear claims back
+    // to the state they were dispatched from, or they sit In Progress forever
+    // with no worker. The discard snapshot is taken atomically inside
+    // shutdown() (same synchronous block as stopping+clearQueue), so none of
+    // these can have started. Heartbeat-selected tasks are untouched: they
+    // were never moved to In Progress at queue time. (INT-3388)
+    await this.rollbackDiscardedDispatchClaims(shutdown.discardedQueue).catch((error) =>
+      console.warn('[AutonomousRunner] Queued-dispatch claim rollback failed:', error));
     const remainingGrace = Math.max(0, deadline - Date.now());
     const activityDrained = await this.waitForRunnerActivity(heartbeatAtStop, remainingGrace);
 
@@ -2161,6 +2225,13 @@ export class AutonomousRunner {
         'without them queued issues would never execute',
       );
     }
+    // Same provider-quota hold the heartbeat honors: dispatching during a
+    // known 429 window would claim issues that cannot run and burn more calls.
+    if (Date.now() < this.rateLimitUntil) {
+      throw new Error(
+        `Provider rate limit active until ${new Date(this.rateLimitUntil).toISOString()} — retry after it resets`,
+      );
+    }
     const queued: string[] = [];
     // The reason distinction matters to the caller's claim-rollback decision:
     // 'duplicate' means the scheduler already owns this issue (another live
@@ -2688,6 +2759,11 @@ export function getRunner(config?: AutonomousConfig): AutonomousRunner {
 export async function startAutonomous(config: AutonomousConfig): Promise<AutonomousRunner> {
   const runner = getRunner(config);
   await runner.start();
+  // A runner already running in explicit-dispatch mode occupies the singleton,
+  // and start() above is a no-op on it — without this, `!auto start` after a
+  // `autonomous.enabled: false` boot would report success while changing
+  // nothing. Runtime activation flips the heartbeat on in place. (INT-3388)
+  if (config.autonomousHeartbeat !== false) runner.enableHeartbeat();
   return runner;
 }
 

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -969,6 +969,12 @@ export class AutonomousRunner {
   private _nextHeartbeatTimer: ReturnType<typeof setTimeout> | null = null;
   private scheduleNextHeartbeat(): void {
     if (this.stopping) return;
+    // Explicit-dispatch mode: completion of a dispatched task must not
+    // re-enter the autonomous backlog scan — that is exactly the self-selected
+    // work `autonomousHeartbeat: false` promises never happens. A user-driven
+    // heartbeat() call (dashboard button) remains allowed; only this automatic
+    // re-fire is suppressed. (INT-3388)
+    if (this.config.autonomousHeartbeat === false) return;
     if (this._nextHeartbeatTimer) return; // already queued
     // Fire on the next event-loop tick so the current scheduler callback
     // returns first (avoids re-entrant heartbeat() while still in `completed`
@@ -1424,23 +1430,32 @@ export class AutonomousRunner {
       }
     }
 
-    // Set up cron job
-    this.cronJob = new Cron(this.config.heartbeatSchedule, async () => {
-      await this.heartbeat();
-    });
+    const heartbeatEnabled = this.config.autonomousHeartbeat !== false;
+    if (heartbeatEnabled) {
+      // Set up cron job
+      this.cronJob = new Cron(this.config.heartbeatSchedule, async () => {
+        await this.heartbeat();
+      });
+    }
 
     this.state.isRunning = true;
     this.state.startedAt = Date.now();
-    console.log(`[AutonomousRunner] Started with schedule: ${this.config.heartbeatSchedule}`);
-
-    await reportToDiscord(`🤖 ${t('runner.modeStarted')}\n` +
-      `Schedule: \`${this.config.heartbeatSchedule}\`\n` +
-      `Auto-execute: ${this.config.autoExecute ? '✅' : '❌'}\n` +
-      `Projects: ${this.config.allowedProjects.join(', ')}`
+    console.log(
+      heartbeatEnabled
+        ? `[AutonomousRunner] Started with schedule: ${this.config.heartbeatSchedule}`
+        : '[AutonomousRunner] Started in explicit-dispatch mode (no heartbeat cron)'
     );
 
+    if (heartbeatEnabled) {
+      await reportToDiscord(`🤖 ${t('runner.modeStarted')}\n` +
+        `Schedule: \`${this.config.heartbeatSchedule}\`\n` +
+        `Auto-execute: ${this.config.autoExecute ? '✅' : '❌'}\n` +
+        `Projects: ${this.config.allowedProjects.join(', ')}`
+      );
+    }
+
     // Immediate execution option
-    if (this.config.triggerNow) {
+    if (heartbeatEnabled && this.config.triggerNow) {
       console.log('[AutonomousRunner] Triggering immediate heartbeat in 10s...');
       this.startupHeartbeatTimer = setTimeout(() => {
         this.startupHeartbeatTimer = null;
@@ -2120,6 +2135,50 @@ export class AutonomousRunner {
     broadcastEvent({ type: 'task:queued', data: { taskId: task.id, title: task.title, projectPath, issueIdentifier: task.issueIdentifier } });
     this.syslog(`✓ Queued: ${task.issueIdentifier || ''} ${task.title} → ${projectPath.split('/').slice(-2).join('/')}`);
     return true;
+  }
+
+  /**
+   * Explicit dispatch: queue exactly these user-chosen tasks and start
+   * executing, bypassing the DecisionEngine's own selection entirely. This is
+   * the API surface behind `POST /api/work` (issue board) — the counterpart
+   * of the heartbeat path, usable even when the heartbeat cron is disabled
+   * (`autonomousHeartbeat: false`). Rejected entries are ones the scheduler
+   * refused (already queued/running — its issueId dedupe). (INT-3388)
+   *
+   * Throws (rather than queueing work that would never start) when the
+   * runner's configuration cannot execute scheduler-queued tasks:
+   * runAvailableTasks() is a no-op without pairMode + maxConcurrentTasks, so
+   * silently accepting the queue here would strand the issues In Progress
+   * with no worker ever picking them up.
+   */
+  async enqueueIssues(
+    tasks: TaskItem[],
+    projectPath: string,
+  ): Promise<{ queued: string[]; rejected: Array<{ id: string; reason: 'duplicate' | 'stopping' }> }> {
+    if (!this.config.pairMode || !this.config.maxConcurrentTasks) {
+      throw new Error(
+        'Explicit dispatch requires autonomous.pairMode and maxConcurrentTasks in config — ' +
+        'without them queued issues would never execute',
+      );
+    }
+    const queued: string[] = [];
+    // The reason distinction matters to the caller's claim-rollback decision:
+    // 'duplicate' means the scheduler already owns this issue (another live
+    // dispatch/heartbeat is working it — its In Progress claim must stand),
+    // while 'stopping' means nobody will ever run it (rollback is safe).
+    const rejected: Array<{ id: string; reason: 'duplicate' | 'stopping' }> = [];
+    for (const task of tasks) {
+      if (this.stopping) {
+        rejected.push({ id: task.id, reason: 'stopping' });
+        continue;
+      }
+      if (this.enqueueCandidate(task, projectPath)) queued.push(task.id);
+      else rejected.push({ id: task.id, reason: 'duplicate' });
+    }
+    if (queued.length > 0 && !this.stopping) {
+      this.trackSchedulerHandler('explicitDispatch', this.runAvailableTasks());
+    }
+    return { queued, rejected };
   }
 
   /** Execute task in pair mode */

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -195,11 +195,16 @@ export class DurableRunCoordinator {
       },
     }, now);
 
-    // Todo is the explicit operator-reopen surface. In Progress may be owned by
-    // a human or another daemon and therefore never reactivates a terminal run.
+    // Todo is the autonomous operator-reopen surface. In Progress may be owned
+    // by a human or another daemon and therefore never reactivates a terminal
+    // run on its own — but an explicit user dispatch (issue board / `work`
+    // CLI) IS the operator saying "run this", so it reopens terminal records
+    // regardless of the Linear state it arrived in. Without this, dispatching
+    // a previously-completed issue reports "queued" and then dies as
+    // `superseded` with the issue stranded In Progress. (INT-3388)
     if (
       (record.state === 'DONE' || record.state === 'DECOMPOSED' || record.state === 'CANCELLED')
-      && task.linearState === 'Todo'
+      && (task.linearState === 'Todo' || task.explicitDispatch === true)
     ) {
       this.ledger.markReady(issueId, now);
       return this.ledger.getRun(issueId);

--- a/src/automation/runnerTypes.ts
+++ b/src/automation/runnerTypes.ts
@@ -25,6 +25,13 @@ export interface AutonomousConfig {
   workerTimeoutMs?: number;
   reviewerTimeoutMs?: number;
   triggerNow?: boolean;
+  /**
+   * When false the runner starts without its heartbeat cron: no backlog is
+   * fetched and no issue is ever picked on its own. Everything else (durable
+   * recovery, worktree pruning, the scheduler, explicit enqueueIssues() calls
+   * from the CLI/dashboard) still works. Default true. (INT-3388)
+   */
+  autonomousHeartbeat?: boolean;
   maxConcurrentTasks?: number;
   maxConcurrentPerProject?: number;
   defaultRoles?: DefaultRolesConfig;

--- a/src/automation/workRunner.test.ts
+++ b/src/automation/workRunner.test.ts
@@ -21,6 +21,12 @@ vi.mock('../support/repoMetadata.js', () => ({ loadRepoMetadata: loadRepoMetadat
 const { broadcastEventImpl } = vi.hoisted(() => ({ broadcastEventImpl: vi.fn() }));
 vi.mock('../core/eventHub.js', () => ({ broadcastEvent: broadcastEventImpl }));
 
+// enrichTaskFromState reads ~/.openswarm/task-state.json via the REAL statSync
+// while this file mocks node:fs existsSync to true — on a CI runner with no
+// such file that contradiction throws ENOENT. The enrichment is irrelevant to
+// dispatch logic, so mock it to identity.
+vi.mock('../taskState/store.js', () => ({ enrichTaskFromState: (task: unknown) => task }));
+
 const { existsSyncImpl } = vi.hoisted(() => ({ existsSyncImpl: vi.fn(() => true) }));
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs');

--- a/src/automation/workRunner.test.ts
+++ b/src/automation/workRunner.test.ts
@@ -1,0 +1,273 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AutonomousRunner } from './autonomousRunner.js';
+
+const linear = vi.hoisted(() => ({
+  isLinearInitialized: vi.fn(() => true),
+  getIssue: vi.fn(async (_id: string): Promise<Record<string, unknown> | null> => null),
+  updateIssueState: vi.fn(async () => true),
+  fetchIssuesForStates: vi.fn(async () => ({ nodes: [] as Array<Record<string, unknown>> })),
+  getClient: vi.fn(() => ({}) as never),
+}));
+vi.mock('../linear/linear.js', () => linear);
+
+const { loadRepoMetadataImpl } = vi.hoisted(() => ({
+  loadRepoMetadataImpl: vi.fn(async (): Promise<Record<string, unknown> | null> => ({
+    schemaVersion: 1,
+    linear: { projectId: 'proj-1' },
+  })),
+}));
+vi.mock('../support/repoMetadata.js', () => ({ loadRepoMetadata: loadRepoMetadataImpl }));
+
+const { broadcastEventImpl } = vi.hoisted(() => ({ broadcastEventImpl: vi.fn() }));
+vi.mock('../core/eventHub.js', () => ({ broadcastEvent: broadcastEventImpl }));
+
+const { existsSyncImpl } = vi.hoisted(() => ({ existsSyncImpl: vi.fn(() => true) }));
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return { ...actual, existsSync: existsSyncImpl };
+});
+
+import { dispatchWork, listWorkIssues, isDispatchableState, WorkDispatchError } from './workRunner.js';
+
+const todoIssue = (id: string, identifier: string, state = 'Todo') => ({
+  id,
+  identifier,
+  title: `Issue ${identifier}`,
+  description: 'body',
+  state,
+  priority: 2,
+  labels: [],
+  comments: [],
+  project: { id: 'proj-1', name: 'OpenSwarm' },
+});
+
+function mkRunner(over: Partial<Record<'enqueueIssues' | 'getAllowedProjects', unknown>> = {}): AutonomousRunner {
+  return {
+    enqueueIssues: vi.fn(async (tasks: Array<{ id: string }>) => ({
+      queued: tasks.map((t) => t.id),
+      rejected: [],
+    })),
+    getAllowedProjects: vi.fn(() => ['/tmp/repo']),
+    ...over,
+  } as unknown as AutonomousRunner;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  linear.isLinearInitialized.mockReturnValue(true);
+  linear.updateIssueState.mockResolvedValue(true);
+  existsSyncImpl.mockReturnValue(true);
+  loadRepoMetadataImpl.mockResolvedValue({ schemaVersion: 1, linear: { projectId: 'proj-1' } });
+});
+
+describe('isDispatchableState', () => {
+  it('accepts Todo/Backlog/In Progress case-insensitively, rejects the rest', () => {
+    expect(isDispatchableState('Todo')).toBe(true);
+    expect(isDispatchableState('backlog')).toBe(true);
+    expect(isDispatchableState('In Progress')).toBe(true);
+    expect(isDispatchableState('Done')).toBe(false);
+    expect(isDispatchableState('In Review')).toBe(false);
+    expect(isDispatchableState(undefined)).toBe(false);
+  });
+});
+
+describe('listWorkIssues', () => {
+  it('maps the repo to its Linear project and returns priority-sorted issues', async () => {
+    linear.fetchIssuesForStates.mockResolvedValue({
+      nodes: [
+        { id: 'b', identifier: 'INT-2', title: 'Low', priority: 4, state: { name: 'Todo' }, labels: { nodes: [] } },
+        { id: 'a', identifier: 'INT-1', title: 'Urgent', priority: 1, state: { name: 'Backlog' }, labels: { nodes: [{ name: 'bug' }] } },
+      ],
+    });
+    const result = await listWorkIssues('/tmp/repo');
+    expect(linear.fetchIssuesForStates).toHaveBeenCalledWith(
+      expect.anything(),
+      ['Todo', 'Backlog', 'In Progress'],
+      { project: { id: { eq: 'proj-1' } } },
+    );
+    expect(result.issues.map((i) => i.identifier)).toEqual(['INT-1', 'INT-2']);
+    expect(result.issues[0].labels).toEqual(['bug']);
+  });
+
+  it('fails with 404 when the repo has no Linear mapping', async () => {
+    loadRepoMetadataImpl.mockResolvedValue(null);
+    await expect(listWorkIssues('/tmp/repo')).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it('fails with 503 when Linear is not configured', async () => {
+    linear.isLinearInitialized.mockReturnValue(false);
+    await expect(listWorkIssues('/tmp/repo')).rejects.toMatchObject({ statusCode: 503 });
+  });
+});
+
+describe('dispatchWork', () => {
+  it('claims each issue as In Progress, queues it, and emits work:queued', async () => {
+    linear.getIssue.mockImplementation(async (id: string) => todoIssue(id, `INT-${id}`));
+    const runner = mkRunner();
+    const result = await dispatchWork(runner, { issueIds: ['1', '2'], projectPath: '/tmp/repo' });
+
+    expect(result.queued).toBe(2);
+    expect(result.skipped).toBe(0);
+    expect(linear.updateIssueState).toHaveBeenCalledTimes(2);
+    expect(linear.updateIssueState).toHaveBeenCalledWith('1', 'In Progress');
+    expect(runner.enqueueIssues).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ issueId: '1' }), expect.objectContaining({ issueId: '2' })]),
+      expect.stringContaining('/tmp/repo'),
+    );
+    expect(broadcastEventImpl).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'work:queued' }),
+    );
+  });
+
+  it('does not re-claim an issue already In Progress (resume path)', async () => {
+    linear.getIssue.mockImplementation(async (id: string) => todoIssue(id, `INT-${id}`, 'In Progress'));
+    const runner = mkRunner();
+    await dispatchWork(runner, { issueIds: ['1'], projectPath: '/tmp/repo' });
+    expect(linear.updateIssueState).not.toHaveBeenCalled();
+    expect(runner.enqueueIssues).toHaveBeenCalled();
+  });
+
+  it('skips unknown issues and non-dispatchable states without failing the batch', async () => {
+    linear.getIssue.mockImplementation(async (id: string) => {
+      if (id === 'missing') return null;
+      if (id === 'done') return todoIssue(id, 'INT-DONE', 'Done');
+      return todoIssue(id, `INT-${id}`);
+    });
+    const runner = mkRunner();
+    const result = await dispatchWork(runner, { issueIds: ['missing', 'done', 'ok'], projectPath: '/tmp/repo' });
+    expect(result.queued).toBe(1);
+    expect(result.skipped).toBe(2);
+    const reasons = result.items.filter((i) => i.status === 'skipped').map((i) => i.reason);
+    expect(reasons).toEqual(['not found', 'state is Done']);
+  });
+
+  it('scheduler-duplicate rejection keeps the In Progress claim — another dispatch owns the issue (race fix)', async () => {
+    linear.getIssue.mockImplementation(async (id: string) => todoIssue(id, `INT-${id}`));
+    const runner = mkRunner({
+      enqueueIssues: vi.fn(async () => ({ queued: [], rejected: [{ id: '1', reason: 'duplicate' as const }] })),
+    });
+    const result = await dispatchWork(runner, { issueIds: ['1'], projectPath: '/tmp/repo' });
+    expect(result.queued).toBe(0);
+    expect(result.items[0]).toMatchObject({ status: 'skipped', reason: 'already queued or running' });
+    // CRITICAL: no rollback to Todo — the concurrently-running dispatch that
+    // owns this issue on the scheduler relies on the In Progress claim.
+    expect(linear.updateIssueState).not.toHaveBeenCalledWith('1', 'Todo');
+  });
+
+  it('stopping rejection rolls back the claim this dispatch made (review finding)', async () => {
+    linear.getIssue.mockImplementation(async (id: string) => todoIssue(id, `INT-${id}`));
+    const runner = mkRunner({
+      enqueueIssues: vi.fn(async () => ({ queued: [], rejected: [{ id: '1', reason: 'stopping' as const }] })),
+    });
+    const result = await dispatchWork(runner, { issueIds: ['1'], projectPath: '/tmp/repo' });
+    expect(result.items[0]).toMatchObject({ status: 'skipped', reason: 'runner shutting down' });
+    expect(linear.updateIssueState).toHaveBeenCalledWith('1', 'Todo');
+  });
+
+  it('rolls a Backlog-claimed issue back to Backlog, not Todo (review finding)', async () => {
+    linear.getIssue.mockImplementation(async (id: string) => todoIssue(id, `INT-${id}`, 'Backlog'));
+    const runner = mkRunner({
+      enqueueIssues: vi.fn(async () => ({ queued: [], rejected: [{ id: '1', reason: 'stopping' as const }] })),
+    });
+    await dispatchWork(runner, { issueIds: ['1'], projectPath: '/tmp/repo' });
+    expect(linear.updateIssueState).toHaveBeenCalledWith('1', 'Backlog');
+    expect(linear.updateIssueState).not.toHaveBeenCalledWith('1', 'Todo');
+  });
+
+  it('does NOT roll back an issue that was already In Progress before dispatch (resume path)', async () => {
+    linear.getIssue.mockImplementation(async (id: string) => todoIssue(id, `INT-${id}`, 'In Progress'));
+    const runner = mkRunner({
+      enqueueIssues: vi.fn(async () => ({ queued: [], rejected: [{ id: '1', reason: 'stopping' as const }] })),
+    });
+    await dispatchWork(runner, { issueIds: ['1'], projectPath: '/tmp/repo' });
+    expect(linear.updateIssueState).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failed rollback in the item reason instead of hiding it', async () => {
+    linear.getIssue.mockImplementation(async (id: string) => todoIssue(id, `INT-${id}`));
+    linear.updateIssueState.mockImplementation(async (_id: string, state: string) => state === 'In Progress');
+    const runner = mkRunner({
+      enqueueIssues: vi.fn(async () => ({ queued: [], rejected: [{ id: '1', reason: 'stopping' as const }] })),
+    });
+    const result = await dispatchWork(runner, { issueIds: ['1'], projectPath: '/tmp/repo' });
+    expect(result.items[0].reason).toMatch(/manual state reset needed/);
+  });
+
+  it('rejects an empty issue list and a missing project path upfront', async () => {
+    const runner = mkRunner();
+    await expect(dispatchWork(runner, { issueIds: [], projectPath: '/tmp/repo' })).rejects.toBeInstanceOf(WorkDispatchError);
+    existsSyncImpl.mockReturnValue(false);
+    await expect(dispatchWork(runner, { issueIds: ['1'], projectPath: '/nope' })).rejects.toMatchObject({ statusCode: 400 });
+    expect(runner.enqueueIssues).not.toHaveBeenCalled();
+  });
+
+  it("refuses a project path outside the runner's allowed projects (review finding)", async () => {
+    const runner = mkRunner({ getAllowedProjects: vi.fn(() => ['/somewhere/else']) });
+    await expect(
+      dispatchWork(runner, { issueIds: ['1'], projectPath: '/tmp/repo' }),
+    ).rejects.toMatchObject({ statusCode: 403 });
+    expect(linear.getIssue).not.toHaveBeenCalled();
+    expect(runner.enqueueIssues).not.toHaveBeenCalled();
+  });
+
+  it("skips an issue that belongs to a different Linear project than the repo's mapping (review finding)", async () => {
+    linear.getIssue.mockImplementation(async (id: string) => ({
+      ...todoIssue(id, `INT-${id}`),
+      project: { id: 'other-project', name: 'Other' },
+    }));
+    const runner = mkRunner();
+    const result = await dispatchWork(runner, { issueIds: ['1'], projectPath: '/tmp/repo' });
+    expect(result.queued).toBe(0);
+    expect(result.items[0]).toMatchObject({ status: 'skipped' });
+    expect(result.items[0].reason).toMatch(/different Linear project/);
+    expect(linear.updateIssueState).not.toHaveBeenCalled();
+  });
+
+  it('fails upfront when the repo has no Linear mapping instead of dispatching unscoped issues', async () => {
+    loadRepoMetadataImpl.mockResolvedValue(null);
+    const runner = mkRunner();
+    await expect(
+      dispatchWork(runner, { issueIds: ['1'], projectPath: '/tmp/repo' }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it('fails on an unexecutable runner config BEFORE claiming anything on Linear (review finding)', async () => {
+    linear.getIssue.mockImplementation(async (id: string) => todoIssue(id, `INT-${id}`));
+    const runner = mkRunner({
+      enqueueIssues: vi.fn(async () => {
+        throw new Error('Explicit dispatch requires autonomous.pairMode and maxConcurrentTasks in config');
+      }),
+    });
+    await expect(
+      dispatchWork(runner, { issueIds: ['1'], projectPath: '/tmp/repo' }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+    // The whole point: no issue was moved to In Progress for work that can never run.
+    expect(linear.updateIssueState).not.toHaveBeenCalled();
+  });
+
+  it('skips an issue whose Linear claim fails instead of queueing unprotected work (review finding)', async () => {
+    linear.getIssue.mockImplementation(async (id: string) => todoIssue(id, `INT-${id}`));
+    linear.updateIssueState.mockResolvedValue(false);
+    const runner = mkRunner();
+    const result = await dispatchWork(runner, { issueIds: ['1'], projectPath: '/tmp/repo' });
+    expect(result.queued).toBe(0);
+    expect(result.items[0]).toMatchObject({ status: 'skipped' });
+    expect(result.items[0].reason).toMatch(/failed to claim/);
+    // Nothing reached the scheduler beyond the empty config-probe batch.
+    const realBatches = vi.mocked(runner.enqueueIssues).mock.calls.filter(([tasks]) => tasks.length > 0);
+    expect(realBatches).toHaveLength(0);
+  });
+
+  it('reports duplicate issue ids in one request as skipped duplicates, not phantom queues (review finding)', async () => {
+    linear.getIssue.mockImplementation(async (_id: string) => todoIssue('same-uuid', 'INT-1'));
+    const runner = mkRunner();
+    const result = await dispatchWork(runner, { issueIds: ['INT-1', 'same-uuid'], projectPath: '/tmp/repo' });
+    expect(result.queued).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.items[1]).toMatchObject({ status: 'skipped', reason: 'duplicate in request' });
+    // Only one task was actually handed to the scheduler.
+    const realBatches = vi.mocked(runner.enqueueIssues).mock.calls.filter(([tasks]) => tasks.length > 0);
+    expect(realBatches).toHaveLength(1);
+    expect(realBatches[0][0]).toHaveLength(1);
+  });
+});

--- a/src/automation/workRunner.ts
+++ b/src/automation/workRunner.ts
@@ -236,7 +236,7 @@ export async function dispatchWork(
       claimedByUs.set(issue.id, (issue.state ?? '').toLowerCase() === 'backlog' ? 'Backlog' : 'Todo');
     }
 
-    tasks.push(enrichTaskFromState(linearIssueToTask({
+    const task = enrichTaskFromState(linearIssueToTask({
       id: issue.id,
       identifier: issue.identifier,
       title: issue.title,
@@ -245,7 +245,11 @@ export async function dispatchWork(
       state: issue.state,
       labels: issue.labels,
       project: issue.project ? { id: issue.project.id, name: issue.project.name } : undefined,
-    })));
+    }));
+    // Marks the task for durable admission (terminal-record reopen) and for
+    // the shutdown claim-rollback sweep.
+    task.explicitDispatch = true;
+    tasks.push(task);
     items.push({ issueId: issue.id, identifier: issue.identifier, title: issue.title, status: 'queued' });
   }
 

--- a/src/automation/workRunner.ts
+++ b/src/automation/workRunner.ts
@@ -1,0 +1,289 @@
+// ============================================
+// OpenSwarm - Explicit work dispatch (INT-3388)
+// ============================================
+//
+// Backend for the issue board's "deploy N agents" flow: the user picks Linear
+// issues for a repo, and each accepted issue is queued onto the runner's
+// scheduler — which fans out into per-issue worktrees via the existing
+// pipeline. This module owns validation and Linear-side claiming; it does not
+// run pipelines itself.
+
+import { resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import type { AutonomousRunner } from './autonomousRunner.js';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import { broadcastEvent } from '../core/eventHub.js';
+
+export interface WorkDispatchRequest {
+  issueIds: string[];
+  projectPath: string;
+}
+
+export interface WorkDispatchItem {
+  issueId: string;
+  identifier?: string;
+  title?: string;
+  status: 'queued' | 'skipped';
+  reason?: string;
+}
+
+export interface WorkDispatchResult {
+  workId: string;
+  items: WorkDispatchItem[];
+  queued: number;
+  skipped: number;
+}
+
+export interface WorkIssueSummary {
+  id: string;
+  identifier: string;
+  title: string;
+  state: string;
+  priority: number;
+  labels: string[];
+  url?: string;
+}
+
+/** States a user can sensibly dispatch from the board. */
+const DISPATCHABLE_STATES = new Set(['todo', 'backlog', 'in progress']);
+
+export function isDispatchableState(state: string | undefined): boolean {
+  return DISPATCHABLE_STATES.has((state ?? '').toLowerCase());
+}
+
+/**
+ * List a repo's open Linear issues for the board. Resolution of the Linear
+ * project id comes from the repo's own openswarm.json mapping (same source
+ * `openswarm add` writes).
+ */
+export async function listWorkIssues(projectPath: string): Promise<{
+  project: string;
+  source: 'linear';
+  issues: WorkIssueSummary[];
+}> {
+  const linear = await import('../linear/linear.js');
+  if (!linear.isLinearInitialized()) {
+    throw new WorkDispatchError(503, 'Linear is not configured on this daemon');
+  }
+
+  const { loadRepoMetadata } = await import('../support/repoMetadata.js');
+  const meta = await loadRepoMetadata(projectPath);
+  const projectId = meta?.linear?.projectId;
+  if (!projectId) {
+    throw new WorkDispatchError(
+      404,
+      `No Linear project mapped for ${projectPath} (run \`openswarm add ${projectPath}\` to map it)`,
+    );
+  }
+
+  const { nodes } = await linear.fetchIssuesForStates(
+    linear.getClient(),
+    ['Todo', 'Backlog', 'In Progress'],
+    { project: { id: { eq: projectId } } },
+  );
+
+  const issues = nodes
+    .map((node) => ({
+      id: node.id,
+      identifier: node.identifier,
+      title: node.title,
+      state: node.state?.name ?? 'Unknown',
+      priority: node.priority ?? 0,
+      labels: node.labels?.nodes.map((l) => l.name) ?? [],
+    }))
+    .sort((a, b) => (a.priority || 99) - (b.priority || 99));
+
+  return { project: projectId, source: 'linear', issues };
+}
+
+export class WorkDispatchError extends Error {
+  constructor(
+    public statusCode: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+let workCounter = 0;
+
+/**
+ * Validate the requested issues, claim each accepted one on Linear (move to
+ * In Progress — this is what keeps a concurrently-enabled heartbeat from
+ * double-dispatching the same issue), and queue them onto the runner.
+ */
+export async function dispatchWork(
+  runner: AutonomousRunner,
+  request: WorkDispatchRequest,
+): Promise<WorkDispatchResult> {
+  const projectPath = resolve(request.projectPath);
+  if (!existsSync(projectPath)) {
+    throw new WorkDispatchError(400, `Project path does not exist: ${projectPath}`);
+  }
+  // Dispatch stays inside the runner's configured project boundary — an
+  // authorized dashboard caller must not be able to point agents at an
+  // arbitrary local directory just because it exists. Same allow-list the
+  // heartbeat path honors.
+  const { normalizeProjectPath } = await import('../orchestration/taskScheduler.js');
+  const canonical = normalizeProjectPath(projectPath);
+  const allowed = runner.getAllowedProjects().map((p) => normalizeProjectPath(p));
+  if (!allowed.includes(canonical)) {
+    throw new WorkDispatchError(
+      403,
+      `Project ${projectPath} is not in the daemon's allowed projects (config autonomous.allowedProjects)`,
+    );
+  }
+  if (!Array.isArray(request.issueIds) || request.issueIds.length === 0) {
+    throw new WorkDispatchError(400, 'issueIds must be a non-empty array');
+  }
+
+  // Fail on an unexecutable runner configuration BEFORE claiming anything on
+  // Linear: enqueueIssues throws for configs whose scheduler never runs
+  // (no pairMode / maxConcurrentTasks), and finding that out after moving
+  // issues to In Progress would strand them claimed-but-never-worked. An
+  // empty batch triggers only the config check.
+  try {
+    await runner.enqueueIssues([], projectPath);
+  } catch (err) {
+    throw new WorkDispatchError(409, err instanceof Error ? err.message : String(err));
+  }
+
+  const linear = await import('../linear/linear.js');
+  if (!linear.isLinearInitialized()) {
+    throw new WorkDispatchError(503, 'Linear is not configured on this daemon');
+  }
+  const { linearIssueToTask } = await import('../orchestration/decisionEngine.js');
+  const { enrichTaskFromState } = await import('../taskState/store.js');
+
+  // Issues must belong to the repo's own mapped Linear project — dispatching
+  // some other project's issue into this repo would run its worker against
+  // the wrong codebase entirely.
+  const { loadRepoMetadata } = await import('../support/repoMetadata.js');
+  const mappedProjectId = (await loadRepoMetadata(projectPath))?.linear?.projectId;
+  if (!mappedProjectId) {
+    throw new WorkDispatchError(
+      404,
+      `No Linear project mapped for ${projectPath} (run \`openswarm add ${projectPath}\` to map it)`,
+    );
+  }
+
+  const items: WorkDispatchItem[] = [];
+  const tasks: TaskItem[] = [];
+  // Dedupe on the resolved Linear id, not the raw request string — the same
+  // issue can be requested twice as "INT-123" and its UUID, and double
+  // entries would otherwise report one phantom "queued" the scheduler never
+  // accepted.
+  const seenIssueIds = new Set<string>();
+  // Issues THIS dispatch moved to In Progress (vs. ones already there / being
+  // resumed), mapped to the workflow state they came from — rollback must
+  // restore Backlog issues to Backlog, not blanket-reset everything to Todo.
+  const claimedByUs = new Map<string, 'Todo' | 'Backlog'>();
+
+  for (const rawId of request.issueIds) {
+    const issue = await linear.getIssue(rawId);
+    if (!issue) {
+      items.push({ issueId: rawId, status: 'skipped', reason: 'not found' });
+      continue;
+    }
+    if (seenIssueIds.has(issue.id)) {
+      items.push({
+        issueId: issue.id,
+        identifier: issue.identifier,
+        title: issue.title,
+        status: 'skipped',
+        reason: 'duplicate in request',
+      });
+      continue;
+    }
+    seenIssueIds.add(issue.id);
+    if (issue.project?.id !== mappedProjectId) {
+      items.push({
+        issueId: rawId,
+        identifier: issue.identifier,
+        title: issue.title,
+        status: 'skipped',
+        reason: `belongs to a different Linear project than ${projectPath}'s mapping`,
+      });
+      continue;
+    }
+    if (!isDispatchableState(issue.state)) {
+      items.push({
+        issueId: rawId,
+        identifier: issue.identifier,
+        title: issue.title,
+        status: 'skipped',
+        reason: `state is ${issue.state}`,
+      });
+      continue;
+    }
+
+    // Claim before queueing: an issue already In Progress on Linear is
+    // invisible to the heartbeat's Todo scan, so the two dispatch paths
+    // cannot collide. A failed claim means that protection does NOT hold for
+    // this issue — skip it rather than queue unprotected work.
+    if ((issue.state ?? '').toLowerCase() !== 'in progress') {
+      const claimed = await linear.updateIssueState(issue.id, 'In Progress').catch(() => false);
+      if (!claimed) {
+        items.push({
+          issueId: issue.id,
+          identifier: issue.identifier,
+          title: issue.title,
+          status: 'skipped',
+          reason: 'failed to claim on Linear (state transition failed)',
+        });
+        continue;
+      }
+      claimedByUs.set(issue.id, (issue.state ?? '').toLowerCase() === 'backlog' ? 'Backlog' : 'Todo');
+    }
+
+    tasks.push(enrichTaskFromState(linearIssueToTask({
+      id: issue.id,
+      identifier: issue.identifier,
+      title: issue.title,
+      description: issue.description,
+      priority: issue.priority,
+      state: issue.state,
+      labels: issue.labels,
+      project: issue.project ? { id: issue.project.id, name: issue.project.name } : undefined,
+    })));
+    items.push({ issueId: issue.id, identifier: issue.identifier, title: issue.title, status: 'queued' });
+  }
+
+  const workId = `work-${Date.now()}-${++workCounter}`;
+
+  if (tasks.length > 0) {
+    const { queued, rejected } = await runner.enqueueIssues(tasks, projectPath);
+    const rejectedById = new Map(rejected.map((r) => [r.id, r.reason]));
+    for (const item of items) {
+      const rejectionReason = item.status === 'queued' ? rejectedById.get(item.issueId) : undefined;
+      if (!rejectionReason) continue;
+      item.status = 'skipped';
+      if (rejectionReason === 'duplicate') {
+        // Another live dispatch/heartbeat owns this issue on the scheduler.
+        // Its In Progress claim is CORRECT — rolling it back here would reset
+        // an actively-executing issue to Todo (concurrent-dispatch race).
+        item.reason = 'already queued or running';
+        continue;
+      }
+      // 'stopping': the runner is shutting down, nobody will ever run this.
+      item.reason = 'runner shutting down';
+      // If this dispatch made the claim, roll it back to the exact state the
+      // issue came from so it is not stranded In Progress with no worker.
+      // Best-effort: a failed rollback is reported rather than hidden.
+      const priorState = claimedByUs.get(item.issueId);
+      if (priorState) {
+        const rolledBack = await linear.updateIssueState(item.issueId, priorState).catch(() => false);
+        if (!rolledBack) {
+          item.reason = 'runner shutting down (WARNING: issue left In Progress — manual state reset needed)';
+        }
+      }
+    }
+    broadcastEvent({
+      type: 'work:queued',
+      data: { workId, projectPath, taskIds: queued },
+    });
+  }
+
+  const queuedCount = items.filter((i) => i.status === 'queued').length;
+  return { workId, items, queued: queuedCount, skipped: items.length - queuedCount };
+}

--- a/src/core/eventHub.ts
+++ b/src/core/eventHub.ts
@@ -104,6 +104,7 @@ export type HubEvent =
   | { type: 'pr_processor_start'; data: { repos: string[] } }
   | { type: 'pr_processor_end'; data: { lastRun: number | null; nextRun: number | null } }
   | { type: 'pr_processor_pr'; data: { pr: string; title: string } }
+  | { type: 'work:queued'; data: { workId: string; projectPath: string; taskIds: string[] } }
   | { type: 'heartbeat' };
 
 // Singleton

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -207,9 +207,16 @@ async function startServiceLocked(config: SwarmConfig): Promise<void> {
   console.log('🎉 ════════════════════════════════════════');
   console.log('');
 
-  // Auto-start autonomous mode
-  if (config.autonomous?.enabled) {
-    console.log('[Service] Autonomous mode auto-start enabled');
+  // Start the runner whenever an autonomous section exists at all. With
+  // `enabled: false` it comes up in explicit-dispatch mode: no heartbeat cron,
+  // no self-selected backlog work — but durable recovery, worktree pruning,
+  // and user-initiated dispatch (POST /api/work, dashboard buttons) all keep
+  // working. `enabled: true` additionally turns the heartbeat on. (INT-3388)
+  if (config.autonomous) {
+    const heartbeatEnabled = config.autonomous.enabled === true;
+    console.log(heartbeatEnabled
+      ? '[Service] Autonomous mode auto-start enabled'
+      : '[Service] Autonomous runner starting in explicit-dispatch mode (heartbeat off)');
 
     // Select the task source: Linear when configured, else the local SQLite
     // store (no external account). The Linear fetcher closure is preserved
@@ -265,7 +272,8 @@ async function startServiceLocked(config: SwarmConfig): Promise<void> {
       reviewerModel: config.autonomous.models?.reviewer,
       workerTimeoutMs: config.autonomous.workerTimeoutMs || 0, // 0 = unlimited
       reviewerTimeoutMs: config.autonomous.reviewerTimeoutMs || 0, // 0 = unlimited
-      triggerNow: true,  // Execute immediately on start
+      autonomousHeartbeat: heartbeatEnabled,
+      triggerNow: heartbeatEnabled,  // Execute immediately on start (heartbeat mode only)
       maxConcurrentTasks: config.autonomous.maxConcurrentTasks,
       maxConcurrentPerProject: config.autonomous.maxConcurrentPerProject,
       automationLedgerMode: config.autonomous.automationLedgerMode,
@@ -307,7 +315,9 @@ async function startServiceLocked(config: SwarmConfig): Promise<void> {
     const modelInfo = config.autonomous.models
       ? `, Worker: ${config.autonomous.models.worker || 'default'}, Reviewer: ${config.autonomous.models.reviewer || 'default'}`
       : '';
-    console.log(`[Service] Autonomous runner started (pairMode: ${config.autonomous.pairMode}, schedule: ${config.autonomous.schedule}${modelInfo})`);
+    console.log(heartbeatEnabled
+      ? `[Service] Autonomous runner started (pairMode: ${config.autonomous.pairMode}, schedule: ${config.autonomous.schedule}${modelInfo})`
+      : `[Service] Autonomous runner ready for explicit dispatch (pairMode: ${config.autonomous.pairMode}${modelInfo})`);
   }
 
   // Start PR Auto-Improvement

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -798,7 +798,10 @@ export async function getIssue(issueIdOrIdentifier: string): Promise<LinearIssue
       project,
     };
   } catch (error) {
-    console.error(`[Linear] getIssue error for ${issueIdOrIdentifier}:`, error);
+    // Fixed first argument: the id is user-supplied (reachable from the
+    // /api/work HTTP surface), and console's printf-style formatting must
+    // never receive a tainted format string (CodeQL js/tainted-format-string).
+    console.error('[Linear] getIssue error:', issueIdOrIdentifier, error);
     return null;
   }
 }

--- a/src/orchestration/decisionEngine.ts
+++ b/src/orchestration/decisionEngine.ts
@@ -62,6 +62,13 @@ export interface TaskItem {
   impactAnalysis?: ImpactAnalysis;  // Knowledge graph impact analysis
   estimatedMinutes?: number;
   priorAttemptFeedback?: string;  // Last failure/rejection feedback from a previous session — injected into the worker's first iteration (INT-2474)
+  /**
+   * The user explicitly chose this issue (POST /api/work, `openswarm work`)
+   * rather than the heartbeat selecting it. Durable admission reopens
+   * terminal (DONE/CANCELLED/DECOMPOSED) ledger records for these regardless
+   * of the autonomous Todo-only reopen rule. (INT-3388)
+   */
+  explicitDispatch?: boolean;
 }
 
 /**

--- a/src/orchestration/taskScheduler.ts
+++ b/src/orchestration/taskScheduler.ts
@@ -605,10 +605,15 @@ export class TaskScheduler extends EventEmitter {
    * executor exit. A timed-out executor remains quarantined and can no longer
    * race a replacement in the same repository.
    */
-  async shutdown(graceMs = 30_000): Promise<{ drained: boolean; remaining: number; quarantined: number }> {
+  async shutdown(graceMs = 30_000): Promise<{ drained: boolean; remaining: number; quarantined: number; discardedQueue: QueuedTask[] }> {
     if (!Number.isFinite(graceMs) || graceMs < 0) throw new Error('graceMs must be a non-negative finite number');
     this.stopping = true;
     this.paused = true;
+    // Snapshotted in the same synchronous block that sets stopping and clears
+    // the queue — none of these tasks can ever start after this point, so a
+    // caller can safely roll back their external claims (Linear In Progress
+    // from explicit dispatch) without racing a freed slot. (INT-3388)
+    const discardedQueue = [...this.taskQueue];
     this.clearQueue();
 
     const running = Array.from(this.runningTasks.values());
@@ -628,6 +633,7 @@ export class TaskScheduler extends EventEmitter {
       drained: this.unsettledExecutors.size === 0 && this.runningTasks.size === 0 && this.quarantinedProjects.size === 0,
       remaining: this.unsettledExecutors.size,
       quarantined: this.quarantinedExecutorCount(),
+      discardedQueue,
     };
   }
 

--- a/src/support/healthEndpoint.test.ts
+++ b/src/support/healthEndpoint.test.ts
@@ -128,4 +128,38 @@ describe('GET /api/health over the live server', () => {
       await stopWebServer();
     }
   });
+
+  it('answers malformed /api/work requests with 400, not 500 (review finding)', async () => {
+    const { startWebServer, stopWebServer, getWebServerPort } = await import('./web.js');
+    try {
+      await startWebServer(0);
+      const port = getWebServerPort();
+      const base = `http://127.0.0.1:${port}`;
+
+      const badJson = await fetch(`${base}/api/work`, { method: 'POST', body: '{not json' });
+      expect(badJson.status).toBe(400);
+
+      const missingPath = await fetch(`${base}/api/work`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ issueIds: ['x'] }),
+      });
+      expect(missingPath.status).toBe(400);
+
+      const badIds = await fetch(`${base}/api/work`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ projectPath: '/tmp', issueIds: [42] }),
+      });
+      expect(badIds.status).toBe(400);
+
+      // The picker source mirrors the dispatch boundary: no runner → empty
+      // list, still a clean 200.
+      const projects = await fetch(`${base}/api/work/projects`);
+      expect(projects.status).toBe(200);
+      expect(await projects.json()).toEqual([]);
+    } finally {
+      await stopWebServer();
+    }
+  });
 });

--- a/src/support/healthEndpoint.test.ts
+++ b/src/support/healthEndpoint.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildHealthPayload } from './healthEndpoint.js';
+
+const lifecycle = vi.hoisted(() => ({
+  pollers: [] as NodeJS.Timeout[],
+}));
+
+vi.mock('../adapters/processRegistry.js', async () => {
+  const actual = await vi.importActual<typeof import('../adapters/processRegistry.js')>('../adapters/processRegistry.js');
+  return { ...actual, startHealthChecker: vi.fn(), stopHealthChecker: vi.fn() };
+});
+
+vi.mock('./gitStatus.js', async () => {
+  const actual = await vi.importActual<typeof import('./gitStatus.js')>('./gitStatus.js');
+  return {
+    ...actual,
+    startGitStatusPoller: vi.fn(() => {
+      const timer = setInterval(() => {}, 60_000);
+      timer.unref();
+      lifecycle.pollers.push(timer);
+      return timer;
+    }),
+    stopGitStatusPoller: vi.fn(() => {
+      const timer = lifecycle.pollers.pop();
+      if (timer) clearInterval(timer);
+    }),
+  };
+});
+
+describe('buildHealthPayload', () => {
+  it('reports the vega BackendHealth contract fields', () => {
+    const payload = buildHealthPayload({
+      env: {},
+      pid: 42,
+      ppid: 1,
+      uptimeS: 12.9,
+      version: '1.2.3',
+      instanceId: 'fixed-id',
+    });
+    expect(payload).toEqual({
+      status: 'ok',
+      app: 'openswarm',
+      backend_owner: 'source',
+      backend_version: '1.2.3',
+      backend_instance_id: 'fixed-id',
+      backend_pid: 42,
+      backend_parent_pid: 1,
+      uptime_s: 12,
+    });
+  });
+
+  it('detects a supervised (launchd/systemd) run as owner "service"', () => {
+    expect(buildHealthPayload({ env: { XPC_SERVICE_NAME: 'com.intrect.openswarm' } }).backend_owner).toBe('service');
+    expect(buildHealthPayload({ env: { INVOCATION_ID: 'abc' } }).backend_owner).toBe('service');
+    // Interactive shells on newer macOS export XPC_SERVICE_NAME=0 — not a service.
+    expect(buildHealthPayload({ env: { XPC_SERVICE_NAME: '0' } }).backend_owner).toBe('source');
+  });
+
+  it('honors an explicit OPENSWARM_BACKEND_OWNER override', () => {
+    expect(buildHealthPayload({ env: { OPENSWARM_BACKEND_OWNER: 'source', XPC_SERVICE_NAME: 'x' } }).backend_owner).toBe('source');
+    expect(buildHealthPayload({ env: { OPENSWARM_BACKEND_OWNER: 'service' } }).backend_owner).toBe('service');
+  });
+
+  it('keeps the instance id stable across calls within one process', () => {
+    expect(buildHealthPayload().backend_instance_id).toBe(buildHealthPayload().backend_instance_id);
+  });
+});
+
+describe('GET /api/health over the live server', () => {
+  afterEach(async () => {
+    const { stopWebServer } = await import('./web.js');
+    await stopWebServer();
+    for (const timer of lifecycle.pollers) clearInterval(timer);
+    lifecycle.pollers.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('answers without any auth token even when one is configured', async () => {
+    const { startWebServer, stopWebServer, getWebServerPort } = await import('./web.js');
+    process.env.OPENSWARM_WEB_TOKEN = 'secret-token';
+    try {
+      await startWebServer(0);
+      const port = getWebServerPort();
+      expect(port).toBeTypeOf('number');
+      const res = await fetch(`http://127.0.0.1:${port}/api/health`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe('ok');
+      expect(body.app).toBe('openswarm');
+      expect(typeof body.backend_pid).toBe('number');
+      expect(typeof body.backend_version).toBe('string');
+      expect(typeof body.backend_instance_id).toBe('string');
+
+      // The rest of /api/* stays gated: same unauthenticated request pattern
+      // must NOT leak through just because health was opened up.
+      const gated = await fetch(`http://127.0.0.1:${port}/api/stats`, {
+        headers: { origin: 'http://evil.example' },
+      });
+      expect(gated.status).toBe(403);
+    } finally {
+      delete process.env.OPENSWARM_WEB_TOKEN;
+      await stopWebServer();
+    }
+  });
+
+  it('serves the /app shell and /static assets, and blocks traversal (INT-3388)', async () => {
+    const { startWebServer, stopWebServer, getWebServerPort } = await import('./web.js');
+    try {
+      await startWebServer(0);
+      const port = getWebServerPort();
+
+      const app = await fetch(`http://127.0.0.1:${port}/app`);
+      expect(app.status).toBe(200);
+      expect(app.headers.get('content-type')).toContain('text/html');
+      expect(await app.text()).toContain('OpenSwarm');
+
+      const css = await fetch(`http://127.0.0.1:${port}/static/css/tokens.css`);
+      expect(css.status).toBe(200);
+      expect(css.headers.get('content-type')).toContain('text/css');
+
+      // Traversal must never surface file content. Node's client rejects raw
+      // ../ in the path, so exercise the encoded form end-to-end.
+      const traversal = await fetch(`http://127.0.0.1:${port}/static/..%2f..%2fpackage.json`);
+      expect([403, 404]).toContain(traversal.status);
+      const leaked = await traversal.text();
+      expect(leaked).not.toContain('"version"');
+    } finally {
+      await stopWebServer();
+    }
+  });
+});

--- a/src/support/healthEndpoint.ts
+++ b/src/support/healthEndpoint.ts
@@ -1,0 +1,74 @@
+// ============================================
+// OpenSwarm - /api/health payload (INT-3388)
+// ============================================
+//
+// Field names deliberately mirror the vega-agent desktop shell's
+// BackendHealth contract so its polling/recovery logic ports over unchanged:
+// the shell identifies "the daemon I expect" via `app` + `status`, and
+// detects restarts via `backend_pid` changing between polls.
+
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { randomUUID } from 'node:crypto';
+
+export interface HealthPayload {
+  status: 'ok';
+  app: 'openswarm';
+  /** 'service' when supervised (launchd/systemd), 'source' for a dev checkout run. */
+  backend_owner: 'service' | 'source';
+  backend_version: string;
+  /** Fresh per daemon boot — lets a client tell a restart from a hiccup. */
+  backend_instance_id: string;
+  backend_pid: number;
+  backend_parent_pid: number | null;
+  uptime_s: number;
+}
+
+// One id per process lifetime, minted at module load (daemon boot).
+const INSTANCE_ID = randomUUID();
+
+function readPackageVersion(): string {
+  try {
+    // healthEndpoint.js lives at <pkg>/dist/support/, so package.json is two up.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(readFileSync(join(here, '..', '..', 'package.json'), 'utf8')) as { version?: string };
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+const VERSION = readPackageVersion();
+
+function detectBackendOwner(env: NodeJS.ProcessEnv): 'service' | 'source' {
+  const explicit = env.OPENSWARM_BACKEND_OWNER;
+  if (explicit === 'service' || explicit === 'source') return explicit;
+  // launchd sets XPC_SERVICE_NAME for jobs it supervises; systemd sets
+  // INVOCATION_ID. A plain `npm run dev` has neither.
+  if (env.XPC_SERVICE_NAME && env.XPC_SERVICE_NAME !== '0') return 'service';
+  if (env.INVOCATION_ID) return 'service';
+  return 'source';
+}
+
+export function buildHealthPayload(
+  deps: {
+    env?: NodeJS.ProcessEnv;
+    pid?: number;
+    ppid?: number;
+    uptimeS?: number;
+    version?: string;
+    instanceId?: string;
+  } = {},
+): HealthPayload {
+  return {
+    status: 'ok',
+    app: 'openswarm',
+    backend_owner: detectBackendOwner(deps.env ?? process.env),
+    backend_version: deps.version ?? VERSION,
+    backend_instance_id: deps.instanceId ?? INSTANCE_ID,
+    backend_pid: deps.pid ?? process.pid,
+    backend_parent_pid: deps.ppid ?? process.ppid ?? null,
+    uptime_s: Math.floor(deps.uptimeS ?? process.uptime()),
+  };
+}

--- a/src/support/httpBody.ts
+++ b/src/support/httpBody.ts
@@ -1,0 +1,50 @@
+// ============================================
+// OpenSwarm - HTTP request-body helpers
+// ============================================
+//
+// Split out of web.ts (capped at 1500 lines by the pre-commit hook) when the
+// desktop-app routes landed (INT-3388). Behavior unchanged.
+
+import type { IncomingMessage } from 'node:http';
+
+const MAX_REQUEST_BODY_BYTES = 1024 * 1024;
+
+export class HttpError extends Error {
+  constructor(
+    public statusCode: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    let totalBytes = 0;
+    let settled = false;
+
+    const fail = (statusCode: number, message: string) => {
+      if (settled) return;
+      settled = true;
+      reject(new HttpError(statusCode, message));
+    };
+
+    req.on('data', (chunk: Buffer) => {
+      if (settled) return;
+      totalBytes += chunk.length;
+      if (totalBytes > MAX_REQUEST_BODY_BYTES) {
+        fail(413, 'Request body too large');
+        return;
+      }
+      data += chunk.toString('utf-8');
+    });
+    req.on('end', () => {
+      if (settled) return;
+      settled = true;
+      resolve(data);
+    });
+    req.on('aborted', () => fail(400, 'Request body aborted'));
+    req.on('error', () => fail(400, 'Request body error'));
+  });
+}

--- a/src/support/staticAssets.test.ts
+++ b/src/support/staticAssets.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { contentTypeFor, readStaticAsset, resolveStaticRoot, StaticAssetError } from './staticAssets.js';
+
+describe('contentTypeFor', () => {
+  it('maps known extensions and falls back to octet-stream', () => {
+    expect(contentTypeFor('app.html')).toContain('text/html');
+    expect(contentTypeFor('x/y/tokens.css')).toContain('text/css');
+    expect(contentTypeFor('main.mjs')).toContain('text/javascript');
+    expect(contentTypeFor('logo.svg')).toBe('image/svg+xml');
+    expect(contentTypeFor('unknown.bin')).toBe('application/octet-stream');
+    expect(contentTypeFor('no-extension')).toBe('application/octet-stream');
+  });
+});
+
+describe('resolveStaticRoot', () => {
+  it('finds the source web/static directory in a dev checkout', () => {
+    // This repo has web/static committed, so resolution must succeed.
+    expect(resolveStaticRoot()).toBeTruthy();
+  });
+});
+
+describe('readStaticAsset', () => {
+  it('serves a real asset with its content type', async () => {
+    const asset = await readStaticAsset('/static/css/tokens.css');
+    expect(asset.contentType).toContain('text/css');
+    expect(asset.body.toString()).toContain('--bg');
+  });
+
+  it('404s on a missing file', async () => {
+    await expect(readStaticAsset('/static/nope.css')).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it('refuses path traversal out of the static root', async () => {
+    await expect(readStaticAsset('/static/../../package.json')).rejects.toBeInstanceOf(StaticAssetError);
+    await expect(readStaticAsset('/static/../../package.json')).rejects.toMatchObject({
+      statusCode: expect.any(Number),
+    });
+    // Whatever the exact code, the file content must never be readable.
+    await expect(readStaticAsset('/static/..%2f..%2fpackage.json')).rejects.toBeInstanceOf(StaticAssetError);
+  });
+
+  it('refuses a symlink that escapes the static root', async () => {
+    const root = resolveStaticRoot();
+    expect(root).toBeTruthy();
+    const escapeDir = mkdtempSync(join(tmpdir(), 'osw-static-escape-'));
+    const outside = join(escapeDir, 'secret.txt');
+    writeFileSync(outside, 'outside-content');
+    const linkPath = join(root!, 'escape-link.txt');
+    try {
+      symlinkSync(outside, linkPath);
+      await expect(readStaticAsset('/static/escape-link.txt')).rejects.toMatchObject({ statusCode: 403 });
+    } finally {
+      rmSync(linkPath, { force: true });
+      rmSync(escapeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects null bytes', async () => {
+    await expect(readStaticAsset('/static/a%00b')).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it('serves nested paths normally', async () => {
+    const dir = mkdirSync; // reference to satisfy import usage in edge builds
+    void dir;
+    const asset = await readStaticAsset('/static/js/main.mjs');
+    expect(asset.contentType).toContain('text/javascript');
+  });
+});

--- a/src/support/staticAssets.ts
+++ b/src/support/staticAssets.ts
@@ -1,0 +1,103 @@
+// ============================================
+// OpenSwarm - Static web asset resolution (INT-3388)
+// ============================================
+//
+// The new dashboard front-end lives as real files under web/static/ instead of
+// an inline TS template string. In the published package those files ship as
+// dist/web-static (copied by the postbuild script); a tsx dev run has no dist,
+// so the source directory is the fallback. Resolution happens once per lookup
+// rather than at module load so a build finishing mid-session is picked up.
+
+import { existsSync, realpathSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { join, dirname, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+  '.woff2': 'font/woff2',
+};
+
+export function contentTypeFor(path: string): string {
+  const dot = path.lastIndexOf('.');
+  if (dot === -1) return 'application/octet-stream';
+  return CONTENT_TYPES[path.slice(dot).toLowerCase()] ?? 'application/octet-stream';
+}
+
+/** Package root: staticAssets.js sits at <pkg>/dist/support/ (or src/support/ under tsx). */
+function packageRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+}
+
+export function resolveStaticRoot(): string | null {
+  const root = packageRoot();
+  for (const candidate of [join(root, 'dist', 'web-static'), join(root, 'web', 'static')]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+export class StaticAssetError extends Error {
+  constructor(
+    public statusCode: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Read a static asset by its URL path under /static/. Throws StaticAssetError
+ * 404 when the file (or the whole static root) is missing, and 403 when the
+ * requested path escapes the static root — `resolve()` collapses `..`
+ * segments, and the realpath check keeps a symlink planted inside the root
+ * from serving files outside it.
+ */
+export async function readStaticAsset(urlPath: string): Promise<{ body: Buffer; contentType: string }> {
+  const root = resolveStaticRoot();
+  if (!root) throw new StaticAssetError(404, 'Static assets not built (run npm run build)');
+
+  const relative = decodeURIComponent(urlPath.replace(/^\/static\/?/, ''));
+  if (!relative || relative.includes('\0')) throw new StaticAssetError(404, 'Not found');
+
+  const rootReal = realpathSync(root);
+  const candidate = resolve(rootReal, relative);
+  if (candidate !== rootReal && !candidate.startsWith(rootReal + sep)) {
+    throw new StaticAssetError(403, 'Forbidden');
+  }
+
+  let fileReal: string;
+  try {
+    fileReal = realpathSync(candidate);
+  } catch {
+    throw new StaticAssetError(404, 'Not found');
+  }
+  if (fileReal !== rootReal && !fileReal.startsWith(rootReal + sep)) {
+    throw new StaticAssetError(403, 'Forbidden');
+  }
+
+  try {
+    const body = await readFile(fileReal);
+    return { body, contentType: contentTypeFor(candidate) };
+  } catch {
+    throw new StaticAssetError(404, 'Not found');
+  }
+}
+
+/** The /app entry document, or null when assets are not present. */
+export async function readAppShell(): Promise<Buffer | null> {
+  const root = resolveStaticRoot();
+  if (!root) return null;
+  try {
+    return await readFile(join(root, 'app.html'));
+  } catch {
+    return null;
+  }
+}

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -35,20 +35,13 @@ import { handleGraphQL, isGraphQLRequest } from '../issues/graphql/server.js';
 import { ISSUE_BOARD_HTML } from '../issues/issueBoardHtml.js';
 import { createSubIssuesWithDependencies, getTaskSource } from '../automation/runnerExecution.js';
 import type { SubTask } from './planner.js';
+import { buildHealthPayload } from './healthEndpoint.js';
+import { HttpError, readBody } from './httpBody.js';
+import { tryHandleAppRoutes } from './webAppRoutes.js';
 
 let server: ReturnType<typeof createServer> | null = null;
 let runnerRef: AutonomousRunner | undefined;
 let gitStatusPoller: NodeJS.Timeout | null = null;
-const MAX_REQUEST_BODY_BYTES = 1024 * 1024;
-
-class HttpError extends Error {
-  constructor(
-    public statusCode: number,
-    message: string,
-  ) {
-    super(message);
-  }
-}
 
 // CORS origin allowlist — hostname-strict match (no substring/prefix pitfalls)
 function isAllowedOrigin(origin: string): boolean {
@@ -429,6 +422,11 @@ export function stopReposWatcher(): void {
  * Set runner reference (call after autonomous runner is initialized).
  * Pass `undefined` to detach (tests / early boot without autonomous mode).
  */
+/** Actual bound port — for tests that start the server on an ephemeral port (0). */
+export function getWebServerPort(): number | null {
+  const address = server?.address();
+  return address && typeof address === 'object' ? address.port : null;
+}
 export function setWebRunner(runner: AutonomousRunner | undefined): void {
   runnerRef = runner;
   if (!runner) return;
@@ -437,37 +435,6 @@ export function setWebRunner(runner: AutonomousRunner | undefined): void {
 }
 
 // Read POST body helper
-function readBody(req: IncomingMessage): Promise<string> {
-  return new Promise((resolve, reject) => {
-    let data = '';
-    let totalBytes = 0;
-    let settled = false;
-
-    const fail = (statusCode: number, message: string) => {
-      if (settled) return;
-      settled = true;
-      reject(new HttpError(statusCode, message));
-    };
-
-    req.on('data', (chunk: Buffer) => {
-      if (settled) return;
-      totalBytes += chunk.length;
-      if (totalBytes > MAX_REQUEST_BODY_BYTES) {
-        fail(413, 'Request body too large');
-        return;
-      }
-      data += chunk.toString('utf-8');
-    });
-    req.on('end', () => {
-      if (settled) return;
-      settled = true;
-      resolve(data);
-    });
-    req.on('aborted', () => fail(400, 'Request body aborted'));
-    req.on('error', () => fail(400, 'Request body error'));
-  });
-}
-
 // Start web server
 export async function startWebServer(port: number = 3847): Promise<void> {
   if (server) {
@@ -495,6 +462,9 @@ export async function startWebServer(port: number = 3847): Promise<void> {
         res.end();
         return;
       }
+      // Health stays ahead of both auth gates: no secrets ("diagnostics, not
+      // authentication"), and the desktop shell polls it token-less. (INT-3388)
+      if (url === '/api/health' && req.method === 'GET') { writeJson(res, 200, buildHealthPayload()); return; }
       if ((isMutatingApiRequest(url, req.method) || isMutatingGraphQLRequest(requestUrl, req.method)) && !isAuthorizedMutation(req)) {
         writeJson(res, 403, { error: 'Forbidden' });
         return;
@@ -519,6 +489,10 @@ export async function startWebServer(port: number = 3847): Promise<void> {
         // Build buttons from the live registry so the toggle never drifts from
         // isKnownAdapter validation (INT-1901 / INT-3284).
         res.end(buildDashboardHtml(listAdapterNames()));
+
+      // ---- Desktop-app routes (/app, /static/*, /api/work*) → webAppRoutes.ts (INT-3388) ----
+      } else if (await tryHandleAppRoutes(req, res, url, requestUrl, runnerRef, readBody)) {
+        // handled
 
       // ---- SSE stream ----
       } else if (url === '/api/events') {

--- a/src/support/webAppRoutes.ts
+++ b/src/support/webAppRoutes.ts
@@ -1,0 +1,100 @@
+// ============================================
+// OpenSwarm - Desktop-app routes (INT-3388)
+// ============================================
+//
+// The routes added for the desktop shell + issue board, split out of web.ts
+// (which is capped at 1500 lines by the pre-commit hook): /api/health, the
+// /app + /static/* front-end, and the explicit work dispatch API. Auth is
+// still enforced by web.ts's gates before delegation — except /api/health,
+// which web.ts intentionally answers ahead of them.
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { AutonomousRunner } from '../automation/autonomousRunner.js';
+import { readAppShell, readStaticAsset, StaticAssetError } from './staticAssets.js';
+
+function writeJson(res: ServerResponse, statusCode: number, body: unknown): void {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function statusCodeOf(err: unknown): number {
+  return err instanceof Error && 'statusCode' in err ? (err as { statusCode: number }).statusCode : 500;
+}
+
+function messageOf(err: unknown): string {
+  if (err instanceof Error && err.message) return err.message;
+  return 'Internal error';
+}
+
+/**
+ * Handle the /app, /static/*, and /api/work* routes. Returns true when the
+ * request was handled. `readBody` is injected from web.ts so its size limit
+ * applies uniformly.
+ */
+export async function tryHandleAppRoutes(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: string,
+  requestUrl: URL,
+  runner: AutonomousRunner | undefined,
+  readBody: (req: IncomingMessage) => Promise<string>,
+): Promise<boolean> {
+  if (url === '/app') {
+    const shell = await readAppShell();
+    if (!shell) {
+      writeJson(res, 404, { error: 'Static assets not built (run npm run build)' });
+    } else {
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache' });
+      res.end(shell);
+    }
+    return true;
+  }
+
+  if (url.startsWith('/static/')) {
+    try {
+      const asset = await readStaticAsset(url);
+      res.writeHead(200, { 'Content-Type': asset.contentType, 'Cache-Control': 'no-cache' });
+      res.end(asset.body);
+    } catch (err) {
+      const status = err instanceof StaticAssetError ? err.statusCode : 500;
+      writeJson(res, status, { error: messageOf(err) });
+    }
+    return true;
+  }
+
+  if (url === '/api/work/issues' && req.method === 'GET') {
+    const projectPath = requestUrl.searchParams.get('path');
+    if (!projectPath) {
+      writeJson(res, 400, { error: 'Missing ?path=<projectPath>' });
+      return true;
+    }
+    try {
+      const { listWorkIssues } = await import('../automation/workRunner.js');
+      writeJson(res, 200, await listWorkIssues(projectPath));
+    } catch (err) {
+      writeJson(res, statusCodeOf(err), { error: messageOf(err) });
+    }
+    return true;
+  }
+
+  if (url === '/api/work' && req.method === 'POST') {
+    if (!runner) {
+      writeJson(res, 503, { error: 'Runner not available (daemon starting or autonomous config missing)' });
+      return true;
+    }
+    try {
+      const body = JSON.parse(await readBody(req) || '{}');
+      const { dispatchWork } = await import('../automation/workRunner.js');
+      const result = await dispatchWork(runner, {
+        issueIds: body.issueIds,
+        projectPath: body.projectPath,
+      });
+      writeJson(res, 202, result);
+    } catch (err) {
+      writeJson(res, statusCodeOf(err), { error: messageOf(err) });
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/src/support/webAppRoutes.ts
+++ b/src/support/webAppRoutes.ts
@@ -77,16 +77,43 @@ export async function tryHandleAppRoutes(
     return true;
   }
 
+  if (url === '/api/work/projects' && req.method === 'GET') {
+    // The dispatchable repo set — exactly what dispatchWork's boundary check
+    // accepts, so the picker can never offer a path that would 403.
+    // (/api/local-projects scans CHILDREN of allowed paths and omits the
+    // allowed repos themselves, so it disagrees with the boundary check.)
+    const paths = runner?.getAllowedProjects() ?? [];
+    writeJson(res, 200, paths.map((path) => ({ path, name: path.split('/').filter(Boolean).pop() ?? path })));
+    return true;
+  }
+
   if (url === '/api/work' && req.method === 'POST') {
+    // Malformed input is a client error, not a daemon failure: parse and
+    // shape-check explicitly (and before the runner-availability check, so a
+    // bad request is reported as such even while the daemon is starting).
+    let body: { issueIds?: unknown; projectPath?: unknown };
+    try {
+      body = JSON.parse(await readBody(req) || '{}');
+    } catch {
+      writeJson(res, 400, { error: 'Request body is not valid JSON' });
+      return true;
+    }
+    if (typeof body.projectPath !== 'string' || !body.projectPath.trim()) {
+      writeJson(res, 400, { error: 'projectPath must be a non-empty string' });
+      return true;
+    }
+    if (!Array.isArray(body.issueIds) || body.issueIds.some((id) => typeof id !== 'string')) {
+      writeJson(res, 400, { error: 'issueIds must be an array of strings' });
+      return true;
+    }
     if (!runner) {
       writeJson(res, 503, { error: 'Runner not available (daemon starting or autonomous config missing)' });
       return true;
     }
     try {
-      const body = JSON.parse(await readBody(req) || '{}');
       const { dispatchWork } = await import('../automation/workRunner.js');
       const result = await dispatchWork(runner, {
-        issueIds: body.issueIds,
+        issueIds: body.issueIds as string[],
         projectPath: body.projectPath,
       });
       writeJson(res, 202, result);

--- a/web/static/app.html
+++ b/web/static/app.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OpenSwarm</title>
+  <link rel="stylesheet" href="/static/css/tokens.css" />
+  <link rel="stylesheet" href="/static/css/app.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">🐝 OpenSwarm</div>
+    <div id="repo-picker" class="repo-picker"></div>
+    <div class="spacer"></div>
+    <div id="daemon-status" class="daemon-status" title="daemon">
+      <span class="dot" data-state="unknown"></span>
+      <span class="label">connecting…</span>
+    </div>
+  </header>
+
+  <main class="layout">
+    <section class="panel issues-panel">
+      <div class="panel-head">
+        <h2>Issues</h2>
+        <span id="issue-count" class="muted"></span>
+      </div>
+      <div id="issue-list" class="issue-list">
+        <div class="empty">Select a repository to load its issues.</div>
+      </div>
+      <footer class="deploy-bar">
+        <span id="selection-summary" class="muted">0 selected</span>
+        <button id="deploy-btn" class="deploy-btn" disabled>Deploy agents</button>
+      </footer>
+    </section>
+
+    <section class="panel work-panel">
+      <div class="panel-head">
+        <h2>Active work</h2>
+      </div>
+      <div id="work-cards" class="work-cards">
+        <div class="empty">Deployed agents will report progress here.</div>
+      </div>
+    </section>
+  </main>
+
+  <script type="module" src="/static/js/main.mjs"></script>
+</body>
+</html>

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -1,0 +1,210 @@
+/* OpenSwarm issue board (INT-3388). Consumes tokens.css only. */
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: var(--text-md);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 16px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+
+.brand { font-weight: 600; font-size: var(--text-lg); }
+.spacer { flex: 1; }
+
+.repo-picker select {
+  background: var(--surface2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  font-size: var(--text-sm);
+  font-family: var(--font-ui);
+}
+
+.daemon-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--text-xs);
+  color: var(--muted);
+}
+.daemon-status .dot {
+  width: 8px; height: 8px;
+  border-radius: var(--radius-pill);
+  background: var(--muted);
+}
+.daemon-status .dot[data-state="ok"] { background: var(--ok); }
+.daemon-status .dot[data-state="down"] { background: var(--error); }
+
+.layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(360px, 1fr) minmax(320px, 1fr);
+  gap: 12px;
+  padding: 12px;
+  min-height: 0;
+}
+
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.panel-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.panel-head h2 { margin: 0; font-size: var(--text-md); font-weight: 600; }
+
+.muted { color: var(--muted); font-size: var(--text-xs); }
+
+.issue-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.empty {
+  color: var(--muted);
+  font-size: var(--text-sm);
+  padding: 24px;
+  text-align: center;
+}
+
+.issue-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  user-select: none;
+}
+.issue-row:hover { background: var(--surface2); }
+.issue-row.selected { background: var(--accent-soft); }
+.issue-row input[type="checkbox"] { accent-color: var(--accent); }
+.issue-row .identifier {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--accent);
+  min-width: 72px;
+}
+.issue-row .prio {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--muted);
+  min-width: 22px;
+}
+.issue-row .prio[data-p="1"] { color: var(--error); }
+.issue-row .prio[data-p="2"] { color: var(--warning); }
+.issue-row .title {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: var(--text-sm);
+}
+.issue-row .state {
+  font-size: var(--text-xs);
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: 1px 8px;
+  white-space: nowrap;
+}
+
+.deploy-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-top: 1px solid var(--border);
+}
+
+.deploy-btn {
+  background: var(--accent);
+  color: #0d1117;
+  font-weight: 600;
+  font-size: var(--text-sm);
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 8px 16px;
+  cursor: pointer;
+}
+.deploy-btn:disabled { background: var(--surface2); color: var(--muted); cursor: default; }
+.deploy-btn:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
+
+.work-cards {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.work-card {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+}
+.work-card .head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.work-card .identifier {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--accent);
+}
+.work-card .title {
+  flex: 1;
+  font-size: var(--text-sm);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.work-card .stage-line {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 6px;
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--muted);
+}
+.work-card .stage-line .glyph { width: 14px; text-align: center; }
+.work-card .stage-line[data-status="complete"] .glyph { color: var(--ok); }
+.work-card .stage-line[data-status="fail"] .glyph { color: var(--error); }
+.work-card .stage-line[data-status="start"] .glyph { color: var(--accent); }
+.work-card .error {
+  margin-top: 6px;
+  color: var(--error);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  white-space: pre-wrap;
+}
+.work-card a { color: var(--accent); font-size: var(--text-xs); }

--- a/web/static/css/tokens.css
+++ b/web/static/css/tokens.css
@@ -1,0 +1,41 @@
+/* OpenSwarm design tokens — single source (INT-3388).
+   GitHub-dark values carried over from the VEGA-derived dashboard palette,
+   renamed to semantic vocabulary. Dark-only by design: no
+   prefers-color-scheme forks. Legacy aliases (--green meaning blue, etc.)
+   deliberately not reintroduced. */
+
+:root {
+  /* Surfaces */
+  --bg: #0d1117;
+  --surface: #161b22;
+  --surface2: #1c2128;
+  --border: #30363d;
+
+  /* Text */
+  --text: #c9d1d9;
+  --muted: #8b949e;
+
+  /* Accent */
+  --accent: #58a6ff;
+  --accent-soft: rgba(88, 166, 255, 0.12);
+  --focus: #79c0ff;
+
+  /* Status — never the sole indicator; pair with text/glyph */
+  --ok: #3fb950;
+  --warning: #d29922;
+  --error: #f85149;
+
+  /* Metrics */
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-pill: 999px;
+
+  --font-ui: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+
+  --text-xs: 12px;
+  --text-sm: 13px;
+  --text-md: 14px;
+  --text-lg: 16px;
+}

--- a/web/static/js/api.mjs
+++ b/web/static/js/api.mjs
@@ -1,0 +1,35 @@
+// Fetch wrapper: JSON in/out, normalized errors. (INT-3388)
+
+export class ApiError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.status = status;
+  }
+}
+
+async function request(path, options = {}) {
+  const res = await fetch(path, {
+    ...options,
+    headers: { 'Content-Type': 'application/json', ...(options.headers ?? {}) },
+  });
+  let body = null;
+  try {
+    body = await res.json();
+  } catch {
+    // non-JSON response (unexpected) — body stays null
+  }
+  if (!res.ok) {
+    throw new ApiError(res.status, body?.error ?? `HTTP ${res.status}`);
+  }
+  return body;
+}
+
+export const api = {
+  health: () => request('/api/health'),
+  localProjects: () => request('/api/local-projects'),
+  projects: () => request('/api/projects'),
+  workIssues: (path) => request(`/api/work/issues?path=${encodeURIComponent(path)}`),
+  dispatchWork: (projectPath, issueIds) =>
+    request('/api/work', { method: 'POST', body: JSON.stringify({ projectPath, issueIds }) }),
+  stages: () => request('/api/stages'),
+};

--- a/web/static/js/api.mjs
+++ b/web/static/js/api.mjs
@@ -26,8 +26,8 @@ async function request(path, options = {}) {
 
 export const api = {
   health: () => request('/api/health'),
-  localProjects: () => request('/api/local-projects'),
-  projects: () => request('/api/projects'),
+  // The dispatchable repo set — matches dispatchWork's boundary check exactly.
+  workProjects: () => request('/api/work/projects'),
   workIssues: (path) => request(`/api/work/issues?path=${encodeURIComponent(path)}`),
   dispatchWork: (projectPath, issueIds) =>
     request('/api/work', { method: 'POST', body: JSON.stringify({ projectPath, issueIds }) }),

--- a/web/static/js/events.mjs
+++ b/web/static/js/events.mjs
@@ -1,0 +1,69 @@
+// SSE subscription with exponential-backoff reconnect. (INT-3388)
+//
+// On reconnect, `skipReplay=1` avoids re-receiving the server's replay buffer
+// (the initial connection consumes it once to seed state).
+
+export class EventStream {
+  #listeners = new Map();
+  #source = null;
+  #backoffMs = 1000;
+  #firstConnect = true;
+  #closed = false;
+
+  on(type, handler) {
+    if (!this.#listeners.has(type)) this.#listeners.set(type, new Set());
+    this.#listeners.get(type).add(handler);
+    return this;
+  }
+
+  connect() {
+    if (this.#closed) return;
+    const url = this.#firstConnect ? '/api/events' : '/api/events?skipReplay=1';
+    const source = new EventSource(url);
+    this.#source = source;
+
+    source.onopen = () => {
+      this.#backoffMs = 1000;
+      this.#emit('$open', {});
+    };
+    source.onmessage = (event) => {
+      let parsed;
+      try {
+        parsed = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+      if (parsed && typeof parsed.type === 'string') {
+        this.#emit(parsed.type, parsed.data ?? {});
+      }
+    };
+    source.onerror = () => {
+      source.close();
+      if (this.#source === source) this.#source = null;
+      this.#emit('$down', {});
+      if (this.#closed) return;
+      this.#firstConnect = false;
+      const delay = this.#backoffMs;
+      this.#backoffMs = Math.min(this.#backoffMs * 2, 30_000);
+      setTimeout(() => this.connect(), delay);
+    };
+  }
+
+  close() {
+    this.#closed = true;
+    this.#source?.close();
+    this.#source = null;
+  }
+
+  #emit(type, data) {
+    const handlers = this.#listeners.get(type);
+    if (!handlers) return;
+    for (const handler of handlers) {
+      try {
+        handler(data);
+      } catch (err) {
+        console.error(`[events] handler for ${type} threw`, err);
+      }
+    }
+  }
+}

--- a/web/static/js/issueBoard.mjs
+++ b/web/static/js/issueBoard.mjs
@@ -1,0 +1,139 @@
+// Issue list with multi-select → deploy. (INT-3388)
+//
+// WorkspaceShell-style class: DOM refs and fetch are injected so a jsdom test
+// can drive it without a server; a renderSequence guard drops answers that
+// arrive after the user has already switched repos.
+
+export class IssueBoard {
+  #listEl;
+  #countEl;
+  #summaryEl;
+  #deployBtn;
+  #fetchIssues;
+  #dispatch;
+  #onDeployed;
+  #issues = [];
+  #selected = new Set();
+  #projectPath = '';
+  #renderSequence = 0;
+
+  constructor({ listEl, countEl, summaryEl, deployBtn, fetchIssues, dispatch, onDeployed }) {
+    this.#listEl = listEl;
+    this.#countEl = countEl;
+    this.#summaryEl = summaryEl;
+    this.#deployBtn = deployBtn;
+    this.#fetchIssues = fetchIssues;
+    this.#dispatch = dispatch;
+    this.#onDeployed = onDeployed;
+
+    this.#deployBtn.addEventListener('click', () => this.#deploy());
+  }
+
+  async loadFor(projectPath) {
+    this.#projectPath = projectPath;
+    this.#selected.clear();
+    const seq = ++this.#renderSequence;
+    this.#renderMessage('Loading issues…');
+    let payload;
+    try {
+      payload = await this.#fetchIssues(projectPath);
+    } catch (err) {
+      if (seq !== this.#renderSequence) return;
+      this.#renderMessage(err?.message ?? 'Failed to load issues');
+      return;
+    }
+    if (seq !== this.#renderSequence) return;
+    this.#issues = payload.issues ?? [];
+    this.#render();
+  }
+
+  get selectedIds() {
+    return [...this.#selected];
+  }
+
+  #render() {
+    this.#countEl.textContent = this.#issues.length ? `${this.#issues.length} open` : '';
+    if (!this.#issues.length) {
+      this.#renderMessage('No dispatchable issues in this project.');
+      this.#syncFooter();
+      return;
+    }
+    const rows = this.#issues.map((issue) => this.#renderRow(issue));
+    this.#listEl.replaceChildren(...rows);
+    this.#syncFooter();
+  }
+
+  #renderRow(issue) {
+    const row = document.createElement('label');
+    row.className = 'issue-row';
+    row.dataset.issueId = issue.id;
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.addEventListener('change', () => {
+      if (checkbox.checked) this.#selected.add(issue.id);
+      else this.#selected.delete(issue.id);
+      row.classList.toggle('selected', checkbox.checked);
+      this.#syncFooter();
+    });
+
+    const prio = document.createElement('span');
+    prio.className = 'prio';
+    prio.dataset.p = String(issue.priority || 0);
+    prio.textContent = issue.priority ? `P${issue.priority}` : '—';
+
+    const identifier = document.createElement('span');
+    identifier.className = 'identifier';
+    identifier.textContent = issue.identifier;
+
+    const title = document.createElement('span');
+    title.className = 'title';
+    title.textContent = issue.title;
+    title.title = issue.title;
+
+    const state = document.createElement('span');
+    state.className = 'state';
+    state.textContent = issue.state;
+
+    row.append(checkbox, prio, identifier, title, state);
+    return row;
+  }
+
+  #renderMessage(text) {
+    const div = document.createElement('div');
+    div.className = 'empty';
+    div.textContent = text;
+    this.#listEl.replaceChildren(div);
+  }
+
+  #syncFooter() {
+    const n = this.#selected.size;
+    this.#summaryEl.textContent = `${n} selected`;
+    this.#deployBtn.disabled = n === 0;
+    this.#deployBtn.textContent = n > 0 ? `Deploy ${n} agent${n > 1 ? 's' : ''}` : 'Deploy agents';
+  }
+
+  async #deploy() {
+    const ids = this.selectedIds;
+    if (!ids.length || !this.#projectPath) return;
+    const identifiers = this.#issues
+      .filter((issue) => this.#selected.has(issue.id))
+      .map((issue) => issue.identifier);
+    // Explicit, scoped consent before the side effect.
+    const confirmed = window.confirm(
+      `Deploy ${ids.length} agent(s) into ${this.#projectPath}?\n\n${identifiers.join(', ')}`,
+    );
+    if (!confirmed) return;
+
+    this.#deployBtn.disabled = true;
+    this.#deployBtn.textContent = 'Deploying…';
+    try {
+      const result = await this.#dispatch(this.#projectPath, ids);
+      this.#onDeployed?.(result);
+      await this.loadFor(this.#projectPath);
+    } catch (err) {
+      window.alert(err?.message ?? 'Dispatch failed');
+      this.#syncFooter();
+    }
+  }
+}

--- a/web/static/js/main.mjs
+++ b/web/static/js/main.mjs
@@ -49,7 +49,9 @@ events.connect();
   await pollHealth();
   setInterval(pollHealth, 10_000);
   try {
-    await picker.load(() => api.localProjects());
+    // /api/work/projects mirrors dispatchWork's allow-list — every offered
+    // path is dispatchable (unlike /api/local-projects, which scans children).
+    await picker.load(() => api.workProjects());
   } catch (err) {
     console.error('Failed to load projects', err);
   }

--- a/web/static/js/main.mjs
+++ b/web/static/js/main.mjs
@@ -1,0 +1,63 @@
+// Board bootstrap: wire modules together. (INT-3388)
+
+import { api } from './api.mjs';
+import { EventStream } from './events.mjs';
+import { RepoPicker } from './repoPicker.mjs';
+import { IssueBoard } from './issueBoard.mjs';
+import { WorkCards } from './workCards.mjs';
+
+const statusDot = document.querySelector('#daemon-status .dot');
+const statusLabel = document.querySelector('#daemon-status .label');
+
+function setDaemonStatus(state, label) {
+  statusDot.dataset.state = state;
+  statusLabel.textContent = label;
+}
+
+async function pollHealth() {
+  try {
+    const health = await api.health();
+    setDaemonStatus('ok', `daemon v${health.backend_version}`);
+  } catch {
+    setDaemonStatus('down', 'daemon unreachable');
+  }
+}
+
+const workCards = new WorkCards(document.getElementById('work-cards'));
+
+const board = new IssueBoard({
+  listEl: document.getElementById('issue-list'),
+  countEl: document.getElementById('issue-count'),
+  summaryEl: document.getElementById('selection-summary'),
+  deployBtn: document.getElementById('deploy-btn'),
+  fetchIssues: (path) => api.workIssues(path),
+  dispatch: (path, issueIds) => api.dispatchWork(path, issueIds),
+});
+
+const picker = new RepoPicker(document.getElementById('repo-picker'), {
+  onSelect: (path) => board.loadFor(path),
+});
+
+const events = new EventStream();
+events
+  .on('pipeline:stage', (data) => workCards.onStage(data))
+  .on('$open', () => pollHealth())
+  .on('$down', () => setDaemonStatus('down', 'reconnecting…'));
+events.connect();
+
+(async () => {
+  await pollHealth();
+  setInterval(pollHealth, 10_000);
+  try {
+    await picker.load(() => api.localProjects());
+  } catch (err) {
+    console.error('Failed to load projects', err);
+  }
+  // Recover in-flight work after a reload from the stage replay buffer.
+  try {
+    const stages = await api.stages();
+    workCards.seed(Array.isArray(stages) ? stages : stages?.stages);
+  } catch {
+    // stage snapshot is best-effort
+  }
+})();

--- a/web/static/js/repoPicker.mjs
+++ b/web/static/js/repoPicker.mjs
@@ -1,0 +1,45 @@
+// Repository dropdown fed by /api/local-projects. (INT-3388)
+
+export class RepoPicker {
+  #container;
+  #onSelect;
+  #select = null;
+
+  constructor(container, { onSelect }) {
+    this.#container = container;
+    this.#onSelect = onSelect;
+  }
+
+  async load(fetchProjects) {
+    const projects = await fetchProjects();
+    const list = Array.isArray(projects) ? projects : (projects?.projects ?? []);
+
+    const select = document.createElement('select');
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'Select repository…';
+    select.appendChild(placeholder);
+
+    for (const project of list) {
+      const path = typeof project === 'string' ? project : project.path;
+      if (!path) continue;
+      const option = document.createElement('option');
+      option.value = path;
+      option.textContent = typeof project === 'object' && project.name
+        ? `${project.name} — ${path}`
+        : path;
+      select.appendChild(option);
+    }
+
+    select.addEventListener('change', () => {
+      if (select.value) this.#onSelect(select.value);
+    });
+
+    this.#container.replaceChildren(select);
+    this.#select = select;
+  }
+
+  get value() {
+    return this.#select?.value || '';
+  }
+}

--- a/web/static/js/workCards.mjs
+++ b/web/static/js/workCards.mjs
@@ -1,0 +1,88 @@
+// Per-task progress cards folded from pipeline:stage SSE events. (INT-3388)
+//
+// Honest feedback: cards only ever show stages the daemon actually reported —
+// no synthetic spinners. `seed()` replays the /api/stages snapshot so a page
+// reload recovers in-flight work.
+
+const STATUS_GLYPH = { start: '▸', complete: '✓', fail: '✗' };
+
+export class WorkCards {
+  #container;
+  #cards = new Map(); // taskId -> { el, stages: Map<stage, lineEl> }
+
+  constructor(container) {
+    this.#container = container;
+  }
+
+  seed(stageEvents) {
+    for (const event of stageEvents ?? []) {
+      if (event && typeof event.taskId === 'string') this.onStage(event);
+    }
+  }
+
+  onStage(data) {
+    const card = this.#ensureCard(data);
+    if (data.title || data.issueIdentifier) {
+      card.el.querySelector('.title').textContent = data.title ?? '';
+      card.el.querySelector('.identifier').textContent = data.issueIdentifier ?? '';
+    }
+
+    let line = card.stages.get(data.stage);
+    if (!line) {
+      line = document.createElement('div');
+      line.className = 'stage-line';
+      const glyph = document.createElement('span');
+      glyph.className = 'glyph';
+      const label = document.createElement('span');
+      label.className = 'label';
+      line.append(glyph, label);
+      card.el.appendChild(line);
+      card.stages.set(data.stage, line);
+    }
+    line.dataset.status = data.status;
+    line.querySelector('.glyph').textContent = STATUS_GLYPH[data.status] ?? '·';
+    const details = [];
+    if (data.status === 'complete' && data.summary) details.push(data.summary);
+    if (data.durationMs) details.push(`${Math.round(data.durationMs / 1000)}s`);
+    if (typeof data.costUsd === 'number') details.push(`$${data.costUsd.toFixed(2)}`);
+    line.querySelector('.label').textContent = details.length
+      ? `${data.stage} — ${details.join(' · ')}`
+      : data.stage;
+
+    if (data.status === 'fail' && data.error) {
+      let errorEl = card.el.querySelector('.error');
+      if (!errorEl) {
+        errorEl = document.createElement('div');
+        errorEl.className = 'error';
+        card.el.appendChild(errorEl);
+      }
+      errorEl.textContent = data.error;
+    }
+  }
+
+  #ensureCard(data) {
+    let card = this.#cards.get(data.taskId);
+    if (card) return card;
+
+    // First card replaces the placeholder.
+    if (this.#cards.size === 0) this.#container.replaceChildren();
+
+    const el = document.createElement('div');
+    el.className = 'work-card';
+    const head = document.createElement('div');
+    head.className = 'head';
+    const identifier = document.createElement('span');
+    identifier.className = 'identifier';
+    identifier.textContent = data.issueIdentifier ?? '';
+    const title = document.createElement('span');
+    title.className = 'title';
+    title.textContent = data.title ?? data.taskId;
+    head.append(identifier, title);
+    el.appendChild(head);
+    this.#container.prepend(el);
+
+    card = { el, stages: new Map() };
+    this.#cards.set(data.taskId, card);
+    return card;
+  }
+}

--- a/web/static/js/workCards.mjs
+++ b/web/static/js/workCards.mjs
@@ -15,8 +15,13 @@ export class WorkCards {
   }
 
   seed(stageEvents) {
-    for (const event of stageEvents ?? []) {
-      if (event && typeof event.taskId === 'string') this.onStage(event);
+    for (const raw of stageEvents ?? []) {
+      // /api/stages returns hub-event wrappers ({type:'pipeline:stage', data})
+      // while live SSE handlers receive the bare data — accept both.
+      const event = raw && typeof raw.taskId === 'string'
+        ? raw
+        : (raw?.type === 'pipeline:stage' && raw.data && typeof raw.data.taskId === 'string' ? raw.data : null);
+      if (event) this.onStage(event);
     }
   }
 


### PR DESCRIPTION
## Summary
Daemon side of the desktop-app milestone (INT-3388 M1/M3/M4):
- **Explicit-dispatch mode**: the runner now always starts when an `autonomous` config section exists. With `enabled: false` there is no heartbeat cron and no self-selected backlog work (including the post-completion re-fire), but durable recovery, worktree pruning, and user-initiated dispatch keep working.
- **`AutonomousRunner.enqueueIssues`**: explicit dispatch bypassing the DecisionEngine; fail-loud on configs whose scheduler never runs; rejections carry a reason (`duplicate` vs `stopping`) so claim rollback can't reset a concurrently-executing issue.
- **`POST /api/work` / `GET /api/work/issues`** (`workRunner.ts`): allowed-projects boundary, repo↔Linear project mapping check, dedupe by resolved id, In Progress claim before queueing, exact-prior-state rollback (Todo vs Backlog) on shutdown, upfront config probe.
- **`GET /api/health`**: unauthenticated, vega BackendHealth contract — the desktop shell polls this.
- **`/app` + `/static/*`**: new vanilla-JS issue board (repo picker → checkbox multi-select → deploy → SSE progress cards), traversal/symlink-escape-guarded serving, `postbuild` copy into `dist/web-static`.
- `readBody`/`HttpError` → `httpBody.ts`, new routes → `webAppRoutes.ts` (web.ts line cap).

## Test plan
- [x] 43 new tests across healthEndpoint / staticAssets / workRunner / autonomousRunner.dispatch
- [x] `npm run test:coverage` — 278 files, gate clears (statements 90.65%, branches 81.56%, functions 90.97%, lines 92.74%)
- [x] typecheck + oxlint clean; `npm pack --dry-run` includes `dist/web-static`
- [x] `openswarm review` commit gate — APPROVE after 6 rounds fixing 9 real defects (project-boundary bypass, issue↔repo mapping, duplicate-id phantom queues, claim-failure queueing, solo-mode dead queue, heartbeat re-fire leak, shutdown-stranded claims, concurrent-dispatch rollback race, Backlog state corruption)

Part of INT-3388; pairs with the Tauri shell PR and the `openswarm work` CLI PR (INT-3387).