### PR TITLE
feat(cli): openswarm work — deploy agents per selected issue into isolated worktrees (INT-3387)

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -51,7 +51,7 @@ import { reportToDiscord, fetchLinearTasks, getTaskSource } from './runnerExecut
 import { t } from '../locale/index.js';
 import { broadcastEvent, type SwarmStats } from '../core/eventHub.js';
 import { writeProviderOverride } from '../core/providerOverride.js';
-import { buildTaskStateSyncComment, getTaskState } from '../taskState/store.js';
+import { getTaskState } from '../taskState/store.js';
 import {
   findPullRequestForBranch,
   inspectWorktreeRecovery,
@@ -84,8 +84,8 @@ import {
   type ExecutionDurabilityHooks,
   type RepositoryAdmissionPolicy,
 } from './durableRunCoordinator.js';
-import type { EffectClaim, EffectInput, ImportRunInput, RunLedgerMode } from './runLedger.js';
-import type { PairCompleteStats } from './taskSource.js';
+import type { EffectClaim, ImportRunInput, RunLedgerMode } from './runLedger.js';
+import { buildCancellationEffect, buildCompletionEffect, deliverTrackerEffect } from './trackerEffects.js';
 
 // Re-export types and integration setters (used by service.ts)
 export { setNotifier, setTaskSource } from './runnerExecution.js';
@@ -118,43 +118,9 @@ export function worktreeFanoutEnabled(config: Pick<AutonomousConfig,
 
 export type RunnableCandidate = { task: TaskItem; projectPath: string };
 
-interface CompletionEffectPayload {
-  version: 1;
-  marker: string;
-  task: TaskItem;
-  stats: PairCompleteStats;
-  projectPath?: string;
-  costUsd?: number;
-}
-
-interface CancellationEffectPayload {
-  version: 1;
-  marker: string;
-  task: TaskItem;
-  /** Frozen at effect creation so retries reuse the same idempotent comment. */
-  comment: string;
-}
-
-function isCompletionEffectPayload(value: unknown): value is CompletionEffectPayload {
-  if (!value || typeof value !== 'object') return false;
-  const payload = value as Partial<CompletionEffectPayload>;
-  return payload.version === 1
-    && typeof payload.marker === 'string'
-    && !!payload.task
-    && typeof payload.task === 'object'
-    && !!payload.stats
-    && typeof payload.stats === 'object';
-}
-
-function isCancellationEffectPayload(value: unknown): value is CancellationEffectPayload {
-  if (!value || typeof value !== 'object') return false;
-  const payload = value as Partial<CancellationEffectPayload>;
-  return payload.version === 1
-    && typeof payload.marker === 'string'
-    && !!payload.task
-    && typeof payload.task === 'object'
-    && typeof payload.comment === 'string';
-}
+// The completion/cancellation effect payload contract (and its delivery) lives
+// in trackerEffects.ts, shared with the `openswarm work` CLI so the marker
+// format cannot drift between the two outbox writers. (INT-3387)
 
 /**
  * Conflict analysis is an admission safety check. If it is unavailable, allow
@@ -989,51 +955,6 @@ export class AutonomousRunner {
     });
   }
 
-  private completionStats(result: PipelineResult): PairCompleteStats {
-    return {
-      attempts: result.iterations,
-      duration: Math.floor(result.totalDuration / 1000),
-      filesChanged: result.workerResult?.filesChanged || [],
-      workerSummary: result.workerResult?.summary,
-      workerCommands: result.workerResult?.commands,
-      reviewerFeedback: result.reviewResult?.feedback,
-      reviewerDecision: result.reviewResult?.decision,
-      testResults: result.testerResult ? {
-        passed: result.testerResult.testsPassed,
-        failed: result.testerResult.testsFailed,
-        coverage: result.testerResult.coverage,
-        failedTests: result.testerResult.failedTests,
-      } : undefined,
-    };
-  }
-
-  private buildCompletionEffect(task: TaskItem, result: PipelineResult, attemptNo: number): EffectInput {
-    const marker = `complete:${task.issueId || task.id}:attempt:${attemptNo}`;
-    const payload: CompletionEffectPayload = {
-      version: 1,
-      marker,
-      task,
-      stats: { ...this.completionStats(result), idempotencyMarker: marker },
-      projectPath: result.taskContext?.projectPath,
-      costUsd: result.totalCost?.costUsd,
-    };
-    return { kind: 'tracker.complete', dedupeKey: marker, payload };
-  }
-
-  private buildCancellationEffect(task: TaskItem, attemptNo: number): EffectInput {
-    const marker = `cancel:${task.issueId || task.id}:attempt:${attemptNo}`;
-    const state = execution.projectCancellationState(task);
-    const payload: CancellationEffectPayload = {
-      version: 1,
-      marker,
-      task,
-      comment: state
-        ? `${buildTaskStateSyncComment(state, 'Task cancelled')}\n\n<!-- openswarm-effect:${marker} -->`
-        : `Task cancelled\n\n<!-- openswarm-effect:${marker} -->`,
-    };
-    return { kind: 'tracker.cancel', dedupeKey: marker, payload };
-  }
-
   private async executeDurably(task: TaskItem, projectPath: string, signal?: AbortSignal): Promise<PipelineResult> {
     const cancelled = (): PipelineResult => ({
       success: false,
@@ -1103,8 +1024,8 @@ export class AutonomousRunner {
       ),
       {
         admission,
-        successEffect: (result, claim) => this.buildCompletionEffect(task, result, claim.attemptNo),
-        cancelEffect: (_result, claim) => this.buildCancellationEffect(task, claim.attemptNo),
+        successEffect: (result, claim) => buildCompletionEffect(task, result, claim.attemptNo),
+        cancelEffect: (_result, claim) => buildCancellationEffect(task, claim.attemptNo),
         retryCancellation: () => this.stopping,
       },
     );
@@ -1155,7 +1076,7 @@ export class AutonomousRunner {
           if (this.durableRuns.recoverPublishedRun(
             run.issueId,
             { prUrl: pr.url, headSha: pr.headSha },
-            this.buildCompletionEffect(task, recoveredResult, run.attemptNo),
+            buildCompletionEffect(task, recoveredResult, run.attemptNo),
           )) {
             console.log(`[Reconciler] Recovered published run ${run.identifier ?? run.issueId}: ${pr.url}`);
           }
@@ -1263,60 +1184,7 @@ export class AutonomousRunner {
   }
 
   private async deliverOutboxEffect(effect: EffectClaim): Promise<void> {
-    if (effect.kind === 'tracker.cancel') {
-      if (!isCancellationEffectPayload(effect.payload)) {
-        throw new Error(`Invalid automation effect payload: ${effect.kind}`);
-      }
-      await execution.syncCancellationState(
-        effect.payload.task,
-        effect.dedupeKey,
-        effect.payload.comment,
-      );
-      return;
-    }
-    if (effect.kind !== 'tracker.complete' || !isCompletionEffectPayload(effect.payload)) {
-      throw new Error(`Unsupported automation effect: ${effect.kind}`);
-    }
-    const payload = effect.payload;
-    const taskSource = getTaskSource();
-    if (!taskSource) throw new Error('Task source unavailable for outbox delivery');
-    const issueId = payload.task.issueId || payload.task.id;
-    const markerComment = `<!-- openswarm-effect:${payload.marker} -->`;
-
-    const comments = taskSource.getExecutionComments
-      ? await taskSource.getExecutionComments(issueId)
-      : [];
-    const alreadyCommented = comments.some((comment) => comment.body.includes(markerComment));
-    if (alreadyCommented) {
-      // The remote comment may have succeeded immediately before a process crash,
-      // while the following state mutation/local ack did not. Reapply the
-      // idempotent state transition but never duplicate the completion comment.
-      const accepted = await taskSource.updateState(issueId, 'Done');
-      if (!accepted) throw new Error(`Tracker refused Done reconciliation for ${issueId}`);
-    } else {
-      await taskSource.logPairComplete(issueId, effect.dedupeKey, payload.stats);
-    }
-
-    execution.projectSuccessState(payload.task);
-    await execution.reconcileCompletionState(payload.task);
-
-    if (payload.projectPath) {
-      await recordTaskOutcome(payload.projectPath, {
-        taskTitle: payload.task.title,
-        derivedFrom: payload.task.issueIdentifier ?? issueId,
-        iterations: payload.stats.attempts,
-      });
-    }
-    if (payload.task.linearProject) {
-      await updateProjectAfterTask(payload.task.linearProject.id, payload.task.linearProject.name, {
-        title: payload.task.title,
-        success: true,
-        duration: payload.stats.duration * 1000,
-        issueIdentifier: payload.task.issueIdentifier,
-        cost: payload.costUsd,
-        projectPath: payload.projectPath,
-      });
-    }
+    return deliverTrackerEffect(effect, getTaskSource());
   }
 
   private async drainDurableOutbox(): Promise<void> {

--- a/src/automation/trackerEffects.ts
+++ b/src/automation/trackerEffects.ts
@@ -1,0 +1,170 @@
+// ============================================
+// OpenSwarm - Tracker outbox effect contract (INT-3387)
+// ============================================
+//
+// The durable run ledger stores tracker side effects (Done transition,
+// completion comment, cancellation comment) as outbox rows that ANY primary
+// process may deliver later — the daemon after a restart, or the standalone
+// `openswarm work` CLI. The marker/payload wire shape below IS that contract:
+// an effect another process cannot parse becomes a dead-letter. These helpers
+// were extracted verbatim from AutonomousRunner's private methods so the daemon
+// and the CLI share one implementation and cannot drift.
+
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import type { PipelineResult } from '../agents/pairPipeline.js';
+import type { EffectClaim, EffectInput } from './runLedger.js';
+import type { ITaskSource, PairCompleteStats } from './taskSource.js';
+import {
+  projectCancellationState,
+  projectSuccessState,
+  reconcileCompletionState,
+  syncCancellationState,
+} from './runnerExecution.js';
+import { buildTaskStateSyncComment } from '../taskState/store.js';
+import { recordTaskOutcome } from '../memory/repoKnowledge.js';
+import { updateProjectAfterTask } from '../linear/projectUpdater.js';
+
+export interface CompletionEffectPayload {
+  version: 1;
+  marker: string;
+  task: TaskItem;
+  stats: PairCompleteStats;
+  projectPath?: string;
+  costUsd?: number;
+}
+
+export interface CancellationEffectPayload {
+  version: 1;
+  marker: string;
+  task: TaskItem;
+  /** Frozen at effect creation so retries reuse the same idempotent comment. */
+  comment: string;
+}
+
+export function isCompletionEffectPayload(value: unknown): value is CompletionEffectPayload {
+  if (!value || typeof value !== 'object') return false;
+  const payload = value as Partial<CompletionEffectPayload>;
+  return payload.version === 1
+    && typeof payload.marker === 'string'
+    && !!payload.task
+    && typeof payload.task === 'object'
+    && !!payload.stats
+    && typeof payload.stats === 'object';
+}
+
+export function isCancellationEffectPayload(value: unknown): value is CancellationEffectPayload {
+  if (!value || typeof value !== 'object') return false;
+  const payload = value as Partial<CancellationEffectPayload>;
+  return payload.version === 1
+    && typeof payload.marker === 'string'
+    && !!payload.task
+    && typeof payload.task === 'object'
+    && typeof payload.comment === 'string';
+}
+
+export function completionStats(result: PipelineResult): PairCompleteStats {
+  return {
+    attempts: result.iterations,
+    duration: Math.floor(result.totalDuration / 1000),
+    filesChanged: result.workerResult?.filesChanged || [],
+    workerSummary: result.workerResult?.summary,
+    workerCommands: result.workerResult?.commands,
+    reviewerFeedback: result.reviewResult?.feedback,
+    reviewerDecision: result.reviewResult?.decision,
+    testResults: result.testerResult ? {
+      passed: result.testerResult.testsPassed,
+      failed: result.testerResult.testsFailed,
+      coverage: result.testerResult.coverage,
+      failedTests: result.testerResult.failedTests,
+    } : undefined,
+  };
+}
+
+export function buildCompletionEffect(task: TaskItem, result: PipelineResult, attemptNo: number): EffectInput {
+  const marker = `complete:${task.issueId || task.id}:attempt:${attemptNo}`;
+  const payload: CompletionEffectPayload = {
+    version: 1,
+    marker,
+    task,
+    stats: { ...completionStats(result), idempotencyMarker: marker },
+    projectPath: result.taskContext?.projectPath,
+    costUsd: result.totalCost?.costUsd,
+  };
+  return { kind: 'tracker.complete', dedupeKey: marker, payload };
+}
+
+export function buildCancellationEffect(task: TaskItem, attemptNo: number): EffectInput {
+  const marker = `cancel:${task.issueId || task.id}:attempt:${attemptNo}`;
+  const state = projectCancellationState(task);
+  const payload: CancellationEffectPayload = {
+    version: 1,
+    marker,
+    task,
+    comment: state
+      ? `${buildTaskStateSyncComment(state, 'Task cancelled')}\n\n<!-- openswarm-effect:${marker} -->`
+      : `Task cancelled\n\n<!-- openswarm-effect:${marker} -->`,
+  };
+  return { kind: 'tracker.cancel', dedupeKey: marker, payload };
+}
+
+/**
+ * Deliver one claimed tracker effect. Shared by the daemon's outbox drain and
+ * the `openswarm work` CLI so both apply the exact same idempotent transition:
+ * marker-comment dedupe first, then either the full completion log or a bare
+ * Done reconciliation, then local state/dependency reconciliation.
+ */
+export async function deliverTrackerEffect(effect: EffectClaim, source: ITaskSource | null): Promise<void> {
+  if (effect.kind === 'tracker.cancel') {
+    if (!isCancellationEffectPayload(effect.payload)) {
+      throw new Error(`Invalid automation effect payload: ${effect.kind}`);
+    }
+    await syncCancellationState(
+      effect.payload.task,
+      effect.dedupeKey,
+      effect.payload.comment,
+    );
+    return;
+  }
+  if (effect.kind !== 'tracker.complete' || !isCompletionEffectPayload(effect.payload)) {
+    throw new Error(`Unsupported automation effect: ${effect.kind}`);
+  }
+  const payload = effect.payload;
+  if (!source) throw new Error('Task source unavailable for outbox delivery');
+  const issueId = payload.task.issueId || payload.task.id;
+  const markerComment = `<!-- openswarm-effect:${payload.marker} -->`;
+
+  const comments = source.getExecutionComments
+    ? await source.getExecutionComments(issueId)
+    : [];
+  const alreadyCommented = comments.some((comment) => comment.body.includes(markerComment));
+  if (alreadyCommented) {
+    // The remote comment may have succeeded immediately before a process crash,
+    // while the following state mutation/local ack did not. Reapply the
+    // idempotent state transition but never duplicate the completion comment.
+    const accepted = await source.updateState(issueId, 'Done');
+    if (!accepted) throw new Error(`Tracker refused Done reconciliation for ${issueId}`);
+  } else {
+    await source.logPairComplete(issueId, effect.dedupeKey, payload.stats);
+  }
+
+  projectSuccessState(payload.task);
+  await reconcileCompletionState(payload.task);
+
+  if (payload.projectPath) {
+    await recordTaskOutcome(payload.projectPath, {
+      taskTitle: payload.task.title,
+      derivedFrom: payload.task.issueIdentifier ?? issueId,
+      iterations: payload.stats.attempts,
+    });
+  }
+  if (payload.task.linearProject) {
+    await updateProjectAfterTask(payload.task.linearProject.id, payload.task.linearProject.name, {
+      title: payload.task.title,
+      success: true,
+      duration: payload.stats.duration * 1000,
+      issueIdentifier: payload.task.issueIdentifier,
+      cost: payload.costUsd,
+      projectPath: payload.projectPath,
+    });
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -509,6 +509,45 @@ program
     }
   });
 
