### PR TITLE
feat(daemon): 콕핏 read API 4종 — 세션 목록·세션별 트랜스크립트·워크트리 diff·quota (INT-3402)

### DIFF
--- a/src/adapters/codexResponses.test.ts
+++ b/src/adapters/codexResponses.test.ts
@@ -496,6 +496,49 @@ describe('429 throttle vs spent quota (INT-2907)', () => {
     expect(err.message).toContain('throttle-retry:');
     expect(fetchMock).toHaveBeenCalledTimes(4); // initial + 3 retries
   });
+
+  it('records healthy-quota headers from a SUCCESS response for the cockpit gauge (INT-3402)', async () => {
+    const { getQuotaSnapshot, __resetQuotaForTests } = await import('./quotaSnapshot.js');
+    __resetQuotaForTests();
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        [
+          'data: {"type":"response.output_text.delta","delta":"ok"}',
+          'data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}',
+          'data: [DONE]',
+          '',
+        ].join('\n'),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/event-stream',
+            'x-codex-primary-used-percent': '37',
+            'x-codex-primary-window-minutes': '300',
+            'x-codex-primary-reset-at': '1900000000',
+          },
+        },
+      ),
+    );
+    const callApi = callerWith(fetchMock);
+    await callApi([{ role: 'user', content: 'hi' }], []);
+
+    const obs = getQuotaSnapshot().providers.find((p) => p.provider === 'codex');
+    expect(obs).toMatchObject({
+      usedPercent: 37,
+      windowMinutes: 300,
+      resetsAt: 1900000000,
+      source: 'success-headers',
+    });
+    __resetQuotaForTests();
+  });
+
+  it('records nothing from a success response without usage headers', async () => {
+    const { getQuotaSnapshot, __resetQuotaForTests } = await import('./quotaSnapshot.js');
+    __resetQuotaForTests();
+    const callApi = callerWith(vi.fn(async () => okStream()));
+    await callApi([{ role: 'user', content: 'hi' }], []);
+    expect(getQuotaSnapshot().providers).toHaveLength(0);
+  });
 });
 
 describe('401 refresh scope', () => {

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -20,6 +20,7 @@ import { parseWorkerResult, parseReviewerResult } from './resultParsing.js';
 import { formatCost } from '../support/costTracker.js';
 import type { ToolDefinition } from './tools.js';
 import { RateLimitError, rateLimitFromCodexHeaders } from './rateLimitError.js';
+import { recordQuotaObservation } from './quotaSnapshot.js';
 import { resolveLimitResponse, type ThrottleState } from './throttleRetry.js';
 import { isInfraError } from './errorClassification.js';
 
@@ -524,6 +525,22 @@ export class CodexResponsesAdapter implements CliAdapter {
             }
           }
           throw new Error(`Codex responses error (${res.status}): ${errText.slice(0, 500)}`);
+        }
+
+        // Successful responses carry the same x-codex-* usage headers as 429s
+        // (when the account exposes them) — the only place a HEALTHY quota
+        // percentage can be observed for the cockpit gauge. (INT-3402)
+        const usedPercent = parseInt(res.headers.get('x-codex-primary-used-percent') ?? '', 10);
+        if (Number.isFinite(usedPercent)) {
+          const windowMinutes = parseInt(res.headers.get('x-codex-primary-window-minutes') ?? '', 10);
+          const resetsAt = parseInt(res.headers.get('x-codex-primary-reset-at') ?? '', 10);
+          recordQuotaObservation({
+            provider: 'codex',
+            usedPercent,
+            windowMinutes: Number.isFinite(windowMinutes) ? windowMinutes : undefined,
+            resetsAt: Number.isFinite(resetsAt) ? resetsAt : undefined,
+            source: 'success-headers',
+          });
         }
 
         return consumeResponsesStream(res, onToken, onReasoning);

--- a/src/adapters/quotaSnapshot.test.ts
+++ b/src/adapters/quotaSnapshot.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getQuotaSnapshot, recordQuotaObservation, __resetQuotaForTests } from './quotaSnapshot.js';
+
+afterEach(() => __resetQuotaForTests());
+
+describe('quotaSnapshot', () => {
+  it('keeps the latest observation per provider', () => {
+    recordQuotaObservation({ provider: 'codex', usedPercent: 30, source: 'success-headers', observedAt: 1 });
+    recordQuotaObservation({ provider: 'codex', usedPercent: 55, source: 'success-headers', observedAt: 2 });
+    recordQuotaObservation({ provider: 'openrouter', retryAfterSeconds: 12, source: 'throttle', observedAt: 3 });
+
+    const { providers } = getQuotaSnapshot();
+    expect(providers).toHaveLength(2);
+    expect(providers.find((p) => p.provider === 'codex')?.usedPercent).toBe(55);
+    expect(providers.find((p) => p.provider === 'openrouter')?.retryAfterSeconds).toBe(12);
+  });
+
+  it('ignores observations carrying no signal at all', () => {
+    recordQuotaObservation({ provider: 'codex', usedPercent: 40, source: 'success-headers' });
+    recordQuotaObservation({ provider: 'codex', source: 'throttle' });
+    expect(getQuotaSnapshot().providers[0].usedPercent).toBe(40);
+  });
+
+  it('stamps observedAt when the caller omits it', () => {
+    const before = Date.now();
+    recordQuotaObservation({ provider: 'codex', usedPercent: 10, source: 'throttle' });
+    expect(getQuotaSnapshot().providers[0].observedAt).toBeGreaterThanOrEqual(before);
+  });
+});

--- a/src/adapters/quotaSnapshot.ts
+++ b/src/adapters/quotaSnapshot.ts
@@ -1,0 +1,43 @@
+// ============================================
+// OpenSwarm - Provider quota observations (INT-3402)
+// ============================================
+//
+// The adapters have always PARSED provider usage signals (x-codex-* headers,
+// retry-after) but threw them away with the RateLimitError that carried them —
+// nothing could render a "58% of the 5h window" gauge. This singleton keeps
+// the latest observation per provider; GET /api/quota serves it.
+//
+// Import-free on purpose: throttleRetry, codexResponses, and route modules all
+// import this — it must never import back.
+
+export interface QuotaObservation {
+  provider: string;
+  /** Percent of the primary window consumed (0-100). */
+  usedPercent?: number;
+  /** Primary window length in minutes. */
+  windowMinutes?: number;
+  /** Unix timestamp (SECONDS) when the window resets — RateLimitError's unit. */
+  resetsAt?: number;
+  retryAfterSeconds?: number;
+  source: 'success-headers' | 'throttle' | 'quota-exhausted';
+  /** Epoch ms. */
+  observedAt: number;
+}
+
+const latestByProvider = new Map<string, QuotaObservation>();
+
+export function recordQuotaObservation(
+  obs: Omit<QuotaObservation, 'observedAt'> & { observedAt?: number },
+): void {
+  // An observation with no signal at all would only overwrite a useful one.
+  if (obs.usedPercent == null && obs.resetsAt == null && obs.retryAfterSeconds == null) return;
+  latestByProvider.set(obs.provider, { ...obs, observedAt: obs.observedAt ?? Date.now() });
+}
+
+export function getQuotaSnapshot(): { providers: QuotaObservation[] } {
+  return { providers: [...latestByProvider.values()] };
+}
+
+export function __resetQuotaForTests(): void {
+  latestByProvider.clear();
+}

--- a/src/adapters/throttleRetry.test.ts
+++ b/src/adapters/throttleRetry.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveLimitResponse } from './throttleRetry.js';
+import { RateLimitError, rateLimitFromCodexHeaders } from './rateLimitError.js';
+import { getQuotaSnapshot, __resetQuotaForTests } from './quotaSnapshot.js';
+
+afterEach(() => __resetQuotaForTests());
+
+const headers = (map: Record<string, string>) => new Headers(map);
+
+describe('resolveLimitResponse quota observations (INT-3402)', () => {
+  it('records the throttle signal before waiting out a short-window 429', async () => {
+    // retry-after: 1 keeps the real (unmocked) wait at 1s instead of the 5s
+    // backoff floor a zero value would fall through to.
+    const result = await resolveLimitResponse(
+      'openrouter',
+      429,
+      headers({ 'retry-after': '1' }),
+      'slow down',
+      { attempts: 0 },
+      {},
+    );
+    expect(result).toBe('retry');
+    const obs = getQuotaSnapshot().providers.find((p) => p.provider === 'openrouter');
+    expect(obs?.source).toBe('throttle');
+    expect(obs?.retryAfterSeconds).toBe(1);
+  });
+
+  it('records the exhausted quota (used%/reset) before the generic RateLimitError leaves', async () => {
+    const codexHeaders = headers({
+      'x-codex-primary-used-percent': '100',
+      'x-codex-primary-reset-at': '1900000000',
+    });
+    await expect(
+      resolveLimitResponse('codex', 429, codexHeaders, 'usage limit reached', { attempts: 0 }, {}),
+    ).rejects.toBeInstanceOf(RateLimitError);
+
+    const obs = getQuotaSnapshot().providers.find((p) => p.provider === 'codex');
+    expect(obs?.source).toBe('quota-exhausted');
+    expect(obs?.usedPercent).toBe(100);
+    expect(obs?.resetsAt).toBe(1900000000);
+  });
+
+  it('carries windowMinutes when the adapter supplies the codex quotaError', async () => {
+    const codexHeaders = headers({
+      'x-codex-primary-used-percent': '100',
+      'x-codex-primary-reset-at': '1900000000',
+      'x-codex-primary-window-minutes': '300',
+    });
+    await expect(
+      resolveLimitResponse('codex', 429, codexHeaders, 'usage limit reached', { attempts: 0 }, {
+        quotaError: (h, b) => rateLimitFromCodexHeaders(h ?? new Headers(), b),
+      }),
+    ).rejects.toBeInstanceOf(RateLimitError);
+
+    const obs = getQuotaSnapshot().providers.find((p) => p.provider === 'codex');
+    expect(obs?.windowMinutes).toBe(300);
+    expect(obs?.usedPercent).toBe(100);
+  });
+
+  it('records nothing for a non-limit response', async () => {
+    const result = await resolveLimitResponse('gpt', 500, undefined, 'boom', { attempts: 0 }, {});
+    expect(result).toBe('other');
+    expect(getQuotaSnapshot().providers).toHaveLength(0);
+  });
+});

--- a/src/adapters/throttleRetry.ts
+++ b/src/adapters/throttleRetry.ts
@@ -19,6 +19,7 @@ import {
   matchesRateLimitMessage,
   rateLimitFromHttpResponse,
 } from './rateLimitError.js';
+import { recordQuotaObservation } from './quotaSnapshot.js';
 
 /** Escalating waits for a throttled retry. */
 export const THROTTLE_BACKOFF_MS = [5_000, 15_000, 40_000] as const;
