### PR TITLE
fix(web): 이슈 보드 deploy가 Tauri 셸에서 무반응 + 저장소 목록 중복 (INT-3395)

### DIFF
--- a/src/support/healthEndpoint.test.ts
+++ b/src/support/healthEndpoint.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 import { buildHealthPayload } from './healthEndpoint.js';
 
 const lifecycle = vi.hoisted(() => ({
@@ -161,5 +162,45 @@ describe('GET /api/health over the live server', () => {
     } finally {
       await stopWebServer();
     }
+  });
+
+  it('collapses tilde/absolute spellings of one repo in /api/work/projects (INT-3395)', async () => {
+    const { tryHandleAppRoutes } = await import('./webAppRoutes.js');
+    const { homedir } = await import('node:os');
+
+    // repos.json persists both spellings so the denylist matches either; the
+    // picker must not show the same repo twice.
+    const runner = {
+      getAllowedProjects: () => [
+        '~/dev/de-artifact',
+        '~/dev/kyte-portal',
+        `${homedir()}/dev/kyte-portal`,
+        `${homedir()}/dev/de-artifact`,
+      ],
+    } as unknown as Parameters<typeof tryHandleAppRoutes>[4];
+
+    let status = 0;
+    let payload = '';
+    const res = {
+      writeHead: (code: number) => { status = code; },
+      end: (body: string) => { payload = body; },
+    } as unknown as ServerResponse;
+
+    const handled = await tryHandleAppRoutes(
+      { method: 'GET', headers: {} } as IncomingMessage,
+      res,
+      '/api/work/projects',
+      new URL('http://127.0.0.1/api/work/projects'),
+      runner,
+      async () => '',
+    );
+
+    expect(handled).toBe(true);
+    expect(status).toBe(200);
+    // First spelling wins; each repo appears exactly once.
+    expect(JSON.parse(payload)).toEqual([
+      { path: '~/dev/de-artifact', name: 'de-artifact' },
+      { path: '~/dev/kyte-portal', name: 'kyte-portal' },
+    ]);
   });
 });

--- a/src/support/webAppRoutes.ts
+++ b/src/support/webAppRoutes.ts
@@ -82,8 +82,21 @@ export async function tryHandleAppRoutes(
     // accepts, so the picker can never offer a path that would 403.
     // (/api/local-projects scans CHILDREN of allowed paths and omits the
     // allowed repos themselves, so it disagrees with the boundary check.)
-    const paths = runner?.getAllowedProjects() ?? [];
-    writeJson(res, 200, paths.map((path) => ({ path, name: path.split('/').filter(Boolean).pop() ?? path })));
+    //
+    // allowedProjects holds both tilde and absolute spellings of the same repo
+    // (repos.json writes both so the denylist matches either), which the picker
+    // would otherwise show as duplicate entries. Collapse by the same
+    // normalization the boundary check applies, keeping the first spelling.
+    const { normalizeProjectPath } = await import('../orchestration/taskScheduler.js');
+    const seen = new Set<string>();
+    const projects: Array<{ path: string; name: string }> = [];
+    for (const path of runner?.getAllowedProjects() ?? []) {
+      const canonical = normalizeProjectPath(path);
+      if (seen.has(canonical)) continue;
+      seen.add(canonical);
+      projects.push({ path, name: path.split('/').filter(Boolean).pop() ?? path });
+    }
+    writeJson(res, 200, projects);
     return true;
   }
 

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -154,6 +154,9 @@ body {
 }
 .deploy-btn:disabled { background: var(--surface2); color: var(--muted); cursor: default; }
 .deploy-btn:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
