### PR TITLE
feat(web): 이슈 보드 카드에 세션 실시간 콘솔 (INT-3397)

### DIFF
--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -568,6 +568,14 @@ export class PairPipeline extends EventEmitter {
               .filter(r => !r.passed && !r.blocking)
               .flatMap(r => r.issues),
             processContext: { taskId: context.task.id, stage: 'reviewer' },
+            // runReviewer has always accepted onLog; nothing passed one, so the
+            // reviewer's turns never reached the dashboard/desktop console the
+            // way the worker's do. (INT-3397)
+            onLog: (line: string) =>
+              broadcastEvent({
+                type: 'log',
+                data: { taskId: context.task.id, stage: 'reviewer', line: `[${prefix}] ${line}` },
+              }),
             signal: this.abortSignal,
           };
 

--- a/tests/web/pendingLogBuffer.test.ts
+++ b/tests/web/pendingLogBuffer.test.ts
@@ -1,0 +1,67 @@
+// The DOM-free half of the issue board's console recovery path (INT-3397):
+// lines that arrive before their card exists are parked, bounded, and moved —
+// never duplicated — when the card materializes. This file lives under tests/
+// (not src/) because it imports a browser ESM asset; vitest transpiles it,
+// while `tsc -p .` only covers src/.
+
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — browser ESM asset without type declarations
+import { PendingLogBuffer } from '../../web/static/js/pendingLogBuffer.mjs';
+
+type Entry = { stage: string; line: string };
+const entry = (line: string, stage = 'worker'): Entry => ({ stage, line });
+
+describe('PendingLogBuffer', () => {
+  it('parks lines and moves them out in arrival order exactly once', () => {
+    const buffer = new PendingLogBuffer();
+    buffer.park('t1', entry('first'));
+    buffer.park('t1', entry('second'));
+    buffer.park('t1', entry('third', 'reviewer'));
+
+    const flushed = buffer.takeFor('t1');
+    expect(flushed.map((e: Entry) => e.line)).toEqual(['first', 'second', 'third']);
+    // Moved, not copied — a second take yields nothing (no duplication).
+    expect(buffer.takeFor('t1')).toEqual([]);
+    expect(buffer.taskCount).toBe(0);
+  });
+
+  it('returns an empty array for a task that never parked anything', () => {
+    const buffer = new PendingLogBuffer();
+    expect(buffer.takeFor('unknown')).toEqual([]);
+  });
+
+  it('caps lines per task by dropping the oldest', () => {
+    const buffer = new PendingLogBuffer({ maxLines: 3 });
+    for (const line of ['a', 'b', 'c', 'd', 'e']) buffer.park('t1', entry(line));
+    expect(buffer.takeFor('t1').map((e: Entry) => e.line)).toEqual(['c', 'd', 'e']);
+  });
+
+  it('evicts the oldest task when the task cap is exceeded', () => {
+    const buffer = new PendingLogBuffer({ maxTasks: 2 });
+    buffer.park('t1', entry('one'));
+    buffer.park('t2', entry('two'));
+    buffer.park('t3', entry('three')); // evicts t1
+
+    expect(buffer.takeFor('t1')).toEqual([]);
+    expect(buffer.takeFor('t2').map((e: Entry) => e.line)).toEqual(['two']);
+    expect(buffer.takeFor('t3').map((e: Entry) => e.line)).toEqual(['three']);
+  });
+
+  it('parking again after a take starts a fresh queue (task id reuse)', () => {
+    const buffer = new PendingLogBuffer();
+    buffer.park('t1', entry('old'));
+    buffer.takeFor('t1');
+    buffer.park('t1', entry('new'));
+    expect(buffer.takeFor('t1').map((e: Entry) => e.line)).toEqual(['new']);
+  });
+
+  it('an existing task queue does not count as a new task for eviction', () => {
+    const buffer = new PendingLogBuffer({ maxTasks: 2 });
+    buffer.park('t1', entry('one'));
+    buffer.park('t2', entry('two'));
+    // t1 already has a queue — parking more must not evict anyone.
+    buffer.park('t1', entry('one-more'));
+    expect(buffer.taskCount).toBe(2);
+    expect(buffer.takeFor('t2').map((e: Entry) => e.line)).toEqual(['two']);
+  });
+});

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -211,3 +211,47 @@ body {
   white-space: pre-wrap;
 }
 .work-card a { color: var(--accent); font-size: var(--text-xs); }