@@ -94,12 +95,29 @@ export async function resolveLimitResponse(
 
   const cls = classifyLimitResponse(headers, body);
   if (cls.quota) {
-    throw (
+    const error =
       opts.quotaError?.(headers, body) ??
       rateLimitFromHttpResponse(status, headers, body) ??
-      new RateLimitError(undefined, `${provider}: usage limit reached`)
-    );
+      new RateLimitError(undefined, `${provider}: usage limit reached`);
+    // Every in-process adapter funnels its 429s through here — record the
+    // signals the error carries before they leave with the throw, so the
+    // cockpit quota gauge sees them. (INT-3402)
+    recordQuotaObservation({
+      provider,
+      usedPercent: error instanceof RateLimitError ? error.usedPercent ?? cls.usedPercent : cls.usedPercent,
+      windowMinutes: error instanceof RateLimitError ? error.windowMinutes : undefined,
+      resetsAt: error instanceof RateLimitError ? error.resetsAt : undefined,
+      retryAfterSeconds: cls.retryAfterSeconds,
+      source: 'quota-exhausted',
+    });
+    throw error;
   }
+  recordQuotaObservation({
+    provider,
+    usedPercent: cls.usedPercent,
+    retryAfterSeconds: cls.retryAfterSeconds,
+    source: 'throttle',
+  });
 
   const window = cls.usedPercent != null ? `, window ${cls.usedPercent}% used` : '';
   if (state.attempts < THROTTLE_BACKOFF_MS.length) {

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -3,7 +3,7 @@
 // Worker → Reviewer → Tester → Documenter pipeline
 // ============================================
 import { EventEmitter } from 'node:events';
-import type { TaskItem } from '../orchestration/decisionEngine.js';
+import { taskEventKey, type TaskItem } from '../orchestration/decisionEngine.js';
 import type { WorkerResult, ReviewResult } from './agentPair.js';
 import type { TesterResult } from './tester.js';
 import type { DocumenterResult } from './documenter.js';
@@ -394,7 +394,7 @@ export class PairPipeline extends EventEmitter {
     const metadata = this.stageMetadata(context);
     console.log(`[${prefix}] Stage starting: ${stage}`);
     this.emit('stage:start', { stage, context, model: stageModel });
-    broadcastEvent({ type: 'pipeline:stage', data: { taskId: context.task.id, stage, status: 'start', model: stageModel, ...metadata } });
+    broadcastEvent({ type: 'pipeline:stage', data: { taskId: taskEventKey(context.task), stage, status: 'start', model: stageModel, ...metadata } });
 
     if (this.config.verbose) {
       this.emit('log', { line: `[verbose] Stage: ${stage} | model: ${stageModel ?? 'default'} | iteration: ${context.currentIteration}` });
@@ -405,7 +405,7 @@ export class PairPipeline extends EventEmitter {
       switch (stage) {
         case 'worker': {
           agentPair.updateSessionStatus(context.session.id, 'working');
-          const taskId = context.task.id;
+          const taskId = taskEventKey(context.task);
           const onLog = (line: string) =>
             broadcastEvent({ type: 'log', data: { taskId, stage: 'worker', line: `[${prefix}] ${line}` } });
 
@@ -486,7 +486,7 @@ export class PairPipeline extends EventEmitter {
             issueIdentifier: context.task.issueIdentifier || context.task.issueId,
             projectName: context.task.linearProject?.name,
             onLog,
-            processContext: { taskId: context.task.id, stage: 'worker' },
+            processContext: { taskId: taskEventKey(context.task), stage: 'worker' },
             workerContext,
             signal: this.abortSignal,
           };
@@ -567,14 +567,14 @@ export class PairPipeline extends EventEmitter {
             guardWarnings: context.guardsResult?.results
               .filter(r => !r.passed && !r.blocking)
               .flatMap(r => r.issues),
-            processContext: { taskId: context.task.id, stage: 'reviewer' },
+            processContext: { taskId: taskEventKey(context.task), stage: 'reviewer' },
             // runReviewer has always accepted onLog; nothing passed one, so the
             // reviewer's turns never reached the dashboard/desktop console the
             // way the worker's do. (INT-3397)
             onLog: (line: string) =>
               broadcastEvent({
                 type: 'log',
-                data: { taskId: context.task.id, stage: 'reviewer', line: `[${prefix}] ${line}` },
+                data: { taskId: taskEventKey(context.task), stage: 'reviewer', line: `[${prefix}] ${line}` },
               }),
             signal: this.abortSignal,
           };
@@ -683,7 +683,7 @@ export class PairPipeline extends EventEmitter {
         this.emit('log', { line: `[verbose] Stage ${stage} completed in ${(stageResult.duration / 1000).toFixed(1)}s${costInfo ? ` | cost: ${formatCost(costInfo)}` : ''}` });
       }
       broadcastEvent({ type: 'pipeline:stage', data: {
-        taskId: context.task.id, stage, status: 'complete',
+        taskId: taskEventKey(context.task), stage, status: 'complete',
         ...metadata,
         model: costInfo?.model ?? stageModel,
         inputTokens: costInfo?.inputTokens,
@@ -711,7 +711,7 @@ export class PairPipeline extends EventEmitter {
       console.log(`[${prefix}] ${stage} failed (${(stageResult.duration / 1000).toFixed(1)}s)`);
       this.emit('stage:fail', { stage, result: stageResult, context, error });
       broadcastEvent({ type: 'pipeline:stage', data: {
-        taskId: context.task.id, stage, status: 'fail',
+        taskId: taskEventKey(context.task), stage, status: 'fail',
         ...metadata,
         model: stageModel,
         durationMs: stageResult.duration,
@@ -848,7 +848,7 @@ export class PairPipeline extends EventEmitter {
         maxIterations,
         context,
       });
-      broadcastEvent({ type: 'pipeline:iteration', data: { taskId: context.task.id, iteration: context.currentIteration } });
+      broadcastEvent({ type: 'pipeline:iteration', data: { taskId: taskEventKey(context.task), iteration: context.currentIteration } });
 
       console.log(`[${context.taskPrefix}] Iteration ${context.currentIteration}/${maxIterations}`);
 
@@ -860,7 +860,7 @@ export class PairPipeline extends EventEmitter {
         iteration: context.currentIteration,
         baseModel: modelForTask(this.config, 'worker', context.task),
         signalEscalation: context.workerEscalation,
-        taskId: context.task.id,
+        taskId: taskEventKey(context.task),
         taskPrefix: context.taskPrefix,
       });
 
@@ -1184,7 +1184,7 @@ export class PairPipeline extends EventEmitter {
               console.log(`[${context.taskPrefix}] Reviewer repeated the same feedback — escalating worker (${target})`);
               this.emit('log', { line: `⬆️ Worker escalation on repeated review feedback (${target})` });
               broadcastEvent({ type: 'pipeline:escalation', data: {
-                taskId: context.task.id,
+                taskId: taskEventKey(context.task),
                 iteration: context.currentIteration,
                 reason: 'repeated-review-feedback',
                 toModel: escalation.model,
@@ -1270,7 +1270,7 @@ export class PairPipeline extends EventEmitter {
     const totalCost = stageCosts.length > 0 ? aggregateCosts(stageCosts) : undefined;
     if (totalCost) {
       console.log(`[${context.taskPrefix}] Total cost: ${formatCost(totalCost)}`);
-      broadcastEvent({ type: 'task:cost', data: { taskId: context.task.id, cost: totalCost } });
+      broadcastEvent({ type: 'task:cost', data: { taskId: taskEventKey(context.task), cost: totalCost } });
     }
     const result: PipelineResult = {
       success,

--- a/src/agents/workerFanoutGate.ts
+++ b/src/agents/workerFanoutGate.ts
@@ -2,7 +2,7 @@
 // OpenSwarm - Adaptive worker fan-out gate
 // ============================================
 
-import type { TaskItem } from '../orchestration/decisionEngine.js';
+import { taskEventKey, type TaskItem } from '../orchestration/decisionEngine.js';
 import type { PipelineGuardsConfig, RoleConfig, WorkerFanoutCandidateConfig } from '../core/types.js';
 import { broadcastEvent } from '../core/eventHub.js';
 import type { WorkerResult } from './agentPair.js';
@@ -147,7 +147,7 @@ export function emitWorkerFanoutGateDecision(input: {
   broadcastEvent({
     type: 'pipeline:fanout',
     data: {
-      taskId: context.task.id,
+      taskId: taskEventKey(context.task),
       iteration: context.currentIteration,
       enabled: decision.enabled,
       shouldFanOut: decision.shouldFanOut,
@@ -165,7 +165,7 @@ export function emitWorkerFanoutGateDecision(input: {
   const line = `[FanoutGate] ${verdict} (${decision.score}/${decision.threshold})${detail}`;
   console.log(`[${context.taskPrefix}] ${line}`);
   input.emit('log', { line });
-  broadcastEvent({ type: 'log', data: { taskId: context.task.id, stage: 'worker', line: `[${context.taskPrefix}] ${line}` } });
+  broadcastEvent({ type: 'log', data: { taskId: taskEventKey(context.task), stage: 'worker', line: `[${context.taskPrefix}] ${line}` } });
 }
 
 export async function runWorkerWithOptionalFanout(input: {

--- a/src/automation/autonomousRunner.serialLifecycle.test.ts
+++ b/src/automation/autonomousRunner.serialLifecycle.test.ts
@@ -1,0 +1,132 @@
+// The serial (maxConcurrentTasks <= 1) execution path must emit the same
+// task:started/completed lifecycle the scheduler emits for the parallel path.
+// Without it the cockpit's per-task transcript buffer never reaches its
+// retention timer and leaks for the process's lifetime. (INT-3402 review)
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { PipelineResult } from '../agents/pairPipeline.js';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import type { HubEvent } from '../core/eventHub.js';
+
+vi.mock('../core/providerOverride.js', () => ({ writeProviderOverride: vi.fn() }));
+vi.mock('../agents/stageModelResolver.js', () => ({ resolveAdapterDefaultModel: vi.fn(async () => 'model') }));
+vi.mock('../memory/repoKnowledge.js', () => ({ recordTaskOutcome: vi.fn(async () => {}) }));
+vi.mock('../linear/projectUpdater.js', () => ({ updateProjectAfterTask: vi.fn(async () => {}) }));
+
+type InternalRunner = {
+  executeDurably: (task: TaskItem, projectPath: string) => Promise<PipelineResult>;
+  executeTaskPairMode: (task: TaskItem) => Promise<void>;
+  resolveProjectPath: (task: TaskItem) => Promise<string | null>;
+  config: { maxConcurrentTasks?: number };
+};
+
+const task: TaskItem = {
+  id: 'task-local-id',
+  issueId: 'issue-uuid',
+  issueIdentifier: 'INT-1',
+  title: 'Serial task',
+  description: '',
+  priority: 2,
+  source: 'linear',
+} as unknown as TaskItem;
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'serial-lifecycle-'));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(root, { recursive: true, force: true });
+});
+
+async function runSerial(result: PipelineResult | Error): Promise<HubEvent[]> {
+  const [{ AutonomousRunner }, hub] = await Promise.all([
+    import('./autonomousRunner.js'),
+    import('../core/eventHub.js'),
+  ]);
+  hub.__resetForTests();
+
+  const runner = new AutonomousRunner({
+    linearTeamId: 'team',
+    allowedProjects: ['/repo'],
+    heartbeatSchedule: '0 * * * *',
+    autoExecute: true,
+    maxConsecutiveTasks: 1,
+    cooldownSeconds: 0,
+    dryRun: true,
+    pairMode: true,
+    // The serial branch: no parallel scheduler, so nothing else emits lifecycle.
+    maxConcurrentTasks: 1,
+    automationLedgerMode: 'off',
+    automationDbPath: join(root, 'automation.db'),
+  });
+  const internal = runner as unknown as InternalRunner;
+  internal.resolveProjectPath = vi.fn(async () => '/repo');
+  internal.executeDurably = vi.fn(async () => {
+    if (result instanceof Error) throw result;
+    return result;
+  });
+
+  try {
+    await internal.executeTaskPairMode(task);
+  } catch {
+    // The throwing case still has to have emitted its terminal event.
+  }
+  return hub.getStageBuffer();
+}
+
+describe('serial execution lifecycle events (INT-3402)', () => {
+  it('emits task:started and task:completed keyed by taskEventKey', async () => {
+    const events = await runSerial({
+      success: true,
+      sessionId: 'session-1',
+      stages: [],
+      finalStatus: 'approved',
+      totalDuration: 1_000,
+      iterations: 1,
+    } as unknown as PipelineResult);
+
+    const started = events.find((e) => e.type === 'task:started');
+    const completed = events.find((e) => e.type === 'task:completed');
+    // issueId wins over the local task id — the key every other emitter uses.
+    expect(started?.data).toMatchObject({ taskId: 'issue-uuid' });
+    expect(completed?.data).toMatchObject({ taskId: 'issue-uuid', success: true, duration: 1_000 });
+  });
+
+  it('still emits a terminal event when the pipeline throws', async () => {
+    const events = await runSerial(new Error('pipeline exploded'));
+    const completed = events.find((e) => e.type === 'task:completed');
+    expect(completed?.data).toMatchObject({ taskId: 'issue-uuid', success: false });
+  });
+
+  it('reaps the transcript buffer once the serial run completes', async () => {
+    const { appendTaskLog, getTaskLog, TASK_LOG_RETENTION_MS, __resetTaskLogsForTests } =
+      await import('../core/taskLogStore.js');
+    __resetTaskLogsForTests();
+    appendTaskLog('issue-uuid', 'worker', 'serial output');
+
+    await runSerial({
+      success: true,
+      sessionId: 'session-1',
+      stages: [],
+      finalStatus: 'approved',
+      totalDuration: 1_000,
+      iterations: 1,
+    } as unknown as PipelineResult);
+
+    vi.useFakeTimers();
+    try {
+      // The completed event above armed the retention timer.
+      vi.advanceTimersByTime(TASK_LOG_RETENTION_MS + 1);
+      expect(getTaskLog('issue-uuid')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+      __resetTaskLogsForTests();
+    }
+  });
+});

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -28,13 +28,7 @@ import {
   type TaskState,
   type ProjectInfo,
 } from './runnerState.js';
-import {
-  DecisionEngine,
-  DecisionResult,
-  TaskItem,
-  getDecisionEngine,
-  classifyStuck,
-} from '../orchestration/decisionEngine.js';
+import { taskEventKey, DecisionEngine, DecisionResult, TaskItem, getDecisionEngine, classifyStuck } from '../orchestration/decisionEngine.js';
 // ExecutorResult used via execution.reportExecutionResult
 import { checkWorkAllowed } from '../support/timeWindow.js';
 import { shouldEarlyStuckForInfeasibility } from '../support/feasibilityDetector.js';
@@ -354,14 +348,14 @@ export class AutonomousRunner {
     this.scheduler.on('started', (running) => {
       const taskCtx = this.formatTaskContext(running.task);
       console.log(`[Scheduler] Task started: ${taskCtx} ${running.task.title}`);
-      broadcastEvent({ type: 'task:started', data: { taskId: running.task.id, title: running.task.title, issueIdentifier: running.task.issueIdentifier } });
+      broadcastEvent({ type: 'task:started', data: { taskId: taskEventKey(running.task), title: running.task.title, issueIdentifier: running.task.issueIdentifier } });
     });
 
     this.scheduler.on('completed', ({ task, result }) => {
       this.trackSchedulerHandler('completed', (async () => {
       const taskCtx = this.formatTaskContext(task);
       console.log(`[Scheduler] Task completed: ${taskCtx} ${task.title}`);
-      broadcastEvent({ type: 'task:completed', data: { taskId: task.id, success: result.success, duration: result.totalDuration } });
+      broadcastEvent({ type: 'task:completed', data: { taskId: taskEventKey(task), success: result.success, duration: result.totalDuration } });
       this.recordPipelineHistory(task, result);
       await reportToDiscord(formatPipelineResultEmbed(result));
 
@@ -458,7 +452,7 @@ export class AutonomousRunner {
       this.recordPipelineHistory(task, result);
       if (task.issueId) setRetryTime(task.issueId, 3, this.failedTaskRetryTimes);
       this.saveTaskState();
-      broadcastEvent({ type: 'log', data: { taskId: task.issueId || task.id, stage: 'preflight', line: 'Existing open PR owns planned files; deferred for re-check' } });
+      broadcastEvent({ type: 'log', data: { taskId: taskEventKey(task), stage: 'preflight', line: 'Existing open PR owns planned files; deferred for re-check' } });
       this.scheduleNextHeartbeat();
     });
 
@@ -466,7 +460,7 @@ export class AutonomousRunner {
       this.trackSchedulerHandler('cancelled', (async () => {
         const taskCtx = this.formatTaskContext(task);
         console.log(`[Scheduler] Task cancelled: ${taskCtx} ${task.title}`);
-        broadcastEvent({ type: 'task:completed', data: { taskId: task.id, success: false, duration: result.totalDuration } });
+        broadcastEvent({ type: 'task:completed', data: { taskId: taskEventKey(task), success: false, duration: result.totalDuration } });
         this.recordPipelineHistory(task, result);
         try {
           // In primary mode cancellation is already atomically parked in
@@ -488,7 +482,7 @@ export class AutonomousRunner {
       const taskCtx = this.formatTaskContext(task);
       console.log(`[Scheduler] Task decomposed: ${taskCtx} ${task.title}`);
       this.recordPipelineHistory(task, result);
-      broadcastEvent({ type: 'task:completed', data: { taskId: task.id, success: false, duration: result.totalDuration } });
+      broadcastEvent({ type: 'task:completed', data: { taskId: taskEventKey(task), success: false, duration: result.totalDuration } });
       // Child issues, rather than the parent execution, now own completion.
       // Re-run discovery without incrementing completed/failed counters.
       this.scheduleNextHeartbeat();
@@ -510,7 +504,7 @@ export class AutonomousRunner {
         console.warn(`[Scheduler] Rate limit hit for ${taskCtx} — pausing until ${resetsLabel} (~${waitSec}s)`);
         broadcastEvent({
           type: 'log',
-          data: { taskId: task.issueId || task.id, stage: 'rate_limit', line: `⏸ Rate limited — pausing ~${waitSec}s (until ${resetsLabel})` },
+          data: { taskId: taskEventKey(task), stage: 'rate_limit', line: `⏸ Rate limited — pausing ~${waitSec}s (until ${resetsLabel})` },
         });
         return;
       }
@@ -550,7 +544,7 @@ export class AutonomousRunner {
       }
 
       console.log(`[Scheduler] Task failed: ${taskCtx} ${task.title}`);
-      broadcastEvent({ type: 'task:completed', data: { taskId: task.id, success: false, duration: result.totalDuration } });
+      broadcastEvent({ type: 'task:completed', data: { taskId: taskEventKey(task), success: false, duration: result.totalDuration } });
       await reportToDiscord(formatPipelineResultEmbed(result));
 
       // Structural infeasibility (⑦, INT-2521): the failure text says the DoD can't
@@ -2064,7 +2058,7 @@ export class AutonomousRunner {
   private enqueueCandidate(task: TaskItem, projectPath: string): boolean {
     this.attachPriorFeedback(task);
     if (!this.scheduler.enqueue(task, projectPath)) return false;
-    broadcastEvent({ type: 'task:queued', data: { taskId: task.id, title: task.title, projectPath, issueIdentifier: task.issueIdentifier } });
+    broadcastEvent({ type: 'task:queued', data: { taskId: taskEventKey(task), title: task.title, projectPath, issueIdentifier: task.issueIdentifier } });
     this.syslog(`✓ Queued: ${task.issueIdentifier || ''} ${task.title} → ${projectPath.split('/').slice(-2).join('/')}`);
     return true;
   }
@@ -2160,7 +2154,7 @@ export class AutonomousRunner {
     // Use scheduler for parallel processing mode
     if (this.config.maxConcurrentTasks && this.config.maxConcurrentTasks > 1) {
       if (this.scheduler.enqueue(task, projectPath)) {
-        broadcastEvent({ type: 'task:queued', data: { taskId: task.id, title: task.title, projectPath, issueIdentifier: task.issueIdentifier } });
+        broadcastEvent({ type: 'task:queued', data: { taskId: taskEventKey(task), title: task.title, projectPath, issueIdentifier: task.issueIdentifier } });
       }
       await this.runAvailableTasks();
       return;
@@ -2178,7 +2172,7 @@ export class AutonomousRunner {
       const waitSec = Math.max(0, Math.ceil((resetsAt - Date.now()) / 1000));
       const resetsLabel = new Date(resetsAt).toISOString();
       console.warn(`[AutonomousRunner] Rate limit hit for ${this.formatTaskContext(task)} — pausing until ${resetsLabel} (~${waitSec}s)`);
-      broadcastEvent({ type: 'log', data: { taskId: task.issueId || task.id, stage: 'rate_limit', line: `⏸ Rate limited — pausing ~${waitSec}s (until ${resetsLabel})` } });
+      broadcastEvent({ type: 'log', data: { taskId: taskEventKey(task), stage: 'rate_limit', line: `⏸ Rate limited — pausing ~${waitSec}s (until ${resetsLabel})` } });
       return;
     }
 
@@ -2503,6 +2497,10 @@ export class AutonomousRunner {
   getQueuedTasks() { return this.scheduler.getQueuedTasks(); }
   getRunningTasks() { return this.scheduler.getRunningTasks(); }
   getPipelineHistory(limit = 50) { return getPipelineHistory(limit); }
+  /** Epoch ms until which the scheduler holds for a provider rate limit (0 = none). */
+  getRateLimitHoldUntil(): number { return this.rateLimitUntil; }
+  /** Durable ledger record for an issue — the authoritative worktree/branch source. */
+  getDurableRun(issueId: string) { return this.durableRuns.getRun(issueId); }
   getFailureCauseSummary(limit = 50) { return aggregateFailureCauses(getPipelineHistory(limit)); }
 
   private recordPipelineHistory(task: TaskItem, result: PipelineResult): void {

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -2160,8 +2160,28 @@ export class AutonomousRunner {
       return;
     }
 
-    // Single execution (legacy)
-    const result = await this.executeDurably(task, projectPath);
+    // Single execution (legacy serial path — maxConcurrentTasks <= 1).
+    // The scheduler emits task:started/completed for the parallel path; this
+    // path never did, so dashboards saw no lifecycle and (since INT-3402) the
+    // transcript buffer was never handed to its retention timer.
+    broadcastEvent({
+      type: 'task:started',
+      data: { taskId: taskEventKey(task), title: task.title, issueIdentifier: task.issueIdentifier },
+    });
+    let result: PipelineResult;
+    try {
+      result = await this.executeDurably(task, projectPath);
+    } catch (err) {
+      broadcastEvent({
+        type: 'task:completed',
+        data: { taskId: taskEventKey(task), success: false, duration: 0 },
+      });
+      throw err;
+    }
+    broadcastEvent({
+      type: 'task:completed',
+      data: { taskId: taskEventKey(task), success: result.success, duration: result.totalDuration },
+    });
 
     // Rate-limited: pause until quota resets. Return before any Discord/Linear
     // reporting or state change — no failure count, no card spam. Same as the

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -453,6 +453,10 @@ export class AutonomousRunner {
       if (task.issueId) setRetryTime(task.issueId, 3, this.failedTaskRetryTimes);
       this.saveTaskState();
       broadcastEvent({ type: 'log', data: { taskId: taskEventKey(task), stage: 'preflight', line: 'Existing open PR owns planned files; deferred for re-check' } });
+      // Terminal for this run: the other scheduler outcomes all emit it, and
+      // consumers keyed on task:completed (transcript retention) would otherwise
+      // hold this task's state forever. (INT-3402 review)
+      broadcastEvent({ type: 'task:completed', data: { taskId: taskEventKey(task), success: false, duration: result.totalDuration } });
       this.scheduleNextHeartbeat();
     });
 
@@ -749,6 +753,11 @@ export class AutonomousRunner {
         finalStatus: timeout ? 'infra_error' : 'failed', failureSignal: timeout ? 'timeout' : undefined,
         totalDuration: Math.max(0, Date.now() - startedAt), iterations: 0,
         taskContext: { issueIdentifier: task.issueIdentifier || task.issueId, projectName: task.linearProject?.name, projectPath, taskTitle: task.title },
+      });
+      // Terminal for this run — see the superseded handler. (INT-3402 review)
+      broadcastEvent({
+        type: 'task:completed',
+        data: { taskId: taskEventKey(task), success: false, duration: Math.max(0, Date.now() - startedAt) },
       });
       await reportToDiscord(t('runner.pipelineError', { title: `${taskCtx} ${task.title}`, error: error.message }));
       })());

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -5,7 +5,7 @@
 
 import { EmbedBuilder } from 'discord.js';
 import { createHash } from 'node:crypto';
-import type { TaskItem, DecisionResult } from '../orchestration/decisionEngine.js';
+import { taskEventKey, type TaskItem, type DecisionResult } from '../orchestration/decisionEngine.js';
 import type { ExecutorResult } from '../orchestration/workflow.js';
 import type { PipelineResult, PipelineRunMetadata } from '../agents/pairPipeline.js';
 import type { DefaultRolesConfig, PipelineStage, JobProfile } from '../core/types.js';
@@ -575,7 +575,7 @@ export async function decomposeTask(
 ): Promise<boolean | 'no-decomp'> {
   console.log(`[AutonomousRunner] Decomposing task: ${task.title}`);
 
-  const taskId = task.issueId || task.id;
+  const taskId = taskEventKey(task);
   const metadata = pipelineMetadata(task, projectPath);
   const maxDepth = ctx.decompositionMaxDepth ?? 2;
   const maxChildren = ctx.decompositionMaxChildren ?? 5;
@@ -754,7 +754,8 @@ export async function executePipeline(
   try {
   if (ctx.enableDraftAnalysis !== false) {
     try {
-      const taskId = task.issueIdentifier || task.issueId || task.id;
+      // Same event key as every other emission — labels ride in metadata (INT-3402).
+      const taskId = taskEventKey(task);
       const metadata = pipelineMetadata(task, projectPath);
       broadcastEvent({ type: 'pipeline:stage', data: { taskId, stage: 'draft', status: 'start', ...metadata } });
 
@@ -871,7 +872,7 @@ export async function executePipeline(
       broadcastEvent({
         type: 'log',
         data: {
-          taskId: task.issueId,
+          taskId: taskEventKey(task),
           stage: 'worktree',
           line: `Worktree: ${actualPath} (branch: ${branchName})`,
         },

--- a/src/core/eventHub.test.ts
+++ b/src/core/eventHub.test.ts
@@ -768,4 +768,37 @@ describe('eventHub', () => {
       expect(getStageBuffer().length).toBeGreaterThan(0);
     });
   });
+
+  describe('per-task transcript store hooks (INT-3402)', () => {
+    it('feeds log events into the per-task ring and lifecycles it on completion', async () => {
+      const { getTaskLog, TASK_LOG_RETENTION_MS } = await import('./taskLogStore.js');
+
+      broadcastEvent({ type: 'log', data: { taskId: 'hooked', stage: 'worker', line: 'one' } });
+      broadcastEvent({ type: 'log', data: { taskId: 'hooked', stage: 'worker', line: 'two' } });
+      expect(getTaskLog('hooked')?.lines.map((l) => l.line)).toEqual(['one', 'two']);
+
+      vi.useFakeTimers();
+      try {
+        broadcastEvent({ type: 'task:completed', data: { taskId: 'hooked', success: true, duration: 1 } });
+        vi.advanceTimersByTime(TASK_LOG_RETENTION_MS + 1);
+        expect(getTaskLog('hooked')).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('task:started cancels a pending cleanup for a reused task id', async () => {
+      const { getTaskLog, TASK_LOG_RETENTION_MS } = await import('./taskLogStore.js');
+      vi.useFakeTimers();
+      try {
+        broadcastEvent({ type: 'log', data: { taskId: 'retry', stage: 'worker', line: 'attempt 1' } });
+        broadcastEvent({ type: 'task:completed', data: { taskId: 'retry', success: false, duration: 1 } });
+        broadcastEvent({ type: 'task:started', data: { taskId: 'retry', title: 'again' } });
+        vi.advanceTimersByTime(TASK_LOG_RETENTION_MS + 1);
+        expect(getTaskLog('retry')).not.toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
 });

--- a/src/core/eventHub.ts
+++ b/src/core/eventHub.ts
@@ -7,6 +7,12 @@ import { EventEmitter } from 'node:events';
 import type { ServerResponse } from 'node:http';
 import type { CostInfo } from '../support/costTracker.js';
 import type { MonitorState } from './types.js';
+import {
+  appendTaskLog,
+  cancelTaskLogCleanup,
+  scheduleTaskLogCleanup,
+  __resetTaskLogsForTests,
+} from './taskLogStore.js';
 
 // Types
 
@@ -155,6 +161,16 @@ export function broadcastEvent(event: HubEvent): void {
   if (event.type !== 'heartbeat') {
     pushReplay(event);
   }
+  // Per-task transcript rings for the cockpit (INT-3402). Fed here — the one
+  // choke point every emitter already goes through — so no broadcast site
+  // changes. task:started/completed drive the retention lifecycle.
+  if (event.type === 'log') {
+    appendTaskLog(event.data.taskId, event.data.stage, event.data.line);
+  } else if (event.type === 'task:started') {
+    cancelTaskLogCleanup(event.data.taskId);
+  } else if (event.type === 'task:completed') {
+    scheduleTaskLogCleanup(event.data.taskId);
+  }
   // Per-type buffers for REST snapshot
   switch (event.type) {
     case 'log':
@@ -244,6 +260,7 @@ export function getChatBuffer(): HubEvent[] {
 export function __resetForTests(): void {
   // Clear all SSE clients
   sseClients.clear();
+  __resetTaskLogsForTests();
   // Clear all buffers
   replayBuffer.length = 0;
   logBuffer.length = 0;

--- a/src/core/taskLogStore.test.ts
+++ b/src/core/taskLogStore.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  appendTaskLog,
+  cancelTaskLogCleanup,
+  getTaskLog,
+  scheduleTaskLogCleanup,
+  TASK_LOG_MAX_BUFFERS,
+  TASK_LOG_MAX_LINE_CHARS,
+  TASK_LOG_RETENTION_MS,
+  TASK_LOG_RING_SIZE,
+  __resetTaskLogsForTests,
+} from './taskLogStore.js';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  __resetTaskLogsForTests();
+});
+
+afterEach(() => {
+  __resetTaskLogsForTests();
+  vi.useRealTimers();
+});
+
+describe('taskLogStore', () => {
+  it('appends lines with stage and timestamp, and snapshots are copies', () => {
+    appendTaskLog('t1', 'worker', 'hello', 111);
+    appendTaskLog('t1', 'reviewer', 'world', 222);
+
+    const snapshot = getTaskLog('t1')!;
+    expect(snapshot.lines).toEqual([
+      { stage: 'worker', line: 'hello', ts: 111 },
+      { stage: 'reviewer', line: 'world', ts: 222 },
+    ]);
+    expect(snapshot.truncated).toBe(false);
+
+    // Mutating the snapshot must not touch the ring (serialization safety).
+    snapshot.lines.push({ stage: 'x', line: 'injected', ts: 0 });
+    expect(getTaskLog('t1')!.lines).toHaveLength(2);
+  });
+
+  it('returns null for an unknown task', () => {
+    expect(getTaskLog('nope')).toBeNull();
+  });
+
+  it('rotates the ring at capacity and flags truncation', () => {
+    for (let i = 0; i < TASK_LOG_RING_SIZE + 5; i++) {
+      appendTaskLog('t1', 'worker', `line ${i}`);
+    }
+    const snapshot = getTaskLog('t1')!;
+    expect(snapshot.lines).toHaveLength(TASK_LOG_RING_SIZE);
+    expect(snapshot.lines[0].line).toBe('line 5');
+    expect(snapshot.truncated).toBe(true);
+  });
+
+  it('cuts oversized lines to the char cap and flags truncation', () => {
+    appendTaskLog('t1', 'worker', 'x'.repeat(TASK_LOG_MAX_LINE_CHARS + 50));
+    const snapshot = getTaskLog('t1')!;
+    expect(snapshot.lines[0].line.length).toBe(TASK_LOG_MAX_LINE_CHARS + 1); // +ellipsis
+    expect(snapshot.truncated).toBe(true);
+  });
+
+  it('deletes the buffer after the retention window post-completion', () => {
+    appendTaskLog('t1', 'worker', 'done soon');
+    scheduleTaskLogCleanup('t1');
+    vi.advanceTimersByTime(TASK_LOG_RETENTION_MS - 1);
+    expect(getTaskLog('t1')).not.toBeNull();
+    vi.advanceTimersByTime(2);
+    expect(getTaskLog('t1')).toBeNull();
+  });
+
+  it('a task id that comes back to life survives its stale cleanup timer', () => {
+    appendTaskLog('t1', 'worker', 'first attempt');
+    scheduleTaskLogCleanup('t1');
+    // Retry reuses the task id — new lines arrive before the timer fires.
+    vi.advanceTimersByTime(TASK_LOG_RETENTION_MS / 2);
+    appendTaskLog('t1', 'worker', 'second attempt');
+    vi.advanceTimersByTime(TASK_LOG_RETENTION_MS);
+    expect(getTaskLog('t1')).not.toBeNull();
+    expect(getTaskLog('t1')!.lines.map((l) => l.line)).toContain('second attempt');
+  });
+
+  it('cancelTaskLogCleanup keeps the buffer alive', () => {
+    appendTaskLog('t1', 'worker', 'line');
+    scheduleTaskLogCleanup('t1');
+    cancelTaskLogCleanup('t1');
+    vi.advanceTimersByTime(TASK_LOG_RETENTION_MS * 2);
+    expect(getTaskLog('t1')).not.toBeNull();
+  });
+
+  it('evicts only completed buffers at the LRU cap, never running ones', () => {
+    // Fill the cap with RUNNING tasks, then one more — nothing evictable, so
+    // the cap is exceeded rather than holing a live transcript.
+    for (let i = 0; i < TASK_LOG_MAX_BUFFERS; i++) {
+      appendTaskLog(`run-${i}`, 'worker', 'live');
+    }
+    appendTaskLog('overflow', 'worker', 'still stored');
+    expect(getTaskLog('run-0')).not.toBeNull();
+    expect(getTaskLog('overflow')).not.toBeNull();
+
+    // Mark the oldest as completed — the NEXT new buffer evicts exactly it.
+    scheduleTaskLogCleanup('run-0');
+    appendTaskLog('newcomer', 'worker', 'takes the slot');
+    expect(getTaskLog('run-0')).toBeNull();
+    expect(getTaskLog('run-1')).not.toBeNull();
+    expect(getTaskLog('newcomer')).not.toBeNull();
+  });
+});

--- a/src/core/taskLogStore.ts
+++ b/src/core/taskLogStore.ts
@@ -1,0 +1,136 @@
+// ============================================
+// OpenSwarm - Per-task log ring buffers (INT-3402)
+// ============================================
+//
+// The hub's global replay keeps only ~50 log lines across ALL tasks, so a page
+// reload loses most of a session's transcript. This store keeps a bounded ring
+// per task, fed by broadcastEvent's 'log' case, and serves the cockpit's
+// GET /api/work/sessions/:taskId/log.
+//
+// Deliberately import-free: eventHub imports this module, and route modules
+// import both — any import from here would be a cycle waiting to happen.
+//
+// Memory bound is threefold: per-line truncation x per-task ring x LRU buffer
+// cap. Worst case 24 x 1000 x (~400 UTF-16 chars + object overhead) ≈ 22 MB;
+// observed agent lines average ~80 chars, so typical usage is 1–3 MB.
+
+export interface TaskLogLine {
+  stage: string;
+  line: string;
+  ts: number;
+}
+
+export interface TaskLogSnapshot {
+  taskId: string;
+  lines: TaskLogLine[];
+  /** True when the ring dropped older lines (or a line was cut to the char cap). */
+  truncated: boolean;
+}
+
+export const TASK_LOG_RING_SIZE = 1000;
+export const TASK_LOG_MAX_LINE_CHARS = 400;
+export const TASK_LOG_MAX_BUFFERS = 24;
+export const TASK_LOG_RETENTION_MS = 10 * 60_000;
+
+interface TaskLogBuffer {
+  lines: TaskLogLine[];
+  truncated: boolean;
+  /** Set once the task completed and a cleanup timer is pending — the only
+   * buffers eligible for LRU eviction. */
+  completed: boolean;
+  lastAppendAt: number;
+}
+
+// Map iteration order is insertion order; entries are re-inserted on append so
+// the first eligible entry found is the least recently used.
+const buffers = new Map<string, TaskLogBuffer>();
+const cleanupTimers = new Map<string, NodeJS.Timeout>();
+
+function evictIfNeeded(): void {
+  if (buffers.size < TASK_LOG_MAX_BUFFERS) return;
+  // Only completed buffers are eviction candidates: evicting a running task's
+  // buffer would silently hole its transcript. If every buffer belongs to a
+  // running task (unrealistic beyond ~24 concurrent), exceed the cap instead.
+  let oldest: string | undefined;
+  for (const [taskId, buffer] of buffers) {
+    if (buffer.completed) {
+      oldest = taskId;
+      break;
+    }
+  }
+  if (oldest !== undefined) {
+    buffers.delete(oldest);
+    cancelTaskLogCleanup(oldest);
+  }
+}
+
+export function appendTaskLog(taskId: string, stage: string, line: string, now = Date.now()): void {
+  if (!taskId || typeof line !== 'string') return;
+  let buffer = buffers.get(taskId);
+  if (!buffer) {
+    evictIfNeeded();
+    buffer = { lines: [], truncated: false, completed: false, lastAppendAt: now };
+    buffers.set(taskId, buffer);
+  } else {
+    // Refresh LRU position and mark live again — a task id that logs after
+    // completion (retry reusing the id) must not be reaped by a stale timer.
+    buffers.delete(taskId);
+    buffers.set(taskId, buffer);
+    cancelTaskLogCleanup(taskId);
+    buffer.lastAppendAt = now;
+  }
+
+  let text = line;
+  if (text.length > TASK_LOG_MAX_LINE_CHARS) {
+    text = `${text.slice(0, TASK_LOG_MAX_LINE_CHARS)}…`;
+    buffer.truncated = true;
+  }
+  buffer.lines.push({ stage, line: text, ts: now });
+  if (buffer.lines.length > TASK_LOG_RING_SIZE) {
+    buffer.lines.shift();
+    buffer.truncated = true;
+  }
+}
+
+/** Snapshot copy (safe to serialize while appends continue). Null → 404. */
+export function getTaskLog(taskId: string): TaskLogSnapshot | null {
+  const buffer = buffers.get(taskId);
+  if (!buffer) return null;
+  return { taskId, lines: buffer.lines.slice(), truncated: buffer.truncated };
+}
+
+/** Called on task:completed — keep the transcript readable for a grace window. */
+export function scheduleTaskLogCleanup(taskId: string, delayMs = TASK_LOG_RETENTION_MS): void {
+  const buffer = buffers.get(taskId);
+  if (!buffer) return;
+  // Replace any prior timer directly — cancelTaskLogCleanup would also clear
+  // the completed flag this function is about to set.
+  const prior = cleanupTimers.get(taskId);
+  if (prior) clearTimeout(prior);
+  buffer.completed = true;
+  const timer = setTimeout(() => {
+    cleanupTimers.delete(taskId);
+    // The completed flag is cleared whenever the task id came back to life —
+    // never delete a buffer that has gone live again.
+    if (buffers.get(taskId)?.completed) buffers.delete(taskId);
+  }, delayMs);
+  timer.unref?.();
+  cleanupTimers.set(taskId, timer);
+}
+
+/** Called on task:started / new log lines — the task id is live (again). */
+export function cancelTaskLogCleanup(taskId: string): void {
+  const timer = cleanupTimers.get(taskId);
+  if (timer) {
+    clearTimeout(timer);
+    cleanupTimers.delete(taskId);
+  }
+  const buffer = buffers.get(taskId);
+  if (buffer) buffer.completed = false;
+}
+
+export function __resetTaskLogsForTests(): void {
+  for (const timer of cleanupTimers.values()) clearTimeout(timer);
+  cleanupTimers.clear();
+  buffers.clear();
+}

--- a/src/orchestration/decisionEngine.ts
+++ b/src/orchestration/decisionEngine.ts
@@ -76,6 +76,18 @@ export interface TaskItem {
  * sub-issues. `parentIds` is the set of issueIds that any fetched task points to via parentId,
  * so a fetched issue that IS such a parent is an umbrella. EPICs are also tagged in the title.
  */
+/**
+ * The ONE key every hub event about a task uses (`taskId` on log /
+ * pipeline:stage / task:queued|started|completed / task:cost / process:*).
+ * For Linear tasks `issueId === id`; TaskItem permits them to differ, and a
+ * mixed-key task splits across cockpit sessions and leaks its transcript
+ * buffer (INT-3402). Human-readable labels (issueIdentifier) ride in event
+ * payloads, never in the key.
+ */
+export function taskEventKey(task: Pick<TaskItem, 'id' | 'issueId'>): string {
+  return task.issueId || task.id;
+}
+
 export function isUmbrellaIssue(task: TaskItem, parentIds: Set<string>): boolean {
   const isEpicTitle = /\[\s*epic\s*\]/i.test(task.title) || /^\s*epic[:\s]/i.test(task.title);
   const isParent = !!task.issueId && parentIds.has(task.issueId);

--- a/src/support/gitTracker.test.ts
+++ b/src/support/gitTracker.test.ts
@@ -35,6 +35,34 @@ describe('gitTracker', () => {
     expect(diff).toContain('+changed');
   });
 
+  it('getDiffText omits untracked files by default but includes them on request', async () => {
+    writeFileSync(join(repo, 'tracked.txt'), 'changed\n');
+    writeFileSync(join(repo, 'brand-new.txt'), 'fresh content\n');
+
+    // Default: `git diff HEAD` ignores untracked files entirely — the cockpit
+    // listed the file with no patch behind it (INT-3402 review).
+    const plain = await getDiffText(repo);
+    expect(plain).toContain('tracked.txt');
+    expect(plain).not.toContain('brand-new.txt');
+
+    const withUntracked = await getDiffText(repo, undefined, 16_000, { includeUntracked: true });
+    expect(withUntracked).toContain('brand-new.txt');
+    expect(withUntracked).toContain('+fresh content');
+    // The modified tracked file still shows, and the real index is untouched.
+    expect(withUntracked).toContain('+changed');
+    const staged = execFileSync('git', ['diff', '--cached', '--name-only'], { cwd: repo, encoding: 'utf-8' });
+    expect(staged.trim()).toBe('');
+  });
+
+  it('getDiffText ignores gitignored files even when including untracked', async () => {
+    writeFileSync(join(repo, '.gitignore'), 'secret.txt\n');
+    writeFileSync(join(repo, 'secret.txt'), 'do not show\n');
+
+    const diff = await getDiffText(repo, undefined, 16_000, { includeUntracked: true });
+    expect(diff).not.toContain('do not show');
+    expect(diff).toContain('.gitignore');
+  });
+
   it('getDiffText diffs against a base ref when given one', async () => {
     const base = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
     writeFileSync(join(repo, 'tracked.txt'), 'committed change\n');

--- a/src/support/gitTracker.ts
+++ b/src/support/gitTracker.ts
@@ -59,12 +59,40 @@ export async function getDiffText(
   projectPath: string,
   since?: string,
   maxBytes = 16_000,
+  opts: {
+    /**
+     * Also show brand-new untracked files as additions. `git diff` ignores
+     * them entirely, so a viewer listing changed files would show a new file
+     * with no patch behind it. Staged into a THROWAWAY index, never the
+     * worktree's own. (INT-3402)
+     */
+    includeUntracked?: boolean;
+  } = {},
 ): Promise<string> {
-  const args = since
-    ? ['diff', '--no-color', '--no-ext-diff', since]
-    : ['diff', '--no-color', '--no-ext-diff', 'HEAD'];
+  const base = since ?? 'HEAD';
   try {
-    const diff = await runGitCommand(projectPath, args);
+    let diff: string;
+    if (opts.includeUntracked) {
+      const dir = await mkdtemp(join(tmpdir(), 'osw-diff-idx-'));
+      const indexFile = join(dir, 'index');
+      try {
+        const env: NodeJS.ProcessEnv = { GIT_INDEX_FILE: indexFile };
+        // `read-tree` seeds the temp index from the base so unchanged files
+        // are not reported; `add -A` then stages the worktree (new files
+        // included, .gitignore honored) and the cached diff shows everything.
+        await runGitCommand(projectPath, ['read-tree', base], env);
+        await runGitCommand(projectPath, ['add', '-A'], env);
+        diff = await runGitCommand(
+          projectPath,
+          ['diff', '--no-color', '--no-ext-diff', '--cached', base],
+          env,
+        );
+      } finally {
+        await rm(dir, { recursive: true, force: true }).catch(() => {});
+      }
+    } else {
+      diff = await runGitCommand(projectPath, ['diff', '--no-color', '--no-ext-diff', base]);
+    }
     if (diff.length <= maxBytes) return diff;
     return `[diff truncated at ${maxBytes} bytes of ${diff.length}; read the files directly for the rest]\n\n${diff.slice(0, maxBytes)}`;
   } catch (error) {

--- a/src/support/webAppRoutes.ts
+++ b/src/support/webAppRoutes.ts
@@ -39,6 +39,13 @@ export async function tryHandleAppRoutes(
   runner: AutonomousRunner | undefined,
   readBody: (req: IncomingMessage) => Promise<string>,
 ): Promise<boolean> {
+  // Cockpit read surface (sessions/transcript/diff/quota) lives in its own
+  // module (INT-3402); web.ts's auth gates already ran before this delegation.
+  {
+    const { tryHandleWorkSessionRoutes } = await import('./workSessionRoutes.js');
+    if (await tryHandleWorkSessionRoutes(req, res, url, requestUrl, runner)) return true;
+  }
+
   if (url === '/app') {
     const shell = await readAppShell();
     if (!shell) {

--- a/src/support/workSessionRoutes.test.ts
+++ b/src/support/workSessionRoutes.test.ts
@@ -1,0 +1,326 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { AutonomousRunner } from '../automation/autonomousRunner.js';
+import type { RunningTask, QueuedTask } from '../orchestration/taskScheduler.js';
+import type { PipelineHistoryEntry } from '../automation/runnerState.js';
+
+const { existsSyncImpl } = vi.hoisted(() => ({ existsSyncImpl: vi.fn(() => true) }));
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return { ...actual, existsSync: existsSyncImpl };
+});
+
+const { getPipelineHistoryImpl } = vi.hoisted(() => ({
+  getPipelineHistoryImpl: vi.fn((): PipelineHistoryEntry[] => []),
+}));
+vi.mock('../automation/runnerState.js', () => ({ getPipelineHistory: getPipelineHistoryImpl }));
+
+const gitTracker = vi.hoisted(() => ({
+  getWorkingDiffDetail: vi.fn(async () => [{ file: 'src/a.ts', added: 3, deleted: 1, isNew: false }]),
+  getDiffText: vi.fn(async () => 'diff --git a/src/a.ts b/src/a.ts\n+added'),
+}));
+vi.mock('./gitTracker.js', () => gitTracker);
+
+import {
+  buildSessionList,
+  buildStageModelIndex,
+  resolveTaskWorktree,
+  tryHandleWorkSessionRoutes,
+} from './workSessionRoutes.js';
+import { appendTaskLog, __resetTaskLogsForTests } from '../core/taskLogStore.js';
+import { recordQuotaObservation, __resetQuotaForTests } from '../adapters/quotaSnapshot.js';
+
+const runningTask = (id: string, over: Partial<RunningTask['task']> = {}): RunningTask =>
+  ({
+    runId: `run-${id}`,
+    task: { id, issueId: id, issueIdentifier: `INT-${id}`, title: `Task ${id}`, ...over },
+    projectPath: '/repo',
+    startedAt: 1000,
+    stage: 'worker',
+  }) as unknown as RunningTask;
+
+const queuedTask = (id: string): QueuedTask =>
+  ({
+    task: { id, issueId: id, issueIdentifier: `INT-${id}`, title: `Task ${id}` },
+    projectPath: '/repo',
+    queuedAt: 500,
+    priority: 2,
+  }) as unknown as QueuedTask;
+
+const historyEntry = (over: Partial<PipelineHistoryEntry> = {}): PipelineHistoryEntry =>
+  ({
+    sessionId: 'sess-1',
+    issueId: 'done-1',
+    issueIdentifier: 'INT-D1',
+    taskTitle: 'Finished task',
+    projectPath: '/repo',
+    success: true,
+    finalStatus: 'completed',
+    iterations: 1,
+    totalDuration: 60_000,
+    stages: [],
+    cost: { costUsd: 0.42, inputTokens: 10, outputTokens: 5 },
+    completedAt: '2026-08-08T10:00:00.000Z',
+    ...over,
+  }) as PipelineHistoryEntry;
+
+function mkRunner(over: Partial<Record<string, unknown>> = {}): AutonomousRunner {
+  return {
+    getRunningTasks: vi.fn(() => [] as RunningTask[]),
+    getQueuedTasks: vi.fn(() => [] as QueuedTask[]),
+    getDurableRun: vi.fn(() => null),
+    getRateLimitHoldUntil: vi.fn(() => 0),
+    ...over,
+  } as unknown as AutonomousRunner;
+}
+
+async function call(
+  url: string,
+  runner: AutonomousRunner | undefined,
+): Promise<{ handled: boolean; status: number; body: any }> {
+  let status = 0;
+  let payload = '';
+  const res = {
+    writeHead: (code: number) => {
+      status = code;
+    },
+    end: (body: string) => {
+      payload = body;
+    },
+  } as unknown as ServerResponse;
+  const requestUrl = new URL(`http://127.0.0.1${url}`);
+  const handled = await tryHandleWorkSessionRoutes(
+    { method: 'GET', headers: {} } as IncomingMessage,
+    res,
+    requestUrl.pathname,
+    requestUrl,
+    runner,
+  );
+  return { handled, status, body: payload ? JSON.parse(payload) : null };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  existsSyncImpl.mockReturnValue(true);
+  getPipelineHistoryImpl.mockReturnValue([]);
+  __resetTaskLogsForTests();
+  __resetQuotaForTests();
+});
+
+describe('buildStageModelIndex', () => {
+  it('keeps the latest model per task and ignores other event types', () => {
+    const index = buildStageModelIndex([
+      { type: 'pipeline:stage', data: { taskId: 't1', model: 'old-model' } },
+      { type: 'task:started', data: { taskId: 't1', model: 'not-a-stage' } },
+      { type: 'pipeline:stage', data: { taskId: 't1', model: 'new-model' } },
+      { type: 'pipeline:stage', data: { taskId: 't2' } },
+    ]);
+    expect(index.get('t1')).toBe('new-model');
+    expect(index.has('t2')).toBe(false);
+  });
+});
+
+describe('buildSessionList', () => {
+  it('merges running, queued, and history with the documented field mappings', () => {
+    const { sessions, recent } = buildSessionList(
+      [runningTask('r1')],
+      [queuedTask('q1')],
+      [historyEntry()],
+      () => ({ worktreePath: '/repo/worktree/r1', branch: 'swarm/INT-r1' }),
+      new Map([['r1', 'gpt-5.5']]),
+    );
+    expect(sessions).toEqual([
+      expect.objectContaining({
+        taskId: 'r1',
+        status: 'running',
+        worktreePath: '/repo/worktree/r1',
+        branch: 'swarm/INT-r1',
+        model: 'gpt-5.5',
+        stage: 'worker',
+        startedAt: 1000,
+      }),
+      // queuedAt maps onto startedAt for queued rows (documented).
+      expect.objectContaining({ taskId: 'q1', status: 'queued', startedAt: 500 }),
+    ]);
+    expect(recent).toEqual([
+      expect.objectContaining({
+        taskId: 'done-1',
+        status: 'completed',
+        costUsd: 0.42,
+        completedAt: Date.parse('2026-08-08T10:00:00.000Z'),
+      }),
+    ]);
+  });
+
+  it('drops history entries whose task id is back on the board (retry)', () => {
+    const { recent } = buildSessionList(
+      [runningTask('done-1')],
+      [],
+      [historyEntry({ issueId: 'done-1' }), historyEntry({ issueId: 'other', success: false, failureCause: 'timeout' })],
+      () => ({}),
+      new Map(),
+    );
+    expect(recent).toEqual([
+      expect.objectContaining({ taskId: 'other', status: 'failed', failureCause: 'timeout' }),
+    ]);
+  });
+});
+
+describe('resolveTaskWorktree', () => {
+  it('prefers the ledger record when its worktree exists on disk', () => {
+    const runner = mkRunner({
+      getRunningTasks: vi.fn(() => [runningTask('t1')]),
+      getDurableRun: vi.fn(() => ({
+        worktreePath: '/repo/worktree/ledger-path',
+        branchName: 'swarm/INT-t1',
+        projectPath: '/repo',
+      })),
+    });
+    expect(resolveTaskWorktree(runner, 't1')).toEqual({
+      worktreePath: '/repo/worktree/ledger-path',
+      branch: 'swarm/INT-t1',
+      projectPath: '/repo',
+    });
+  });
+
+  it('falls back to the conventional layout for a running task without a ledger row', () => {
+    const runner = mkRunner({ getRunningTasks: vi.fn(() => [runningTask('t1')]) });
+    expect(resolveTaskWorktree(runner, 't1')).toEqual({
+      worktreePath: '/repo/worktree/t1',
+      branch: undefined,
+      projectPath: '/repo',
+    });
+  });
+
+  it('returns null when nothing exists on disk — never a guessed path', () => {
+    existsSyncImpl.mockReturnValue(false);
+    const runner = mkRunner({ getRunningTasks: vi.fn(() => [runningTask('t1')]) });
+    expect(resolveTaskWorktree(runner, 't1')).toBeNull();
+  });
+});
+
+describe('GET /api/work/sessions', () => {
+  it('serves history with runnerAvailable=false when the runner is absent', async () => {
+    getPipelineHistoryImpl.mockReturnValue([historyEntry()]);
+    const { handled, status, body } = await call('/api/work/sessions', undefined);
+    expect(handled).toBe(true);
+    expect(status).toBe(200);
+    expect(body.runnerAvailable).toBe(false);
+    expect(body.sessions).toEqual([]);
+    expect(body.recent).toHaveLength(1);
+  });
+
+  it('serves the merged list with worktree resolution when the runner is up', async () => {
+    const runner = mkRunner({
+      getRunningTasks: vi.fn(() => [runningTask('t1')]),
+      getQueuedTasks: vi.fn(() => [queuedTask('q1')]),
+    });
+    const { status, body } = await call('/api/work/sessions', runner);
+    expect(status).toBe(200);
+    expect(body.runnerAvailable).toBe(true);
+    expect(body.sessions.map((s: { taskId: string }) => s.taskId)).toEqual(['t1', 'q1']);
+    expect(body.sessions[0].worktreePath).toBe('/repo/worktree/t1');
+  });
+});
+
+describe('GET /api/work/sessions/:taskId/log', () => {
+  it('returns the transcript snapshot', async () => {
+    appendTaskLog('t1', 'worker', 'hello', 42);
+    const { status, body } = await call('/api/work/sessions/t1/log', mkRunner());
+    expect(status).toBe(200);
+    expect(body).toEqual({ taskId: 't1', lines: [{ stage: 'worker', line: 'hello', ts: 42 }], truncated: false });
+  });
+
+  it('404s for an unknown task and decodes the id', async () => {
+    appendTaskLog('weird id', 'worker', 'line');
+    expect((await call('/api/work/sessions/nope/log', mkRunner())).status).toBe(404);
+    expect((await call('/api/work/sessions/weird%20id/log', mkRunner())).status).toBe(200);
+  });
+});
+
+describe('GET /api/work/diff', () => {
+  it('400s without taskId and 503s without a runner', async () => {
+    expect((await call('/api/work/diff', mkRunner())).status).toBe(400);
+    expect((await call('/api/work/diff?taskId=t1', undefined)).status).toBe(503);
+  });
+
+  it('404s when the task has no worktree, without touching git', async () => {
+    existsSyncImpl.mockReturnValue(false);
+    const { status } = await call('/api/work/diff?taskId=t1', mkRunner({ getRunningTasks: vi.fn(() => [runningTask('t1')]) }));
+    expect(status).toBe(404);
+    expect(gitTracker.getWorkingDiffDetail).not.toHaveBeenCalled();
+  });
+
+  it('never lets a traversal-shaped taskId reach git — resolution is server-side only', async () => {
+    existsSyncImpl.mockReturnValue(false);
+    const { status } = await call(`/api/work/diff?taskId=${encodeURIComponent('../../etc')}`, mkRunner());
+    expect(status).toBe(404);
+    expect(gitTracker.getWorkingDiffDetail).not.toHaveBeenCalled();
+    expect(gitTracker.getDiffText).not.toHaveBeenCalled();
+  });
+
+  it('404s when the resolved worktree escapes the project boundary', async () => {
+    const runner = mkRunner({
+      getRunningTasks: vi.fn(() => [runningTask('t1')]),
+      getDurableRun: vi.fn(() => ({
+        worktreePath: '/elsewhere/worktree/t1',
+        branchName: 'swarm/INT-t1',
+        projectPath: '/repo',
+      })),
+    });
+    const { status } = await call('/api/work/diff?taskId=t1', runner);
+    expect(status).toBe(404);
+    expect(gitTracker.getWorkingDiffDetail).not.toHaveBeenCalled();
+  });
+
+  it('serves files + diff text from the resolved worktree', async () => {
+    const runner = mkRunner({ getRunningTasks: vi.fn(() => [runningTask('t1')]) });
+    const { status, body } = await call('/api/work/diff?taskId=t1', runner);
+    expect(status).toBe(200);
+    expect(body.worktreePath).toBe('/repo/worktree/t1');
+    expect(body.files).toHaveLength(1);
+    expect(body.diff).toContain('diff --git');
+    expect(body.truncated).toBe(false);
+    expect(gitTracker.getWorkingDiffDetail).toHaveBeenCalledWith('/repo/worktree/t1');
+  });
+
+  it('caps the requested maxBytes at the hard limit', async () => {
+    const runner = mkRunner({ getRunningTasks: vi.fn(() => [runningTask('t1')]) });
+    await call('/api/work/diff?taskId=t1&maxBytes=99999999', runner);
+    expect(gitTracker.getDiffText).toHaveBeenCalledWith('/repo/worktree/t1', undefined, 262_144);
+  });
+});
+
+describe('GET /api/quota', () => {
+  it('serves observations and the scheduler hold when active', async () => {
+    recordQuotaObservation({ provider: 'codex', usedPercent: 37, source: 'success-headers', observedAt: 7 });
+    const holdUntil = Date.now() + 60_000;
+    const runner = mkRunner({ getRateLimitHoldUntil: vi.fn(() => holdUntil) });
+    const { status, body } = await call('/api/quota', runner);
+    expect(status).toBe(200);
+    expect(body.providers).toEqual([
+      { provider: 'codex', usedPercent: 37, source: 'success-headers', observedAt: 7 },
+    ]);
+    expect(body.schedulerHoldUntil).toBe(holdUntil);
+  });
+
+  it('always 200s — empty providers and null hold without observations/runner', async () => {
+    const { status, body } = await call('/api/quota', undefined);
+    expect(status).toBe(200);
+    expect(body).toEqual({ providers: [], schedulerHoldUntil: null });
+  });
+});
+
+describe('non-matching requests', () => {
+  it('passes through unrelated URLs and non-GET methods', async () => {
+    expect((await call('/api/work/issues', mkRunner())).handled).toBe(false);
+    let handled = await tryHandleWorkSessionRoutes(
+      { method: 'POST', headers: {} } as IncomingMessage,
+      {} as ServerResponse,
+      '/api/quota',
+      new URL('http://127.0.0.1/api/quota'),
+      undefined,
+    );
+    expect(handled).toBe(false);
+  });
+});

--- a/src/support/workSessionRoutes.test.ts
+++ b/src/support/workSessionRoutes.test.ts
@@ -18,6 +18,7 @@ vi.mock('../automation/runnerState.js', () => ({ getPipelineHistory: getPipeline
 const gitTracker = vi.hoisted(() => ({
   getWorkingDiffDetail: vi.fn(async () => [{ file: 'src/a.ts', added: 3, deleted: 1, isNew: false }]),
   getDiffText: vi.fn(async () => 'diff --git a/src/a.ts b/src/a.ts\n+added'),
+  isGitRepo: vi.fn(async () => true),
 }));
 vi.mock('./gitTracker.js', () => gitTracker);
 
@@ -103,6 +104,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   existsSyncImpl.mockReturnValue(true);
   getPipelineHistoryImpl.mockReturnValue([]);
+  gitTracker.getWorkingDiffDetail.mockResolvedValue([{ file: 'src/a.ts', added: 3, deleted: 1, isNew: false }]);
+  gitTracker.getDiffText.mockResolvedValue('diff --git a/src/a.ts b/src/a.ts\n+added');
+  gitTracker.isGitRepo.mockResolvedValue(true);
   __resetTaskLogsForTests();
   __resetQuotaForTests();
 });
@@ -150,6 +154,18 @@ describe('buildSessionList', () => {
         completedAt: Date.parse('2026-08-08T10:00:00.000Z'),
       }),
     ]);
+  });
+
+  it('keeps a decomposed run distinct from a completed one', () => {
+    const { recent } = buildSessionList(
+      [],
+      [],
+      [historyEntry({ issueId: 'parent-1', success: true, finalStatus: 'decomposed' })],
+      () => ({}),
+      new Map(),
+    );
+    // success:true, but the children own the work now — not a completion.
+    expect(recent[0]).toMatchObject({ status: 'decomposed', finalStatus: 'decomposed' });
   });
 
   it('drops history entries whose task id is back on the board (retry)', () => {
@@ -284,10 +300,34 @@ describe('GET /api/work/diff', () => {
     expect(gitTracker.getWorkingDiffDetail).toHaveBeenCalledWith('/repo/worktree/t1');
   });
 
-  it('caps the requested maxBytes at the hard limit', async () => {
+  it('caps the requested maxBytes at the hard limit and asks for untracked content', async () => {
     const runner = mkRunner({ getRunningTasks: vi.fn(() => [runningTask('t1')]) });
     await call('/api/work/diff?taskId=t1&maxBytes=99999999', runner);
-    expect(gitTracker.getDiffText).toHaveBeenCalledWith('/repo/worktree/t1', undefined, 262_144);
+    // includeUntracked: a brand-new file appears in `files` but `git diff HEAD`
+    // would show no patch for it (review finding).
+    expect(gitTracker.getDiffText).toHaveBeenCalledWith('/repo/worktree/t1', undefined, 262_144, {
+      includeUntracked: true,
+    });
+  });
+
+  it('409s instead of reporting a clean diff when the worktree is no longer a git repo', async () => {
+    gitTracker.getWorkingDiffDetail.mockResolvedValue([]);
+    gitTracker.getDiffText.mockResolvedValue('');
+    gitTracker.isGitRepo.mockResolvedValue(false);
+    const runner = mkRunner({ getRunningTasks: vi.fn(() => [runningTask('t1')]) });
+    const { status, body } = await call('/api/work/diff?taskId=t1', runner);
+    expect(status).toBe(409);
+    expect(body.error).toContain('no longer a valid git repository');
+  });
+
+  it('200s with an empty diff when the worktree is healthy and simply clean', async () => {
+    gitTracker.getWorkingDiffDetail.mockResolvedValue([]);
+    gitTracker.getDiffText.mockResolvedValue('');
+    const runner = mkRunner({ getRunningTasks: vi.fn(() => [runningTask('t1')]) });
+    const { status, body } = await call('/api/work/diff?taskId=t1', runner);
+    expect(status).toBe(200);
+    expect(body.files).toEqual([]);
+    expect(body.diff).toBe('');
   });
 });
 

--- a/src/support/workSessionRoutes.ts
+++ b/src/support/workSessionRoutes.ts
@@ -1,0 +1,283 @@
+// ============================================
+// OpenSwarm - Cockpit session routes (INT-3402)
+// ============================================
+//
+// The read surface behind the session cockpit: a clean session list (the old
+// /api/tasks serializes AbortController fields as {}), per-task transcripts,
+// a worktree diff, and provider quota. Lives outside web.ts (1500-line cap);
+// webAppRoutes delegates here AFTER web.ts's auth gates ran.
+//
+// Security invariant for the diff route: the client never supplies a path in
+// any form. taskId resolves to a worktree server-side (ledger first, then the
+// deterministic worktree layout), and the result must stay under the task's
+// own project root.
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { existsSync } from 'node:fs';
+import type { AutonomousRunner } from '../automation/autonomousRunner.js';
+import type { RunningTask, QueuedTask } from '../orchestration/taskScheduler.js';
+import { taskEventKey } from '../orchestration/decisionEngine.js';
+import type { PipelineHistoryEntry } from '../automation/runnerState.js';
+import { getTaskLog } from '../core/taskLogStore.js';
+import { getStageBuffer } from '../core/eventHub.js';
+import { getQuotaSnapshot } from '../adapters/quotaSnapshot.js';
+
+function writeJson(res: ServerResponse, statusCode: number, body: unknown): void {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+export interface WorkSessionEntry {
+  taskId: string;
+  issueIdentifier?: string;
+  title: string;
+  projectPath: string;
+  worktreePath?: string;
+  branch?: string;
+  stage?: string;
+  model?: string;
+  startedAt: number;
+  status: 'running' | 'queued';
+}
+
+export interface WorkSessionRecent {
+  taskId: string;
+  issueIdentifier?: string;
+  title: string;
+  projectPath?: string;
+  status: 'completed' | 'failed';
+  completedAt: number;
+  costUsd?: number;
+  durationMs: number;
+  failureCause?: string;
+}
+
+export interface WorkSessionsResponse {
+  runnerAvailable: boolean;
+  sessions: WorkSessionEntry[];
+  recent: WorkSessionRecent[];
+}
+
+/** Latest model seen per taskId, folded from the hub's stage buffer. */
+export function buildStageModelIndex(
+  stageEvents: Array<{ type: string; data?: { taskId?: string; model?: string } }>,
+): Map<string, string> {
+  const models = new Map<string, string>();
+  for (const event of stageEvents) {
+    if (event.type !== 'pipeline:stage') continue;
+    const { taskId, model } = event.data ?? {};
+    if (typeof taskId === 'string' && typeof model === 'string' && model) {
+      models.set(taskId, model);
+    }
+  }
+  return models;
+}
+
+/**
+ * Pure fold of scheduler + history state into the response shape — the route
+ * only gathers inputs. Exported for direct fixture tests.
+ */
+export function buildSessionList(
+  running: RunningTask[],
+  queued: QueuedTask[],
+  history: PipelineHistoryEntry[],
+  resolveWorktree: (task: RunningTask) => { worktreePath?: string; branch?: string },
+  stageModels: Map<string, string>,
+): Omit<WorkSessionsResponse, 'runnerAvailable'> {
+  // The session list must use the same key every hub event uses — see
+  // taskEventKey's doc for why a mixed key splits a session.
+  const sessions: WorkSessionEntry[] = [];
+  for (const item of running) {
+    const worktree = resolveWorktree(item);
+    sessions.push({
+      taskId: taskEventKey(item.task),
+      issueIdentifier: item.task.issueIdentifier,
+      title: item.task.title,
+      projectPath: item.projectPath,
+      worktreePath: worktree.worktreePath,
+      branch: worktree.branch,
+      stage: item.stage,
+      model: stageModels.get(taskEventKey(item.task)),
+      startedAt: item.startedAt,
+      status: 'running',
+    });
+  }
+  for (const item of queued) {
+    sessions.push({
+      taskId: taskEventKey(item.task),
+      issueIdentifier: item.task.issueIdentifier,
+      title: item.task.title,
+      projectPath: item.projectPath,
+      // Documented mapping: a queued session has not started — this is queuedAt.
+      startedAt: item.queuedAt,
+      status: 'queued',
+    });
+  }
+
+  // Sessions still on the board must not ALSO appear as history (a retried
+  // task id has both a running entry and older completed entries).
+  const active = new Set(sessions.map((s) => s.taskId));
+  const recent: WorkSessionRecent[] = [];
+  for (const entry of history) {
+    const taskId = entry.issueId ?? entry.sessionId;
+    if (active.has(taskId)) continue;
+    const completedAt = Date.parse(entry.completedAt);
+    recent.push({
+      taskId,
+      issueIdentifier: entry.issueIdentifier,
+      title: entry.taskTitle,
+      projectPath: entry.projectPath,
+      status: entry.success ? 'completed' : 'failed',
+      completedAt: Number.isFinite(completedAt) ? completedAt : 0,
+      costUsd: entry.cost?.costUsd,
+      durationMs: entry.totalDuration,
+      failureCause: entry.failureCause,
+    });
+  }
+  return { sessions, recent };
+}
+
+/**
+ * Server-side taskId → worktree mapping. Ledger first (attachWorktree records
+ * the real path), then the deterministic `{projectPath}/worktree/{issueId}`
+ * layout. Returns null when nothing exists on disk — never a guessed path.
+ */
+export function resolveTaskWorktree(
+  runner: AutonomousRunner,
+  taskId: string,
+): { worktreePath: string; branch?: string; projectPath: string } | null {
+  // Clients hold the session list's taskId (= taskEventKey); accept the raw
+  // task.id too so nothing depends on which spelling a caller saved.
+  const running = runner
+    .getRunningTasks()
+    .find((t) => taskEventKey(t.task) === taskId || t.task.id === taskId);
+  const issueId = running?.task.issueId ?? taskId;
+  const projectPath = running?.projectPath;
+
+  const record = runner.getDurableRun(issueId);
+  if (record?.worktreePath && existsSync(record.worktreePath)) {
+    return {
+      worktreePath: record.worktreePath,
+      branch: record.branchName,
+      projectPath: projectPath ?? record.projectPath ?? record.worktreePath,
+    };
+  }
+  if (projectPath) {
+    const conventional = `${projectPath}/worktree/${issueId}`;
+    if (existsSync(conventional)) {
+      return { worktreePath: conventional, branch: record?.branchName, projectPath };
+    }
+  }
+  return null;
+}
+
+const DIFF_DEFAULT_MAX_BYTES = 16_000;
+const DIFF_HARD_MAX_BYTES = 262_144;
+
+export async function tryHandleWorkSessionRoutes(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: string,
+  requestUrl: URL,
+  runner: AutonomousRunner | undefined,
+): Promise<boolean> {
+  if (req.method !== 'GET') return false;
+
+  if (url === '/api/work/sessions') {
+    const limitRaw = parseInt(requestUrl.searchParams.get('limit') ?? '20', 10);
+    const limit = Math.min(Math.max(Number.isFinite(limitRaw) ? limitRaw : 20, 0), 100);
+    // History lives in runnerState (module-level) — readable even without a
+    // runner, so a dashboard-only daemon still shows recent work.
+    const { getPipelineHistory } = await import('../automation/runnerState.js');
+    const history = getPipelineHistory(limit);
+    if (!runner) {
+      const { sessions, recent } = buildSessionList([], [], history, () => ({}), new Map());
+      writeJson(res, 200, { runnerAvailable: false, sessions, recent });
+      return true;
+    }
+    const stageModels = buildStageModelIndex(getStageBuffer() as Array<{ type: string; data?: { taskId?: string; model?: string } }>);
+    const { sessions, recent } = buildSessionList(
+      runner.getRunningTasks(),
+      runner.getQueuedTasks(),
+      history,
+      (task) => {
+        const resolved = resolveTaskWorktree(runner, task.task.id);
+        return resolved ? { worktreePath: resolved.worktreePath, branch: resolved.branch } : {};
+      },
+      stageModels,
+    );
+    writeJson(res, 200, { runnerAvailable: true, sessions, recent });
+    return true;
+  }
+
+  const logMatch = url.match(/^\/api\/work\/sessions\/([^/]+)\/log$/);
+  if (logMatch) {
+    const taskId = decodeURIComponent(logMatch[1]);
+    const snapshot = getTaskLog(taskId);
+    if (!snapshot) {
+      writeJson(res, 404, { error: `No transcript for task ${taskId} (unknown, or retention expired)` });
+      return true;
+    }
+    writeJson(res, 200, snapshot);
+    return true;
+  }
+
+  if (url === '/api/work/diff') {
+    const taskId = requestUrl.searchParams.get('taskId');
+    if (!taskId) {
+      writeJson(res, 400, { error: 'Missing ?taskId=' });
+      return true;
+    }
+    if (!runner) {
+      writeJson(res, 503, { error: 'Runner not available (daemon starting or autonomous config missing)' });
+      return true;
+    }
+    const resolved = resolveTaskWorktree(runner, taskId);
+    if (!resolved) {
+      writeJson(res, 404, { error: `No worktree for task ${taskId}` });
+      return true;
+    }
+    // Defense in depth: even the server-resolved path must stay inside the
+    // task's own project boundary.
+    const { normalizeProjectPath } = await import('../orchestration/taskScheduler.js');
+    const canonicalWorktree = normalizeProjectPath(resolved.worktreePath);
+    const canonicalProject = normalizeProjectPath(resolved.projectPath);
+    if (canonicalWorktree !== canonicalProject && !canonicalWorktree.startsWith(`${canonicalProject}/`)) {
+      writeJson(res, 404, { error: `No worktree for task ${taskId}` });
+      return true;
+    }
+    const maxRaw = parseInt(requestUrl.searchParams.get('maxBytes') ?? '', 10);
+    const maxBytes = Math.min(
+      Number.isFinite(maxRaw) && maxRaw > 0 ? maxRaw : DIFF_DEFAULT_MAX_BYTES,
+      DIFF_HARD_MAX_BYTES,
+    );
+    const { getWorkingDiffDetail, getDiffText } = await import('./gitTracker.js');
+    // Working tree vs HEAD — changes the worker already committed on the
+    // branch are not shown; the cockpit's per-stage filesChanged covers those.
+    const [files, diff] = await Promise.all([
+      getWorkingDiffDetail(resolved.worktreePath),
+      getDiffText(resolved.worktreePath, undefined, maxBytes),
+    ]);
+    writeJson(res, 200, {
+      taskId,
+      worktreePath: resolved.worktreePath,
+      branch: resolved.branch,
+      files,
+      diff,
+      truncated: diff.startsWith('[diff truncated'),
+    });
+    return true;
+  }
+
+  if (url === '/api/quota') {
+    const snapshot = getQuotaSnapshot();
+    const holdUntil = runner?.getRateLimitHoldUntil() ?? 0;
+    writeJson(res, 200, {
+      providers: snapshot.providers,
+      schedulerHoldUntil: holdUntil > Date.now() ? holdUntil : null,
+    });
+    return true;
+  }
+
+  return false;
+}

--- a/src/support/workSessionRoutes.ts
+++ b/src/support/workSessionRoutes.ts
@@ -45,7 +45,14 @@ export interface WorkSessionRecent {
   issueIdentifier?: string;
   title: string;
   projectPath?: string;
-  status: 'completed' | 'failed';
+  /**
+   * 'decomposed' is NOT a completion: the run succeeded at splitting the issue
+   * and its children now own the work. Folding it into 'completed' told the
+   * cockpit a parent issue was finished. (review finding)
+   */
+  status: 'completed' | 'failed' | 'decomposed';
+  /** Raw pipeline finalStatus, for cases the three buckets flatten. */
+  finalStatus: string;
   completedAt: number;
   costUsd?: number;
   durationMs: number;
@@ -127,7 +134,8 @@ export function buildSessionList(
       issueIdentifier: entry.issueIdentifier,
       title: entry.taskTitle,
       projectPath: entry.projectPath,
-      status: entry.success ? 'completed' : 'failed',
+      status: entry.finalStatus === 'decomposed' ? 'decomposed' : entry.success ? 'completed' : 'failed',
+      finalStatus: entry.finalStatus,
       completedAt: Number.isFinite(completedAt) ? completedAt : 0,
       costUsd: entry.cost?.costUsd,
       durationMs: entry.totalDuration,
@@ -254,10 +262,28 @@ export async function tryHandleWorkSessionRoutes(
     const { getWorkingDiffDetail, getDiffText } = await import('./gitTracker.js');
     // Working tree vs HEAD — changes the worker already committed on the
     // branch are not shown; the cockpit's per-stage filesChanged covers those.
+    //
+    // `git diff HEAD` omits untracked files entirely, so a brand-new file
+    // would appear in `files` with no patch to show. `--intent-to-add` on a
+    // throwaway index makes git emit their content as an addition without
+    // touching the worktree's real index. (review finding)
     const [files, diff] = await Promise.all([
       getWorkingDiffDetail(resolved.worktreePath),
-      getDiffText(resolved.worktreePath, undefined, maxBytes),
+      getDiffText(resolved.worktreePath, undefined, maxBytes, { includeUntracked: true }),
     ]);
+    // Both helpers swallow git errors into []/'' (they are advisory elsewhere).
+    // Here that would render as "no changes" on a broken worktree — report the
+    // ambiguity instead of a clean-looking lie. (review finding)
+    if (files.length === 0 && !diff) {
+      const { isGitRepo } = await import('./gitTracker.js');
+      if (!(await isGitRepo(resolved.worktreePath))) {
+        writeJson(res, 409, {
+          error: `Worktree for task ${taskId} is no longer a valid git repository`,
+          worktreePath: resolved.worktreePath,
+        });
+        return true;
+      }
+    }
     writeJson(res, 200, {
       taskId,
       worktreePath: resolved.worktreePath,

--- a/tests/web/quotaGauge.test.ts
+++ b/tests/web/quotaGauge.test.ts
@@ -1,0 +1,54 @@
+// Formatting half of the status-bar quota gauge (INT-3402). Lives under
+// tests/ because it imports a browser ESM asset; `tsc -p .` only covers src/.
+
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — browser ESM asset without type declarations
+import { formatBar, formatObservation, formatQuota, formatResetIn } from '../../web/static/js/quotaGauge.mjs';
+
+const NOW = 1_800_000_000_000; // epoch ms
+const nowSeconds = NOW / 1000;
+
+describe('quota gauge formatting', () => {
+  it('renders a four-segment bar proportional to usage', () => {
+    expect(formatBar(0)).toBe('░░░░');
+    expect(formatBar(58)).toBe('▓▓░░');
+    expect(formatBar(100)).toBe('▓▓▓▓');
+    // Out-of-range input clamps instead of producing a ragged bar.
+    expect(formatBar(140)).toBe('▓▓▓▓');
+    expect(formatBar(-5)).toBe('░░░░');
+  });
+
+  it('formats the reset countdown by magnitude, and drops it once past', () => {
+    expect(formatResetIn(nowSeconds + 30, NOW)).toBe('30s');
+    expect(formatResetIn(nowSeconds + 45 * 60, NOW)).toBe('45m');
+    expect(formatResetIn(nowSeconds + 3 * 3600, NOW)).toBe('3h');
+    expect(formatResetIn(nowSeconds - 10, NOW)).toBe('');
+    expect(formatResetIn(undefined, NOW)).toBe('');
+  });
+
+  it('shows nothing for a provider with no observed percentage — never a fake 0%', () => {
+    expect(formatObservation({ provider: 'codex', retryAfterSeconds: 5 }, NOW)).toBeNull();
+    expect(formatObservation({ provider: 'codex', usedPercent: 37 }, NOW)).toBe('codex ▓░░░ 37%');
+  });
+
+  it('joins providers and appends the scheduler pause when held', () => {
+    const snapshot = {
+      providers: [
+        { provider: 'codex', usedPercent: 58, resetsAt: nowSeconds + 5 * 3600 },
+        { provider: 'openrouter', retryAfterSeconds: 3 }, // no percentage → omitted
+      ],
+      schedulerHoldUntil: NOW + 60_000,
+    };
+    expect(formatQuota(snapshot, NOW)).toBe('codex ▓▓░░ 58% · 5h · ⏸ paused');
+  });
+
+  it('renders an empty string when nothing was ever observed', () => {
+    expect(formatQuota({ providers: [], schedulerHoldUntil: null }, NOW)).toBe('');
+    expect(formatQuota(undefined, NOW)).toBe('');
+  });
+
+  it('omits the pause marker once the hold has expired', () => {
+    const snapshot = { providers: [{ provider: 'codex', usedPercent: 10 }], schedulerHoldUntil: NOW - 1 };
+    expect(formatQuota(snapshot, NOW)).toBe('codex ░░░░ 10%');
+  });
+});

--- a/web/static/app.html
+++ b/web/static/app.html
@@ -12,6 +12,7 @@
     <div class="brand">🐝 OpenSwarm</div>
     <div id="repo-picker" class="repo-picker"></div>
     <div class="spacer"></div>
+    <div id="quota-gauge" class="quota-gauge" title="provider rate limit — observed from usage headers" hidden></div>
     <div id="daemon-status" class="daemon-status" title="daemon">
       <span class="dot" data-state="unknown"></span>
       <span class="label">connecting…</span>

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -42,6 +42,15 @@ body {
   font-size: var(--text-xs);
   color: var(--muted);
 }
+
+/* Provider rate-limit gauge — hidden until the daemon observes usage headers. */
+.quota-gauge {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--muted);
+  white-space: nowrap;
+}
+.quota-gauge[hidden] { display: none; }
 .daemon-status .dot {
   width: 8px; height: 8px;
   border-radius: var(--radius-pill);

--- a/web/static/js/api.mjs
+++ b/web/static/js/api.mjs
@@ -32,4 +32,5 @@ export const api = {
   dispatchWork: (projectPath, issueIds) =>
     request('/api/work', { method: 'POST', body: JSON.stringify({ projectPath, issueIds }) }),
   stages: () => request('/api/stages'),
+  quota: () => request('/api/quota'),
 };

--- a/web/static/js/main.mjs
+++ b/web/static/js/main.mjs
@@ -5,6 +5,7 @@ import { EventStream } from './events.mjs';
 import { RepoPicker } from './repoPicker.mjs';
 import { IssueBoard } from './issueBoard.mjs';
 import { WorkCards } from './workCards.mjs';
+import { QuotaGauge } from './quotaGauge.mjs';
 
 const statusDot = document.querySelector('#daemon-status .dot');
 const statusLabel = document.querySelector('#daemon-status .label');
@@ -49,6 +50,12 @@ events
 // not matter: log lines that arrive before their card exists are parked in
 // WorkCards' bounded pending buffer and flushed when the card materializes.
 events.connect();
+
+// Independent of the bootstrap chain: a hanging /api/health request must not
+// keep the gauge from ever starting. Usage windows move in hours, so a slow
+// poll is plenty, and the gauge stays hidden until the daemon has actually
+// observed a provider header.
+new QuotaGauge(document.getElementById('quota-gauge'), { fetchQuota: () => api.quota() }).start();
 
 (async () => {
   await pollHealth();

--- a/web/static/js/quotaGauge.mjs
+++ b/web/static/js/quotaGauge.mjs
@@ -1,0 +1,76 @@
+// Provider rate-limit gauge for the status bar. (INT-3402)
+//
+// Renders what the daemon actually observed from provider usage headers — no
+// estimate, no placeholder. Nothing observed yet (fresh daemon, or a provider
+// that sends no usage headers) renders nothing at all rather than a fake 0%.
+//
+// DOM-free formatting so it is unit-testable; the caller owns the element.
+
+const BAR_SEGMENTS = 4;
+
+/** "3h" / "45m" / "30s" until an epoch-SECONDS reset, or '' when unknown/past. */
+export function formatResetIn(resetsAtSeconds, nowMs) {
+  if (typeof resetsAtSeconds !== 'number' || !Number.isFinite(resetsAtSeconds)) return '';
+  const seconds = Math.round(resetsAtSeconds - nowMs / 1000);
+  if (seconds <= 0) return '';
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  return `${Math.round(seconds / 3600)}h`;
+}
+
+/** Filled/empty block bar, e.g. 58% → "▓▓░░". */
+export function formatBar(usedPercent) {
+  const clamped = Math.max(0, Math.min(100, usedPercent));
+  const filled = Math.round((clamped / 100) * BAR_SEGMENTS);
+  return '▓'.repeat(filled) + '░'.repeat(BAR_SEGMENTS - filled);
+}
+
+/**
+ * One provider observation → display text, or null when there is nothing
+ * honest to show (no usage percentage was ever observed for it).
+ */
+export function formatObservation(observation, nowMs = Date.now()) {
+  if (typeof observation?.usedPercent !== 'number' || !Number.isFinite(observation.usedPercent)) {
+    return null;
+  }
+  const resetIn = formatResetIn(observation.resetsAt, nowMs);
+  const percent = `${Math.round(observation.usedPercent)}%`;
+  return `${observation.provider} ${formatBar(observation.usedPercent)} ${percent}${resetIn ? ` · ${resetIn}` : ''}`;
+}
+
+export function formatQuota(snapshot, nowMs = Date.now()) {
+  const parts = (snapshot?.providers ?? [])
+    .map((observation) => formatObservation(observation, nowMs))
+    .filter(Boolean);
+  const held = typeof snapshot?.schedulerHoldUntil === 'number' && snapshot.schedulerHoldUntil > nowMs;
+  if (held) parts.push('⏸ paused');
+  return parts.join(' · ');
+}
+
+export class QuotaGauge {
+  #el;
+  #fetchQuota;
+
+  constructor(el, { fetchQuota }) {
+    this.#el = el;
+    this.#fetchQuota = fetchQuota;
+  }
+
+  async refresh() {
+    let text = '';
+    try {
+      text = formatQuota(await this.#fetchQuota());
+    } catch {
+      // A daemon without the endpoint (older build) simply shows no gauge.
+      text = '';
+    }
+    this.#el.textContent = text;
+    this.#el.hidden = !text;
+  }
+
+  /** Poll; usage windows move in hours, so a slow cadence is plenty. */
+  start(intervalMs = 60_000) {
+    void this.refresh();
+    return setInterval(() => void this.refresh(), intervalMs);
+  }
+}


### PR DESCRIPTION
## TL;DR

Orca 스타일 세션 콕핏(승인된 계획, INT-3402)의 **백엔드 절반**. 프론트 소비자는 후속 PR(F1~F3)에서 붙는다 — 각 단계가 독립 머지·배포 가능하도록 의도적으로 분할한 스테이징이며, API는 이미 라이브 데몬에서 손검증됨.

## 신규 API (전부 `workSessionRoutes.ts`, web.ts 0줄 변경)

| API | 내용 |
|---|---|
| `GET /api/work/sessions` | 정제된 running/queued/recent 목록 (기존 /api/tasks는 AbortController가 `{}`로 직렬화되는 오염 형태). worktree/branch는 **ledger 우선 → 결정적 레이아웃** 해석, 추측 반환 없음 |
| `GET /api/work/sessions/:taskId/log` | 세션별 트랜스크립트 (전역 리플레이 50줄 한계 해소) |
| `GET /api/work/diff?taskId=` | gitTracker 재사용. **클라이언트는 경로를 어떤 형태로도 못 보냄** — taskId를 서버가 해석하고 project root 경계 재확인 |
| `GET /api/quota` | codex `x-codex-*` 사용률 — 성공 응답 헤더 + throttleRetry 초크포인트(5개 어댑터 공통)에서 관측 |

## 핵심 수정: 이벤트 키 통일 (`taskEventKey` = `issueId \|\| id`)

리뷰 게이트 3라운드가 연쇄로 잡아낸 실결함: draft 단계는 `issueIdentifier`(INT-XXX), pairPipeline은 `task.id`, 생애주기 이벤트는 `id`로 **한 태스크가 키 3종으로 분열** — draft 트랜스크립트는 세션 API로 못 읽고 영원히 안 지워지며, 보드에 카드가 두 장 그려짐. 모든 log/stage/task:*/cost/process 방출부를 단일 헬퍼로 통일.

## 메모리 바운드 (taskLogStore)

라인 400자 × 태스크당 1000줄 × 24버퍼 LRU = 최악 ~22MB, 통상 1–3MB. 완료 10분 후 정리 타이머(unref), taskId 재사용(재시도) 시 취소, **running 버퍼는 축출 금지**. 스냅샷은 slice 사본(직렬화 중 링 회전 경합 없음).

## 검증

- 신규 테스트 37건 + 전체 커버리지 게이트 286파일 green + tsc/oxlint clean
- 라이브: sessions(실 히스토리 반환)/quota/log 404/diff 400 확인
- 커밋 게이트 4라운드: 실결함 3건 수정(키 분열), 최종 라운드 지적은 "프론트 소비자 부재" — 위 스테이징 의도와 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)