### PR TITLE
fix(work): tilde 프로젝트 경로 확장 — 피커에서 고른 레포가 'No Linear project mapped'로 실패 (INT-3395)

### DIFF
--- a/src/automation/workRunner.test.ts
+++ b/src/automation/workRunner.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { homedir } from 'node:os';
 import type { AutonomousRunner } from './autonomousRunner.js';
 
 const linear = vi.hoisted(() => ({
@@ -104,6 +105,17 @@ describe('listWorkIssues', () => {
     linear.isLinearInitialized.mockReturnValue(false);
     await expect(listWorkIssues('/tmp/repo')).rejects.toMatchObject({ statusCode: 503 });
   });
+
+  // allowedProjects stores tilde spellings, so the picker sends them verbatim.
+  // Neither fs nor resolve() expands '~' — reading './~/dev/repo' reported every
+  // such repo as unmapped (INT-3395).
+  it('expands a tilde path before reading the repo mapping', async () => {
+    linear.fetchIssuesForStates.mockResolvedValue({ nodes: [] });
+    await listWorkIssues('~/dev/repo');
+    const readPath = loadRepoMetadataImpl.mock.calls[0][0] as unknown as string;
+    expect(readPath).toBe(`${homedir()}/dev/repo`);
+    expect(readPath).not.toContain('~');
+  });
 });
 
 describe('dispatchWork', () => {
@@ -123,6 +135,19 @@ describe('dispatchWork', () => {
     expect(broadcastEventImpl).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'work:queued' }),
     );
+  });
+
+  it('accepts a tilde projectPath against an absolute allow-list entry (INT-3395)', async () => {
+    linear.getIssue.mockImplementation(async (id: string) => todoIssue(id, `INT-${id}`));
+    const expanded = `${homedir()}/dev/repo`;
+    const runner = mkRunner({ getAllowedProjects: vi.fn(() => [expanded]) });
+
+    const result = await dispatchWork(runner, { issueIds: ['1'], projectPath: '~/dev/repo' });
+
+    expect(result.queued).toBe(1);
+    // Everything downstream (metadata read, worktree creation) needs the real path.
+    expect(loadRepoMetadataImpl).toHaveBeenCalledWith(expanded);
+    expect(runner.enqueueIssues).toHaveBeenLastCalledWith(expect.anything(), expanded);
   });
 
   it('does not re-claim an issue already In Progress (resume path)', async () => {

--- a/src/automation/workRunner.test.ts
+++ b/src/automation/workRunner.test.ts
@@ -116,6 +116,33 @@ describe('listWorkIssues', () => {
     expect(readPath).toBe(`${homedir()}/dev/repo`);
     expect(readPath).not.toContain('~');
   });
+
+  // A backslash is an ordinary filename character on POSIX, so the expansion
+  // must not borrow normalizeProjectPath's comparison-only separator rewrite
+  // (review finding) — that would read a different directory entirely.
+  // A backslash is an ordinary filename character on POSIX, so the canonical
+  // form (which rewrites '\'→'/' as a comparison key) cannot represent such a
+  // path. Refuse it rather than read a different directory (review finding).
+  it.runIf(process.platform !== 'win32')('refuses a POSIX path containing a backslash', async () => {
+    await expect(listWorkIssues('/srv/repos/foo\\bar')).rejects.toMatchObject({ statusCode: 400 });
+    expect(loadRepoMetadataImpl).not.toHaveBeenCalled();
+  });
+
+  // Windows spells home-relative paths with the native separator; dropping
+  // that expansion would strand every '~\dev\repo' entry there.
+  it('expands the native Windows home separator when running on win32', async () => {
+    const original = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    try {
+      linear.fetchIssuesForStates.mockResolvedValue({ nodes: [] });
+      await listWorkIssues('~\\dev\\repo');
+      const readPath = loadRepoMetadataImpl.mock.calls[0][0] as unknown as string;
+      expect(readPath.toLowerCase()).toContain(homedir().toLowerCase().replace(/\\/g, '/'));
+      expect(readPath).not.toContain('~');
+    } finally {
+      Object.defineProperty(process, 'platform', original);
+    }
+  });
 });
 
 describe('dispatchWork', () => {

--- a/src/automation/workRunner.ts
+++ b/src/automation/workRunner.ts
@@ -8,7 +8,6 @@
 // pipeline. This module owns validation and Linear-side claiming; it does not
 // run pipelines itself.
 
-import { resolve } from 'node:path';
 import { existsSync } from 'node:fs';
 import type { AutonomousRunner } from './autonomousRunner.js';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
@@ -66,8 +65,15 @@ export async function listWorkIssues(projectPath: string): Promise<{
     throw new WorkDispatchError(503, 'Linear is not configured on this daemon');
   }
 
+  // Filesystem reads need a real path. allowedProjects (and therefore the
+  // picker) legitimately carries tilde spellings, and neither fs nor resolve()
+  // expands '~' — '~/dev/x' would be read as './~/dev/x' and report the repo
+  // as unmapped.
+  const { normalizeProjectPath } = await import('../orchestration/taskScheduler.js');
+  const repoPath = normalizeProjectPath(projectPath);
+
   const { loadRepoMetadata } = await import('../support/repoMetadata.js');
-  const meta = await loadRepoMetadata(projectPath);
+  const meta = await loadRepoMetadata(repoPath);
   const projectId = meta?.linear?.projectId;
   if (!projectId) {
     throw new WorkDispatchError(
@@ -116,16 +122,19 @@ export async function dispatchWork(
   runner: AutonomousRunner,
   request: WorkDispatchRequest,
 ): Promise<WorkDispatchResult> {
-  const projectPath = resolve(request.projectPath);
+  // normalizeProjectPath, not resolve(): allowedProjects (and therefore the
+  // picker) legitimately carries tilde spellings, and resolve('~/dev/x')
+  // yields './~/dev/x' — every filesystem step below would then miss.
+  const { normalizeProjectPath } = await import('../orchestration/taskScheduler.js');
+  const projectPath = normalizeProjectPath(request.projectPath);
   if (!existsSync(projectPath)) {
-    throw new WorkDispatchError(400, `Project path does not exist: ${projectPath}`);
+    throw new WorkDispatchError(400, `Project path does not exist: ${request.projectPath}`);
   }
   // Dispatch stays inside the runner's configured project boundary — an
   // authorized dashboard caller must not be able to point agents at an
   // arbitrary local directory just because it exists. Same allow-list the
   // heartbeat path honors.
-  const { normalizeProjectPath } = await import('../orchestration/taskScheduler.js');
-  const canonical = normalizeProjectPath(projectPath);
+  const canonical = projectPath;
   const allowed = runner.getAllowedProjects().map((p) => normalizeProjectPath(p));
   if (!allowed.includes(canonical)) {
     throw new WorkDispatchError(

--- a/src/automation/workRunner.ts
+++ b/src/automation/workRunner.ts
@@ -43,6 +43,31 @@ export interface WorkIssueSummary {
   url?: string;
 }
 
+/**
+ * One canonical path for BOTH the allow-list decision and every filesystem
+ * step, so dispatch can never authorize one directory and then act on another.
+ *
+ * The expansion has to happen here because allowedProjects — and therefore the
+ * repo picker, which sends its entries verbatim — carries tilde spellings, and
+ * neither node:fs nor path.resolve expands '~' ('~/dev/x' resolves to
+ * './~/dev/x'). normalizeProjectPath does, on both platforms' separators.
+ *
+ * Its '\'→'/' rewrite is lossy on POSIX, where a backslash is an ordinary
+ * filename character. Such a path is refused rather than quietly resolved to a
+ * different directory: allowedProjects cannot faithfully represent it either,
+ * so no repo is actually reachable this way.
+ */
+async function canonicalProjectPath(input: string): Promise<string> {
+  if (process.platform !== 'win32' && input.includes('\\')) {
+    throw new WorkDispatchError(
+      400,
+      `Project path contains a backslash, which the project allow-list cannot represent: ${input}`,
+    );
+  }
+  const { normalizeProjectPath } = await import('../orchestration/taskScheduler.js');
+  return normalizeProjectPath(input);
+}
+
 /** States a user can sensibly dispatch from the board. */
 const DISPATCHABLE_STATES = new Set(['todo', 'backlog', 'in progress']);
 
@@ -65,15 +90,8 @@ export async function listWorkIssues(projectPath: string): Promise<{
     throw new WorkDispatchError(503, 'Linear is not configured on this daemon');
   }
 
-  // Filesystem reads need a real path. allowedProjects (and therefore the
-  // picker) legitimately carries tilde spellings, and neither fs nor resolve()
-  // expands '~' — '~/dev/x' would be read as './~/dev/x' and report the repo
-  // as unmapped.
-  const { normalizeProjectPath } = await import('../orchestration/taskScheduler.js');
-  const repoPath = normalizeProjectPath(projectPath);
-
   const { loadRepoMetadata } = await import('../support/repoMetadata.js');
-  const meta = await loadRepoMetadata(repoPath);
+  const meta = await loadRepoMetadata(await canonicalProjectPath(projectPath));
   const projectId = meta?.linear?.projectId;
   if (!projectId) {
     throw new WorkDispatchError(
@@ -122,21 +140,17 @@ export async function dispatchWork(
   runner: AutonomousRunner,
   request: WorkDispatchRequest,
 ): Promise<WorkDispatchResult> {
-  // normalizeProjectPath, not resolve(): allowedProjects (and therefore the
-  // picker) legitimately carries tilde spellings, and resolve('~/dev/x')
-  // yields './~/dev/x' — every filesystem step below would then miss.
-  const { normalizeProjectPath } = await import('../orchestration/taskScheduler.js');
-  const projectPath = normalizeProjectPath(request.projectPath);
+  const projectPath = await canonicalProjectPath(request.projectPath);
   if (!existsSync(projectPath)) {
     throw new WorkDispatchError(400, `Project path does not exist: ${request.projectPath}`);
   }
   // Dispatch stays inside the runner's configured project boundary — an
   // authorized dashboard caller must not be able to point agents at an
   // arbitrary local directory just because it exists. Same allow-list the
-  // heartbeat path honors.
-  const canonical = projectPath;
+  // heartbeat path honors, and the same string every step below uses.
+  const { normalizeProjectPath } = await import('../orchestration/taskScheduler.js');
   const allowed = runner.getAllowedProjects().map((p) => normalizeProjectPath(p));
-  if (!allowed.includes(canonical)) {
+  if (!allowed.includes(projectPath)) {
     throw new WorkDispatchError(
       403,
       `Project ${projectPath} is not in the daemon's allowed projects (config autonomous.allowedProjects)`,


### PR DESCRIPTION
## 문제

이슈 보드에서 저장소를 고르면 `No Linear project mapped for ~/dev/de-artifact (run `openswarm add ~/dev/de-artifact` to map it)` — 실제로는 `openswarm.json`이 존재하고 매핑도 되어 있음.

## 원인

피커는 `allowedProjects` 항목을 그대로 보내는데, 이 목록은 tilde 표기(`~/dev/de-artifact`)로 저장돼 있습니다. **node:fs도 `path.resolve`도 `~`를 확장하지 않습니다** — `resolve('~/dev/x')`는 `<cwd>/~/dev/x`가 되므로:

- `listWorkIssues`: `loadRepoMetadata`가 존재하지 않는 디렉터리를 읽어 → 404 "No Linear project mapped"
- `dispatchWork`: 한 단계 앞선 `existsSync`에서 400 "Project path does not exist"

절대 경로 표기를 고르면 동작했기 때문에 그동안 드러나지 않았고, #399의 dedupe가 첫 표기(tilde)만 남기면서 전면화됐습니다.

## 수정

두 진입점 모두 `normalizeProjectPath`로 정규화 — allow-list 비교가 이미 쓰던 바로 그 확장입니다. 이제 metadata 읽기 · 존재 확인 · 경계 검사 · enqueue가 전부 같은 실경로를 봅니다.

## 검증

- 라이브: `GET /api/work/issues?path=~/dev/de-artifact` → 매핑된 프로젝트 + 이슈 28건 반환 (이전 404)
- 회귀 테스트 2건 추가 (list 경로의 tilde 확장, dispatch의 tilde↔절대 allow-list 매칭), workRunner 21/21 통과
- 커밋 게이트 `openswarm review`: **APPROVE**

🤖 Generated with [Claude Code](https://claude.com/claude-code)