+
+/* Live agent output — a terminal pane fed by the hub's `log` events. */
+.console-toggle {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--muted);
+  font-size: var(--text-xs);
+  padding: 2px 8px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.console-toggle:hover { color: var(--text); border-color: var(--muted); }
+.console-toggle:focus-visible { outline: 2px solid var(--focus); outline-offset: 1px; }
+
+.work-card .console {
+  margin-top: 8px;
+  /* Deep ground against the card so the stream reads as a terminal. */
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 6px 8px;
+  /* Tall enough to show context, capped so several cards stay visible. */
+  max-height: 260px;
+  overflow-y: auto;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  color: var(--text);
+}
+.work-card .console:empty { display: none; }
+.work-card.console-hidden .console { display: none; }
+
+.work-card .console-line {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.work-card .console-stage {
+  color: var(--accent);
+  margin: 6px 0 2px;
+  white-space: nowrap;
+}
+.work-card .console-stage:first-child { margin-top: 0; }

--- a/web/static/js/main.mjs
+++ b/web/static/js/main.mjs
@@ -41,8 +41,13 @@ const picker = new RepoPicker(document.getElementById('repo-picker'), {
 const events = new EventStream();
 events
   .on('pipeline:stage', (data) => workCards.onStage(data))
+  .on('log', (data) => workCards.onLog(data))
   .on('$open', () => pollHealth())
   .on('$down', () => setDaemonStatus('down', 'reconnecting…'));
+// Connect immediately — delaying SSE behind the snapshot fetch opened a
+// live-output blind window. Ordering against the async stage snapshot does
+// not matter: log lines that arrive before their card exists are parked in
+// WorkCards' bounded pending buffer and flushed when the card materializes.
 events.connect();
 
 (async () => {
@@ -55,11 +60,16 @@ events.connect();
   } catch (err) {
     console.error('Failed to load projects', err);
   }
-  // Recover in-flight work after a reload from the stage replay buffer.
+  // Recover in-flight work from the stage snapshot. Stage events are folded
+  // idempotently, so replaying them on top of the SSE replay is harmless.
+  //
+  // Console history deliberately has NO snapshot pass of its own: the SSE
+  // replay is the single source for console recovery — fewer lines than
+  // /api/logs would carry, but each line exactly once (no duplication).
   try {
     const stages = await api.stages();
     workCards.seed(Array.isArray(stages) ? stages : stages?.stages);
   } catch {
-    // stage snapshot is best-effort
+    // stage snapshot is best-effort — SSE replay still seeds recent cards
   }
 })();

--- a/web/static/js/pendingLogBuffer.mjs
+++ b/web/static/js/pendingLogBuffer.mjs
@@ -1,0 +1,56 @@
+// Bounded holding area for log lines whose work card does not exist yet.
+// (INT-3397)
+//
+// After a reload, the SSE replay and the /api/stages snapshot race, and a
+// task's stage events can fall out of both windows while its recent log lines
+// survive — so an unknown-task line cannot simply be dropped. It cannot create
+// a card either (the hub broadcasts every task the daemon runs, not just ones
+// this user deployed). Parking is the middle ground: lines wait here, bounded,
+// until the task's card materializes.
+//
+// DOM-free on purpose: this is the unit-testable half of the console recovery
+// path, and the seed of the session cockpit's transcript model.
+
+export class PendingLogBuffer {
+  #queues = new Map(); // taskId -> [{stage, line}] in arrival order
+  #maxTasks;
+  #maxLines;
+
+  constructor({ maxTasks = 20, maxLines = 100 } = {}) {
+    this.#maxTasks = maxTasks;
+    this.#maxLines = maxLines;
+  }
+
+  /** Park one line for a task that has no card yet. */
+  park(taskId, entry) {
+    let queue = this.#queues.get(taskId);
+    if (!queue) {
+      if (this.#queues.size >= this.#maxTasks) {
+        // Map iteration order is insertion order — evict the oldest task, so
+        // daemon work that never materializes a card cannot grow memory.
+        const oldest = this.#queues.keys().next().value;
+        this.#queues.delete(oldest);
+      }
+      queue = [];
+      this.#queues.set(taskId, queue);
+    }
+    queue.push(entry);
+    if (queue.length > this.#maxLines) queue.shift();
+  }
+
+  /**
+   * Remove and return the parked lines for a task (empty array when none).
+   * Moving — not copying — is what guarantees a flushed line can never be
+   * delivered twice.
+   */
+  takeFor(taskId) {
+    const queue = this.#queues.get(taskId);
+    if (!queue) return [];
+    this.#queues.delete(taskId);
+    return queue;
+  }
+
+  get taskCount() {
+    return this.#queues.size;
+  }
+}

--- a/web/static/js/workCards.mjs
+++ b/web/static/js/workCards.mjs
@@ -1,14 +1,29 @@
-// Per-task progress cards folded from pipeline:stage SSE events. (INT-3388)
+// Per-task progress cards folded from pipeline:stage SSE events, each with a
+// live console of the agent's own output. (INT-3388, console INT-3397)
 //
 // Honest feedback: cards only ever show stages the daemon actually reported —
 // no synthetic spinners. `seed()` replays the /api/stages snapshot so a page
-// reload recovers in-flight work.
+// reload recovers in-flight work; console history comes from the SSE replay
+// buffer alone (see main.mjs — seeding it twice duplicated every line).
+
+import { PendingLogBuffer } from './pendingLogBuffer.mjs';
 
 const STATUS_GLYPH = { start: '▸', complete: '✓', fail: '✗' };
 
+// Ring buffer per card. The agent stream is chatty (one line per tool call and
+// per reasoning chunk); an unbounded console would grow without limit across a
+// long run.
+const CONSOLE_MAX_LINES = 500;
+
+// A console counts as "following" while the viewer is within this many pixels
+// of the bottom. Scrolling up parks it — the classic terminal contract, so a
+// line you are reading is never yanked away.
+const FOLLOW_THRESHOLD_PX = 24;
+
 export class WorkCards {
   #container;
-  #cards = new Map(); // taskId -> { el, stages: Map<stage, lineEl> }
+  #cards = new Map(); // taskId -> { el, stages: Map<stage, lineEl>, console, lastLogStage }
+  #pendingLogs = new PendingLogBuffer(); // lines awaiting their card (see module doc)
 
   constructor(container) {
     this.#container = container;
@@ -41,7 +56,7 @@ export class WorkCards {
       const label = document.createElement('span');
       label.className = 'label';
       line.append(glyph, label);
-      card.el.appendChild(line);
+      card.stagesEl.appendChild(line);
       card.stages.set(data.stage, line);
     }
     line.dataset.status = data.status;
@@ -59,10 +74,62 @@ export class WorkCards {
       if (!errorEl) {
         errorEl = document.createElement('div');
         errorEl.className = 'error';
-        card.el.appendChild(errorEl);
+        card.stagesEl.appendChild(errorEl);
       }
       errorEl.textContent = data.error;
     }
+  }
+
+  /**
+   * Append one agent output line to its task's console.
+   *
+   * Logs for an unknown task never CREATE a card: the hub broadcasts every
+   * task the daemon runs, and synthesizing cards here would fill the board
+   * with work the user never deployed. They are parked in a bounded pending
+   * buffer instead and flushed if that task's card materializes later — a
+   * replayed line must not be lost just because its stage event lost the
+   * snapshot/replay race (review finding).
+   */
+  onLog(data) {
+    if (typeof data.taskId !== 'string' || typeof data.line !== 'string' || !data.line) return;
+    const card = this.#cards.get(data.taskId);
+    if (!card) {
+      this.#pendingLogs.park(data.taskId, { stage: data.stage, line: data.line });
+      return;
+    }
+    this.#appendLine(card, data);
+  }
+
+  #appendLine(card, { stage, line }) {
+    const consoleEl = card.console;
+    const following = this.#isFollowing(consoleEl);
+
+    // Mark stage transitions so a long stream stays readable.
+    if (stage && stage !== card.lastLogStage) {
+      card.lastLogStage = stage;
+      const divider = document.createElement('div');
+      divider.className = 'console-stage';
+      divider.textContent = `── ${stage} ──`;
+      consoleEl.appendChild(divider);
+    }
+
+    const lineEl = document.createElement('div');
+    lineEl.className = 'console-line';
+    lineEl.textContent = line;
+    consoleEl.appendChild(lineEl);
+
+    while (consoleEl.childElementCount > CONSOLE_MAX_LINES) {
+      consoleEl.removeChild(consoleEl.firstElementChild);
+    }
+    if (following) consoleEl.scrollTop = consoleEl.scrollHeight;
+  }
+
+
+  #isFollowing(consoleEl) {
+    const distance = consoleEl.scrollHeight - consoleEl.scrollTop - consoleEl.clientHeight;
+    // A console that has never been scrolled (or is shorter than its box)
+    // reports 0 and follows.
+    return distance <= FOLLOW_THRESHOLD_PX;
   }
 
   #ensureCard(data) {
@@ -74,6 +141,7 @@ export class WorkCards {
 
     const el = document.createElement('div');
     el.className = 'work-card';
+
     const head = document.createElement('div');
     head.className = 'head';
     const identifier = document.createElement('span');
@@ -82,12 +150,42 @@ export class WorkCards {
     const title = document.createElement('span');
     title.className = 'title';
     title.textContent = data.title ?? data.taskId;
-    head.append(identifier, title);
+    const toggle = document.createElement('button');
+    toggle.className = 'console-toggle';
+    toggle.type = 'button';
+    toggle.textContent = 'Hide output';
+    toggle.setAttribute('aria-expanded', 'true');
+    head.append(identifier, title, toggle);
     el.appendChild(head);
+
+    const stagesEl = document.createElement('div');
+    stagesEl.className = 'stages';
+    el.appendChild(stagesEl);
+
+    const consoleEl = document.createElement('div');
+    consoleEl.className = 'console';
+    consoleEl.setAttribute('role', 'log');
+    consoleEl.setAttribute('aria-label', `Agent output for ${data.issueIdentifier ?? data.taskId}`);
+    el.appendChild(consoleEl);
+
+    toggle.addEventListener('click', () => {
+      const hidden = el.classList.toggle('console-hidden');
+      toggle.textContent = hidden ? 'Show output' : 'Hide output';
+      toggle.setAttribute('aria-expanded', String(!hidden));
+      // Reopening lands at the newest output, not wherever it was parked.
+      if (!hidden) consoleEl.scrollTop = consoleEl.scrollHeight;
+    });
+
     this.#container.prepend(el);
 
-    card = { el, stages: new Map() };
+    card = { el, stagesEl, console: consoleEl, stages: new Map(), lastLogStage: null };
     this.#cards.set(data.taskId, card);
+
+    // Flush lines that arrived before the card existed (moved, not copied —
+    // no duplication with the live stream).
+    for (const entry of this.#pendingLogs.takeFor(data.taskId)) {
+      this.#appendLine(card, entry);
+    }
     return card;
   }
 }


### PR DESCRIPTION
## TL;DR

Deploy된 에이전트 카드마다 **터미널 스타일 실시간 콘솔**을 붙였다 — 데몬이 이미 브로드캐스트하던 `log` 이벤트(💭 사고 · 🔧 도구 호출)를 보드에서 스트리밍한다. stage 요약만 보이던 "지금 뭘 하는지 안 보임" 문제 해소.

## 구현

- **카드별 콘솔**: 500줄 링버퍼, stage 구분선(`── worker ──`), show/hide 토글(재오픈 시 tail로), **stick-to-bottom** — 위로 스크롤하면 고정 해제, 바닥 복귀 시 재개(터미널 계약).
- **유실·중복 없는 복구**: 콘솔 히스토리는 SSE 리플레이 단일 소스(스냅샷 이중 시딩은 전 라인 중복이라 제거). 카드가 아직 없는 라인은 **바운드된 move-only `PendingLogBuffer`**(20 tasks × 100 lines)에 파킹 후 카드 생성 시 flush — stage 이벤트가 스냅샷·리플레이 양쪽 윈도에서 밀려나도 로그가 살아남는 리로드 레이스를 닫는다. SSE는 즉시 연결(스냅샷 뒤로 미루면 라이브 공백 발생).
- **reviewer 스트림 배선**: `runReviewer`는 `onLog`를 원래 받지만 아무도 연결하지 않아 reviewer 턴이 어떤 대시보드에도 안 보였음 — pairPipeline에서 배선.
- 미지 taskId는 카드를 **합성하지 않음**(데몬의 무관한 작업으로 보드 오염 방지) — 파킹만.

## 검증

- `PendingLogBuffer` DOM-free 추출 + vitest 6케이스(순서·move-only 중복 방지·라인 캡·LRU 축출·재사용)
- DOM 동작은 실행 중인 데몬 상대로 Chrome 라이브 검증: 역순 도착 flush, stage 구분, 500줄 캡, follow/park 스크롤, 토글
- 커밋 게이트 `openswarm review` **APPROVE** (REVISE 3라운드 실수정: 이중 시딩 중복 → 시딩 순서 레이스 → SSE 지연의 라이브 공백)
- tsc/oxlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)