+// openswarm work [issueIds...] — deploy agents per selected Linear issue into
+// isolated worktrees (INT-3387)
+
+program
+  .command('work')
+  .description('Pick Linear issues and deploy an agent pipeline per issue into isolated git worktrees')
+  .argument('[issueIds...]', 'Issue ids/identifiers (e.g. INT-123); omit for the interactive picker')
+  .option('--path <path>', 'Repository path (default: cwd)')
+  .option('--concurrency <n>', 'Max issues in flight (default: min(selected, config autonomous.maxConcurrentTasks ?? 4))', parsePositiveIntegerOption)
+  .option('--dry-run', 'Print the execution plan (issue → branch/worktree/resume) and exit')
+  .option('--yes', 'Skip the confirmation prompt')
+  .option('--adapter <name>', 'Adapter override for the worker/reviewer')
+  .option('--json', 'Emit the final summary as JSON on stdout (progress logs go to stderr)')
+  .action(async (issueIds: string[], opts: {
+    path?: string;
+    concurrency?: number;
+    dryRun?: boolean;
+    yes?: boolean;
+    adapter?: string;
+    json?: boolean;
+  }) => {
+    try {
+      const { runWorkCommand } = await import('./cli/workCommand.js');
+      const exitCode = await runWorkCommand({
+        issueIds,
+        path: opts.path,
+        concurrency: opts.concurrency,
+        dryRun: opts.dryRun,
+        yes: opts.yes,
+        adapter: opts.adapter,
+        json: opts.json,
+      });
+      if (exitCode) process.exitCode = exitCode;
+    } catch (e) {
+      console.error(e instanceof Error ? e.message : String(e));
+      process.exitCode = 1;
+    }
+  });
+
 // openswarm exec <prompt>
 
 program