+/* Two-step confirmation state (in-page consent — the Tauri WebView has no JS dialogs). */
+.deploy-btn.arm { background: var(--warning); }
+#selection-summary.error { color: var(--error); }
 
 .work-cards {
   flex: 1;

--- a/web/static/js/issueBoard.mjs
+++ b/web/static/js/issueBoard.mjs
@@ -16,6 +16,8 @@ export class IssueBoard {
   #selected = new Set();
   #projectPath = '';
   #renderSequence = 0;
+  #armed = false;
+  #armTimer = null;
 
   constructor({ listEl, countEl, summaryEl, deployBtn, fetchIssues, dispatch, onDeployed }) {
     this.#listEl = listEl;
@@ -107,33 +109,58 @@ export class IssueBoard {
   }
 
   #syncFooter() {
+    this.#disarm();
     const n = this.#selected.size;
-    this.#summaryEl.textContent = `${n} selected`;
+    this.#status(`${n} selected`);
     this.#deployBtn.disabled = n === 0;
     this.#deployBtn.textContent = n > 0 ? `Deploy ${n} agent${n > 1 ? 's' : ''}` : 'Deploy agents';
+  }
+
+  #status(text, isError = false) {
+    this.#summaryEl.textContent = text;
+    this.#summaryEl.classList.toggle('error', isError);
+  }
+
+  #disarm() {
+    if (this.#armTimer) {
+      clearTimeout(this.#armTimer);
+      this.#armTimer = null;
+    }
+    this.#armed = false;
+    this.#deployBtn.classList.remove('arm');
   }
 
   async #deploy() {
     const ids = this.selectedIds;
     if (!ids.length || !this.#projectPath) return;
-    const identifiers = this.#issues
-      .filter((issue) => this.#selected.has(issue.id))
-      .map((issue) => issue.identifier);
-    // Explicit, scoped consent before the side effect.
-    const confirmed = window.confirm(
-      `Deploy ${ids.length} agent(s) into ${this.#projectPath}?\n\n${identifiers.join(', ')}`,
-    );
-    if (!confirmed) return;
 
+    // Consent is an in-page two-step arm, NOT window.confirm: the Tauri shell's
+    // WKWebView implements no JS dialogs, so confirm()/alert() return falsy
+    // without showing anything — the deploy click was silently swallowed there.
+    if (!this.#armed) {
+      const identifiers = this.#issues
+        .filter((issue) => this.#selected.has(issue.id))
+        .map((issue) => issue.identifier);
+      this.#armed = true;
+      this.#deployBtn.classList.add('arm');
+      this.#deployBtn.textContent = `Confirm: deploy ${ids.length}?`;
+      this.#status(`${identifiers.join(', ')} → ${this.#projectPath} — click again to confirm.`);
+      this.#armTimer = setTimeout(() => this.#syncFooter(), 6000);
+      return;
+    }
+
+    this.#disarm();
     this.#deployBtn.disabled = true;
     this.#deployBtn.textContent = 'Deploying…';
     try {
       const result = await this.#dispatch(this.#projectPath, ids);
       this.#onDeployed?.(result);
       await this.loadFor(this.#projectPath);
+      // After loadFor's re-render resets the footer, surface the outcome.
+      this.#status(`Queued ${result?.queued ?? 0}, skipped ${result?.skipped ?? 0}.`);
     } catch (err) {
-      window.alert(err?.message ?? 'Dispatch failed');
       this.#syncFooter();
+      this.#status(err?.message ?? 'Dispatch failed', true);
     }
   }
 }


### PR DESCRIPTION
## 문제

1. **Deploy 무반응** — 데스크탑 셸에서 이슈를 골라 "Deploy N agents"를 눌러도 아무 일도 일어나지 않음 (POST /api/work 자체가 안 나감).
2. **저장소 목록 중복** — 피커에 같은 레포가 두 번씩 표시.

## 원인

1. `issueBoard.mjs`가 배포 확인을 `window.confirm()`으로 받는데, **Tauri(wry) WKWebView는 JS 다이얼로그를 구현하지 않아** 다이얼로그 없이 falsy를 반환 → 조용히 중단. 브라우저에서만 동작. 에러 경로의 `window.alert`도 같은 이유로 무음.
2. `allowedProjects`가 같은 레포의 tilde(`~/dev/x`)/absolute(`/Users/me/dev/x`) 두 표기를 모두 담고 있음 (denylist가 양쪽 다 매칭하도록 repos.json이 둘 다 기록).

## 수정

- 다이얼로그 대신 **인페이지 2단계 확인**: 1클릭 → 버튼이 `Confirm: deploy N?`(warning 톤) + 6초 자동 해제 + 선택 변경 시 해제, 2클릭 → dispatch. 에러/결과(`Queued N, skipped M`)는 footer 상태줄에 인라인 표시.
- `/api/work/projects`를 dispatch 경계와 **동일한 `normalizeProjectPath`로 dedupe** (첫 표기 유지).

## 검증

- 실제 데몬 상대로 라이브 확인: arm 상태 → footer 힌트 → 6초 자동 해제 전부 동작
- `/api/work/projects`가 dispatch 가능한 3개만 반환 (이전 5개, 중복 2건)
- 커밋 게이트 `openswarm review` **APPROVE** ×2 (각 커밋별)
- 타깃 테스트 27건 + tsc/oxlint clean

> 참고: "not in the daemon's allowed projects" 오류를 봤다면 stale `dist/web-static`입니다 — 구 번들은 `/api/local-projects`(허용 경로의 **하위** 디렉터리·worktree를 스캔)를 써서 경계 검사가 거부하는 경로를 제안했습니다. `npm run build`로 갱신되며, `/api/work/projects`는 dispatch 가능한 경로만 제공합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)