--- a/src/cli/workCommand.test.ts
+++ b/src/cli/workCommand.test.ts
@@ -1,0 +1,649 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { LinearIssueInfo, SwarmConfig } from '../core/types.js';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import type { PipelineResult } from '../agents/pairPipeline.js';
+import type { ITaskSource } from '../automation/taskSource.js';
+import type { ExecutionContext } from '../automation/runnerExecution.js';
+import type { ExecutionDurabilityHooks } from '../automation/durableRunCoordinator.js';
+import type { EffectClaim, EffectInput } from '../automation/runLedger.js';
+import {
+  buildWorkAdmission,
+  formatWorkSummary,
+  runWorkCommand,
+  summarizeSettled,
+  WORK_EXIT_FAILED,
+  WORK_EXIT_INTERRUPTED,
+  WORK_EXIT_NOT_RUN,
+  WORK_EXIT_OK,
+  type WorkCommandDeps,
+  type WorkCoordinator,
+} from './workCommand.js';
+
+function issue(overrides: Partial<LinearIssueInfo> = {}): LinearIssueInfo {
+  return {
+    id: `uuid-${overrides.identifier ?? 'INT-1'}`,
+    identifier: 'INT-1',
+    title: 'Fix the thing',
+    state: 'Todo',
+    priority: 2,
+    labels: [],
+    comments: [],
+    project: { id: 'proj-1', name: 'OpenSwarm' },
+    ...overrides,
+  };
+}
+
+function pipelineResult(overrides: Partial<PipelineResult> = {}): PipelineResult {
+  return {
+    success: true,
+    sessionId: 'sess-1',
+    stages: [],
+    finalStatus: 'approved',
+    totalDuration: 1000,
+    iterations: 1,
+    ...overrides,
+  };
+}
+
+const fakeSource = { kind: 'linear' } as unknown as ITaskSource;
+
+const noopHooks: ExecutionDurabilityHooks = {
+  onWorktree: async () => true,
+  onStage: async () => true,
+  beforePublish: async () => true,
+  onPublication: async () => true,
+};
+
+/** Coordinator fake: runs the executor inline, queues success effects, drains them. */
+function fakeCoordinator(): WorkCoordinator & { effects: EffectInput[]; closed: () => boolean } {
+  const effects: EffectInput[] = [];
+  let closed = false;
+  return {
+    effects,
+    closed: () => closed,
+    async execute(task: TaskItem, _projectPath, executor, options) {
+      const result = await executor(noopHooks, new AbortController().signal);
+      if (result.success && options?.successEffect) {
+        effects.push(options.successEffect(result, {
+          issueId: task.issueId ?? task.id,
+          ownerInstanceId: 'test',
+          leaseToken: 'lease',
+          leaseEpoch: 1,
+          attemptNo: 1,
+          leaseExpiresAt: Date.now() + 60_000,
+        }));
+      }
+      return result;
+    },
+    async drainOutbox(deliver) {
+      for (const [index, effect] of effects.entries()) {
+        await deliver({
+          ...effect,
+          id: index + 1,
+          issueId: 'x',
+          attemptNo: 1,
+          ownerInstanceId: 'test',
+          deliveryToken: 'token',
+          leaseExpiresAt: Date.now() + 60_000,
+        } as unknown as EffectClaim);
+      }
+      return { applied: effects.length, retried: 0, dead: 0 };
+    },
+    close: () => {
+      closed = true;
+    },
+  };
+}
+
+function baseDeps(overrides: Partial<WorkCommandDeps> = {}): WorkCommandDeps & {
+  logs: string[];
+  outs: string[];
+  coordinator: ReturnType<typeof fakeCoordinator>;
+  exec: ReturnType<typeof vi.fn>;
+} {
+  const logs: string[] = [];
+  const outs: string[] = [];
+  const coordinator = fakeCoordinator();
+  const exec = vi.fn(async (
+    _ctx: ExecutionContext,
+    _task: TaskItem,
+    _projectPath: string,
+    _signal?: AbortSignal,
+  ) => pipelineResult());
+  const deps: WorkCommandDeps = {
+    loadConfig: () => ({ autonomous: { maxConcurrentTasks: 4 } }) as unknown as SwarmConfig,
+    ensureTaskSource: async () => fakeSource,
+    registerTaskSource: vi.fn(),
+    isValidProjectPath: async () => true,
+    loadRepoMetadata: async () => null,
+    getIssue: async (id) => issue({ identifier: id, id: `uuid-${id}` }),
+    hasRecoverableWorktree: async () => false,
+    createCoordinator: () => coordinator,
+    executePipeline: exec,
+    deliverEffect: vi.fn(async () => undefined),
+    installSigintHandler: () => () => undefined,
+    isTTY: true,
+    confirm: async () => true,
+    log: (line) => logs.push(line),
+    out: (line) => outs.push(line),
+    ...overrides,
+  } as WorkCommandDeps;
+  return Object.assign(deps, { logs, outs, coordinator, exec });
+}
+
+describe('runWorkCommand — direct issue ids (INT-3387)', () => {
+  it('deploys one pipeline per issue with the work command contract in the context', async () => {
+    const deps = baseDeps();
+    const code = await runWorkCommand(
+      { issueIds: ['INT-1', 'INT-2'], path: '/repo', yes: true },
+      deps,
+    );
+    expect(code).toBe(WORK_EXIT_OK);
+    expect(deps.exec).toHaveBeenCalledTimes(2);
+    for (const call of deps.exec.mock.calls) {
+      const ctx = call[0] as ExecutionContext;
+      expect(ctx.worktreeMode).toBe(true);
+      expect(ctx.enableDecomposition).toBe(false);
+      expect(ctx.allowedProjects).toEqual(['/repo']);
+      expect(ctx.durability).toBe(noopHooks);
+      expect(ctx.peerIssues).toHaveLength(2);
+    }
+    const identifiers = deps.exec.mock.calls.map((call) => (call[1] as TaskItem).issueIdentifier);
+    expect(identifiers).toEqual(['INT-1', 'INT-2']);
+  });
+
+  it('registers the task source so pipeline tracker writes work (setTaskSource)', async () => {
+    const deps = baseDeps();
+    await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps);
+    expect(deps.registerTaskSource).toHaveBeenCalledWith(fakeSource);
+  });
+
+  it('fails fast when any listed issue does not resolve — nothing starts', async () => {
+    const deps = baseDeps({
+      getIssue: async (id) => (id === 'NONEXIST-999' ? null : issue({ identifier: id })),
+    });
+    const code = await runWorkCommand(
+      { issueIds: ['INT-1', 'NONEXIST-999'], path: '/repo', yes: true },
+      deps,
+    );
+    expect(code).toBe(WORK_EXIT_NOT_RUN);
+    expect(deps.exec).not.toHaveBeenCalled();
+    expect(deps.logs.join('\n')).toContain('Issue not found: NONEXIST-999');
+  });
+
+  it('skips Done/In Review issues with a reason and still runs the rest', async () => {
+    const deps = baseDeps({
+      getIssue: async (id) => issue({
+        identifier: id,
+        id: `uuid-${id}`,
+        state: id === 'INT-1' ? 'Done' : 'Todo',
+      }),
+    });
+    const code = await runWorkCommand(
+      { issueIds: ['INT-1', 'INT-2'], path: '/repo', yes: true },
+      deps,
+    );
+    expect(code).toBe(WORK_EXIT_OK);
+    expect(deps.exec).toHaveBeenCalledTimes(1);
+    expect(deps.logs.join('\n')).toContain('Skipping INT-1: state is Done');
+  });
+
+  it('exits 2 when every listed issue is skipped', async () => {
+    const deps = baseDeps({ getIssue: async (id) => issue({ identifier: id, state: 'Done' }) });
+    const code = await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps);
+    expect(code).toBe(WORK_EXIT_NOT_RUN);
+    expect(deps.exec).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates repeated ids resolving to the same issue', async () => {
+    const deps = baseDeps();
+    await runWorkCommand({ issueIds: ['INT-1', 'INT-1'], path: '/repo', yes: true }, deps);
+    expect(deps.exec).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('runWorkCommand — bootstrap validation', () => {
+  it('exits 2 for a non-project path', async () => {
+    const deps = baseDeps({ isValidProjectPath: async () => false });
+    expect(await runWorkCommand({ issueIds: ['INT-1'], path: '/nope', yes: true }, deps))
+      .toBe(WORK_EXIT_NOT_RUN);
+    expect(deps.exec).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 with guidance when Linear is not configured', async () => {
+    const deps = baseDeps({ ensureTaskSource: async () => null });
+    expect(await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps))
+      .toBe(WORK_EXIT_NOT_RUN);
+    expect(deps.logs.join('\n')).toContain('Linear is not configured');
+  });
+
+  it('exits 2 when the config cannot be loaded', async () => {
+    const deps = baseDeps({
+      loadConfig: () => {
+        throw new Error('bad yaml');
+      },
+    });
+    expect(await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps))
+      .toBe(WORK_EXIT_NOT_RUN);
+    expect(deps.logs.join('\n')).toContain('bad yaml');
+  });
+
+  it('exits 2 when openswarm.json exists but is unreadable', async () => {
+    const deps = baseDeps({
+      loadRepoMetadata: async () => {
+        throw new Error('corrupt metadata');
+      },
+    });
+    expect(await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps))
+      .toBe(WORK_EXIT_NOT_RUN);
+    expect(deps.logs.join('\n')).toContain('corrupt metadata');
+  });
+});
+
+describe('runWorkCommand — interactive picker', () => {
+  it('filters the team fetch to the mapped project and runs the selection', async () => {
+    const all = [
+      issue({ identifier: 'INT-1', id: 'uuid-1' }),
+      issue({ identifier: 'OTHER-1', id: 'uuid-o', project: { id: 'proj-x', name: 'X' } }),
+    ];
+    const selectIssues = vi.fn(async (candidates: LinearIssueInfo[]) => candidates);
+    const deps = baseDeps({
+      loadRepoMetadata: async () => ({
+        schemaVersion: 1,
+        linear: { projectId: '11111111-1111-4111-8111-111111111111' },
+      }) as never,
+      listIssues: async () => all.map((entry) => ({
+        ...entry,
+        project: entry.project?.id === 'proj-1'
+          ? { ...entry.project, id: '11111111-1111-4111-8111-111111111111' }
+          : entry.project,
+      })),
+      selectIssues,
+    });
+    const code = await runWorkCommand({ path: '/repo' }, deps);
+    expect(code).toBe(WORK_EXIT_OK);
+    expect(selectIssues).toHaveBeenCalledTimes(1);
+    expect((selectIssues.mock.calls[0][0] as LinearIssueInfo[]).map((entry) => entry.identifier))
+      .toEqual(['INT-1']);
+    expect(deps.exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('exits 2 when the repo has no Linear project mapping', async () => {
+    const deps = baseDeps({ loadRepoMetadata: async () => null });
+    expect(await runWorkCommand({ path: '/repo' }, deps)).toBe(WORK_EXIT_NOT_RUN);
+    expect(deps.logs.join('\n')).toContain('no Linear project mapping');
+  });
+
+  it('exits 2 quietly when the picker is aborted with Ctrl-C', async () => {
+    const abort = new Error('ctrl-c');
+    abort.name = 'ExitPromptError';
+    const deps = baseDeps({
+      loadRepoMetadata: async () => ({
+        schemaVersion: 1,
+        linear: { projectId: '11111111-1111-4111-8111-111111111111' },
+      }) as never,
+      listIssues: async () => [issue({
+        project: { id: '11111111-1111-4111-8111-111111111111', name: 'OpenSwarm' },
+      })],
+      selectIssues: async () => {
+        throw abort;
+      },
+    });
+    expect(await runWorkCommand({ path: '/repo' }, deps)).toBe(WORK_EXIT_NOT_RUN);
+    expect(deps.exec).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 when the picker returns an empty selection', async () => {
+    const deps = baseDeps({
+      loadRepoMetadata: async () => ({
+        schemaVersion: 1,
+        linear: { projectId: '11111111-1111-4111-8111-111111111111' },
+      }) as never,
+      listIssues: async () => [issue({
+        project: { id: '11111111-1111-4111-8111-111111111111', name: 'OpenSwarm' },
+      })],
+      selectIssues: async () => [],
+    });
+    expect(await runWorkCommand({ path: '/repo' }, deps)).toBe(WORK_EXIT_NOT_RUN);
+  });
+});
+
+describe('runWorkCommand — dry run', () => {
+  it('prints the plan (branch + resume flag) and never executes', async () => {
+    const deps = baseDeps({
+      hasRecoverableWorktree: async (_repo, issueId) => issueId === 'uuid-INT-1',
+    });
+    const code = await runWorkCommand(
+      { issueIds: ['INT-1', 'INT-2'], path: '/repo', dryRun: true },
+      deps,
+    );
+    expect(code).toBe(WORK_EXIT_OK);
+    expect(deps.exec).not.toHaveBeenCalled();
+    const plan = deps.outs.join('\n');
+    expect(plan).toContain('INT-1');
+    expect(plan).toContain('swarm/INT-1-fix-the-thing');
+    expect(plan).toContain('[resume]');
+    expect(plan).toContain('[fresh]');
+  });
+
+  it('emits the plan as JSON with --json', async () => {
+    const deps = baseDeps();
+    const code = await runWorkCommand(
+      { issueIds: ['INT-1'], path: '/repo', dryRun: true, json: true },
+      deps,
+    );
+    expect(code).toBe(WORK_EXIT_OK);
+    const doc = JSON.parse(deps.outs.join('\n'));
+    expect(doc.dryRun).toBe(true);
+    expect(doc.plan).toEqual([expect.objectContaining({
+      identifier: 'INT-1',
+      branch: 'swarm/INT-1-fix-the-thing',
+      resumes: false,
+    })]);
+  });
+});
+
+describe('runWorkCommand — confirmation gate', () => {
+  it('prompts for direct-id runs and aborts on decline', async () => {
+    const confirm = vi.fn(async () => false);
+    const deps = baseDeps({ confirm });
+    expect(await runWorkCommand({ issueIds: ['INT-1'], path: '/repo' }, deps))
+      .toBe(WORK_EXIT_NOT_RUN);
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(deps.exec).not.toHaveBeenCalled();
+  });
+
+  it('refuses headless direct-id runs without --yes', async () => {
+    const deps = baseDeps({ isTTY: false });
+    expect(await runWorkCommand({ issueIds: ['INT-1'], path: '/repo' }, deps))
+      .toBe(WORK_EXIT_NOT_RUN);
+    expect(deps.logs.join('\n')).toContain('pass --yes');
+  });
+
+  it('treats Ctrl-C at the confirm prompt as a quiet exit 2', async () => {
+    const abort = new Error('ctrl-c');
+    abort.name = 'ExitPromptError';
+    const deps = baseDeps({
+      confirm: async () => {
+        throw abort;
+      },
+    });
+    expect(await runWorkCommand({ issueIds: ['INT-1'], path: '/repo' }, deps))
+      .toBe(WORK_EXIT_NOT_RUN);
+  });
+});
+
+describe('runWorkCommand — completion delivery', () => {
+  it('drains the outbox after the pool: success effects reach the deliverer', async () => {
+    const deliverEffect = vi.fn(async () => undefined);
+    const deps = baseDeps({ deliverEffect });
+    const code = await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps);
+    expect(code).toBe(WORK_EXIT_OK);
+    expect(deliverEffect).toHaveBeenCalledTimes(1);
+    const [effect, source] = deliverEffect.mock.calls[0] as unknown as [EffectClaim, ITaskSource];
+    expect(effect.kind).toBe('tracker.complete');
+    expect(effect.dedupeKey).toBe('complete:uuid-INT-1:attempt:1');
+    expect(source).toBe(fakeSource);
+    expect(deps.coordinator.closed()).toBe(true);
+  });
+
+  it('a failed drain is reported but does not change the run outcome', async () => {
+    const deps = baseDeps();
+    deps.coordinator.drainOutbox = async () => {
+      throw new Error('linear down');
+    };
+    const code = await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps);
+    expect(code).toBe(WORK_EXIT_OK);
+    expect(deps.logs.join('\n')).toContain('Completion delivery failed');
+    expect(deps.coordinator.closed()).toBe(true);
+  });
+});
+
+describe('runWorkCommand — abort propagation (SIGINT)', () => {
+  it('first Ctrl-C aborts the pipeline signal and the run exits 130', async () => {
+    let handler: (() => void) | undefined;
+    const observedAborts: boolean[] = [];
+    const deps = baseDeps({
+      installSigintHandler: (fn) => {
+        handler = fn;
+        return () => undefined;
+      },
+    });
+    deps.exec.mockImplementation(async (_ctx, _task, _path, signal?: AbortSignal) => {
+      handler?.();
+      observedAborts.push(!!signal?.aborted);
+      return pipelineResult({ success: false, finalStatus: 'cancelled' });
+    });
+    const code = await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps);
+    expect(code).toBe(WORK_EXIT_INTERRUPTED);
+    expect(observedAborts).toEqual([true]);
+    expect(deps.logs.join('\n')).toContain('re-run the same command to resume');
+  });
+
+  it('second Ctrl-C force-quits with 130', async () => {
+    let handler: (() => void) | undefined;
+    const exit = vi.fn((code: number) => {
+      throw new Error(`exit ${code}`);
+    });
+    const deps = baseDeps({
+      installSigintHandler: (fn) => {
+        handler = fn;
+        return () => undefined;
+      },
+      exit: exit as never,
+    });
+    deps.exec.mockImplementation(async () => {
+      handler?.();
+      expect(() => handler?.()).toThrow('exit 130');
+      return pipelineResult({ success: false, finalStatus: 'cancelled' });
+    });
+    await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps);
+    expect(exit).toHaveBeenCalledWith(130);
+  });
+});
+
+describe('runWorkCommand — exit code matrix', () => {
+  it('all approved → 0', async () => {
+    const deps = baseDeps();
+    expect(await runWorkCommand({ issueIds: ['INT-1', 'INT-2'], path: '/repo', yes: true }, deps))
+      .toBe(WORK_EXIT_OK);
+  });
+
+  it('any failure → 1', async () => {
+    const deps = baseDeps();
+    deps.exec
+      .mockResolvedValueOnce(pipelineResult())
+      .mockResolvedValueOnce(pipelineResult({ success: false, finalStatus: 'failed' }));
+    expect(await runWorkCommand({ issueIds: ['INT-1', 'INT-2'], path: '/repo', yes: true }, deps))
+      .toBe(WORK_EXIT_FAILED);
+  });
+
+  it('an executor throw → 1', async () => {
+    const deps = baseDeps();
+    deps.exec.mockRejectedValueOnce(new Error('boom'));
+    expect(await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps))
+      .toBe(WORK_EXIT_FAILED);
+    expect(deps.logs.join('\n')).toContain('boom');
+  });
+
+  it('superseded (owned by another process) does not count as failure → 0', async () => {
+    const deps = baseDeps();
+    deps.exec.mockResolvedValue(pipelineResult({ success: false, finalStatus: 'superseded' }));
+    const code = await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps);
+    expect(code).toBe(WORK_EXIT_OK);
+    expect(deps.outs.join('\n')).toContain('owned by another process');
+  });
+});
+
+describe('runWorkCommand — options plumbing', () => {
+  it('defaults concurrency to min(selected, autonomous.maxConcurrentTasks ?? 4)', async () => {
+    const createCoordinator = vi.fn(() => fakeCoordinator());
+    const deps = baseDeps({
+      createCoordinator,
+      loadConfig: () => ({ autonomous: { maxConcurrentTasks: 1 } }) as unknown as SwarmConfig,
+    });
+    await runWorkCommand({ issueIds: ['INT-1', 'INT-2'], path: '/repo', yes: true }, deps);
+    expect(createCoordinator).toHaveBeenCalledWith(expect.objectContaining({ maxActive: 1 }));
+  });
+
+  it('honors an explicit --concurrency over the config default', async () => {
+    const createCoordinator = vi.fn(() => fakeCoordinator());
+    const deps = baseDeps({ createCoordinator });
+    await runWorkCommand(
+      { issueIds: ['INT-1'], path: '/repo', yes: true, concurrency: 3 },
+      deps,
+    );
+    expect(createCoordinator).toHaveBeenCalledWith(expect.objectContaining({ maxActive: 3 }));
+  });
+
+  it('passes the automation db override from config into the coordinator', async () => {
+    const createCoordinator = vi.fn(() => fakeCoordinator());
+    const deps = baseDeps({
+      createCoordinator,
+      loadConfig: () => ({
+        autonomous: { maxConcurrentTasks: 4, automationDbPath: '/tmp/automation-test.db' },
+      }) as unknown as SwarmConfig,
+    });
+    await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps);
+    expect(createCoordinator).toHaveBeenCalledWith(expect.objectContaining({
+      dbPath: '/tmp/automation-test.db',
+    }));
+  });
+
+  it('threads --adapter into the execution context roles', async () => {
+    const deps = baseDeps();
+    await runWorkCommand(
+      { issueIds: ['INT-1'], path: '/repo', yes: true, adapter: 'claude' },
+      deps,
+    );
+    const ctx = deps.exec.mock.calls[0][0] as ExecutionContext;
+    expect(ctx.getRolesForProject('/repo')?.worker.adapter).toBe('claude');
+  });
+
+  it('emits the final summary as parseable JSON on stdout in --json mode', async () => {
+    const deps = baseDeps();
+    const code = await runWorkCommand(
+      { issueIds: ['INT-1'], path: '/repo', yes: true, json: true },
+      deps,
+    );
+    expect(code).toBe(WORK_EXIT_OK);
+    const doc = JSON.parse(deps.outs.join('\n'));
+    expect(doc.results).toEqual([expect.objectContaining({
+      identifier: 'INT-1',
+      status: 'approved',
+      success: true,
+      worktreePreserved: false,
+    })]);
+    expect(doc.exitCode).toBe(WORK_EXIT_OK);
+  });
+
+  it('reroutes pipeline console.log noise to stderr while --json executes', async () => {
+    const originalLog = console.log;
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      const deps = baseDeps();
+      deps.exec.mockImplementation(async () => {
+        // The pipeline logs to stdout; in --json mode that must land on stderr.
+        console.log('pipeline noise');
+        expect(console.log).not.toBe(originalLog);
+        return pipelineResult();
+      });
+      const code = await runWorkCommand(
+        { issueIds: ['INT-1'], path: '/repo', yes: true, json: true },
+        deps,
+      );
+      expect(code).toBe(WORK_EXIT_OK);
+      // stdout stayed a clean JSON document…
+      expect(() => JSON.parse(deps.outs.join('\n'))).not.toThrow();
+      // …the noise went to stderr, and console.log was restored afterwards.
+      expect(errSpy).toHaveBeenCalledWith('pipeline noise');
+      expect(console.log).toBe(originalLog);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('default log/out write to the console (stderr for diagnostics)', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      const deps = baseDeps();
+      delete deps.log;
+      delete deps.out;
+      const code = await runWorkCommand({ issueIds: ['INT-1'], path: '/nope' }, {
+        ...deps,
+        isValidProjectPath: async () => false,
+      });
+      expect(code).toBe(WORK_EXIT_NOT_RUN);
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Not a project directory'));
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('default SIGINT wiring installs and removes a process listener symmetrically', async () => {
+    const before = process.listenerCount('SIGINT');
+    const deps = baseDeps();
+    delete deps.installSigintHandler;
+    const code = await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps);
+    expect(code).toBe(WORK_EXIT_OK);
+    expect(process.listenerCount('SIGINT')).toBe(before);
+  });
+});
+
+describe('pure helpers', () => {
+  const row = {
+    task: {
+      id: 'uuid-1',
+      source: 'linear',
+      title: 'T',
+      priority: 2,
+      issueId: 'uuid-1',
+      issueIdentifier: 'INT-1',
+      createdAt: 0,
+    } as TaskItem,
+    branchName: 'swarm/INT-1-t',
+    resumes: false,
+  };
+
+  it('buildWorkAdmission matches the daemon fan-out defaults (capacity-only admit)', () => {
+    expect(buildWorkAdmission(3)).toEqual({
+      maxConcurrent: 3,
+      conflictScope: undefined,
+      maxFailuresPerHour: 6,
+      circuitCooldownMs: 3_600_000,
+    });
+  });
+
+  it('summarizeSettled maps approved success to a removed worktree', () => {
+    expect(summarizeSettled(row, { value: pipelineResult({ prUrl: 'https://pr/1' }) }))
+      .toMatchObject({ status: 'approved', success: true, prUrl: 'https://pr/1', worktreePreserved: false });
+  });
+
+  it('summarizeSettled preserves the worktree for non-approved outcomes and errors', () => {
+    expect(summarizeSettled(row, { value: pipelineResult({ success: false, finalStatus: 'rejected' }) }))
+      .toMatchObject({ status: 'rejected', worktreePreserved: true });
+    expect(summarizeSettled(row, { error: new Error('boom') }))
+      .toMatchObject({ status: 'error', worktreePreserved: true, note: 'boom' });
+  });
+
+  it('summarizeSettled marks superseded runs as externally owned', () => {
+    const summary = summarizeSettled(row, {
+      value: pipelineResult({ success: false, finalStatus: 'superseded' }),
+    });
+    expect(summary.note).toContain('owned by another process');
+    expect(summary.worktreePreserved).toBe(false);
+  });
+
+  it('formatWorkSummary renders one aligned row per issue', () => {
+    const lines = formatWorkSummary([
+      summarizeSettled(row, { value: pipelineResult({ prUrl: 'https://pr/1' }) }),
+      summarizeSettled({ ...row, resumes: true }, { value: pipelineResult({ success: false, finalStatus: 'failed' }) }),
+    ]);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('INT-1');
+    expect(lines[0]).toContain('https://pr/1');
+    expect(lines[0]).toContain('worktree removed');
+    expect(lines[1]).toContain('worktree preserved');
+    expect(lines[1]).toContain('(resumed)');
+  });
+});

--- a/src/cli/workCommand.test.ts
+++ b/src/cli/workCommand.test.ts
@@ -6,6 +6,7 @@ import type { ITaskSource } from '../automation/taskSource.js';
 import type { ExecutionContext } from '../automation/runnerExecution.js';
 import type { ExecutionDurabilityHooks } from '../automation/durableRunCoordinator.js';
 import type { EffectClaim, EffectInput } from '../automation/runLedger.js';
+import type { RepoMetadata } from '../support/repoMetadata.js';
 import {
   buildWorkAdmission,
   formatWorkSummary,
@@ -76,7 +77,10 @@ function fakeCoordinator(): WorkCoordinator & { effects: EffectInput[]; closed: 
       return result;
     },
     async drainOutbox(deliver) {
-      for (const [index, effect] of effects.entries()) {
+      // Mirrors the real ledger: delivered effects leave the outbox, so a
+      // second pass applies zero (the command's drain loop relies on this).
+      const pending = effects.splice(0, effects.length);
+      for (const [index, effect] of pending.entries()) {
         await deliver({
           ...effect,
           id: index + 1,
@@ -87,7 +91,7 @@ function fakeCoordinator(): WorkCoordinator & { effects: EffectInput[]; closed: 
           leaseExpiresAt: Date.now() + 60_000,
         } as unknown as EffectClaim);
       }
-      return { applied: effects.length, retried: 0, dead: 0 };
+      return { applied: pending.length, retried: 0, dead: 0 };
     },
     close: () => {
       closed = true;
@@ -115,6 +119,7 @@ function baseDeps(overrides: Partial<WorkCommandDeps> = {}): WorkCommandDeps & {
     ensureTaskSource: async () => fakeSource,
     registerTaskSource: vi.fn(),
     isValidProjectPath: async () => true,
+    isGitRepo: () => true,
     loadRepoMetadata: async () => null,
     getIssue: async (id) => issue({ identifier: id, id: `uuid-${id}` }),
     hasRecoverableWorktree: async () => false,
@@ -130,6 +135,98 @@ function baseDeps(overrides: Partial<WorkCommandDeps> = {}): WorkCommandDeps & {
   } as WorkCommandDeps;
   return Object.assign(deps, { logs, outs, coordinator, exec });
 }
+
+describe('runWorkCommand — review-finding gates (INT-3387)', () => {
+  it('refuses a repo whose openswarm.json disables automation', async () => {
+    const deps = baseDeps({
+      loadRepoMetadata: async () => ({ schemaVersion: 1, automation: { enabled: false } } as unknown as RepoMetadata),
+    });
+    const code = await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps);
+    expect(code).toBe(WORK_EXIT_NOT_RUN);
+    expect(deps.exec).not.toHaveBeenCalled();
+    expect(deps.logs.join('\n')).toMatch(/automation\.enabled: false/);
+  });
+
+  it('layers repo automation limits into admission', () => {
+    const admission = buildWorkAdmission(8, {
+      enabled: true,
+      maxConcurrent: 2,
+      maxAttemptsPerHour: 5,
+      maxFailuresPerHour: 3,
+      maxCostUsdPerDay: 10,
+      circuitCooldownMinutes: 30,
+    });
+    expect(admission).toMatchObject({
+      maxConcurrent: 2,
+      maxAttemptsPerHour: 5,
+      maxFailuresPerHour: 3,
+      maxCostUsdPerDay: 10,
+      circuitCooldownMs: 30 * 60_000,
+    });
+    // No policy → CLI concurrency + daemon defaults.
+    expect(buildWorkAdmission(8)).toMatchObject({ maxConcurrent: 8, maxFailuresPerHour: 6 });
+  });
+
+  it("skips a direct id that belongs to a different Linear project than the repo's mapping", async () => {
+    const deps = baseDeps({
+      loadRepoMetadata: async () => ({ schemaVersion: 1, linear: { projectId: 'proj-1' } } as unknown as RepoMetadata),
+      getIssue: async (id) => issue({
+        identifier: id,
+        id: `uuid-${id}`,
+        project: id === 'INT-2' ? { id: 'other-proj', name: 'Other' } : { id: 'proj-1', name: 'OpenSwarm' },
+      }),
+    });
+    const code = await runWorkCommand({ issueIds: ['INT-1', 'INT-2'], path: '/repo', yes: true }, deps);
+    expect(code).toBe(WORK_EXIT_OK);
+    expect(deps.exec).toHaveBeenCalledTimes(1);
+    expect(deps.logs.join('\n')).toMatch(/INT-2.*different Linear project/);
+  });
+
+  it('skips an issue whose blockers are unresolved — including a blocker selected in the same batch', async () => {
+    const blockerUuid = 'uuid-INT-1';
+    const deps = baseDeps({
+      getIssue: async (id) => {
+        if (id === 'INT-1' || id === blockerUuid) return issue({ identifier: 'INT-1', id: blockerUuid, state: 'Todo' });
+        return issue({ identifier: id, id: `uuid-${id}`, blockedBy: [blockerUuid] });
+      },
+    });
+    const code = await runWorkCommand({ issueIds: ['INT-1', 'INT-2'], path: '/repo', yes: true }, deps);
+    expect(code).toBe(WORK_EXIT_OK);
+    // Only the blocker runs; the dependent is skipped with a reason.
+    expect(deps.exec).toHaveBeenCalledTimes(1);
+    expect(deps.logs.join('\n')).toMatch(/INT-2.*blocked by 1 unresolved/);
+  });
+
+  it('lets an issue through when its blockers are Done', async () => {
+    const deps = baseDeps({
+      getIssue: async (id) => {
+        if (id === 'blocker-uuid') return issue({ identifier: 'INT-9', id: 'blocker-uuid', state: 'Done' });
+        return issue({ identifier: id, id: `uuid-${id}`, blockedBy: ['blocker-uuid'] });
+      },
+    });
+    const code = await runWorkCommand({ issueIds: ['INT-2'], path: '/repo', yes: true }, deps);
+    expect(code).toBe(WORK_EXIT_OK);
+    expect(deps.exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the real Linear createdAt for grooming order instead of Date.now()', async () => {
+    const deps = baseDeps({
+      getIssue: async (id) => issue({ identifier: id, id: `uuid-${id}`, createdAt: '2026-01-02T03:04:05.000Z' }),
+    });
+    await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps);
+    const task = (deps.exec as ReturnType<typeof vi.fn>).mock.calls[0][1] as TaskItem;
+    expect(task.createdAt).toBe(Date.parse('2026-01-02T03:04:05.000Z'));
+  });
+
+  it('refuses a non-git directory before resolving anything', async () => {
+    const deps = baseDeps({ isGitRepo: () => false });
+    const getIssueSpy = vi.fn();
+    deps.getIssue = getIssueSpy as unknown as WorkCommandDeps['getIssue'];
+    const code = await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps);
+    expect(code).toBe(WORK_EXIT_NOT_RUN);
+    expect(getIssueSpy).not.toHaveBeenCalled();
+  });
+});
 
 describe('runWorkCommand — direct issue ids (INT-3387)', () => {
   it('deploys one pipeline per issue with the work command contract in the context', async () => {

--- a/src/cli/workCommand.ts
+++ b/src/cli/workCommand.ts
@@ -14,7 +14,8 @@
 // 2 = nothing was deployed at all (validation failed / nothing selected),
 // 130 = interrupted.
 
-import { resolve } from 'node:path';
+import { join, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
 import { loadConfig } from '../core/config.js';
 import type { LinearIssueInfo, SwarmConfig } from '../core/types.js';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
@@ -52,14 +53,23 @@ export const WORK_EXIT_FAILED = 1;
 export const WORK_EXIT_NOT_RUN = 2;
 export const WORK_EXIT_INTERRUPTED = 130;
 
-/** The daemon's fan-out admission defaults (autonomousRunner.executeDurably):
- *  capacity-only admit — worktree isolation replaces file-scope serialization. */
-export function buildWorkAdmission(concurrency: number): RepositoryAdmissionPolicy {
+/** The daemon's fan-out admission (autonomousRunner.executeDurably) with the
+ *  repository's own openswarm.json automation policy layered in: capacity-only
+ *  admit (worktree isolation replaces file-scope serialization), but attempt/
+ *  failure/cost circuits and the repo's concurrency cap are authoritative. */
+export function buildWorkAdmission(
+  concurrency: number,
+  automation?: RepoMetadata['automation'],
+): RepositoryAdmissionPolicy {
   return {
-    maxConcurrent: concurrency,
+    maxConcurrent: automation?.maxConcurrent !== undefined
+      ? Math.min(concurrency, automation.maxConcurrent)
+      : concurrency,
     conflictScope: undefined,
-    maxFailuresPerHour: 6,
-    circuitCooldownMs: 60 * 60_000,
+    maxAttemptsPerHour: automation?.maxAttemptsPerHour,
+    maxFailuresPerHour: automation?.maxFailuresPerHour ?? 6,
+    maxCostUsdPerDay: automation?.maxCostUsdPerDay,
+    circuitCooldownMs: (automation?.circuitCooldownMinutes ?? 60) * 60_000,
   };
 }
 
@@ -98,6 +108,7 @@ export interface WorkCommandDeps {
   /** Registers the source as runnerExecution's module-global task source. */
   registerTaskSource?: (source: ITaskSource) => void;
   isValidProjectPath?: (path: string) => Promise<boolean>;
+  isGitRepo?: (path: string) => boolean;
   loadRepoMetadata?: (path: string) => Promise<RepoMetadata | null>;
   getIssue?: (idOrIdentifier: string) => Promise<LinearIssueInfo | null>;
   listIssues?: () => Promise<LinearIssueInfo[]>;
@@ -232,10 +243,36 @@ export async function runWorkCommand(
   const out = deps.out ?? ((line: string) => console.log(line));
   const repoPath = resolve(opts.path ?? process.cwd());
 
+  // In --json mode stdout carries one document. Redirection must cover the
+  // WHOLE lifecycle: loadConfig/setTaskSource/getMyIssues all console.log
+  // during bootstrap, and any of it ahead of the JSON body breaks `| jq`.
+  const restoreConsole = opts.json ? redirectConsoleLogToStderr() : null;
+  try {
+    return await runWorkCommandInner(opts, deps, { log, out, repoPath });
+  } finally {
+    restoreConsole?.();
+  }
+}
+
+async function runWorkCommandInner(
+  opts: WorkCommandOptions,
+  deps: WorkCommandDeps,
+  io: { log: (line: string) => void; out: (line: string) => void; repoPath: string },
+): Promise<number> {
+  const { log, out, repoPath } = io;
+
   // ---- Bootstrap -----------------------------------------------------------
   const validate = deps.isValidProjectPath ?? isValidProjectPath;
   if (!(await validate(repoPath))) {
     log(`Not a project directory (needs .git, package.json, or pyproject.toml): ${repoPath}`);
+    return WORK_EXIT_NOT_RUN;
+  }
+  // Worktree mode is this command's contract, and worktrees need a real git
+  // repository — a bare package.json/pyproject.toml directory would pass the
+  // generic check, then resolve issues, claim durable runs, and spend model
+  // budget on draft analysis before createWorktree inevitably fails.
+  if (!(deps.isGitRepo ?? ((p: string) => existsSync(join(p, '.git'))))(repoPath)) {
+    log(`Not a git repository (worktree fan-out requires one): ${repoPath}`);
     return WORK_EXIT_NOT_RUN;
   }
 
@@ -266,6 +303,14 @@ export async function runWorkCommand(
   }
   const projectId = meta?.linear?.projectId;
 
+  // Repository automation policy is authoritative here too — `openswarm work`
+  // spends model budget and publishes PRs exactly like the daemon does, and
+  // openswarm.json's kill switch / spend limits exist to bound that.
+  if (meta?.automation?.enabled === false) {
+    log(`Automation is disabled for this repository (openswarm.json automation.enabled: false) — remove that setting to allow \`openswarm work\`.`);
+    return WORK_EXIT_NOT_RUN;
+  }
+
   // ---- Issue resolution ----------------------------------------------------
   const directIds = [...new Set((opts.issueIds ?? []).map((id) => id.trim()).filter(Boolean))];
   const skipped: Array<{ identifier: string; reason: string }> = [];
@@ -289,6 +334,15 @@ export async function runWorkCommand(
       seen.add(issue.id);
       if ((WORK_SKIP_STATES as readonly string[]).includes(issue.state)) {
         skipped.push({ identifier: issue.identifier, reason: `state is ${issue.state}` });
+      } else if (projectId && issue.project?.id !== projectId) {
+        // An authoritative repo mapping exists and this issue belongs to a
+        // different Linear project — running it here would edit the wrong
+        // codebase, publish a PR from it, and mark the foreign issue Done.
+        // (Repos without a mapping keep the explicit-id escape hatch.)
+        skipped.push({
+          identifier: issue.identifier,
+          reason: `belongs to a different Linear project than this repo's mapping`,
+        });
       } else {
         picked.push(issue);
       }
@@ -320,23 +374,58 @@ export async function runWorkCommand(
     }
   }
 
+  // Blocked-by gate: a dependent fanned out concurrently with (or before) its
+  // blocker runs from the base branch without the blocker's changes and can
+  // publish prematurely. Any unresolved blocker skips the issue — including
+  // one selected in this same batch (it isn't finished either).
+  if (picked.some((issue) => (issue.blockedBy?.length ?? 0) > 0)) {
+    const getIssueForBlockCheck = deps.getIssue
+      ?? (async (id: string) => (await import('../linear/linear.js')).getIssue(id));
+    const blockerStates = new Map<string, string | null>();
+    const blockerIds = [...new Set(picked.flatMap((issue) => issue.blockedBy ?? []))];
+    await Promise.all(blockerIds.map(async (id) => {
+      const blocker = await getIssueForBlockCheck(id).catch(() => null);
+      blockerStates.set(id, blocker?.state ?? null);
+    }));
+    const blockerDone = (state: string | null): boolean =>
+      state === null // unknown/deleted blocker — don't dead-lock on stale relations
+      || ['done', 'canceled', 'cancelled'].includes(state.toLowerCase());
+    picked = picked.filter((issue) => {
+      const open = (issue.blockedBy ?? []).filter((id) => !blockerDone(blockerStates.get(id) ?? null));
+      if (open.length === 0) return true;
+      skipped.push({ identifier: issue.identifier, reason: `blocked by ${open.length} unresolved issue(s)` });
+      return false;
+    });
+  }
+
   for (const skip of skipped) log(`Skipping ${skip.identifier}: ${skip.reason}`);
   if (picked.length === 0) {
     log('No issues selected — nothing to deploy.');
     return WORK_EXIT_NOT_RUN;
   }
 
-  const tasks = picked.map((issue) => enrichTaskFromState(linearIssueToTask({
-    id: issue.id,
-    identifier: issue.identifier,
-    title: issue.title,
-    description: issue.description,
-    priority: issue.priority,
-    state: issue.state,
-    labels: issue.labels,
-    blockedBy: issue.blockedBy,
-    project: issue.project ? { id: issue.project.id, name: issue.project.name } : undefined,
-  })));
+  const tasks = picked.map((issue) => {
+    const task = enrichTaskFromState(linearIssueToTask({
+      id: issue.id,
+      identifier: issue.identifier,
+      title: issue.title,
+      description: issue.description,
+      priority: issue.priority,
+      state: issue.state,
+      labels: issue.labels,
+      blockedBy: issue.blockedBy,
+      project: issue.project ? { id: issue.project.id, name: issue.project.name } : undefined,
+    }));
+    task.explicitDispatch = true;
+    // Real issue age, not Date.now(): duplicate grooming keeps the OLDER of
+    // two overlapping issues as canonical, and fabricated timestamps let
+    // selection order cancel the genuinely older issue.
+    if (issue.createdAt) {
+      const created = Date.parse(issue.createdAt);
+      if (Number.isFinite(created)) task.createdAt = created;
+    }
+    return task;
+  });
 
   const concurrency = opts.concurrency
     ?? Math.min(tasks.length, config.autonomous?.maxConcurrentTasks ?? 4);
@@ -407,7 +496,7 @@ export async function runWorkCommand(
       maxActiveForProject: o.maxActive,
     })))({ dbPath: config.autonomous?.automationDbPath, maxActive: concurrency });
 
-  const admission = buildWorkAdmission(concurrency);
+  const admission = buildWorkAdmission(concurrency, meta?.automation);
   const exec = deps.executePipeline ?? executePipeline;
 
   const sigint = new AbortController();
@@ -424,10 +513,27 @@ export async function runWorkCommand(
     return () => process.removeListener('SIGINT', handler);
   }))(onSigint);
 
-  const restoreConsole = opts.json ? redirectConsoleLogToStderr() : null;
   let settledRows: Array<{ value?: PipelineResult; error?: unknown }>;
   try {
     settledRows = await runPool(plan, concurrency, async (row) => {
+      // Ctrl-C: runPool keeps pulling queued rows — skip them outright instead
+      // of entering coordinator.execute, which would still claim the issue and
+      // run comment refresh + draft analysis before the abort lands.
+      if (sigint.signal.aborted) {
+        return {
+          success: false,
+          sessionId: `work-interrupted-${Date.now()}`,
+          stages: [],
+          finalStatus: 'cancelled',
+          totalDuration: 0,
+          iterations: 0,
+          taskContext: {
+            issueIdentifier: row.task.issueIdentifier,
+            projectPath: repoPath,
+            taskTitle: row.task.title,
+          },
+        } satisfies PipelineResult;
+      }
       log(`[${row.task.issueIdentifier}] deploying${row.resumes ? ' (resume)' : ''}…`);
       return coordinator.execute(
         row.task,
@@ -464,16 +570,20 @@ export async function runWorkCommand(
     });
 
     // Deliver queued completion effects (Done transition + completion comment)
-    // now instead of leaving them for the next daemon start.
+    // now instead of leaving them for the next daemon start. drainOutbox's
+    // default batch is 20 — loop until a pass applies nothing, or issues past
+    // the twentieth would report success while still In Progress on Linear.
     try {
-      await coordinator.drainOutbox(
-        (effect) => (deps.deliverEffect ?? deliverWorkCompletionEffect)(effect, source),
-      );
+      const deliver = (effect: EffectClaim) =>
+        (deps.deliverEffect ?? deliverWorkCompletionEffect)(effect, source);
+      for (let pass = 0; pass < 50; pass++) {
+        const drained = await coordinator.drainOutbox(deliver) as { applied?: number } | undefined;
+        if (!drained || (drained.applied ?? 0) === 0) break;
+      }
     } catch (err) {
       log(`Completion delivery failed — the shared outbox retains it for retry (daemon or next run): ${err instanceof Error ? err.message : String(err)}`);
     }
   } finally {
-    restoreConsole?.();
     uninstallSigint();
     coordinator.close();
   }

--- a/src/cli/workCommand.ts
+++ b/src/cli/workCommand.ts
@@ -1,0 +1,503 @@
+// ============================================
+// OpenSwarm - `openswarm work` (INT-3387)
+// ============================================
+//
+// Pick Linear issues (by id or interactively) and deploy the worker/reviewer
+// pipeline per issue into isolated git worktrees, in parallel. Uses the same
+// durable run ledger as the daemon (~/.openswarm/automation.db), so a running
+// daemon and this command arbitrate ownership through claims instead of
+// double-executing, and completion effects survive a crash in the shared
+// outbox either process can drain.
+//
+// Exit codes: 0 = every deployed issue succeeded (superseded issues — owned by
+// another process — do not count as failures), 1 = at least one failed,
+// 2 = nothing was deployed at all (validation failed / nothing selected),
+// 130 = interrupted.
+
+import { resolve } from 'node:path';
+import { loadConfig } from '../core/config.js';
+import type { LinearIssueInfo, SwarmConfig } from '../core/types.js';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import { linearIssueToTask } from '../orchestration/decisionEngine.js';
+import { enrichTaskFromState } from '../taskState/store.js';
+import type { PipelineResult } from '../agents/pairPipeline.js';
+import type { ITaskSource } from '../automation/taskSource.js';
+import {
+  executePipeline,
+  isValidProjectPath,
+  setTaskSource,
+  type ExecutionContext,
+} from '../automation/runnerExecution.js';
+import {
+  DurableRunCoordinator,
+  type DurableExecuteOptions,
+  type ExecutionDurabilityHooks,
+  type RepositoryAdmissionPolicy,
+} from '../automation/durableRunCoordinator.js';
+import type { EffectClaim } from '../automation/runLedger.js';
+import { loadRepoMetadata, type RepoMetadata } from '../support/repoMetadata.js';
+import { buildBranchName, hasRecoverableWorktree } from '../support/worktreeManager.js';
+import { runPool } from '../support/concurrencyPool.js';
+import { ensureTaskSource } from './reviewCommand.js';
+import { filterRepoIssues, selectIssuesInteractive, WORK_SKIP_STATES } from './workSelect.js';
+import {
+  buildWorkCancellationEffect,
+  buildWorkCompletionEffect,
+  buildWorkExecutionContext,
+  deliverWorkCompletionEffect,
+} from './workExecution.js';
+
+export const WORK_EXIT_OK = 0;
+export const WORK_EXIT_FAILED = 1;
+export const WORK_EXIT_NOT_RUN = 2;
+export const WORK_EXIT_INTERRUPTED = 130;
+
+/** The daemon's fan-out admission defaults (autonomousRunner.executeDurably):
+ *  capacity-only admit — worktree isolation replaces file-scope serialization. */
+export function buildWorkAdmission(concurrency: number): RepositoryAdmissionPolicy {
+  return {
+    maxConcurrent: concurrency,
+    conflictScope: undefined,
+    maxFailuresPerHour: 6,
+    circuitCooldownMs: 60 * 60_000,
+  };
+}
+
+export interface WorkCommandOptions {
+  /** Issue ids/identifiers (e.g. INT-123). Empty → interactive picker. */
+  issueIds?: string[];
+  /** Repository path (default: cwd). */
+  path?: string;
+  /** Max issues in flight (default: min(selected, autonomous.maxConcurrentTasks ?? 4)). */
+  concurrency?: number;
+  /** Print the execution plan and exit. */
+  dryRun?: boolean;
+  /** Skip the confirmation prompt. */
+  yes?: boolean;
+  /** Adapter override for the worker/reviewer. */
+  adapter?: string;
+  /** Emit the final summary as JSON on stdout (progress logs go to stderr). */
+  json?: boolean;
+}
+
+/** The coordinator surface this command uses — injectable for tests. */
+export interface WorkCoordinator {
+  execute(
+    task: TaskItem,
+    projectPath: string,
+    executor: (hooks: ExecutionDurabilityHooks, leaseSignal: AbortSignal) => Promise<PipelineResult>,
+    options?: DurableExecuteOptions,
+  ): Promise<PipelineResult>;
+  drainOutbox(deliver: (effect: EffectClaim) => Promise<void>): Promise<unknown>;
+  close(): void;
+}
+
+export interface WorkCommandDeps {
+  loadConfig?: () => SwarmConfig;
+  ensureTaskSource?: () => Promise<ITaskSource | null>;
+  /** Registers the source as runnerExecution's module-global task source. */
+  registerTaskSource?: (source: ITaskSource) => void;
+  isValidProjectPath?: (path: string) => Promise<boolean>;
+  loadRepoMetadata?: (path: string) => Promise<RepoMetadata | null>;
+  getIssue?: (idOrIdentifier: string) => Promise<LinearIssueInfo | null>;
+  listIssues?: () => Promise<LinearIssueInfo[]>;
+  selectIssues?: (issues: LinearIssueInfo[]) => Promise<LinearIssueInfo[]>;
+  confirm?: (message: string) => Promise<boolean>;
+  createCoordinator?: (opts: { dbPath?: string; maxActive: number }) => WorkCoordinator;
+  executePipeline?: (
+    ctx: ExecutionContext,
+    task: TaskItem,
+    projectPath: string,
+    signal?: AbortSignal,
+  ) => Promise<PipelineResult>;
+  deliverEffect?: (effect: EffectClaim, source: ITaskSource | null) => Promise<void>;
+  hasRecoverableWorktree?: (repoPath: string, issueId: string, branchName: string) => Promise<boolean>;
+  /** Installs the SIGINT handler; returns the uninstaller. */
+  installSigintHandler?: (onSigint: () => void) => () => void;
+  isTTY?: boolean;
+  /** Progress/diagnostics — stderr, so `--json | jq` parses. */
+  log?: (line: string) => void;
+  /** Final summary — stdout. */
+  out?: (line: string) => void;
+  /** Immediate force-quit on the second Ctrl-C. */
+  exit?: (code: number) => never;
+}
+
+interface PlanRow {
+  task: TaskItem;
+  branchName: string;
+  /** A preserved worktree or task branch already exists — the run resumes it. */
+  resumes: boolean;
+}
+
+export interface WorkIssueSummary {
+  identifier: string;
+  issueId: string;
+  title: string;
+  /** PipelineResult.finalStatus, or 'error' when the executor threw. */
+  status: string;
+  success: boolean;
+  prUrl?: string;
+  worktreePreserved: boolean;
+  resumed: boolean;
+  note?: string;
+}
+
+/** Classify one pool slot into the user-facing summary row. Pure. */
+export function summarizeSettled(
+  row: PlanRow,
+  settled: { value?: PipelineResult; error?: unknown },
+): WorkIssueSummary {
+  const base = {
+    identifier: row.task.issueIdentifier ?? row.task.issueId ?? row.task.id,
+    issueId: row.task.issueId ?? row.task.id,
+    title: row.task.title,
+    resumed: row.resumes,
+  };
+  if (settled.error !== undefined || !settled.value) {
+    return {
+      ...base,
+      status: 'error',
+      success: false,
+      worktreePreserved: true,
+      note: settled.error instanceof Error ? settled.error.message : String(settled.error),
+    };
+  }
+  const result = settled.value;
+  if (result.finalStatus === 'superseded') {
+    // The ledger refused the claim: a daemon (or another `work` session) owns
+    // this issue, or its failure circuit is open. Not a failure of this run.
+    return {
+      ...base,
+      status: 'superseded',
+      success: false,
+      worktreePreserved: false,
+      note: 'owned by another process (daemon or another session), or its circuit is open',
+    };
+  }
+  const delivered = result.success && result.finalStatus === 'approved';
+  return {
+    ...base,
+    status: result.finalStatus,
+    success: result.success,
+    prUrl: result.prUrl,
+    // Mirrors executePipeline's keepWorktree: anything short of an approved
+    // success preserves the tree so a re-run resumes the partial work.
+    worktreePreserved: !delivered,
+  };
+}
+
+/** Render the human summary table. Pure. */
+export function formatWorkSummary(summaries: WorkIssueSummary[]): string[] {
+  const idWidth = Math.max(...summaries.map((s) => s.identifier.length), 5);
+  const statusWidth = Math.max(...summaries.map((s) => s.status.length), 6);
+  return summaries.map((s) => {
+    const parts = [
+      s.identifier.padEnd(idWidth),
+      s.status.padEnd(statusWidth),
+      s.prUrl ?? '-',
+      s.worktreePreserved ? 'worktree preserved' : 'worktree removed',
+    ];
+    if (s.resumed) parts.push('(resumed)');
+    if (s.note) parts.push(`— ${s.note}`);
+    return parts.join('  ');
+  });
+}
+
+async function defaultConfirm(message: string): Promise<boolean> {
+  const { confirm } = await import('@inquirer/prompts');
+  return confirm({ message, default: true });
+}
+
+/** In --json mode stdout carries one document; reroute pipeline console.log noise. */
+function redirectConsoleLogToStderr(): () => void {
+  const original = console.log;
+  console.log = (...args: unknown[]) => {
+    console.error(...args);
+  };
+  return () => {
+    console.log = original;
+  };
+}
+
+function isExitPromptError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'ExitPromptError';
+}
+
+export async function runWorkCommand(
+  opts: WorkCommandOptions = {},
+  deps: WorkCommandDeps = {},
+): Promise<number> {
+  const log = deps.log ?? ((line: string) => console.error(line));
+  const out = deps.out ?? ((line: string) => console.log(line));
+  const repoPath = resolve(opts.path ?? process.cwd());
+
+  // ---- Bootstrap -----------------------------------------------------------
+  const validate = deps.isValidProjectPath ?? isValidProjectPath;
+  if (!(await validate(repoPath))) {
+    log(`Not a project directory (needs .git, package.json, or pyproject.toml): ${repoPath}`);
+    return WORK_EXIT_NOT_RUN;
+  }
+
+  let config: SwarmConfig;
+  try {
+    config = (deps.loadConfig ?? loadConfig)();
+  } catch (err) {
+    log(`Could not load config: ${err instanceof Error ? err.message : String(err)}`);
+    return WORK_EXIT_NOT_RUN;
+  }
+
+  const source = await (deps.ensureTaskSource ?? ensureTaskSource)();
+  if (!source) {
+    log('Linear is not configured — `openswarm work` picks issues from your tracker.');
+    log('Run `openswarm auth login --provider linear` (or set linearApiKey + linearTeamId in config.yaml), then re-run.');
+    return WORK_EXIT_NOT_RUN;
+  }
+  // executePipeline routes In Progress transitions and audit comments through
+  // runnerExecution's module-global task source — registration is mandatory.
+  (deps.registerTaskSource ?? setTaskSource)(source);
+
+  let meta: RepoMetadata | null = null;
+  try {
+    meta = await (deps.loadRepoMetadata ?? loadRepoMetadata)(repoPath);
+  } catch (err) {
+    log(`Unreadable openswarm.json in ${repoPath}: ${err instanceof Error ? err.message : String(err)}`);
+    return WORK_EXIT_NOT_RUN;
+  }
+  const projectId = meta?.linear?.projectId;
+
+  // ---- Issue resolution ----------------------------------------------------
+  const directIds = [...new Set((opts.issueIds ?? []).map((id) => id.trim()).filter(Boolean))];
+  const skipped: Array<{ identifier: string; reason: string }> = [];
+  let picked: LinearIssueInfo[] = [];
+
+  if (directIds.length > 0) {
+    const getIssue = deps.getIssue
+      ?? (async (id: string) => (await import('../linear/linear.js')).getIssue(id));
+    const resolved = await Promise.all(
+      directIds.map(async (id) => ({ id, issue: await getIssue(id) })),
+    );
+    const missing = resolved.filter((entry) => !entry.issue);
+    if (missing.length > 0) {
+      for (const entry of missing) log(`Issue not found: ${entry.id}`);
+      log('Nothing started — every listed issue must resolve before deploying (fail-fast).');
+      return WORK_EXIT_NOT_RUN;
+    }
+    const seen = new Set<string>();
+    for (const { issue } of resolved as Array<{ id: string; issue: LinearIssueInfo }>) {
+      if (seen.has(issue.id)) continue;
+      seen.add(issue.id);
+      if ((WORK_SKIP_STATES as readonly string[]).includes(issue.state)) {
+        skipped.push({ identifier: issue.identifier, reason: `state is ${issue.state}` });
+      } else {
+        picked.push(issue);
+      }
+    }
+  } else {
+    if (!projectId) {
+      log('This repo has no Linear project mapping (openswarm.json) — the picker cannot scope the issue list.');
+      log(`Run \`openswarm add ${repoPath}\` once to map it, or pass issue ids explicitly.`);
+      return WORK_EXIT_NOT_RUN;
+    }
+    const list = deps.listIssues
+      ?? (async () => (await import('../linear/linear.js')).getMyIssues({ slim: true }));
+    let candidates: LinearIssueInfo[];
+    try {
+      candidates = filterRepoIssues(await list(), projectId);
+    } catch (err) {
+      log(`Could not fetch issues: ${err instanceof Error ? err.message : String(err)}`);
+      return WORK_EXIT_NOT_RUN;
+    }
+    if (candidates.length === 0) {
+      log('No selectable issues (Todo / Backlog / In Progress) for this repo.');
+      return WORK_EXIT_NOT_RUN;
+    }
+    try {
+      picked = await (deps.selectIssues ?? selectIssuesInteractive)(candidates);
+    } catch (err) {
+      if (isExitPromptError(err)) return WORK_EXIT_NOT_RUN;
+      throw err;
+    }
+  }
+
+  for (const skip of skipped) log(`Skipping ${skip.identifier}: ${skip.reason}`);
+  if (picked.length === 0) {
+    log('No issues selected — nothing to deploy.');
+    return WORK_EXIT_NOT_RUN;
+  }
+
+  const tasks = picked.map((issue) => enrichTaskFromState(linearIssueToTask({
+    id: issue.id,
+    identifier: issue.identifier,
+    title: issue.title,
+    description: issue.description,
+    priority: issue.priority,
+    state: issue.state,
+    labels: issue.labels,
+    blockedBy: issue.blockedBy,
+    project: issue.project ? { id: issue.project.id, name: issue.project.name } : undefined,
+  })));
+
+  const concurrency = opts.concurrency
+    ?? Math.min(tasks.length, config.autonomous?.maxConcurrentTasks ?? 4);
+
+  // ---- Plan ----------------------------------------------------------------
+  const recoverable = deps.hasRecoverableWorktree ?? hasRecoverableWorktree;
+  const plan: PlanRow[] = await Promise.all(tasks.map(async (task) => {
+    const branchName = buildBranchName(task.issueIdentifier ?? task.issueId ?? task.id, task.title);
+    const resumes = await recoverable(repoPath, task.issueId ?? task.id, branchName)
+      .catch(() => false);
+    return { task, branchName, resumes };
+  }));
+
+  if (opts.dryRun) {
+    if (opts.json) {
+      out(JSON.stringify({
+        repoPath,
+        dryRun: true,
+        concurrency,
+        plan: plan.map((row) => ({
+          identifier: row.task.issueIdentifier,
+          issueId: row.task.issueId,
+          title: row.task.title,
+          state: row.task.linearState,
+          branch: row.branchName,
+          resumes: row.resumes,
+        })),
+        skipped,
+      }, null, 2));
+    } else {
+      out(`Plan: ${plan.length} issue(s) → isolated worktrees of ${repoPath} (concurrency ${concurrency})`);
+      for (const row of plan) {
+        const marks = [row.resumes ? 'resume' : 'fresh'];
+        if (row.task.linearState === 'In Progress') marks.push('in progress');
+        out(`  ${row.task.issueIdentifier}  ${row.branchName}  [${marks.join(', ')}]`);
+      }
+    }
+    return WORK_EXIT_OK;
+  }
+
+  // ---- Confirmation --------------------------------------------------------
+  // The interactive picker is its own confirmation; only directly-addressed
+  // runs prompt. Headless without --yes fails closed: this command spends
+  // model budget and publishes PRs.
+  if (!opts.yes && directIds.length > 0) {
+    const isTTY = deps.isTTY ?? !!process.stdin.isTTY;
+    if (!isTTY) {
+      log('Refusing to deploy without confirmation on a non-interactive stdin — pass --yes.');
+      return WORK_EXIT_NOT_RUN;
+    }
+    let confirmed: boolean;
+    try {
+      confirmed = await (deps.confirm ?? defaultConfirm)(
+        `Deploy ${tasks.length} agent pipeline(s) into isolated worktrees of ${repoPath}?`,
+      );
+    } catch (err) {
+      if (isExitPromptError(err)) return WORK_EXIT_NOT_RUN;
+      throw err;
+    }
+    if (!confirmed) return WORK_EXIT_NOT_RUN;
+  }
+
+  // ---- Execution -----------------------------------------------------------
+  const coordinator = (deps.createCoordinator
+    ?? ((o: { dbPath?: string; maxActive: number }) => new DurableRunCoordinator({
+      mode: 'primary',
+      dbPath: o.dbPath,
+      maxActiveForProject: o.maxActive,
+    })))({ dbPath: config.autonomous?.automationDbPath, maxActive: concurrency });
+
+  const admission = buildWorkAdmission(concurrency);
+  const exec = deps.executePipeline ?? executePipeline;
+
+  const sigint = new AbortController();
+  let interrupts = 0;
+  const forceExit = deps.exit ?? ((code: number) => process.exit(code));
+  const onSigint = (): void => {
+    interrupts += 1;
+    if (interrupts > 1) forceExit(WORK_EXIT_INTERRUPTED);
+    log('Interrupted — aborting running pipelines. Worktrees holding work are preserved; re-run the same command to resume. (Ctrl-C again to force quit)');
+    sigint.abort(new Error('SIGINT'));
+  };
+  const uninstallSigint = (deps.installSigintHandler ?? ((handler: () => void) => {
+    process.on('SIGINT', handler);
+    return () => process.removeListener('SIGINT', handler);
+  }))(onSigint);
+
+  const restoreConsole = opts.json ? redirectConsoleLogToStderr() : null;
+  let settledRows: Array<{ value?: PipelineResult; error?: unknown }>;
+  try {
+    settledRows = await runPool(plan, concurrency, async (row) => {
+      log(`[${row.task.issueIdentifier}] deploying${row.resumes ? ' (resume)' : ''}…`);
+      return coordinator.execute(
+        row.task,
+        repoPath,
+        (durability, leaseSignal) => exec(
+          buildWorkExecutionContext({
+            autonomous: config.autonomous,
+            repoPath,
+            peerIssues: tasks,
+            durability,
+            adapter: opts.adapter as import('../core/types.js').AgentAdapterName | undefined,
+            log,
+          }),
+          row.task,
+          repoPath,
+          AbortSignal.any([sigint.signal, leaseSignal]),
+        ),
+        {
+          admission,
+          successEffect: (result, claim) => buildWorkCompletionEffect(row.task, result, claim.attemptNo),
+          cancelEffect: (_result, claim) => buildWorkCancellationEffect(row.task, claim.attemptNo),
+          // Interruptions are resumable — never turn Ctrl-C into a tracker cancel.
+          retryCancellation: () => true,
+        },
+      );
+    }, (settled) => {
+      const row = plan[settled.index];
+      if (settled.error !== undefined) {
+        log(`[${row.task.issueIdentifier}] error: ${settled.error instanceof Error ? settled.error.message : String(settled.error)}`);
+      } else if (settled.value) {
+        const prNote = settled.value.prUrl ? ` → ${settled.value.prUrl}` : '';
+        log(`[${row.task.issueIdentifier}] ${settled.value.finalStatus}${prNote}`);
+      }
+    });
+
+    // Deliver queued completion effects (Done transition + completion comment)
+    // now instead of leaving them for the next daemon start.
+    try {
+      await coordinator.drainOutbox(
+        (effect) => (deps.deliverEffect ?? deliverWorkCompletionEffect)(effect, source),
+      );
+    } catch (err) {
+      log(`Completion delivery failed — the shared outbox retains it for retry (daemon or next run): ${err instanceof Error ? err.message : String(err)}`);
+    }
+  } finally {
+    restoreConsole?.();
+    uninstallSigint();
+    coordinator.close();
+  }
+
+  // ---- Summary -------------------------------------------------------------
+  const summaries = plan.map((row, index) => summarizeSettled(row, settledRows[index] ?? {}));
+  const failed = summaries.some((s) => !s.success && s.status !== 'superseded');
+  const exitCode = interrupts > 0
+    ? WORK_EXIT_INTERRUPTED
+    : failed ? WORK_EXIT_FAILED : WORK_EXIT_OK;
+
+  if (opts.json) {
+    out(JSON.stringify({
+      repoPath,
+      concurrency,
+      interrupted: interrupts > 0,
+      results: summaries,
+      skipped,
+      exitCode,
+    }, null, 2));
+  } else {
+    out('');
+    out(`Results (${summaries.length} issue(s)):`);
+    for (const line of formatWorkSummary(summaries)) out(`  ${line}`);
+  }
+  return exitCode;
+}

--- a/src/cli/workExecution.test.ts
+++ b/src/cli/workExecution.test.ts
@@ -1,0 +1,395 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { EmbedBuilder } from 'discord.js';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import type { PipelineResult } from '../agents/pairPipeline.js';
+import type { ITaskSource } from '../automation/taskSource.js';
+import type { EffectClaim, EffectInput } from '../automation/runLedger.js';
+import { resetTaskStateStoreForTests } from '../taskState/store.js';
+import { setTaskSource } from '../automation/runnerExecution.js';
+import {
+  isCancellationEffectPayload,
+  isCompletionEffectPayload,
+  type CancellationEffectPayload,
+  type CompletionEffectPayload,
+} from '../automation/trackerEffects.js';
+import {
+  applyAdapterOverride,
+  buildWorkCancellationEffect,
+  buildWorkCompletionEffect,
+  buildWorkExecutionContext,
+  deliverWorkCompletionEffect,
+  describeNotification,
+  resolveRolesForProject,
+  rolesSourceFromConfig,
+} from './workExecution.js';
+
+// Local-state writes (markTaskBacklog/markTaskDone projections) must never
+// touch the real ~/.openswarm/task-state.json from a unit test.
+const stateDir = mkdtempSync(join(tmpdir(), 'openswarm-work-exec-test-'));
+process.env.OPENSWARM_TASK_STATE_FILE = join(stateDir, 'task-state.json');
+
+function task(overrides: Partial<TaskItem> = {}): TaskItem {
+  return {
+    id: 'uuid-1',
+    source: 'linear',
+    title: 'Fix the thing',
+    priority: 2,
+    issueId: 'uuid-1',
+    issueIdentifier: 'INT-1',
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function pipelineResult(overrides: Partial<PipelineResult> = {}): PipelineResult {
+  return {
+    success: true,
+    sessionId: 'sess-1',
+    stages: [],
+    finalStatus: 'approved',
+    totalDuration: 65_000,
+    iterations: 2,
+    ...overrides,
+  };
+}
+
+function mockSource(overrides: Partial<Record<keyof ITaskSource, unknown>> = {}): ITaskSource {
+  return {
+    kind: 'linear',
+    fetchTasks: vi.fn(async () => []),
+    createTask: vi.fn(),
+    updateState: vi.fn(async () => true),
+    addComment: vi.fn(async () => undefined),
+    getExecutionComments: vi.fn(async () => []),
+    createSubIssue: vi.fn(),
+    logPairStart: vi.fn(async () => undefined),
+    logPairComplete: vi.fn(async () => undefined),
+    logBlocked: vi.fn(async () => undefined),
+    logStuck: vi.fn(async () => undefined),
+    unstick: vi.fn(async () => undefined),
+    logHalt: vi.fn(async () => undefined),
+    markAsDecomposed: vi.fn(async () => undefined),
+    ...overrides,
+  } as unknown as ITaskSource;
+}
+
+function claimOf(effect: EffectInput): EffectClaim {
+  return {
+    ...effect,
+    id: 1,
+    issueId: 'uuid-1',
+    attemptNo: 1,
+    status: 'pending',
+    attempts: 1,
+    ownerInstanceId: 'test-owner',
+    deliveryToken: 'token',
+    leaseExpiresAt: Date.now() + 60_000,
+  } as unknown as EffectClaim;
+}
+
+beforeEach(() => {
+  resetTaskStateStoreForTests();
+});
+
+describe('resolveRolesForProject mirrors AutonomousRunner.getRolesForProject (INT-3387)', () => {
+  it('falls back to the legacy worker/reviewer model config when nothing else is set', () => {
+    const roles = resolveRolesForProject(
+      { workerModel: 'legacy-worker', reviewerModel: 'legacy-reviewer', workerTimeoutMs: 111 },
+      '/Users/u/dev/Repo',
+    );
+    expect(roles).toEqual({
+      worker: { enabled: true, model: 'legacy-worker', timeoutMs: 111 },
+      reviewer: { enabled: true, model: 'legacy-reviewer', timeoutMs: 0 },
+    });
+  });
+
+  it('returns defaultRoles untouched when no projectAgents entry matches', () => {
+    const defaultRoles = {
+      worker: { enabled: true, model: 'base-w', timeoutMs: 0 },
+      reviewer: { enabled: true, model: 'base-r', timeoutMs: 0 },
+    };
+    expect(resolveRolesForProject({ defaultRoles }, '/Users/u/dev/Repo')).toEqual(defaultRoles);
+  });
+
+  it('matches projectAgents by tilde-stripped path substring and merges role overrides', () => {
+    const roles = resolveRolesForProject({
+      defaultRoles: {
+        worker: { enabled: true, model: 'base-w', timeoutMs: 5 },
+        reviewer: { enabled: true, model: 'base-r', timeoutMs: 0 },
+        tester: { enabled: false, timeoutMs: 0 },
+      },
+      projectAgents: [{
+        projectPath: '~/dev/Repo',
+        roles: {
+          worker: { model: 'proj-w' },
+          tester: { enabled: true },
+        },
+      }],
+    }, '/Users/u/dev/Repo');
+    expect(roles).toEqual({
+      worker: { enabled: true, model: 'proj-w', timeoutMs: 5 },
+      reviewer: { enabled: true, model: 'base-r', timeoutMs: 0 },
+      tester: { enabled: true, timeoutMs: 0 },
+      documenter: undefined,
+    });
+  });
+
+  it('uses the built-in modelless base when projectAgents overrides exist without defaultRoles', () => {
+    const roles = resolveRolesForProject({
+      projectAgents: [{ projectPath: '/dev/Repo', roles: { worker: { model: 'proj-w' } } }],
+    }, '/Users/u/dev/Repo');
+    expect(roles?.worker).toEqual({ enabled: true, timeoutMs: 0, model: 'proj-w' });
+    expect(roles?.reviewer).toEqual({ enabled: true, timeoutMs: 0 });
+  });
+
+  it('a matching projectAgents entry without roles yields the base roles', () => {
+    const defaultRoles = {
+      worker: { enabled: true, model: 'base-w', timeoutMs: 0 },
+      reviewer: { enabled: true, timeoutMs: 0 },
+    };
+    expect(resolveRolesForProject(
+      { defaultRoles, projectAgents: [{ projectPath: '/dev/Repo' }] },
+      '/Users/u/dev/Repo',
+    )).toEqual(defaultRoles);
+  });
+});
+
+describe('rolesSourceFromConfig', () => {
+  it('maps the config.yaml autonomous block onto the runner-config shape', () => {
+    expect(rolesSourceFromConfig({
+      enabled: true,
+      pairMode: true,
+      schedule: '* * * * *',
+      maxAttempts: 3,
+      allowedProjects: [],
+      models: { worker: 'w-model', reviewer: 'r-model' },
+      workerTimeoutMs: 1,
+      reviewerTimeoutMs: 2,
+    })).toEqual({
+      defaultRoles: undefined,
+      projectAgents: undefined,
+      workerModel: 'w-model',
+      reviewerModel: 'r-model',
+      workerTimeoutMs: 1,
+      reviewerTimeoutMs: 2,
+    });
+    expect(rolesSourceFromConfig(undefined)).toEqual({
+      defaultRoles: undefined,
+      projectAgents: undefined,
+      workerModel: undefined,
+      reviewerModel: undefined,
+      workerTimeoutMs: undefined,
+      reviewerTimeoutMs: undefined,
+    });
+  });
+});
+
+describe('applyAdapterOverride', () => {
+  const roles = {
+    worker: { enabled: true, adapter: 'codex' as const, timeoutMs: 0 },
+    reviewer: { enabled: true, timeoutMs: 0 },
+    tester: { enabled: true, adapter: 'codex' as const, timeoutMs: 0 },
+  };
+
+  it('overrides worker and reviewer adapters only', () => {
+    const overridden = applyAdapterOverride(roles, 'claude');
+    expect(overridden?.worker.adapter).toBe('claude');
+    expect(overridden?.reviewer.adapter).toBe('claude');
+    expect(overridden?.tester?.adapter).toBe('codex');
+  });
+
+  it('is a no-op without an adapter or without roles', () => {
+    expect(applyAdapterOverride(roles, undefined)).toBe(roles);
+    expect(applyAdapterOverride(undefined, 'claude')).toBeUndefined();
+  });
+});
+
+describe('describeNotification', () => {
+  it('passes strings through', () => {
+    expect(describeNotification('hello')).toBe('hello');
+  });
+
+  it('flattens an embed into title/description/fields', () => {
+    const embed = new EmbedBuilder()
+      .setTitle('Pipeline start')
+      .setDescription('desc')
+      .addFields({ name: 'Task', value: 'T' }, { name: 'Issue', value: 'INT-1' });
+    expect(describeNotification(embed)).toBe('Pipeline start — desc — Task: T · Issue: INT-1');
+  });
+
+  it('falls back to a placeholder for an empty embed', () => {
+    expect(describeNotification(new EmbedBuilder())).toBe('[notification]');
+  });
+});
+
+describe('buildWorkExecutionContext (INT-3387)', () => {
+  it('pins the command contract: worktreeMode on, decomposition off, repo-only scope', () => {
+    const ctx = buildWorkExecutionContext({ repoPath: '/repo' });
+    expect(ctx.worktreeMode).toBe(true);
+    expect(ctx.enableDecomposition).toBe(false);
+    expect(ctx.allowedProjects).toEqual(['/repo']);
+    expect(ctx.pairMaxAttempts).toBe(3);
+  });
+
+  it('maps config.autonomous knobs (maxAttempts, planner, guards, verify, profiles)', () => {
+    const ctx = buildWorkExecutionContext({
+      repoPath: '/repo',
+      autonomous: {
+        enabled: true,
+        pairMode: true,
+        schedule: '* * * * *',
+        maxAttempts: 5,
+        allowedProjects: ['/elsewhere'],
+        decomposition: {
+          enabled: true,
+          thresholdMinutes: 30,
+          plannerModel: 'planner-m',
+          plannerTimeoutMs: 1234,
+        },
+        guards: { qualityGate: true } as never,
+        verify: { enabled: true, blockOnNewFailures: true, maxCommands: 3 },
+        maxReflections: 2,
+        jobProfiles: [],
+      },
+    });
+    expect(ctx.pairMaxAttempts).toBe(5);
+    expect(ctx.plannerModel).toBe('planner-m');
+    expect(ctx.plannerTimeoutMs).toBe(1234);
+    expect(ctx.guards).toEqual({ qualityGate: true });
+    expect(ctx.verify).toEqual({ enabled: true, blockOnNewFailures: true, maxCommands: 3 });
+    expect(ctx.maxReflections).toBe(2);
+    expect(ctx.jobProfiles).toEqual([]);
+    // Decomposition stays off even when the daemon config enables it.
+    expect(ctx.enableDecomposition).toBe(false);
+    // The command scopes execution to the one repo it was pointed at.
+    expect(ctx.allowedProjects).toEqual(['/repo']);
+  });
+
+  it('routes notifications to the injected log and applies the adapter override to roles', async () => {
+    const lines: string[] = [];
+    const ctx = buildWorkExecutionContext({
+      repoPath: '/repo',
+      adapter: 'claude',
+      log: (line) => lines.push(line),
+    });
+    await ctx.reportToDiscord('progress line');
+    expect(lines).toEqual(['progress line']);
+    const roles = ctx.getRolesForProject('/repo');
+    expect(roles?.worker.adapter).toBe('claude');
+    expect(roles?.reviewer.adapter).toBe('claude');
+  });
+});
+
+describe('completion effect wire contract (must match the daemon outbox)', () => {
+  it('builds kind tracker.complete with marker complete:{issueId}:attempt:{n}', () => {
+    const result = pipelineResult({
+      taskContext: { projectPath: '/repo' },
+      totalCost: { costUsd: 1.5 } as never,
+    });
+    const effect = buildWorkCompletionEffect(task(), result, 3);
+    expect(effect.kind).toBe('tracker.complete');
+    expect(effect.dedupeKey).toBe('complete:uuid-1:attempt:3');
+    const payload = effect.payload as CompletionEffectPayload;
+    expect(payload.version).toBe(1);
+    expect(payload.marker).toBe('complete:uuid-1:attempt:3');
+    expect(payload.stats.idempotencyMarker).toBe('complete:uuid-1:attempt:3');
+    expect(payload.stats.attempts).toBe(2);
+    expect(payload.stats.duration).toBe(65);
+    expect(payload.projectPath).toBe('/repo');
+    expect(payload.costUsd).toBe(1.5);
+    // The daemon's payload guard must accept what the CLI enqueues.
+    expect(isCompletionEffectPayload(payload)).toBe(true);
+  });
+
+  it('falls back to task.id when issueId is absent', () => {
+    const effect = buildWorkCompletionEffect(task({ issueId: undefined }), pipelineResult(), 1);
+    expect(effect.dedupeKey).toBe('complete:uuid-1:attempt:1');
+  });
+
+  it('builds kind tracker.cancel with marker cancel:{issueId}:attempt:{n} and a frozen marker comment', () => {
+    const effect = buildWorkCancellationEffect(task(), 2);
+    expect(effect.kind).toBe('tracker.cancel');
+    expect(effect.dedupeKey).toBe('cancel:uuid-1:attempt:2');
+    const payload = effect.payload as CancellationEffectPayload;
+    expect(payload.version).toBe(1);
+    expect(payload.marker).toBe('cancel:uuid-1:attempt:2');
+    expect(payload.comment).toContain('<!-- openswarm-effect:cancel:uuid-1:attempt:2 -->');
+    expect(isCancellationEffectPayload(payload)).toBe(true);
+  });
+});
+
+describe('deliverWorkCompletionEffect (idempotent delivery)', () => {
+  it('logs the full completion when the marker comment is absent', async () => {
+    const source = mockSource();
+    const effect = buildWorkCompletionEffect(task(), pipelineResult(), 1);
+    await deliverWorkCompletionEffect(claimOf(effect), source);
+    expect(source.logPairComplete).toHaveBeenCalledTimes(1);
+    expect(source.logPairComplete).toHaveBeenCalledWith(
+      'uuid-1',
+      'complete:uuid-1:attempt:1',
+      expect.objectContaining({ idempotencyMarker: 'complete:uuid-1:attempt:1' }),
+    );
+    expect(source.updateState).not.toHaveBeenCalled();
+  });
+
+  it('reapplies only the Done transition when the marker comment already exists', async () => {
+    const source = mockSource({
+      getExecutionComments: vi.fn(async () => [
+        { body: 'done!\n\n<!-- openswarm-effect:complete:uuid-1:attempt:1 -->', createdAt: '2026-01-01' },
+      ]),
+    });
+    const effect = buildWorkCompletionEffect(task(), pipelineResult(), 1);
+    await deliverWorkCompletionEffect(claimOf(effect), source);
+    expect(source.updateState).toHaveBeenCalledWith('uuid-1', 'Done');
+    expect(source.logPairComplete).not.toHaveBeenCalled();
+  });
+
+  it('throws when the tracker refuses the Done reconciliation (effect stays queued)', async () => {
+    const source = mockSource({
+      getExecutionComments: vi.fn(async () => [
+        { body: '<!-- openswarm-effect:complete:uuid-1:attempt:1 -->', createdAt: '2026-01-01' },
+      ]),
+      updateState: vi.fn(async () => false),
+    });
+    const effect = buildWorkCompletionEffect(task(), pipelineResult(), 1);
+    await expect(deliverWorkCompletionEffect(claimOf(effect), source))
+      .rejects.toThrow(/refused Done reconciliation/);
+  });
+
+  it('throws without a task source (delivery must retry, not silently drop)', async () => {
+    const effect = buildWorkCompletionEffect(task(), pipelineResult(), 1);
+    await expect(deliverWorkCompletionEffect(claimOf(effect), null))
+      .rejects.toThrow(/Task source unavailable/);
+  });
+
+  it('rejects unknown effect kinds and malformed payloads', async () => {
+    await expect(deliverWorkCompletionEffect(
+      claimOf({ kind: 'tracker.unknown', dedupeKey: 'k', payload: {} }),
+      mockSource(),
+    )).rejects.toThrow(/Unsupported automation effect/);
+    await expect(deliverWorkCompletionEffect(
+      claimOf({ kind: 'tracker.complete', dedupeKey: 'k', payload: { version: 2 } }),
+      mockSource(),
+    )).rejects.toThrow(/Unsupported automation effect/);
+    await expect(deliverWorkCompletionEffect(
+      claimOf({ kind: 'tracker.cancel', dedupeKey: 'k', payload: { nope: true } }),
+      mockSource(),
+    )).rejects.toThrow(/Invalid automation effect payload/);
+  });
+
+  it('delivers a cancellation through the registered task source with the frozen comment', async () => {
+    const source = mockSource();
+    setTaskSource(source); // syncCancellationState routes through the module-global source
+    const effect = buildWorkCancellationEffect(task(), 1);
+    await deliverWorkCompletionEffect(claimOf(effect), source);
+    expect(source.updateState).toHaveBeenCalledWith('uuid-1', 'Backlog');
+    expect(source.addComment).toHaveBeenCalledWith(
+      'uuid-1',
+      expect.stringContaining('<!-- openswarm-effect:cancel:uuid-1:attempt:1 -->'),
+      'cancel:uuid-1:attempt:1',
+    );
+  });
+});

--- a/src/cli/workExecution.ts
+++ b/src/cli/workExecution.ts
@@ -107,7 +107,9 @@ export function resolveRolesForProject(
     return base;
   }
 
-  // Merge overrides
+  // Merge overrides — every role DefaultRolesConfig supports. Dropping keys
+  // here silently disables configured stages (auditor/skill-documenter were
+  // lost in the first cut — review finding).
   return {
     worker: { ...base.worker, ...projectConfig.roles.worker },
     reviewer: { ...base.reviewer, ...projectConfig.roles.reviewer },
@@ -117,6 +119,12 @@ export function resolveRolesForProject(
     documenter: projectConfig.roles.documenter
       ? { ...base.documenter, ...projectConfig.roles.documenter }
       : base.documenter,
+    auditor: projectConfig.roles.auditor
+      ? { ...base.auditor, ...projectConfig.roles.auditor }
+      : base.auditor,
+    'skill-documenter': projectConfig.roles['skill-documenter']
+      ? { ...base['skill-documenter'], ...projectConfig.roles['skill-documenter'] }
+      : base['skill-documenter'],
   } as DefaultRolesConfig;
 }
 

--- a/src/cli/workExecution.ts
+++ b/src/cli/workExecution.ts
@@ -1,0 +1,186 @@
+// ============================================
+// OpenSwarm - `openswarm work` execution wiring (INT-3387)
+// ============================================
+//
+// Builds the daemon-shaped ExecutionContext for a standalone CLI run and
+// re-exports the shared tracker-effect contract. Two hard command contracts
+// live here: `worktreeMode` is always on (every issue gets an isolated
+// worktree + PR), and `enableDecomposition` is always off (the user picked
+// concrete issues — never split them into sub-issues).
+
+import type { EmbedBuilder } from 'discord.js';
+import type {
+  AgentAdapterName,
+  AutonomousStartupConfig,
+  DefaultRolesConfig,
+  ProjectAgentConfig,
+} from '../core/types.js';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import type { ExecutionContext } from '../automation/runnerExecution.js';
+import type { ExecutionDurabilityHooks } from '../automation/durableRunCoordinator.js';
+import type { EffectClaim } from '../automation/runLedger.js';
+import type { ITaskSource } from '../automation/taskSource.js';
+import {
+  buildCancellationEffect,
+  buildCompletionEffect,
+  deliverTrackerEffect,
+} from '../automation/trackerEffects.js';
+
+// The completion/cancellation outbox contract is shared with the daemon
+// (src/automation/trackerEffects.ts): marker `complete:{issueId}:attempt:{n}`,
+// kind `tracker.complete`. Re-exported under the command's names so the CLI
+// surface reads locally while the wire format stays single-sourced.
+export const buildWorkCompletionEffect = buildCompletionEffect;
+export const buildWorkCancellationEffect = buildCancellationEffect;
+
+/** Deliver one claimed outbox effect using the shared daemon delivery path. */
+export async function deliverWorkCompletionEffect(
+  effect: EffectClaim,
+  source: ITaskSource | null,
+): Promise<void> {
+  return deliverTrackerEffect(effect, source);
+}
+
+/**
+ * The role-resolution inputs `AutonomousRunner.getRolesForProject` reads off
+ * its runner config, normalized so a pure function can mirror its behavior.
+ */
+export interface RolesConfigSource {
+  defaultRoles?: DefaultRolesConfig;
+  projectAgents?: ProjectAgentConfig[];
+  workerModel?: string;
+  reviewerModel?: string;
+  workerTimeoutMs?: number;
+  reviewerTimeoutMs?: number;
+}
+
+/** Map the persisted config.yaml `autonomous` block onto the runner-config shape. */
+export function rolesSourceFromConfig(autonomous: AutonomousStartupConfig | undefined): RolesConfigSource {
+  return {
+    defaultRoles: autonomous?.defaultRoles,
+    projectAgents: autonomous?.projectAgents,
+    workerModel: autonomous?.models?.worker,
+    reviewerModel: autonomous?.models?.reviewer,
+    workerTimeoutMs: autonomous?.workerTimeoutMs,
+    reviewerTimeoutMs: autonomous?.reviewerTimeoutMs,
+  };
+}
+
+/**
+ * Pure port of AutonomousRunner.getRolesForProject (defaultRoles/projectAgents
+ * merge + legacy workerModel fallback). Behavior equivalence is asserted by
+ * workExecution.test.ts against the daemon's documented cases.
+ */
+export function resolveRolesForProject(
+  cfg: RolesConfigSource,
+  projectPath: string,
+): DefaultRolesConfig | undefined {
+  // Find per-project configuration
+  const projectConfig = cfg.projectAgents?.find(
+    (pa) => projectPath.includes(pa.projectPath.replace('~', '')),
+  );
+
+  if (!projectConfig?.roles && !cfg.defaultRoles) {
+    // Convert from legacy configuration
+    return {
+      worker: {
+        enabled: true,
+        model: cfg.workerModel, // unset → role adapter's getDefaultModel()
+        timeoutMs: cfg.workerTimeoutMs ?? 0,
+      },
+      reviewer: {
+        enabled: true,
+        model: cfg.reviewerModel, // unset → role adapter's getDefaultModel()
+        timeoutMs: cfg.reviewerTimeoutMs ?? 0,
+      },
+    };
+  }
+
+  // Apply per-project overrides
+  const base = cfg.defaultRoles || {
+    // No model → each role's adapter resolves its own default (getDefaultModel).
+    worker: { enabled: true, timeoutMs: 0 },
+    reviewer: { enabled: true, timeoutMs: 0 },
+  };
+
+  if (!projectConfig?.roles) {
+    return base;
+  }
+
+  // Merge overrides
+  return {
+    worker: { ...base.worker, ...projectConfig.roles.worker },
+    reviewer: { ...base.reviewer, ...projectConfig.roles.reviewer },
+    tester: projectConfig.roles.tester
+      ? { ...base.tester, ...projectConfig.roles.tester }
+      : base.tester,
+    documenter: projectConfig.roles.documenter
+      ? { ...base.documenter, ...projectConfig.roles.documenter }
+      : base.documenter,
+  } as DefaultRolesConfig;
+}
+
+/** `--adapter` overrides the worker/reviewer adapters; other roles keep theirs. */
+export function applyAdapterOverride(
+  roles: DefaultRolesConfig | undefined,
+  adapter: AgentAdapterName | undefined,
+): DefaultRolesConfig | undefined {
+  if (!adapter || !roles) return roles;
+  return {
+    ...roles,
+    worker: { ...roles.worker, adapter },
+    reviewer: { ...roles.reviewer, adapter },
+  };
+}
+
+/** Flatten a notifier message (string or Discord embed) into one loggable line. */
+export function describeNotification(message: string | EmbedBuilder): string {
+  if (typeof message === 'string') return message;
+  const data = message.data ?? {};
+  const fields = (data.fields ?? [])
+    .map((field) => `${field.name}: ${field.value}`)
+    .join(' · ');
+  return [data.title, data.description, fields].filter(Boolean).join(' — ') || '[notification]';
+}
+
+export interface WorkExecutionContextOptions {
+  /** The loaded config.yaml `autonomous` block (may be absent entirely). */
+  autonomous?: AutonomousStartupConfig;
+  repoPath: string;
+  /** The other selected issues, for same-project duplicate grooming in draft. */
+  peerIssues?: TaskItem[];
+  /** Fenced durable-run callbacks from DurableRunCoordinator.execute. */
+  durability?: ExecutionDurabilityHooks;
+  /** `--adapter` override for the worker/reviewer roles. */
+  adapter?: AgentAdapterName;
+  /** Progress sink (default stderr) — replaces the daemon's Discord notifier. */
+  log?: (line: string) => void;
+}
+
+/** Build the ExecutionContext `executePipeline` needs for a standalone CLI run. */
+export function buildWorkExecutionContext(opts: WorkExecutionContextOptions): ExecutionContext {
+  const autonomous = opts.autonomous;
+  const log = opts.log ?? ((line: string) => console.error(line));
+  const rolesSource = rolesSourceFromConfig(autonomous);
+  return {
+    allowedProjects: [opts.repoPath],
+    plannerModel: autonomous?.decomposition?.plannerModel,
+    plannerTimeoutMs: autonomous?.decomposition?.plannerTimeoutMs,
+    pairMaxAttempts: autonomous?.maxAttempts ?? 3,
+    // Command contract: the user picked these exact issues — never decompose.
+    enableDecomposition: false,
+    jobProfiles: autonomous?.jobProfiles,
+    getRolesForProject: (projectPath) =>
+      applyAdapterOverride(resolveRolesForProject(rolesSource, projectPath), opts.adapter),
+    reportToDiscord: async (message) => {
+      log(describeNotification(message));
+    },
+    // Command contract: isolated worktree per issue + auto PR — always on.
+    worktreeMode: true,
+    guards: autonomous?.guards,
+    verify: autonomous?.verify,
+    maxReflections: autonomous?.maxReflections,
+    durability: opts.durability,
+    peerIssues: opts.peerIssues,
+  };
+}

--- a/src/cli/workSelect.test.ts
+++ b/src/cli/workSelect.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { LinearIssueInfo } from '../core/types.js';
+import {
+  filterRepoIssues,
+  formatIssueChoice,
+  selectIssuesInteractive,
+  WORK_SELECTABLE_STATES,
+  WORK_SKIP_STATES,
+} from './workSelect.js';
+
+function issue(overrides: Partial<LinearIssueInfo> = {}): LinearIssueInfo {
+  return {
+    id: 'id-1',
+    identifier: 'INT-1',
+    title: 'Fix the thing',
+    state: 'Todo',
+    priority: 2,
+    labels: [],
+    comments: [],
+    project: { id: 'proj-1', name: 'OpenSwarm' },
+    ...overrides,
+  };
+}
+
+describe('filterRepoIssues (INT-3387)', () => {
+  it('keeps only issues of the given project', () => {
+    const issues = [
+      issue({ id: 'a', identifier: 'INT-1' }),
+      issue({ id: 'b', identifier: 'INT-2', project: { id: 'other', name: 'Other' } }),
+      issue({ id: 'c', identifier: 'INT-3', project: undefined }),
+    ];
+    expect(filterRepoIssues(issues, 'proj-1').map((i) => i.id)).toEqual(['a']);
+  });
+
+  it('keeps only selectable states (Todo/Backlog/In Progress)', () => {
+    const issues = [
+      issue({ id: 'a', state: 'Todo' }),
+      issue({ id: 'b', state: 'Backlog' }),
+      issue({ id: 'c', state: 'In Progress' }),
+      issue({ id: 'd', state: 'Done' }),
+      issue({ id: 'e', state: 'In Review' }),
+      issue({ id: 'f', state: 'Canceled' }),
+    ];
+    expect(filterRepoIssues(issues, 'proj-1').map((i) => i.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('sorts by priority with Linear "no priority" (0) last, then by identifier', () => {
+    const issues = [
+      issue({ id: 'none', identifier: 'INT-9', priority: 0 }),
+      issue({ id: 'low', identifier: 'INT-8', priority: 4 }),
+      issue({ id: 'urgent', identifier: 'INT-7', priority: 1 }),
+      issue({ id: 'urgent2', identifier: 'INT-10', priority: 1 }),
+    ];
+    expect(filterRepoIssues(issues, 'proj-1').map((i) => i.id)).toEqual([
+      'urgent', 'urgent2', 'low', 'none',
+    ]);
+  });
+
+  it('orders identifier ties numerically (INT-2 before INT-10)', () => {
+    const issues = [
+      issue({ id: 'ten', identifier: 'INT-10', priority: 1 }),
+      issue({ id: 'two', identifier: 'INT-2', priority: 1 }),
+    ];
+    expect(filterRepoIssues(issues, 'proj-1').map((i) => i.id)).toEqual(['two', 'ten']);
+  });
+
+  it('state constants stay disjoint (a state must not be both selectable and skipped)', () => {
+    for (const state of WORK_SELECTABLE_STATES) {
+      expect(WORK_SKIP_STATES).not.toContain(state);
+    }
+  });
+});
+
+describe('formatIssueChoice (INT-3387)', () => {
+  it('renders `[identifier] P<n> title — state`', () => {
+    expect(formatIssueChoice(issue({ identifier: 'INT-42', priority: 1, title: 'Ship it', state: 'Todo' })))
+      .toBe('[INT-42] P1 Ship it — Todo');
+  });
+
+  it('omits the priority tag for "no priority" (0)', () => {
+    expect(formatIssueChoice(issue({ priority: 0, title: 'Later', state: 'Backlog' })))
+      .toBe('[INT-1] Later — Backlog');
+  });
+
+  it('truncates to the column budget with an ellipsis', () => {
+    const long = formatIssueChoice(issue({ title: 'x'.repeat(200) }), 40);
+    expect(long.length).toBeLessThanOrEqual(40);
+    expect(long.endsWith('…')).toBe(true);
+  });
+});
+
+describe('selectIssuesInteractive (INT-3387)', () => {
+  it('maps the prompt selection back to issues, preserving prompt order', async () => {
+    const issues = [issue({ id: 'a', identifier: 'INT-1' }), issue({ id: 'b', identifier: 'INT-2' })];
+    const prompt = vi.fn(async () => ['b', 'a']);
+    const picked = await selectIssuesInteractive(issues, { prompt });
+    expect(picked.map((i) => i.id)).toEqual(['b', 'a']);
+    expect(prompt).toHaveBeenCalledWith(expect.objectContaining({
+      choices: [
+        { name: '[INT-1] P2 Fix the thing — Todo', value: 'a' },
+        { name: '[INT-2] P2 Fix the thing — Todo', value: 'b' },
+      ],
+    }));
+  });
+
+  it('drops ids the prompt returns that are not in the offered set', async () => {
+    const issues = [issue({ id: 'a' })];
+    const picked = await selectIssuesInteractive(issues, { prompt: async () => ['a', 'ghost'] });
+    expect(picked.map((i) => i.id)).toEqual(['a']);
+  });
+
+  it('propagates the prompt rejection (Ctrl-C ExitPromptError) to the caller', async () => {
+    const abort = new Error('ctrl-c');
+    abort.name = 'ExitPromptError';
+    await expect(selectIssuesInteractive([issue()], { prompt: async () => { throw abort; } }))
+      .rejects.toMatchObject({ name: 'ExitPromptError' });
+  });
+});

--- a/src/cli/workSelect.ts
+++ b/src/cli/workSelect.ts
@@ -1,0 +1,74 @@
+// ============================================
+// OpenSwarm - `openswarm work` issue selection (INT-3387)
+// ============================================
+//
+// Pure helpers for the interactive issue picker: filter the team-wide Linear
+// fetch down to this repo's project, format one checkbox row per issue, and
+// run the multi-select prompt. The prompt itself is injectable so tests never
+// need a TTY.
+
+import type { LinearIssueInfo } from '../core/types.js';
+import { truncateLine } from './reviewProgress.js';
+
+/** States the picker offers for deployment. `In Progress` resumes preserved work. */
+export const WORK_SELECTABLE_STATES = ['Todo', 'Backlog', 'In Progress'] as const;
+
+/**
+ * States a directly-addressed issue is refused in: completed or under review
+ * work must not be silently redone, and a cancelled issue is not work at all.
+ */
+export const WORK_SKIP_STATES = ['Done', 'In Review', 'Canceled', 'Cancelled'] as const;
+
+/**
+ * Keep only this repo's actionable issues, ordered by priority (Linear's 0 =
+ * "no priority" sorts last, mirroring linear.ts) then by identifier.
+ */
+export function filterRepoIssues(issues: LinearIssueInfo[], projectId: string): LinearIssueInfo[] {
+  return issues
+    .filter((issue) => issue.project?.id === projectId)
+    .filter((issue) => (WORK_SELECTABLE_STATES as readonly string[]).includes(issue.state))
+    .sort((a, b) => {
+      const pa = a.priority === 0 ? 999 : a.priority;
+      const pb = b.priority === 0 ? 999 : b.priority;
+      if (pa !== pb) return pa - pb;
+      return a.identifier.localeCompare(b.identifier, undefined, { numeric: true });
+    });
+}
+
+/** One checkbox row: `[INT-123] P1 Title — Todo`, truncated to a column budget. */
+export function formatIssueChoice(issue: LinearIssueInfo, width = 100): string {
+  const priority = issue.priority > 0 ? `P${issue.priority} ` : '';
+  return truncateLine(`[${issue.identifier}] ${priority}${issue.title} — ${issue.state}`, width);
+}
+
+export interface SelectIssuesDeps {
+  /** Multi-select prompt returning the chosen issue ids (default: @inquirer/prompts checkbox). */
+  prompt?: (options: {
+    message: string;
+    choices: Array<{ name: string; value: string }>;
+    pageSize?: number;
+  }) => Promise<string[]>;
+}
+
+/**
+ * Interactive multi-select over the filtered issues. Throws @inquirer's
+ * ExitPromptError on Ctrl-C — the caller treats it as a quiet exit.
+ */
+export async function selectIssuesInteractive(
+  issues: LinearIssueInfo[],
+  deps: SelectIssuesDeps = {},
+): Promise<LinearIssueInfo[]> {
+  const prompt = deps.prompt ?? (async (options) => {
+    const { checkbox } = await import('@inquirer/prompts');
+    return checkbox<string>(options);
+  });
+  const byId = new Map(issues.map((issue) => [issue.id, issue]));
+  const pickedIds = await prompt({
+    message: 'Select issues to deploy agents on:',
+    choices: issues.map((issue) => ({ name: formatIssueChoice(issue), value: issue.id })),
+    pageSize: 15,
+  });
+  return pickedIds
+    .map((id) => byId.get(id))
+    .filter((issue): issue is LinearIssueInfo => !!issue);
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -67,6 +67,8 @@ export type LinearIssueInfo = {
   project?: LinearProjectInfo;
   /** Issue UUIDs that block this issue (from structured relations + "블로커:" prose). */
   blockedBy?: string[];
+  /** ISO timestamp of issue creation — duplicate grooming orders peers by real age. (INT-3387) */
+  createdAt?: string;
 };
 
 /**

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -75,6 +75,7 @@ interface RawIssueNode {
   title: string;
   description?: string | null;
   priority: number;
+  createdAt?: string;
   updatedAt?: string;
   state?: { name?: string } | null;
   project?: { id: string; name: string; icon?: string | null; color?: string | null } | null;
@@ -91,6 +92,7 @@ const ISSUES_QUERY = `
         title
         description
         priority
+        createdAt
         state { name }
         project { id name icon color }
         labels { nodes { name } }
@@ -673,6 +675,7 @@ export async function getMyIssues(
           labels: issue.labels?.nodes?.map((l) => l.name) ?? [],
           comments: [],
           project: p ? { id: p.id, name: p.name, icon: p.icon ?? undefined, color: p.color ?? undefined } : undefined,
+          createdAt: issue.createdAt,
         } as LinearIssueInfo);
       }
 
@@ -781,6 +784,25 @@ export async function getIssue(issueIdOrIdentifier: string): Promise<LinearIssue
       getProjectInfo(issue),
     ]);
 
+    // Blockers from BOTH sources. The bulk (slim) path only parses prose;
+    // this single-issue path can afford the structured-relations call, and
+    // `openswarm work`'s unresolved-blocker gate depends on it — without
+    // this, direct-id dispatch never saw any blocker at all.
+    const blockedBy = new Set<string>();
+    try {
+      const inverse = await issue.inverseRelations();
+      for (const rel of inverse.nodes) {
+        if (rel.type !== 'blocks') continue;
+        const blocker = await rel.issue;
+        if (blocker?.id && blocker.id !== issue.id) blockedBy.add(blocker.id);
+      }
+    } catch {
+      // relations unavailable — prose below still covers the common case
+    }
+    for (const ident of parseBlockerIdentifiers(issue.description ?? undefined)) {
+      if (ident.toUpperCase() !== issue.identifier.toUpperCase()) blockedBy.add(ident);
+    }
+
     return {
       id: issue.id,
       identifier: issue.identifier,
@@ -796,6 +818,8 @@ export async function getIssue(issueIdOrIdentifier: string): Promise<LinearIssue
         user: undefined,
       })),
       project,
+      blockedBy: blockedBy.size > 0 ? [...blockedBy] : undefined,
+      createdAt: issue.createdAt instanceof Date ? issue.createdAt.toISOString() : undefined,
     };
   } catch (error) {
     // Fixed first argument: the id is user-supplied (reachable from the

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -196,7 +196,7 @@ const ALLOWED_COMMANDS = new Set([
   'add', 'annotate', 'auth', 'chat', 'check', 'dash', 'design-pipeline', 'doctor',
   'exec', 'fix', 'init', 'login', 'logout', 'mcp', 'memory', 'models', 'openswarm',
   'pr', 'projects', 'provider', 'remove', 'resume', 'review', 'run', 'schedule', 'start',
-  'status', 'stop', 'upgrade', 'validate', 'version',
+  'status', 'stop', 'upgrade', 'validate', 'version', 'work',
 ]);
 
 /**


### PR DESCRIPTION
## Summary
The explicit replacement for the disabled autonomous heartbeat: pick Linear issues, get one agent per issue in an isolated worktree.

```
openswarm work INT-123 INT-456     # direct ids
openswarm work                     # interactive checkbox multi-select
  --path <repo> --concurrency <n> --dry-run --yes --adapter <name> --json
```

- `workCommand.ts`: bootstrap (Linear task source + `setTaskSource`) → issue resolution (fail-fast on unknown ids; Done/In Review/Canceled gated; In Progress = resume) → `DurableRunCoordinator` (primary, shared `~/.openswarm/automation.db` — daemon collisions blocked by ledger claims) + `runPool` → outbox delivery (Done transitions) → summary/`--json`. SIGINT once = abort + preserve worktrees with resume hint; twice = exit 130.
- `workExecution.ts`: CLI ExecutionContext (worktreeMode forced on, decomposition forced off), pure `resolveRolesForProject` port, `--adapter` override.
- `trackerEffects.ts`: the daemon's completion/cancellation outbox helpers extracted verbatim into a shared module (daemon delegates to it — wire-format drift between CLI and daemon is now structurally impossible), contract-tested (`complete:{issueId}:attempt:{n}`, `tracker.complete`).
- `workSelect.ts`: first use of `@inquirer/checkbox`.
- telemetry ALLOWED_COMMANDS + cli.ts registration.

## Test plan
- [x] 74 new tests (workCommand 40 / workSelect 11 / workExecution 23) + telemetry 40, all passing; no real delays
- [x] `npm run test:coverage` exit 0 (lines 92.59% / statements 90.52% / functions 90.59% / branches 81.29%)
- [x] typecheck (incl. separate test-file pass) + oxlint clean
- [x] CLI smoke: `work --help`, `work NONEXIST-999 --dry-run` → exit 2 against real Linear

Closes INT-3387. Note: touches `autonomousRunner.ts` (helper extraction) — will need a trivial merge after the daemon-side PR (#395) lands.