### PR TITLE
feat(web): Orca 스타일 세션 콕핏 — 사이드바 트리·트랜스크립트·해시 라우팅 (INT-3402)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@vitest/coverage-v8": "^4.0.18",
         "bun-types": "^1.1.0",
         "ink-testing-library": "^4.0.0",
+        "jsdom": "^26.1.0",
         "oxlint": "^1.43.0",
         "playwright": "^1.47.0",
         "tsx": "^4.21.0",
@@ -99,6 +100,20 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -178,6 +193,121 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -3000,6 +3130,16 @@
         "node": ">=12.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -3796,12 +3936,77 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3819,6 +4024,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -3986,6 +4198,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/environment": {
@@ -4644,6 +4869,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4669,6 +4907,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -4913,6 +5179,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -4989,6 +5262,96 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/json-bignum": {
       "version": "0.0.3",
@@ -5630,6 +5993,13 @@
         }
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6085,6 +6455,16 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
@@ -6290,6 +6670,13 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6315,6 +6702,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -6787,6 +7187,13 @@
         "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/table-layout": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
@@ -6914,6 +7321,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -6921,6 +7348,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -7275,11 +7715,61 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -7402,6 +7892,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@vitest/coverage-v8": "^4.0.18",
     "bun-types": "^1.1.0",
     "ink-testing-library": "^4.0.0",
+    "jsdom": "^26.1.0",
     "oxlint": "^1.43.0",
     "playwright": "^1.47.0",
     "tsx": "^4.21.0",

--- a/src/core/eventHub.test.ts
+++ b/src/core/eventHub.test.ts
@@ -787,6 +787,19 @@ describe('eventHub', () => {
       }
     });
 
+    it('stamps one timestamp shared by the ring and the SSE copy of a log line', async () => {
+      const { getTaskLog } = await import('./taskLogStore.js');
+      const event: HubEvent = { type: 'log', data: { taskId: 'stamped', stage: 'worker', line: 'hello' } };
+
+      broadcastEvent(event);
+
+      // Same value on both sides — that identity is what lets a client merge a
+      // REST transcript snapshot with lines that streamed in mid-request.
+      const stored = getTaskLog('stamped')!.lines[0];
+      expect(typeof (event.data as { ts?: number }).ts).toBe('number');
+      expect(stored.ts).toBe((event.data as { ts?: number }).ts);
+    });
+
     it('task:started cancels a pending cleanup for a reused task id', async () => {
       const { getTaskLog, TASK_LOG_RETENTION_MS } = await import('./taskLogStore.js');
       vi.useFakeTimers();

--- a/src/core/eventHub.ts
+++ b/src/core/eventHub.ts
@@ -84,7 +84,8 @@ export type HubEvent =
       threshold: number;
       reasons: string[];
     } }
-  | { type: 'log'; data: { taskId: string; stage: string; line: string } }
+  // `ts`/`seq` are stamped by broadcastEvent, not by emitters — see its log case.
+  | { type: 'log'; data: { taskId: string; stage: string; line: string; ts?: number; seq?: number } }
   | { type: 'project:toggled'; data: { projectPath: string; enabled: boolean } }
   | { type: 'task:cost'; data: { taskId: string; cost: CostInfo } }
   | { type: 'chat:user'; data: { text: string; ts: number } }
@@ -165,7 +166,14 @@ export function broadcastEvent(event: HubEvent): void {
   // choke point every emitter already goes through — so no broadcast site
   // changes. task:started/completed drive the retention lifecycle.
   if (event.type === 'log') {
-    appendTaskLog(event.data.taskId, event.data.stage, event.data.line);
+    // The ring and the SSE copy of this line carry the SAME ts AND sequence,
+    // which is what lets a client merge a REST transcript snapshot with lines
+    // that streamed in while the request was in flight. The sequence — not the
+    // millisecond — is the join key: an agent emits several lines per ms.
+    // (INT-3402)
+    const ts = Date.now();
+    event.data.ts = ts;
+    event.data.seq = appendTaskLog(event.data.taskId, event.data.stage, event.data.line, ts);
   } else if (event.type === 'task:started') {
     cancelTaskLogCleanup(event.data.taskId);
   } else if (event.type === 'task:completed') {

--- a/src/core/eventHub.ts
+++ b/src/core/eventHub.ts
@@ -13,6 +13,14 @@ import {
   scheduleTaskLogCleanup,
   __resetTaskLogsForTests,
 } from './taskLogStore.js';
+import { getInstanceId } from '../support/healthEndpoint.js';
+
+// Resolved once; healthEndpoint mints it at module load.
+let cachedGeneration: string | null = null;
+function daemonGeneration(): string {
+  cachedGeneration ??= getInstanceId();
+  return cachedGeneration;
+}
 
 // Types
 
@@ -85,7 +93,7 @@ export type HubEvent =
       reasons: string[];
     } }
   // `ts`/`seq` are stamped by broadcastEvent, not by emitters — see its log case.
-  | { type: 'log'; data: { taskId: string; stage: string; line: string; ts?: number; seq?: number } }
+  | { type: 'log'; data: { taskId: string; stage: string; line: string; ts?: number; seq?: number; gen?: string } }
   | { type: 'project:toggled'; data: { projectPath: string; enabled: boolean } }
   | { type: 'task:cost'; data: { taskId: string; cost: CostInfo } }
   | { type: 'chat:user'; data: { text: string; ts: number } }
@@ -174,6 +182,9 @@ export function broadcastEvent(event: HubEvent): void {
     const ts = Date.now();
     event.data.ts = ts;
     event.data.seq = appendTaskLog(event.data.taskId, event.data.stage, event.data.line, ts);
+    // Which process the sequence belongs to. Carried ON the line so a client
+    // needs no separate round trip (and no ordering luck) to notice a restart.
+    event.data.gen = daemonGeneration();
   } else if (event.type === 'task:started') {
     cancelTaskLogCleanup(event.data.taskId);
   } else if (event.type === 'task:completed') {

--- a/src/core/taskLogStore.test.ts
+++ b/src/core/taskLogStore.test.ts
@@ -27,15 +27,33 @@ describe('taskLogStore', () => {
     appendTaskLog('t1', 'reviewer', 'world', 222);
 
     const snapshot = getTaskLog('t1')!;
-    expect(snapshot.lines).toEqual([
+    expect(snapshot.lines).toMatchObject([
       { stage: 'worker', line: 'hello', ts: 111 },
       { stage: 'reviewer', line: 'world', ts: 222 },
     ]);
     expect(snapshot.truncated).toBe(false);
 
     // Mutating the snapshot must not touch the ring (serialization safety).
-    snapshot.lines.push({ stage: 'x', line: 'injected', ts: 0 });
+    snapshot.lines.push({ stage: 'x', line: 'injected', ts: 0, seq: 0 });
     expect(getTaskLog('t1')!.lines).toHaveLength(2);
+  });
+
+  it('assigns a strictly increasing sequence — the client merge key', () => {
+    // Same millisecond on purpose: an agent emits several lines per ms, so a
+    // timestamp cannot order them and a `> lastTs` merge drops the ties.
+    const first = appendTaskLog('t1', 'worker', 'a', 500);
+    const second = appendTaskLog('t1', 'worker', 'b', 500);
+    const otherTask = appendTaskLog('t2', 'worker', 'c', 500);
+
+    expect(second).toBeGreaterThan(first);
+    expect(otherTask).toBeGreaterThan(second); // monotonic ACROSS tasks
+    expect(getTaskLog('t1')!.lines.map((l) => l.seq)).toEqual([first, second]);
+  });
+
+  it('returns 0 without storing when the line is unusable', () => {
+    expect(appendTaskLog('', 'worker', 'x')).toBe(0);
+    expect(appendTaskLog('t1', 'worker', undefined as unknown as string)).toBe(0);
+    expect(getTaskLog('t1')).toBeNull();
   });
 
   it('returns null for an unknown task', () => {

--- a/src/core/taskLogStore.ts
+++ b/src/core/taskLogStore.ts
@@ -18,6 +18,13 @@ export interface TaskLogLine {
   stage: string;
   line: string;
   ts: number;
+  /**
+   * Strictly increasing across every line this process appends. A wall-clock
+   * `ts` is not enough to reconcile a snapshot with a live stream: an agent
+   * easily emits several lines inside one millisecond, and a `> lastTs` merge
+   * silently drops the ties. (INT-3402)
+   */
+  seq: number;
 }
 
 export interface TaskLogSnapshot {
@@ -45,6 +52,7 @@ interface TaskLogBuffer {
 // the first eligible entry found is the least recently used.
 const buffers = new Map<string, TaskLogBuffer>();
 const cleanupTimers = new Map<string, NodeJS.Timeout>();
+let nextSeq = 1;
 
 function evictIfNeeded(): void {
   if (buffers.size < TASK_LOG_MAX_BUFFERS) return;
@@ -64,8 +72,9 @@ function evictIfNeeded(): void {
   }
 }
 
-export function appendTaskLog(taskId: string, stage: string, line: string, now = Date.now()): void {
-  if (!taskId || typeof line !== 'string') return;
+/** Returns the sequence assigned to the line (0 when nothing was stored). */
+export function appendTaskLog(taskId: string, stage: string, line: string, now = Date.now()): number {
+  if (!taskId || typeof line !== 'string') return 0;
   let buffer = buffers.get(taskId);
   if (!buffer) {
     evictIfNeeded();
@@ -85,11 +94,13 @@ export function appendTaskLog(taskId: string, stage: string, line: string, now =
     text = `${text.slice(0, TASK_LOG_MAX_LINE_CHARS)}…`;
     buffer.truncated = true;
   }
-  buffer.lines.push({ stage, line: text, ts: now });
+  const seq = nextSeq++;
+  buffer.lines.push({ stage, line: text, ts: now, seq });
   if (buffer.lines.length > TASK_LOG_RING_SIZE) {
     buffer.lines.shift();
     buffer.truncated = true;
   }
+  return seq;
 }
 
 /** Snapshot copy (safe to serialize while appends continue). Null → 404. */

--- a/src/support/healthEndpoint.ts
+++ b/src/support/healthEndpoint.ts
@@ -28,6 +28,15 @@ export interface HealthPayload {
 // One id per process lifetime, minted at module load (daemon boot).
 const INSTANCE_ID = randomUUID();
 
+/**
+ * The daemon generation. Log sequences are process-local and restart at 1, so
+ * consumers that dedupe on them must know WHICH process a number belongs to —
+ * broadcastEvent stamps this alongside each line. (INT-3402)
+ */
+export function getInstanceId(): string {
+  return INSTANCE_ID;
+}
+
 function readPackageVersion(): string {
   try {
     // healthEndpoint.js lives at <pkg>/dist/support/, so package.json is two up.

--- a/src/support/workSessionRoutes.test.ts
+++ b/src/support/workSessionRoutes.test.ts
@@ -251,6 +251,12 @@ describe('GET /api/work/sessions/:taskId/log', () => {
     expect(typeof body.lines[0].seq).toBe('number');
   });
 
+  it('400s on a malformed percent-escape instead of throwing a 500', async () => {
+    const { status, body } = await call('/api/work/sessions/%zz/log', mkRunner());
+    expect(status).toBe(400);
+    expect(body.error).toContain('Malformed');
+  });
+
   it('404s for an unknown task and decodes the id', async () => {
     appendTaskLog('weird id', 'worker', 'line');
     expect((await call('/api/work/sessions/nope/log', mkRunner())).status).toBe(404);

--- a/src/support/workSessionRoutes.test.ts
+++ b/src/support/workSessionRoutes.test.ts
@@ -244,7 +244,11 @@ describe('GET /api/work/sessions/:taskId/log', () => {
     appendTaskLog('t1', 'worker', 'hello', 42);
     const { status, body } = await call('/api/work/sessions/t1/log', mkRunner());
     expect(status).toBe(200);
-    expect(body).toEqual({ taskId: 't1', lines: [{ stage: 'worker', line: 'hello', ts: 42 }], truncated: false });
+    expect(body).toMatchObject({ taskId: 't1', truncated: false });
+    // seq is the client's merge key — it must reach the wire, not just the ring.
+    expect(body.lines).toHaveLength(1);
+    expect(body.lines[0]).toMatchObject({ stage: 'worker', line: 'hello', ts: 42 });
+    expect(typeof body.lines[0].seq).toBe('number');
   });
 
   it('404s for an unknown task and decodes the id', async () => {

--- a/src/support/workSessionRoutes.ts
+++ b/src/support/workSessionRoutes.ts
@@ -234,7 +234,10 @@ export async function tryHandleWorkSessionRoutes(
       writeJson(res, 404, { error: `No transcript for task ${taskId} (unknown, or retention expired)` });
       return true;
     }
-    writeJson(res, 200, snapshot);
+    // Same generation the SSE lines carry: sequences only mean anything
+    // within one daemon process.
+    const { getInstanceId } = await import('./healthEndpoint.js');
+    writeJson(res, 200, { ...snapshot, gen: getInstanceId() });
     return true;
   }
 

--- a/src/support/workSessionRoutes.ts
+++ b/src/support/workSessionRoutes.ts
@@ -220,7 +220,15 @@ export async function tryHandleWorkSessionRoutes(
 
   const logMatch = url.match(/^\/api\/work\/sessions\/([^/]+)\/log$/);
   if (logMatch) {
-    const taskId = decodeURIComponent(logMatch[1]);
+    let taskId: string;
+    try {
+      taskId = decodeURIComponent(logMatch[1]);
+    } catch {
+      // A malformed escape ('%', '%zz') is a bad request, not a server fault —
+      // decodeURIComponent throws and would otherwise surface as a 500.
+      writeJson(res, 400, { error: 'Malformed taskId encoding' });
+      return true;
+    }
     const snapshot = getTaskLog(taskId);
     if (!snapshot) {
       writeJson(res, 404, { error: `No transcript for task ${taskId} (unknown, or retention expired)` });

--- a/tests/web/diffPanel.test.ts
+++ b/tests/web/diffPanel.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+//
+// Worktree diff rendering (INT-3402): the parser is pure, and the panel's
+// states — loading, empty, clean, unavailable, error — must each say what is
+// actually true rather than defaulting to "no changes".
+
+import { describe, expect, it, vi } from 'vitest';
+// @ts-expect-error — browser ESM asset without type declarations
+import { DiffPanel, parseUnifiedDiff, summarizeFiles } from '../../web/static/js/diffPanel.mjs';
+
+const DIFF = [
+  'diff --git a/src/a.ts b/src/a.ts',
+  'index 111..222 100644',
+  '--- a/src/a.ts',
+  '+++ b/src/a.ts',
+  '@@ -1,3 +1,4 @@',
+  ' const unchanged = 1;',
+  '-const removed = 2;',
+  '+const added = 3;',
+  '',
+].join('\n');
+
+describe('parseUnifiedDiff', () => {
+  it('classifies file headers, hunks, metadata, and +/- lines', () => {
+    const rows = parseUnifiedDiff(DIFF);
+    expect(rows.map((r: { type: string }) => r.type)).toEqual([
+      'file', 'file', 'meta', 'meta', 'hunk', 'context', 'del', 'add',
+    ]);
+    expect(rows.at(-1).text).toBe('+const added = 3;');
+  });
+
+  it('does not mistake --- / +++ headers for removed/added lines', () => {
+    const rows = parseUnifiedDiff('--- a/x\n+++ b/x');
+    expect(rows.map((r: { type: string }) => r.type)).toEqual(['meta', 'meta']);
+  });
+
+  it('handles empty input', () => {
+    expect(parseUnifiedDiff('')).toEqual([]);
+    expect(parseUnifiedDiff(undefined)).toEqual([]);
+  });
+});
+
+describe('summarizeFiles', () => {
+  it('totals the per-file counts and pluralizes', () => {
+    expect(summarizeFiles([{ file: 'a', added: 40, deleted: 5 }, { file: 'b', added: 2, deleted: 2 }]))
+      .toBe('2 files · +42 −7');
+    expect(summarizeFiles([{ file: 'a', added: 1, deleted: 0 }])).toBe('1 file · +1 −0');
+    expect(summarizeFiles([])).toBe('No file changes');
+  });
+});
+
+describe('DiffPanel', () => {
+  const mount = (fetchDiff: () => Promise<unknown>) => {
+    const el = document.createElement('div');
+    return { el, panel: new DiffPanel(el, { fetchDiff }) };
+  };
+
+  it('renders the summary, file list, and colored diff rows', async () => {
+    const { el, panel } = mount(async () => ({
+      taskId: 't1',
+      worktreePath: '/repo/worktree/t1',
+      branch: 'swarm/INT-1',
+      files: [{ file: 'src/a.ts', added: 1, deleted: 1, isNew: false }],
+      diff: DIFF,
+      truncated: false,
+    }));
+    await panel.load('t1');
+
+    expect(el.querySelector('.diff-summary')?.textContent).toBe('1 file · +1 −1 · swarm/INT-1');
+    expect(el.querySelector('.diff-file')?.textContent).toContain('src/a.ts');
+    expect(el.querySelectorAll('.diff-line.add')).toHaveLength(1);
+    expect(el.querySelectorAll('.diff-line.del')).toHaveLength(1);
+  });
+
+  it('flags truncation and new files', async () => {
+    const { el, panel } = mount(async () => ({
+      files: [{ file: 'new.ts', added: 9, deleted: 0, isNew: true }],
+      diff: DIFF,
+      truncated: true,
+    }));
+    await panel.load('t1');
+    expect(el.querySelector('.diff-summary')?.textContent).toContain('truncated');
+    expect(el.querySelector('.diff-file')?.textContent).toContain('new new.ts');
+  });
+
+  it('says the tree is clean rather than showing nothing', async () => {
+    const { el, panel } = mount(async () => ({ files: [], diff: '', truncated: false }));
+    await panel.load('t1');
+    expect(el.querySelector('.empty')?.textContent).toBe('Working tree is clean.');
+  });
+
+  it('distinguishes "files but no patch text" from a clean tree', async () => {
+    const { el, panel } = mount(async () => ({
+      files: [{ file: 'image.png', added: 0, deleted: 0, isNew: true }],
+      diff: '',
+    }));
+    await panel.load('t1');
+    expect(el.querySelector('.empty')?.textContent).toBe('No patch text for these changes.');
+  });
+
+  it('reports an unavailable endpoint instead of an empty diff', async () => {
+    const { el, panel } = mount(async () => null); // api.workDiff maps 404 → null
+    await panel.load('t1');
+    expect(el.querySelector('.empty')?.textContent).toContain('does not expose worktree diffs');
+  });
+
+  it('surfaces a git failure verbatim rather than claiming no changes', async () => {
+    const { el, panel } = mount(async () => {
+      throw new Error('Worktree for task t1 is no longer a valid git repository');
+    });
+    await panel.load('t1');
+    expect(el.querySelector('.empty')?.textContent).toContain('no longer a valid git repository');
+  });
+
+  it('does not let a stale FAILED request overwrite a newer render of the same task', async () => {
+    let failFirst: (reason: unknown) => void = () => {};
+    let call = 0;
+    const fetchDiff = vi.fn(() => {
+      call += 1;
+      return call === 1
+        ? new Promise((_, reject) => { failFirst = reject; })
+        : Promise.resolve({ files: [{ file: 'fresh.ts', added: 2, deleted: 0 }], diff: DIFF });
+    });
+    const { el, panel } = mount(fetchDiff as unknown as () => Promise<unknown>);
+
+    const stale = panel.load('t1');
+    await panel.load('t1'); // same task, re-opened — supersedes the first
+    failFirst(new Error('stale failure'));
+    await stale;
+
+    expect(el.querySelector('.diff-file')?.textContent).toContain('fresh.ts');
+    expect(el.querySelector('.empty')).toBeNull();
+  });
+
+  it('does not paint after clear()', async () => {
+    let release: (value: unknown) => void = () => {};
+    const fetchDiff = vi.fn(() => new Promise((resolve) => { release = resolve; }));
+    const { el, panel } = mount(fetchDiff as unknown as () => Promise<unknown>);
+
+    const pending = panel.load('t1');
+    panel.clear();
+    release({ files: [{ file: 'late.ts', added: 1, deleted: 0 }], diff: DIFF });
+    await pending;
+
+    expect(el.childElementCount).toBe(0);
+  });
+
+  it('ignores a response for a task the user already navigated away from', async () => {
+    let resolveFirst: (v: unknown) => void = () => {};
+    const fetchDiff = vi.fn((taskId: string) =>
+      taskId === 'slow'
+        ? new Promise((resolve) => { resolveFirst = resolve; })
+        : Promise.resolve({ files: [{ file: 'fast.ts', added: 1, deleted: 0 }], diff: DIFF }),
+    );
+    const { el, panel } = mount(fetchDiff as unknown as () => Promise<unknown>);
+
+    const slow = panel.load('slow');
+    await panel.load('fast');
+    resolveFirst({ files: [{ file: 'stale.ts', added: 99, deleted: 0 }], diff: DIFF });
+    await slow;
+
+    expect(el.querySelector('.diff-file')?.textContent).toContain('fast.ts');
+  });
+});

--- a/tests/web/format.test.ts
+++ b/tests/web/format.test.ts
@@ -1,0 +1,72 @@
+// Cockpit display formatting (INT-3402).
+
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — browser ESM asset without type declarations
+import {
+  formatCost,
+  formatDuration,
+  formatRelativeTime,
+  formatTokens,
+  shortenPath,
+  truncate,
+} from '../../web/static/js/format.mjs';
+
+const NOW = 1_800_000_000_000;
+
+describe('formatRelativeTime', () => {
+  it('scales by magnitude and never renders a negative age', () => {
+    expect(formatRelativeTime(NOW - 5_000, NOW)).toBe('just now');
+    expect(formatRelativeTime(NOW - 5 * 60_000, NOW)).toBe('5m');
+    expect(formatRelativeTime(NOW - 3 * 3_600_000, NOW)).toBe('3h');
+    expect(formatRelativeTime(NOW - 2 * 86_400_000, NOW)).toBe('2d');
+    // Clock skew (daemon slightly ahead) must not read as "-1m".
+    expect(formatRelativeTime(NOW + 60_000, NOW)).toBe('just now');
+    expect(formatRelativeTime(undefined, NOW)).toBe('');
+  });
+});
+
+describe('formatDuration', () => {
+  it('renders seconds, minutes with padded seconds, and hours', () => {
+    expect(formatDuration(8_000)).toBe('8s');
+    expect(formatDuration(125_000)).toBe('2m 05s');
+    expect(formatDuration(4_320_000)).toBe('1h 12m');
+    expect(formatDuration(-1)).toBe('');
+    expect(formatDuration(NaN)).toBe('');
+  });
+});
+
+describe('formatCost', () => {
+  it('keeps sub-cent magnitudes instead of rounding them to $0.00', () => {
+    expect(formatCost(0)).toBe('$0');
+    expect(formatCost(0.0042)).toBe('$0.0042');
+    expect(formatCost(1.5)).toBe('$1.50');
+    expect(formatCost(-1)).toBe('');
+  });
+});
+
+describe('formatTokens', () => {
+  it('compacts thousands and millions', () => {
+    expect(formatTokens(847)).toBe('847');
+    expect(formatTokens(1_240)).toBe('1.2k');
+    expect(formatTokens(2_500_000)).toBe('2.5M');
+    expect(formatTokens(undefined)).toBe('');
+  });
+});
+
+describe('shortenPath', () => {
+  it('marks home and keeps the identifying tail', () => {
+    expect(shortenPath('/Users/me/dev/repo', { home: '/Users/me' })).toBe('~/dev/repo');
+    expect(shortenPath('/Users/me/dev/repo/worktree/abc', { home: '/Users/me' })).toBe('~/…/repo/worktree/abc');
+    expect(shortenPath('/a/b', { home: '/Users/me' })).toBe('/a/b');
+    expect(shortenPath('/very/deep/nested/path/here')).toBe('…/nested/path/here');
+    expect(shortenPath('')).toBe('');
+  });
+});
+
+describe('truncate', () => {
+  it('cuts with an ellipsis only when over the cap', () => {
+    expect(truncate('short', 10)).toBe('short');
+    expect(truncate('a much longer title', 8)).toBe('a much …');
+    expect(truncate('x', 0)).toBe('x');
+  });
+});

--- a/tests/web/sessionSelection.test.ts
+++ b/tests/web/sessionSelection.test.ts
@@ -1,0 +1,37 @@
+// What the Sessions view shows, given the URL and what is known yet (INT-3402).
+// The hash is read at startup while the session list arrives asynchronously,
+// so the same question is asked again after the snapshot lands.
+
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — browser ESM asset without type declarations
+import { EMPTY_MESSAGE, resolveSelection } from '../../web/static/js/sessionSelection.mjs';
+
+const sessions = [{ taskId: 'a' }, { taskId: 'b' }];
+
+describe('resolveSelection', () => {
+  it('honors a deep link once its session is known', () => {
+    expect(resolveSelection({ hashTaskId: 'b', sessions, snapshotLoaded: true })).toEqual({ taskId: 'b' });
+  });
+
+  it('waits rather than declaring a deep link dead before the snapshot lands', () => {
+    // The deep link is probably valid — the list just has not arrived. Saying
+    // "not in history" here would be a guess presented as fact.
+    const choice = resolveSelection({ hashTaskId: 'unknown', sessions: [], snapshotLoaded: false });
+    expect(choice.message).toBe('Loading session…');
+    expect(choice.taskId).toBeUndefined();
+  });
+
+  it('reports a genuinely unknown session only after the snapshot answered', () => {
+    const choice = resolveSelection({ hashTaskId: 'unknown', sessions, snapshotLoaded: true });
+    expect(choice.message).toContain('not in this daemon');
+  });
+
+  it('falls back to the most recent session when the hash names none', () => {
+    expect(resolveSelection({ hashTaskId: null, sessions, snapshotLoaded: true })).toEqual({ taskId: 'a' });
+  });
+
+  it('shows the deploy prompt when there is nothing at all', () => {
+    expect(resolveSelection({ hashTaskId: null, sessions: [], snapshotLoaded: true }))
+      .toEqual({ message: EMPTY_MESSAGE });
+  });
+});

--- a/tests/web/sessionStore.test.ts
+++ b/tests/web/sessionStore.test.ts
@@ -1,0 +1,182 @@
+// Cockpit session state machine (INT-3402). Under tests/ because it imports a
+// browser ESM asset; `tsc -p .` only covers src/.
+
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — browser ESM asset without type declarations
+import { SessionStore, TERMINAL_PHASES } from '../../web/static/js/sessionStore.mjs';
+
+const stage = (over: Record<string, unknown> = {}) => ({
+  taskId: 't1',
+  stage: 'worker',
+  status: 'start',
+  ...over,
+});
+
+describe('SessionStore', () => {
+  it('creates a session from task:queued and promotes it through the phases', () => {
+    const store = new SessionStore();
+    store.applyEvent('task:queued', { taskId: 't1', title: 'Task', projectPath: '/repo' });
+    expect(store.get('t1')).toMatchObject({ phase: 'queued', title: 'Task', projectPath: '/repo' });
+
+    store.applyEvent('task:started', { taskId: 't1', title: 'Task' });
+    expect(store.get('t1').phase).toBe('running');
+
+    store.applyEvent('task:completed', { taskId: 't1', success: true, duration: 1000 });
+    expect(store.get('t1')).toMatchObject({ phase: 'completed', durationMs: 1000 });
+  });
+
+  it('creates a session from a stage event alone (replay lost the lifecycle)', () => {
+    const store = new SessionStore();
+    store.applyEvent('pipeline:stage', stage({ issueIdentifier: 'INT-1', title: 'From stage' }));
+    expect(store.get('t1')).toMatchObject({ phase: 'running', issueIdentifier: 'INT-1', title: 'From stage' });
+  });
+
+  it('refuses phase regressions so replayed events cannot resurrect a finished session', () => {
+    const store = new SessionStore();
+    store.applyEvent('task:completed', { taskId: 't1', success: true, duration: 5 });
+    // The SSE replay re-delivers older events after the snapshot seeded us.
+    // Only task:started may re-open a session (a real retry) — see below.
+    store.applyEvent('task:queued', { taskId: 't1', title: 'Task' });
+    store.applyEvent('pipeline:stage', stage());
+    store.applyEvent('pipeline:iteration', { taskId: 't1', iteration: 2 });
+    expect(store.get('t1').phase).toBe('completed');
+    expect(TERMINAL_PHASES.has(store.get('t1').phase)).toBe(true);
+  });
+
+  it('lets task:started re-open a finished session — the daemon retries the same id', () => {
+    const store = new SessionStore();
+    store.applyEvent('pipeline:stage', stage({ status: 'fail', error: 'attempt 1 blew up' }));
+    store.applyEvent('task:completed', { taskId: 't1', success: false, duration: 3_000 });
+    expect(store.get('t1').phase).toBe('failed');
+
+    store.applyEvent('task:started', { taskId: 't1', title: 'Task' });
+
+    const session = store.get('t1');
+    expect(session.phase).toBe('running');
+    // Last attempt's outcome must not sit next to live work.
+    expect(session.error).toBeUndefined();
+    expect(session.durationMs).toBeUndefined();
+    expect(session.stages.size).toBe(0);
+  });
+
+  it('does NOT let a replayed stage event re-open a finished session', () => {
+    const store = new SessionStore();
+    store.applyEvent('task:completed', { taskId: 't1', success: true, duration: 10 });
+    store.applyEvent('pipeline:stage', stage({ status: 'start' }));
+    expect(store.get('t1').phase).toBe('completed');
+  });
+
+  it('folds stages idempotently and keeps prior detail on re-application', () => {
+    const store = new SessionStore();
+    store.applyEvent('pipeline:stage', stage({ status: 'start' }));
+    store.applyEvent('pipeline:stage', stage({
+      status: 'complete',
+      durationMs: 8_000,
+      costUsd: 0.4,
+      summary: 'did the thing',
+      filesChanged: ['a.ts'],
+    }));
+    // A replayed 'start' must not erase the completion detail.
+    store.applyEvent('pipeline:stage', stage({ status: 'start' }));
+
+    const worker = store.get('t1').stages.get('worker');
+    expect(worker).toMatchObject({ durationMs: 8_000, costUsd: 0.4, summary: 'did the thing' });
+    expect(store.get('t1').stages.size).toBe(1);
+  });
+
+  it('keeps a session running when a STAGE fails — the pipeline iterates', () => {
+    const store = new SessionStore();
+    store.applyEvent('pipeline:stage', stage({ status: 'fail', error: 'reviewer said revise' }));
+    // Only task:completed decides the outcome; a failed reviewer stage is a
+    // normal step on the way to success.
+    expect(store.get('t1')).toMatchObject({ phase: 'running', error: 'reviewer said revise' });
+
+    store.applyEvent('task:completed', { taskId: 't1', success: true, duration: 9 });
+    expect(store.get('t1').phase).toBe('completed');
+  });
+
+  it('treats the first terminal outcome as final against a replayed second one', () => {
+    const store = new SessionStore();
+    store.applyEvent('task:completed', { taskId: 't1', success: true, duration: 9 });
+    // A replayed stage failure (or a duplicate completion) must not rewrite
+    // how this session ended.
+    store.applyEvent('pipeline:stage', stage({ status: 'fail', error: 'stale failure' }));
+    store.applyEvent('task:completed', { taskId: 't1', success: false, duration: 1 });
+    expect(store.get('t1').phase).toBe('completed');
+  });
+
+  it('ignores empty patch values so a sparse event cannot blank known metadata', () => {
+    const store = new SessionStore();
+    store.applyEvent('pipeline:stage', stage({ model: 'gpt-5.5', title: 'Real title' }));
+    store.applyEvent('pipeline:stage', stage({ model: '', title: undefined }));
+    expect(store.get('t1')).toMatchObject({ model: 'gpt-5.5', title: 'Real title' });
+  });
+
+  it('tracks cost and escalation', () => {
+    const store = new SessionStore();
+    store.applyEvent('pipeline:stage', stage());
+    store.applyEvent('pipeline:escalation', { taskId: 't1', toModel: 'gpt-5.5-high' });
+    store.applyEvent('task:cost', { taskId: 't1', cost: { costUsd: 1.25, inputTokens: 10, outputTokens: 3 } });
+    expect(store.get('t1')).toMatchObject({ model: 'gpt-5.5-high', costUsd: 1.25, inputTokens: 10 });
+  });
+
+  it('ignores unknown event types and malformed payloads', () => {
+    const store = new SessionStore();
+    store.applyEvent('log', { taskId: 't1', line: 'x' }); // transcript owns this
+    store.applyEvent('some:future:event', { taskId: 't1' });
+    store.applyEvent('task:started', {});
+    store.applyEvent('task:started', null);
+    expect(store.list()).toHaveLength(0);
+  });
+
+  it('seeds running/queued/recent from the sessions snapshot', () => {
+    const store = new SessionStore();
+    store.seed({
+      sessions: [
+        { taskId: 'r1', status: 'running', title: 'Running', projectPath: '/repo', stage: 'worker', branch: 'swarm/x' },
+        { taskId: 'q1', status: 'queued', title: 'Queued', projectPath: '/repo' },
+      ],
+      recent: [
+        { taskId: 'd1', status: 'failed', title: 'Failed', projectPath: '/repo', failureCause: 'timeout' },
+        { taskId: 'p1', status: 'decomposed', title: 'Parent', projectPath: '/repo' },
+      ],
+    });
+    expect(store.get('r1')).toMatchObject({ phase: 'running', currentStage: 'worker', branch: 'swarm/x' });
+    expect(store.get('q1').phase).toBe('queued');
+    expect(store.get('d1')).toMatchObject({ phase: 'failed', failureCause: 'timeout' });
+    expect(store.get('p1').phase).toBe('decomposed');
+    expect(store.byProject('/repo')).toHaveLength(4);
+  });
+
+  it('does not let a snapshot roll back a live session', () => {
+    const store = new SessionStore();
+    store.applyEvent('task:completed', { taskId: 'r1', success: true, duration: 1 });
+    // Snapshot fetched before the completion lands afterwards.
+    store.seed({ sessions: [{ taskId: 'r1', status: 'running', title: 'Running', projectPath: '/repo' }], recent: [] });
+    expect(store.get('r1').phase).toBe('completed');
+  });
+
+  it('emits session:new once and session:phase only on real transitions', () => {
+    const store = new SessionStore();
+    const created: string[] = [];
+    const phases: string[] = [];
+    store.addEventListener('session:new', (e: CustomEvent) => created.push(e.detail.session.taskId));
+    store.addEventListener('session:phase', (e: CustomEvent) => phases.push(e.detail.session.phase));
+
+    store.applyEvent('task:queued', { taskId: 't1', title: 'T', projectPath: '/repo' });
+    store.applyEvent('task:started', { taskId: 't1', title: 'T' });
+    store.applyEvent('pipeline:stage', stage()); // still running — no transition
+    store.applyEvent('task:completed', { taskId: 't1', success: false, duration: 2 });
+
+    expect(created).toEqual(['t1']);
+    expect(phases).toEqual(['running', 'failed']);
+  });
+
+  it('lists most recently updated first', () => {
+    const store = new SessionStore();
+    store.applyEvent('task:queued', { taskId: 'old', title: 'Old', projectPath: '/repo' });
+    store.applyEvent('task:queued', { taskId: 'new', title: 'New', projectPath: '/repo' });
+    store.applyEvent('pipeline:stage', stage({ taskId: 'old' }));
+    expect(store.list().map((s: { taskId: string }) => s.taskId)).toEqual(['old', 'new']);
+  });
+});

--- a/tests/web/sessionStore.test.ts
+++ b/tests/web/sessionStore.test.ts
@@ -180,3 +180,103 @@ describe('SessionStore', () => {
     expect(store.list().map((s: { taskId: string }) => s.taskId)).toEqual(['old', 'new']);
   });
 });
+
+describe('SessionStore — path and terminal semantics (INT-3402 review)', () => {
+  it('groups by REPOSITORY, not by the per-task worktree the stage reports', () => {
+    const store = new SessionStore();
+    // Stage events report the ACTIVE directory, which in worktree mode is the
+    // task's own worktree — grouping on it would give every task its own node.
+    store.applyEvent('pipeline:stage', {
+      taskId: 't1', stage: 'worker', status: 'start',
+      projectPath: '/repo/worktree/t1', worktree: 't1',
+    });
+    store.applyEvent('pipeline:stage', {
+      taskId: 't2', stage: 'worker', status: 'start',
+      projectPath: '/repo/worktree/t2', worktree: 't2',
+    });
+
+    expect(store.byProject('/repo')).toHaveLength(2);
+    expect(store.get('t1')).toMatchObject({
+      projectPath: '/repo',
+      worktreePath: '/repo/worktree/t1',
+      worktreeName: 't1', // the short label, never the path
+    });
+  });
+
+  it('keeps a non-worktree project path as-is', () => {
+    const store = new SessionStore();
+    store.applyEvent('pipeline:stage', { taskId: 't1', stage: 'worker', status: 'start', projectPath: '/repo' });
+    expect(store.get('t1').projectPath).toBe('/repo');
+    expect(store.get('t1').worktreePath).toBeUndefined();
+  });
+
+  it('does not let a stage overwrite the seeded worktree path', () => {
+    const store = new SessionStore();
+    store.seed({
+      sessions: [{ taskId: 't1', status: 'running', title: 'T', projectPath: '/repo', worktreePath: '/real/worktree/path' }],
+      recent: [],
+    });
+    store.applyEvent('pipeline:stage', { taskId: 't1', stage: 'worker', status: 'start', projectPath: '/repo' });
+    expect(store.get('t1').worktreePath).toBe('/real/worktree/path');
+  });
+
+  it('clears a stage error once the task completes successfully', () => {
+    const store = new SessionStore();
+    store.applyEvent('pipeline:stage', { taskId: 't1', stage: 'reviewer', status: 'fail', error: 'revise' });
+    store.applyEvent('task:completed', { taskId: 't1', success: true, duration: 5 });
+    expect(store.get('t1').error).toBeUndefined();
+  });
+
+  it('lets daemon history refine one terminal phase into a more specific one', () => {
+    const store = new SessionStore();
+    // A decomposition reports success, so the live event says "completed".
+    store.applyEvent('task:completed', { taskId: 'parent', success: true, duration: 5 });
+    store.seed({
+      sessions: [],
+      recent: [{ taskId: 'parent', status: 'decomposed', title: 'Parent', projectPath: '/repo' }],
+    });
+    expect(store.get('parent').phase).toBe('decomposed');
+  });
+
+  it('history never overwrites metadata a newer attempt reported live', () => {
+    const store = new SessionStore();
+    store.applyEvent('pipeline:stage', {
+      taskId: 't1', stage: 'worker', status: 'start', title: 'Live title', projectPath: '/repo',
+    });
+    store.seed({
+      sessions: [],
+      recent: [{ taskId: 't1', status: 'failed', title: 'Stale title', projectPath: '/old', failureCause: 'timeout' }],
+    });
+    const session = store.get('t1');
+    expect(session.title).toBe('Live title');
+    expect(session.projectPath).toBe('/repo');
+    expect(session.failureCause).toBe('timeout'); // gaps still get filled
+  });
+});
+
+describe('terminal refinement is narrow (INT-3402 review)', () => {
+  it('does not let older history overwrite a newer live outcome', () => {
+    const store = new SessionStore();
+    // A fresh attempt just failed…
+    store.applyEvent('task:completed', { taskId: 't1', success: false, duration: 3 });
+    // …while history still remembers the previous attempt succeeding.
+    store.seed({ sessions: [], recent: [{ taskId: 't1', status: 'completed', title: 'T', projectPath: '/repo' }] });
+    expect(store.get('t1').phase).toBe('failed');
+  });
+
+  it('only refines the completed → decomposed case', () => {
+    const store = new SessionStore();
+    store.applyEvent('task:completed', { taskId: 'a', success: true, duration: 1 });
+    store.applyEvent('task:completed', { taskId: 'b', success: false, duration: 1 });
+    store.seed({
+      sessions: [],
+      recent: [
+        { taskId: 'a', status: 'decomposed', title: 'A', projectPath: '/repo' },
+        // failed → decomposed is not a refinement; the live outcome stands.
+        { taskId: 'b', status: 'decomposed', title: 'B', projectPath: '/repo' },
+      ],
+    });
+    expect(store.get('a').phase).toBe('decomposed');
+    expect(store.get('b').phase).toBe('failed');
+  });
+});

--- a/tests/web/sessionViews.test.ts
+++ b/tests/web/sessionViews.test.ts
@@ -18,6 +18,8 @@ import { SessionTree } from '../../web/static/js/sessionTree.mjs';
 import { SessionPanel } from '../../web/static/js/sessionPanel.mjs';
 // @ts-expect-error — browser ESM assets without type declarations
 import { Nav, parseHash } from '../../web/static/js/nav.mjs';
+// @ts-expect-error — browser ESM assets without type declarations
+import { DiffPanel } from '../../web/static/js/diffPanel.mjs';
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -123,15 +125,52 @@ describe('TranscriptView', () => {
 });
 
 describe('SessionPanel', () => {
-  function mount(fetchLog = vi.fn(async () => null)) {
+  function mount(fetchLog = vi.fn(async () => null), fetchDiff = vi.fn(async () => null)) {
     const root = document.createElement('div');
     document.body.appendChild(root);
     const store = new SessionStore();
     const transcripts = new TranscriptModel();
     const view = new TranscriptView(document.createElement('div'), { model: transcripts });
-    const panel = new SessionPanel(root, { store, transcripts, transcriptView: view, fetchLog });
-    return { root, store, transcripts, panel, fetchLog };
+    const diffPanel = new DiffPanel(document.createElement('div'), { fetchDiff });
+    const panel = new SessionPanel(root, { store, transcripts, transcriptView: view, diffPanel, fetchLog });
+    return { root, store, transcripts, panel, fetchLog, fetchDiff, view, diffPanel };
   }
+
+  it('shows the transcript first and fetches the diff only when that tab is opened', async () => {
+    const fetchDiff = vi.fn(async () => ({ files: [{ file: 'a.ts', added: 1, deleted: 0 }], diff: '' }));
+    const { root, store, panel, view, diffPanel } = mount(vi.fn(async () => null), fetchDiff);
+    store.applyEvent('pipeline:stage', { taskId: 't1', stage: 'worker', status: 'start', title: 'T', projectPath: '/repo' });
+    await panel.show('t1');
+
+    expect(view.element.hidden).toBe(false);
+    expect(diffPanel.element.hidden).toBe(true);
+    expect(fetchDiff).not.toHaveBeenCalled(); // a diff is a git call, not a poll
+
+    const diffTab = [...root.querySelectorAll('.session-tab')].find(
+      (b) => (b as HTMLElement).dataset.tab === 'diff',
+    ) as HTMLButtonElement;
+    diffTab.click();
+    await flush();
+
+    expect(fetchDiff).toHaveBeenCalledWith('t1');
+    expect(diffPanel.element.hidden).toBe(false);
+    expect(view.element.hidden).toBe(true);
+    expect(diffTab.classList.contains('active')).toBe(true);
+  });
+
+  it('returns to the transcript tab when another session is selected', async () => {
+    const { root, store, panel, view, diffPanel } = mount();
+    store.applyEvent('pipeline:stage', { taskId: 't1', stage: 'worker', status: 'start', title: 'T', projectPath: '/repo' });
+    store.applyEvent('pipeline:stage', { taskId: 't2', stage: 'worker', status: 'start', title: 'U', projectPath: '/repo' });
+    await panel.show('t1');
+    (([...root.querySelectorAll('.session-tab')].find(
+      (b) => (b as HTMLElement).dataset.tab === 'diff',
+    )) as HTMLButtonElement).click();
+
+    await panel.show('t2');
+    expect(view.element.hidden).toBe(false);
+    expect(diffPanel.element.hidden).toBe(true);
+  });
 
   it('renders the header and usage strip from store state', async () => {
     const { root, store, panel } = mount();

--- a/tests/web/sessionViews.test.ts
+++ b/tests/web/sessionViews.test.ts
@@ -1,0 +1,298 @@
+// @vitest-environment jsdom
+//
+// DOM-level coverage for the cockpit views (INT-3402): the tree, the
+// transcript renderer, and the session panel that binds them. These exercise
+// the SAME modules main.mjs loads, so "the Sessions view actually renders" is
+// verified in CI rather than by a browser spot-check.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// @ts-expect-error — browser ESM assets without type declarations
+import { SessionStore } from '../../web/static/js/sessionStore.mjs';
+// @ts-expect-error — browser ESM assets without type declarations
+import { TranscriptModel } from '../../web/static/js/transcriptModel.mjs';
+// @ts-expect-error — browser ESM assets without type declarations
+import { TranscriptView } from '../../web/static/js/transcriptView.mjs';
+// @ts-expect-error — browser ESM assets without type declarations
+import { SessionTree } from '../../web/static/js/sessionTree.mjs';
+// @ts-expect-error — browser ESM assets without type declarations
+import { SessionPanel } from '../../web/static/js/sessionPanel.mjs';
+// @ts-expect-error — browser ESM assets without type declarations
+import { Nav, parseHash } from '../../web/static/js/nav.mjs';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  document.body.removeAttribute('data-view');
+  window.location.hash = '';
+});
+
+describe('SessionTree', () => {
+  it('groups sessions under their repository with a running count', () => {
+    const el = document.createElement('div');
+    const store = new SessionStore();
+    new SessionTree(el, { store, onSelect: () => {} });
+
+    store.applyEvent('task:started', { taskId: 'a', title: 'Alpha', issueIdentifier: 'INT-1' });
+    store.applyEvent('pipeline:stage', { taskId: 'a', stage: 'worker', status: 'start', projectPath: '/repo' });
+    store.applyEvent('pipeline:stage', { taskId: 'b', stage: 'worker', status: 'start', projectPath: '/repo', issueIdentifier: 'INT-2' });
+    store.applyEvent('task:completed', { taskId: 'b', success: true, duration: 10 });
+
+    expect(el.querySelector('.tree-project')?.textContent).toContain('repo');
+    expect(el.querySelector('.tree-badge')?.textContent).toBe('1'); // only 'a' runs
+    const rows = [...el.querySelectorAll('.tree-session')];
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => (r as HTMLElement).dataset.phase).sort()).toEqual(['completed', 'running']);
+    expect(rows.map((r) => r.querySelector('.label')?.textContent)).toContain('INT-1');
+  });
+
+  it('renders an empty state and marks the selected row', () => {
+    const el = document.createElement('div');
+    const store = new SessionStore();
+    const tree = new SessionTree(el, { store, onSelect: () => {} });
+    tree.render();
+    expect(el.querySelector('.tree-empty')).not.toBeNull();
+
+    store.applyEvent('pipeline:stage', { taskId: 'a', stage: 'worker', status: 'start', projectPath: '/repo' });
+    tree.select('a');
+    expect(el.querySelector('.tree-session.selected')).not.toBeNull();
+  });
+
+  it('reports the clicked task id', () => {
+    const el = document.createElement('div');
+    const store = new SessionStore();
+    const onSelect = vi.fn();
+    new SessionTree(el, { store, onSelect });
+    store.applyEvent('pipeline:stage', { taskId: 'a', stage: 'worker', status: 'start', projectPath: '/repo' });
+
+    (el.querySelector('.tree-session') as HTMLButtonElement).click();
+    expect(onSelect).toHaveBeenCalledWith('a');
+  });
+});
+
+describe('TranscriptView', () => {
+  it('renders stage markers, prose lines, and collapsible tool groups', () => {
+    const el = document.createElement('div');
+    const model = new TranscriptModel();
+    const view = new TranscriptView(el, { model });
+
+    model.append('t1', { stage: 'worker', line: '💭 planning the change' });
+    model.append('t1', { stage: 'worker', line: '🔧 read_file: a.ts' });
+    model.append('t1', { stage: 'worker', line: '🔧 read_file: b.ts' });
+    view.show('t1');
+
+    expect(el.querySelector('.transcript-stage')?.textContent).toBe('── worker ──');
+    expect(el.querySelector('.transcript-line.thinking')?.textContent).toBe('💭 planning the change');
+    const group = el.querySelector('details.activity-row')!;
+    expect(group.querySelector('summary')?.textContent).toBe('read_file ×2');
+    expect(group.querySelectorAll('.activity-line')).toHaveLength(2);
+  });
+
+  it('appends live lines for the shown task and ignores other tasks', () => {
+    const el = document.createElement('div');
+    const model = new TranscriptModel();
+    const view = new TranscriptView(el, { model });
+    model.append('t1', { stage: 'worker', line: 'first' });
+    view.show('t1');
+
+    model.append('t1', { stage: 'worker', line: 'second' });
+    expect(el.querySelectorAll('.transcript-line')).toHaveLength(2);
+
+    model.append('other', { stage: 'worker', line: 'not mine' });
+    expect(el.querySelectorAll('.transcript-line')).toHaveLength(2);
+  });
+
+  it('shows an honest empty state rather than a blank pane', () => {
+    const el = document.createElement('div');
+    const view = new TranscriptView(el, { model: new TranscriptModel() });
+    view.show('unknown');
+    expect(el.querySelector('.empty')?.textContent).toContain('No output captured');
+  });
+
+  it('clear() detaches the current task', () => {
+    const el = document.createElement('div');
+    const model = new TranscriptModel();
+    const view = new TranscriptView(el, { model });
+    model.append('t1', { stage: 'worker', line: 'x' });
+    view.show('t1');
+    view.clear();
+    expect(el.childElementCount).toBe(0);
+    model.append('t1', { stage: 'worker', line: 'y' }); // must not re-render
+    expect(el.childElementCount).toBe(0);
+  });
+});
+
+describe('SessionPanel', () => {
+  function mount(fetchLog = vi.fn(async () => null)) {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    const store = new SessionStore();
+    const transcripts = new TranscriptModel();
+    const view = new TranscriptView(document.createElement('div'), { model: transcripts });
+    const panel = new SessionPanel(root, { store, transcripts, transcriptView: view, fetchLog });
+    return { root, store, transcripts, panel, fetchLog };
+  }
+
+  it('renders the header and usage strip from store state', async () => {
+    const { root, store, panel } = mount();
+    store.applyEvent('pipeline:stage', {
+      taskId: 't1', stage: 'worker', status: 'start',
+      issueIdentifier: 'INT-7', title: 'Fix the thing', projectPath: '/repo',
+      model: 'gpt-5.5', branch: 'swarm/INT-7', worktree: '/repo/worktree/t1',
+    });
+    await panel.show('t1');
+
+    expect(root.querySelector('.session-header .identifier')?.textContent).toBe('INT-7');
+    expect(root.querySelector('.session-header .title')?.textContent).toBe('Fix the thing');
+    expect(root.querySelector('.session-header .phase')?.textContent).toBe('Working — worker');
+    const meta = root.querySelector('.session-meta')?.textContent ?? '';
+    expect(meta).toContain('gpt-5.5');
+    expect(meta).toContain('swarm/INT-7');
+  });
+
+  it('updates the header live as the session progresses', async () => {
+    const { root, store, panel } = mount();
+    store.applyEvent('pipeline:stage', { taskId: 't1', stage: 'worker', status: 'start', title: 'T', projectPath: '/repo' });
+    await panel.show('t1');
+    store.applyEvent('task:completed', { taskId: 't1', success: false, duration: 4_000 });
+
+    const phase = root.querySelector('.session-header .phase') as HTMLElement;
+    expect(phase.textContent).toBe('Failed');
+    expect(phase.dataset.phase).toBe('failed');
+    expect(root.querySelector('.session-meta')?.textContent).toContain('4s');
+  });
+
+  it('seeds transcript history from REST exactly once, replacing live lines', async () => {
+    const fetchLog = vi.fn(async () => ({
+      taskId: 't1',
+      lines: [{ stage: 'worker', line: 'from REST' }],
+      truncated: false,
+    }));
+    const { store, transcripts, panel } = mount(fetchLog);
+    store.applyEvent('pipeline:stage', { taskId: 't1', stage: 'worker', status: 'start', title: 'T', projectPath: '/repo' });
+    transcripts.append('t1', { stage: 'worker', line: 'live line' });
+
+    await panel.show('t1');
+    await flush();
+
+    const texts = transcripts.entries('t1')
+      .filter((e: { kind: string }) => e.kind === 'line')
+      .map((e: { text: string }) => e.text);
+    // REST replaces rather than appends — a line can never render twice.
+    expect(texts).toEqual(['from REST']);
+
+    await panel.show('t1'); // re-selection must not refetch and clobber live lines
+    expect(fetchLog).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps live lines that stream in WHILE the snapshot request is in flight', async () => {
+    let release: (value: unknown) => void = () => {};
+    const gate = new Promise((resolve) => { release = resolve; });
+    const fetchLog = vi.fn(async () => {
+      await gate;
+      return {
+        taskId: 't1',
+        // Daemon-stamped sequence: the join key both sides share.
+        lines: [
+          { stage: 'worker', line: 'history 1', ts: 100, seq: 1 },
+          { stage: 'worker', line: 'history 2', ts: 100, seq: 2 },
+        ],
+        truncated: false,
+      };
+    });
+    const { store, transcripts, panel } = mount(fetchLog);
+    store.applyEvent('pipeline:stage', { taskId: 't1', stage: 'worker', status: 'start', title: 'T', projectPath: '/repo' });
+
+    const showing = panel.show('t1');
+    // These arrive after the server took its snapshot — nothing else can
+    // deliver them, so dropping them loses output permanently.
+    transcripts.append('t1', { stage: 'worker', line: 'streamed during fetch', ts: 100, seq: 3 });
+    transcripts.append('t1', { stage: 'worker', line: 'and another', ts: 100, seq: 4 });
+    release(null);
+    await showing;
+    await flush();
+
+    const texts = transcripts.entries('t1')
+      .filter((e: { kind: string }) => e.kind === 'line')
+      .map((e: { text: string }) => e.text);
+    expect(texts).toEqual(['history 1', 'history 2', 'streamed during fetch', 'and another']);
+  });
+
+  it('drops overlapping live lines rather than duplicating when the daemon sends no sequence', async () => {
+    const fetchLog = vi.fn(async () => ({
+      taskId: 't1',
+      lines: [{ stage: 'worker', line: 'history' }], // no seq — older daemon
+      truncated: false,
+    }));
+    const { store, transcripts, panel } = mount(fetchLog);
+    store.applyEvent('pipeline:stage', { taskId: 't1', stage: 'worker', status: 'start', title: 'T', projectPath: '/repo' });
+    transcripts.append('t1', { stage: 'worker', line: 'history' }); // same line, live
+
+    await panel.show('t1');
+    await flush();
+
+    const texts = transcripts.entries('t1')
+      .filter((e: { kind: string }) => e.kind === 'line')
+      .map((e: { text: string }) => e.text);
+    expect(texts).toEqual(['history']); // shown once, not twice
+  });
+
+  it('survives a daemon without the transcript endpoint', async () => {
+    const fetchLog = vi.fn(async () => { throw new Error('404'); });
+    const { store, panel, root } = mount(fetchLog);
+    store.applyEvent('pipeline:stage', { taskId: 't1', stage: 'worker', status: 'start', title: 'T', projectPath: '/repo' });
+    await expect(panel.show('t1')).resolves.toBeUndefined();
+    expect(root.querySelector('.session-header')).not.toBeNull();
+  });
+
+  it('showEmpty renders a message and drops the selection', () => {
+    const { root, panel } = mount();
+    panel.showEmpty('nothing here');
+    expect(root.querySelector('.empty')?.textContent).toBe('nothing here');
+    expect(panel.taskId).toBeNull();
+  });
+});
+
+describe('Nav', () => {
+  it('switches body[data-view], marks the active button, and emits the change', () => {
+    const sessionsBtn = document.createElement('button');
+    sessionsBtn.dataset.view = 'sessions';
+    const issuesBtn = document.createElement('button');
+    issuesBtn.dataset.view = 'issues';
+    document.body.append(sessionsBtn, issuesBtn);
+
+    const nav = new Nav({ buttons: [sessionsBtn, issuesBtn] });
+    const seen: Array<{ view: string; taskId: string | null }> = [];
+    nav.addEventListener('change', (e: Event) => seen.push((e as CustomEvent).detail));
+
+    nav.start();
+    expect(document.body.dataset.view).toBe('issues'); // default
+
+    nav.show('sessions', 'task-1');
+    expect(parseHash(window.location.hash)).toEqual({ view: 'sessions', taskId: 'task-1' });
+    expect(document.body.dataset.view).toBe('sessions');
+    expect(sessionsBtn.classList.contains('active')).toBe(true);
+    expect(issuesBtn.getAttribute('aria-current')).toBe('false');
+    expect(seen.at(-1)).toEqual({ view: 'sessions', taskId: 'task-1' });
+  });
+
+  it('survives a malformed escape in the hash instead of killing the bootstrap', () => {
+    // decodeURIComponent throws on '%' / '%zz'; parseHash runs during startup.
+    expect(parseHash('#/sessions/%')).toEqual({ view: 'sessions', taskId: '%' });
+    expect(parseHash('#/sessions/%zz')).toEqual({ view: 'sessions', taskId: '%zz' });
+
+    window.location.hash = '#/sessions/%';
+    const nav = new Nav({ buttons: [] });
+    expect(() => nav.start()).not.toThrow();
+    expect(document.body.dataset.view).toBe('sessions');
+  });
+
+  it('re-emits when asked to show the hash it is already on', () => {
+    const nav = new Nav({ buttons: [] });
+    nav.show('sessions', 'x');
+    let emitted = 0;
+    nav.addEventListener('change', () => emitted++);
+    nav.show('sessions', 'x');
+    expect(emitted).toBe(1);
+  });
+});

--- a/tests/web/sessionViews.test.ts
+++ b/tests/web/sessionViews.test.ts
@@ -276,6 +276,35 @@ describe('SessionPanel', () => {
     expect(texts).toEqual(['history']); // shown once, not twice
   });
 
+  it('keeps post-restart lines when the daemon restarts during the snapshot request', async () => {
+    let release: (value: unknown) => void = () => {};
+    const gate = new Promise((resolve) => { release = resolve; });
+    const fetchLog = vi.fn(async () => {
+      await gate;
+      return {
+        taskId: 't1',
+        gen: 'daemon-1',
+        lines: [{ stage: 'worker', line: 'before restart', ts: 1, seq: 900, gen: 'daemon-1' }],
+        truncated: false,
+      };
+    });
+    const { store, transcripts, panel } = mount(fetchLog);
+    store.applyEvent('pipeline:stage', { taskId: 't1', stage: 'worker', status: 'start', title: 'T', projectPath: '/repo' });
+
+    const showing = panel.show('t1');
+    // The daemon restarted mid-request: its sequence restarted at 1, so a
+    // numeric comparison against the old snapshot would throw this away.
+    transcripts.append('t1', { stage: 'worker', line: 'after restart', ts: 2, seq: 1, gen: 'daemon-2' });
+    release(null);
+    await showing;
+    await flush();
+
+    const texts = transcripts.entries('t1')
+      .filter((e: { kind: string }) => e.kind === 'line')
+      .map((e: { text: string }) => e.text);
+    expect(texts).toEqual(['before restart', 'after restart']);
+  });
+
   it('survives a daemon without the transcript endpoint', async () => {
     const fetchLog = vi.fn(async () => { throw new Error('404'); });
     const { store, panel, root } = mount(fetchLog);

--- a/tests/web/transcriptModel.test.ts
+++ b/tests/web/transcriptModel.test.ts
@@ -142,3 +142,66 @@ describe('TranscriptModel', () => {
     expect(model.has('t1')).toBe(false);
   });
 });
+
+describe('production line shapes (INT-3402 review)', () => {
+  // pairPipeline emits `[${prefix}] ${line}` — the bare-glyph fixtures above
+  // pass while real output would classify as plain.
+  const PREFIXED_THINK = '[INT-3402|worktree/abc] 💭 reading the file';
+  const PREFIXED_TOOL = '[INT-3402|worktree/abc] 🔧 read_file: src/a.ts';
+
+  it('classifies task-prefixed lines by their glyph', () => {
+    expect(classifyLine(PREFIXED_THINK)).toBe('thinking');
+    expect(classifyLine(PREFIXED_TOOL)).toBe('tool');
+  });
+
+  it('summarizes prefixed tool runs by verb, not by prefix', () => {
+    expect(summarizeToolGroup([PREFIXED_TOOL])).toBe('read_file: src/a.ts');
+    expect(summarizeToolGroup([PREFIXED_TOOL, '[INT-3402|worktree/abc] 🔧 read_file: b.ts']))
+      .toBe('read_file ×2');
+  });
+
+  it('collapses a prefixed tool run into one group', () => {
+    const model = new TranscriptModel();
+    model.append('t1', { stage: 'worker', line: PREFIXED_THINK });
+    model.append('t1', { stage: 'worker', line: PREFIXED_TOOL });
+    model.append('t1', { stage: 'worker', line: PREFIXED_TOOL });
+    expect(model.entries('t1').map((e: Entry) => e.kind)).toEqual(['stage', 'line', 'tools']);
+  });
+
+  it('caps one tool group so a long run cannot escape the entry limit', () => {
+    const model = new TranscriptModel({ maxGroupLines: 3 });
+    for (let i = 0; i < 7; i++) model.append('t1', { stage: 'worker', line: `🔧 read_file: ${i}.ts` });
+    const groups = model.entries('t1').filter((e: Entry) => e.kind === 'tools');
+    expect(groups).toHaveLength(3); // 3 + 3 + 1
+    expect(groups.every((g: Entry) => (g.lines?.length ?? 0) <= 3)).toBe(true);
+  });
+
+  it('drops sequence high-water marks when a line arrives from a restarted daemon', () => {
+    const model = new TranscriptModel();
+    model.append('t1', { stage: 'worker', line: 'before restart', seq: 900, gen: 'daemon-1' });
+
+    // A restarted daemon numbers from 1 again — without a reset every new line
+    // would be discarded as a duplicate. The generation rides ON the line, so
+    // this cannot lose a race with a separate health request.
+    model.append('t1', { stage: 'worker', line: 'after restart', seq: 1, gen: 'daemon-2' });
+
+    const texts = model.entries('t1').filter((e: Entry) => e.kind === 'line').map((e: Entry) => e.text);
+    expect(texts).toEqual(['before restart', 'after restart']);
+  });
+
+  it('does not reset on the first generation it learns', () => {
+    const model = new TranscriptModel();
+    model.append('t1', { stage: 'worker', line: 'one', seq: 5, gen: 'daemon-1' });
+    model.append('t1', { stage: 'worker', line: 'duplicate', seq: 5, gen: 'daemon-1' });
+    expect(model.entries('t1').filter((e: Entry) => e.kind === 'line')).toHaveLength(1);
+  });
+
+  it('still dedupes within one generation after a restart reset', () => {
+    const model = new TranscriptModel();
+    model.append('t1', { stage: 'worker', line: 'old', seq: 900, gen: 'daemon-1' });
+    model.append('t1', { stage: 'worker', line: 'new', seq: 1, gen: 'daemon-2' });
+    model.append('t1', { stage: 'worker', line: 'new', seq: 1, gen: 'daemon-2' }); // replay
+    const texts = model.entries('t1').filter((e: Entry) => e.kind === 'line').map((e: Entry) => e.text);
+    expect(texts).toEqual(['old', 'new']);
+  });
+});

--- a/tests/web/transcriptModel.test.ts
+++ b/tests/web/transcriptModel.test.ts
@@ -1,0 +1,144 @@
+// Transcript classification, tool grouping, and bounded history (INT-3402).
+
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — browser ESM asset without type declarations
+import { TranscriptModel, classifyLine, summarizeToolGroup } from '../../web/static/js/transcriptModel.mjs';
+
+type Entry = { kind: string; type?: string; text?: string; stage?: string; lines?: string[] };
+
+describe('classifyLine', () => {
+  it('recognizes thinking and tool prefixes, defaulting to plain', () => {
+    expect(classifyLine('💭 reading the file')).toBe('thinking');
+    expect(classifyLine('  🔧 read_file: a.ts')).toBe('tool'); // leading space tolerated
+    expect(classifyLine('git add -A')).toBe('plain');
+    expect(classifyLine(undefined)).toBe('plain');
+  });
+});
+
+describe('summarizeToolGroup', () => {
+  it('names a single call, counts a same-verb run, and falls back when mixed', () => {
+    expect(summarizeToolGroup(['🔧 read_file: a.ts'])).toBe('read_file: a.ts');
+    expect(summarizeToolGroup(['🔧 read_file: a.ts', '🔧 read_file: b.ts'])).toBe('read_file ×2');
+    expect(summarizeToolGroup(['🔧 read_file: a.ts', '🔧 bash: ls', '🔧 edit_file: c.ts'])).toBe('3 tool calls');
+  });
+});
+
+describe('TranscriptModel', () => {
+  it('collapses consecutive tool lines into one group and breaks on a non-tool line', () => {
+    const model = new TranscriptModel();
+    model.append('t1', { stage: 'worker', line: '💭 planning' });
+    model.append('t1', { stage: 'worker', line: '🔧 read_file: a.ts' });
+    model.append('t1', { stage: 'worker', line: '🔧 read_file: b.ts' });
+    model.append('t1', { stage: 'worker', line: '💭 now editing' });
+    model.append('t1', { stage: 'worker', line: '🔧 edit_file: a.ts' });
+
+    const kinds = model.entries('t1').map((e: Entry) => e.kind);
+    expect(kinds).toEqual(['stage', 'line', 'tools', 'line', 'tools']);
+    expect(model.entries('t1')[2].lines).toHaveLength(2);
+    expect(model.entries('t1')[4].lines).toHaveLength(1);
+  });
+
+  it('inserts a stage marker on change and never merges groups across stages', () => {
+    const model = new TranscriptModel();
+    model.append('t1', { stage: 'worker', line: '🔧 read_file: a.ts' });
+    model.append('t1', { stage: 'reviewer', line: '🔧 bash: git diff' });
+
+    const entries = model.entries('t1');
+    expect(entries.map((e: Entry) => e.kind)).toEqual(['stage', 'tools', 'stage', 'tools']);
+    expect(entries[0].stage).toBe('worker');
+    expect(entries[2].stage).toBe('reviewer');
+  });
+
+  it('bounds history by whole entries, never half a tool group', () => {
+    const model = new TranscriptModel({ maxEntries: 3 });
+    for (let i = 0; i < 10; i++) {
+      model.append('t1', { stage: 'worker', line: `💭 thought ${i}` });
+    }
+    const entries = model.entries('t1');
+    expect(entries).toHaveLength(3);
+    expect(entries.at(-1).text).toBe('💭 thought 9');
+  });
+
+  it('stops appending to an evicted tool group', () => {
+    const model = new TranscriptModel({ maxEntries: 2 });
+    model.append('t1', { stage: 'worker', line: '🔧 read_file: a.ts' }); // stage + tools
+    model.append('t1', { stage: 'worker', line: '💭 pushes the group out' });
+    model.append('t1', { stage: 'worker', line: '🔧 edit_file: a.ts' });
+
+    const entries = model.entries('t1');
+    // The new tool line starts a FRESH group rather than mutating the evicted one.
+    expect(entries.at(-1).kind).toBe('tools');
+    expect(entries.at(-1).lines).toEqual(['🔧 edit_file: a.ts']);
+  });
+
+  it('keeps tasks isolated', () => {
+    const model = new TranscriptModel();
+    model.append('t1', { stage: 'worker', line: 'a' });
+    model.append('t2', { stage: 'worker', line: 'b' });
+    expect(model.entries('t1').filter((e: Entry) => e.kind === 'line')).toHaveLength(1);
+    expect(model.entries('t2').filter((e: Entry) => e.kind === 'line')).toHaveLength(1);
+    expect(model.entries('missing')).toEqual([]);
+  });
+
+  it('replace() swaps history wholesale and emits once, not per line', () => {
+    const model = new TranscriptModel();
+    model.append('t1', { stage: 'worker', line: 'live line' });
+
+    let appends = 0;
+    let replaces = 0;
+    model.addEventListener('append', () => appends++);
+    model.addEventListener('replace', () => replaces++);
+
+    model.replace('t1', [
+      { stage: 'worker', line: 'from REST 1' },
+      { stage: 'worker', line: 'from REST 2' },
+    ]);
+
+    const texts = model.entries('t1').filter((e: Entry) => e.kind === 'line').map((e: Entry) => e.text);
+    expect(texts).toEqual(['from REST 1', 'from REST 2']); // the live line is gone
+    expect(appends).toBe(0);
+    expect(replaces).toBe(1);
+  });
+
+  it('ignores a line it has already seen, by daemon sequence', () => {
+    const model = new TranscriptModel();
+    model.append('t1', { stage: 'worker', line: 'one', seq: 1 });
+    model.append('t1', { stage: 'worker', line: 'two', seq: 2 });
+    // The SSE replay hands back lines the live stream already delivered.
+    model.append('t1', { stage: 'worker', line: 'one', seq: 1 });
+    model.append('t1', { stage: 'worker', line: 'two', seq: 2 });
+    model.append('t1', { stage: 'worker', line: 'three', seq: 3 });
+
+    const texts = model.entries('t1').filter((e: Entry) => e.kind === 'line').map((e: Entry) => e.text);
+    expect(texts).toEqual(['one', 'two', 'three']);
+  });
+
+  it('still accepts lines from a daemon that stamps no sequence', () => {
+    const model = new TranscriptModel();
+    model.append('t1', { stage: 'worker', line: 'a' });
+    model.append('t1', { stage: 'worker', line: 'b' });
+    expect(model.entries('t1').filter((e: Entry) => e.kind === 'line')).toHaveLength(2);
+  });
+
+  it('carries the sequence high-water mark through replace()', () => {
+    const model = new TranscriptModel();
+    model.append('t1', { stage: 'worker', line: 'live', seq: 7 });
+    model.replace('t1', [
+      { stage: 'worker', line: 'history', seq: 5 },
+      { stage: 'worker', line: 'live', seq: 7 },
+    ]);
+    // A replayed line at or below the snapshot's last sequence is a duplicate.
+    model.append('t1', { stage: 'worker', line: 'live', seq: 7 });
+    model.append('t1', { stage: 'worker', line: 'newer', seq: 8 });
+
+    const texts = model.entries('t1').filter((e: Entry) => e.kind === 'line').map((e: Entry) => e.text);
+    expect(texts).toEqual(['history', 'live', 'newer']);
+  });
+
+  it('ignores empty lines', () => {
+    const model = new TranscriptModel();
+    model.append('t1', { stage: 'worker', line: '' });
+    model.append('t1', { stage: 'worker', line: undefined as unknown as string });
+    expect(model.has('t1')).toBe(false);
+  });
+});

--- a/web/static/app.html
+++ b/web/static/app.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="/static/css/app.css" />
 </head>
 <body data-view="issues">
+  <button id="sidebar-toggle" class="sidebar-toggle" type="button" aria-label="Toggle sidebar" aria-expanded="false">☰</button>
   <aside class="sidebar">
     <div class="brand">🐝 OpenSwarm</div>
     <nav class="view-nav">

--- a/web/static/app.html
+++ b/web/static/app.html
@@ -5,44 +5,68 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>OpenSwarm</title>
   <link rel="stylesheet" href="/static/css/tokens.css" />
+  <link rel="stylesheet" href="/static/css/cockpit.css" />
   <link rel="stylesheet" href="/static/css/app.css" />
 </head>
-<body>
-  <header class="topbar">
+<body data-view="issues">
+  <aside class="sidebar">
     <div class="brand">🐝 OpenSwarm</div>
+    <nav class="view-nav">
+      <button type="button" class="nav-item" data-view="sessions">Sessions</button>
+      <button type="button" class="nav-item" data-view="issues">Issues</button>
+    </nav>
+    <div class="sidebar-section-head">Repository</div>
     <div id="repo-picker" class="repo-picker"></div>
-    <div class="spacer"></div>
+    <div id="session-tree" class="session-tree"></div>
+  </aside>
+
+  <main class="main">
+    <section class="view view-issues" data-view-panel="issues">
+      <div class="panel issues-panel">
+        <div class="panel-head">
+          <h2>Issues</h2>
+          <span id="issue-count" class="muted"></span>
+        </div>
+        <div id="issue-list" class="issue-list">
+          <div class="empty">Select a repository to load its issues.</div>
+        </div>
+        <footer class="deploy-bar">
+          <span id="selection-summary" class="muted">0 selected</span>
+          <button id="deploy-btn" class="deploy-btn" disabled>Deploy agents</button>
+        </footer>
+      </div>
+
+      <div class="panel work-panel">
+        <div class="panel-head">
+          <h2>Active work</h2>
+        </div>
+        <div id="work-cards" class="work-cards">
+          <div class="empty">Deployed agents will report progress here.</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="view view-sessions" data-view-panel="sessions">
+      <div class="panel session-panel">
+        <div class="panel-head">
+          <h2>Sessions</h2>
+          <span id="session-count" class="muted"></span>
+        </div>
+        <div id="session-body" class="session-body">
+          <div class="empty">Deploy issues to start a session. Live agent output appears here.</div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="statusbar">
     <div id="quota-gauge" class="quota-gauge" title="provider rate limit — observed from usage headers" hidden></div>
+    <div class="spacer"></div>
     <div id="daemon-status" class="daemon-status" title="daemon">
       <span class="dot" data-state="unknown"></span>
       <span class="label">connecting…</span>
     </div>
-  </header>
-
-  <main class="layout">
-    <section class="panel issues-panel">
-      <div class="panel-head">
-        <h2>Issues</h2>
-        <span id="issue-count" class="muted"></span>
-      </div>
-      <div id="issue-list" class="issue-list">
-        <div class="empty">Select a repository to load its issues.</div>
-      </div>
-      <footer class="deploy-bar">
-        <span id="selection-summary" class="muted">0 selected</span>
-        <button id="deploy-btn" class="deploy-btn" disabled>Deploy agents</button>
-      </footer>
-    </section>
-
-    <section class="panel work-panel">
-      <div class="panel-head">
-        <h2>Active work</h2>
-      </div>
-      <div id="work-cards" class="work-cards">
-        <div class="empty">Deployed agents will report progress here.</div>
-      </div>
-    </section>
-  </main>
+  </footer>
 
   <script type="module" src="/static/js/main.mjs"></script>
 </body>

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -1,31 +1,9 @@
-/* OpenSwarm issue board (INT-3388). Consumes tokens.css only. */
-
-* { box-sizing: border-box; }
-
-body {
-  margin: 0;
-  background: var(--bg);
-  color: var(--text);
-  font-family: var(--font-ui);
-  font-size: var(--text-md);
-  height: 100vh;
-  display: flex;
-  flex-direction: column;
-}
-
-.topbar {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 10px 16px;
-  background: var(--surface);
-  border-bottom: 1px solid var(--border);
-}
-
-.brand { font-weight: 600; font-size: var(--text-lg); }
-.spacer { flex: 1; }
+/* OpenSwarm issue board components (INT-3388). Consumes tokens.css only.
+   The shell (body grid, sidebar, views, status bar) lives in cockpit.css —
+   this file owns the Issues view's own widgets. */
 
 .repo-picker select {
+  width: 100%;
   background: var(--surface2);
   color: var(--text);
   border: 1px solid var(--border);
@@ -58,15 +36,6 @@ body {
 }
 .daemon-status .dot[data-state="ok"] { background: var(--ok); }
 .daemon-status .dot[data-state="down"] { background: var(--error); }
-
-.layout {
-  flex: 1;
-  display: grid;
-  grid-template-columns: minmax(360px, 1fr) minmax(320px, 1fr);
-  gap: 12px;
-  padding: 12px;
-  min-height: 0;
-}
 
 .panel {
   background: var(--surface);

--- a/web/static/css/cockpit.css
+++ b/web/static/css/cockpit.css
@@ -171,6 +171,47 @@ body[data-view="sessions"] .view-sessions { display: flex; }
   text-overflow: ellipsis;
 }
 
+.session-tabs { display: flex; gap: 4px; }
+
+.session-tab {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--muted);
+  font: inherit;
+  font-size: var(--text-xs);
+  padding: 3px 10px;
+  cursor: pointer;
+}
+.session-tab:hover { color: var(--text); }
+.session-tab.active { color: var(--accent); border-color: var(--border); background: var(--accent-soft); }
+.session-tab:focus-visible { outline: 2px solid var(--focus); outline-offset: 1px; }
+
+/* ── Diff ────────────────────────────────────────────────────────────── */
+
+.diff-pane {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+.diff-pane[hidden] { display: none; }
+.diff-summary { color: var(--text); margin-bottom: 6px; }
+.diff-file { color: var(--muted); }
+.diff-body { margin-top: 8px; }
+.diff-line { white-space: pre; line-height: 1.45; }
+.diff-line.file { color: var(--purple); margin-top: 8px; }
+.diff-line.hunk { color: var(--accent); }
+.diff-line.meta { color: var(--muted); }
+.diff-line.add { color: var(--ok); }
+.diff-line.del { color: var(--error); }
+.diff-line.context { color: var(--muted); }
+
 /* ── Transcript ──────────────────────────────────────────────────────── */
 
 .transcript {
@@ -185,6 +226,7 @@ body[data-view="sessions"] .view-sessions { display: flex; }
   /* NEVER smooth: it breaks stick-to-bottom detection (vega INT-1411). */
   scroll-behavior: auto;
 }
+.transcript[hidden] { display: none; }
 
 .transcript-stage { color: var(--accent); margin: 8px 0 4px; font-family: var(--font-mono); font-size: var(--text-xs); }
 .transcript-stage:first-child { margin-top: 0; }

--- a/web/static/css/cockpit.css
+++ b/web/static/css/cockpit.css
@@ -1,0 +1,232 @@
+/* Cockpit shell: sidebar + view area + status bar. (INT-3402)
+   Consumes tokens.css only. Component styling for the Issues view stays in
+   app.css — this file owns the frame. */
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: var(--text-md);
+  height: 100vh;
+  display: grid;
+  grid-template:
+    "sidebar main" 1fr
+    "statusbar statusbar" auto
+    / var(--sidebar-w) minmax(0, 1fr);
+}
+
+/* ── Sidebar ─────────────────────────────────────────────────────────── */
+
+.sidebar {
+  grid-area: sidebar;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  padding: 10px 10px 0;
+  gap: 10px;
+}
+
+.brand { font-weight: 600; font-size: var(--text-lg); padding: 2px 4px; }
+
+.view-nav { display: flex; flex-direction: column; gap: 2px; }
+
+.nav-item {
+  text-align: left;
+  background: none;
+  border: none;
+  border-radius: var(--radius-md);
+  color: var(--muted);
+  font: inherit;
+  font-size: var(--text-sm);
+  padding: 6px 10px;
+  cursor: pointer;
+}
+.nav-item:hover { background: var(--surface2); color: var(--text); }
+.nav-item.active { background: var(--accent-soft); color: var(--accent); }
+.nav-item:focus-visible { outline: 2px solid var(--focus); outline-offset: -2px; }
+
+.sidebar-section-head {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  padding: 0 4px;
+}
+
+.session-tree {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  margin: 0 -10px;
+  padding: 0 10px 10px;
+}
+
+/* ── Main / views ────────────────────────────────────────────────────── */
+
+.main { grid-area: main; min-width: 0; min-height: 0; display: flex; }
+
+/* One attribute on <body> decides which view is mounted; the others stay in
+   the DOM (state, scroll positions, and in-flight renders survive switching). */
+.view { display: none; flex: 1; min-width: 0; min-height: 0; padding: 12px; gap: 12px; }
+body[data-view="issues"] .view-issues { display: grid; grid-template-columns: minmax(360px, 1fr) minmax(320px, 1fr); }
+body[data-view="sessions"] .view-sessions { display: flex; }
+
+.session-panel { flex: 1; min-width: 0; }
+.session-body { flex: 1; min-height: 0; padding: 10px 12px; display: flex; flex-direction: column; gap: 6px; }
+
+/* ── Session tree (sidebar) ──────────────────────────────────────────── */
+
+.tree-empty { color: var(--muted); font-size: var(--text-xs); padding: 8px 4px; }
+
+.tree-project {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--text-xs);
+  color: var(--muted);
+  padding: 8px 4px 2px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.tree-badge {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-radius: var(--radius-pill);
+  padding: 0 6px;
+  font-size: 10px;
+  letter-spacing: 0;
+}
+
+.tree-session {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-md);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--text-sm);
+  padding: 4px 8px;
+  cursor: pointer;
+  text-align: left;
+}
+.tree-session:hover { background: var(--surface2); }
+.tree-session.selected { background: var(--accent-soft); }
+.tree-session:focus-visible { outline: 2px solid var(--focus); outline-offset: -2px; }
+.tree-session .glyph { width: 12px; text-align: center; color: var(--muted); }
+.tree-session[data-phase="running"] .glyph { color: var(--accent); }
+.tree-session[data-phase="completed"] .glyph { color: var(--ok); }
+.tree-session[data-phase="failed"] .glyph { color: var(--error); }
+.tree-session[data-phase="decomposed"] .glyph { color: var(--purple); }
+.tree-session .label {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tree-session .time { font-size: 10px; color: var(--muted); white-space: nowrap; }
+
+/* ── Session panel ───────────────────────────────────────────────────── */
+
+.session-header { display: flex; align-items: baseline; gap: 8px; min-width: 0; }
+.session-header .identifier {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--accent);
+}
+.session-header .title {
+  flex: 1;
+  font-size: var(--text-sm);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.session-header .phase {
+  font-size: var(--text-xs);
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: 1px 8px;
+  white-space: nowrap;
+}
+.session-header .phase[data-phase="running"] { color: var(--accent); border-color: var(--accent); }
+.session-header .phase[data-phase="completed"] { color: var(--ok); border-color: var(--ok); }
+.session-header .phase[data-phase="failed"] { color: var(--error); border-color: var(--error); }
+
+.session-meta {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Transcript ──────────────────────────────────────────────────────── */
+
+.transcript {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: auto;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  /* NEVER smooth: it breaks stick-to-bottom detection (vega INT-1411). */
+  scroll-behavior: auto;
+}
+
+.transcript-stage { color: var(--accent); margin: 8px 0 4px; font-family: var(--font-mono); font-size: var(--text-xs); }
+.transcript-stage:first-child { margin-top: 0; }
+
+.transcript-line { font-size: var(--text-sm); line-height: 1.55; white-space: pre-wrap; word-break: break-word; max-width: 760px; }
+.transcript-line.thinking { color: var(--text); }
+.transcript-line.plain { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); }
+
+.activity-row { margin: 2px 0; font-family: var(--font-mono); font-size: var(--text-xs); }
+.activity-row > summary { cursor: pointer; color: var(--muted); list-style: none; }
+.activity-row > summary::before { content: '▸ '; color: var(--purple); }
+.activity-row[open] > summary::before { content: '▾ '; }
+.activity-row > summary:hover { color: var(--text); }
+.activity-line { color: var(--muted); padding-left: 14px; white-space: pre-wrap; word-break: break-word; }
+
+/* ── Status bar ──────────────────────────────────────────────────────── */
+
+.statusbar {
+  grid-area: statusbar;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 4px 12px;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  font-size: var(--text-xs);
+  color: var(--muted);
+}
+.statusbar .spacer { flex: 1; }
+
+/* ── Narrow windows ──────────────────────────────────────────────────── */
+
+@media (max-width: 900px) {
+  body { grid-template: "main" 1fr "statusbar" auto / minmax(0, 1fr); }
+  .sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: var(--sidebar-w);
+    z-index: 10;
+    transform: translateX(-100%);
+    transition: transform 120ms ease-out;
+  }
+  body.sidebar-open .sidebar { transform: none; }
+  body[data-view="issues"] .view-issues { grid-template-columns: minmax(0, 1fr); }
+}

--- a/web/static/css/cockpit.css
+++ b/web/static/css/cockpit.css
@@ -259,6 +259,9 @@ body[data-view="sessions"] .view-sessions { display: flex; }
 
 /* ── Narrow windows ──────────────────────────────────────────────────── */
 
+/* Wide windows keep the sidebar pinned, so its toggle is noise. */
+.sidebar-toggle { display: none; }
+
 @media (max-width: 900px) {
   body { grid-template: "main" 1fr "statusbar" auto / minmax(0, 1fr); }
   .sidebar {
@@ -271,4 +274,25 @@ body[data-view="sessions"] .view-sessions { display: flex; }
   }
   body.sidebar-open .sidebar { transform: none; }
   body[data-view="issues"] .view-issues { grid-template-columns: minmax(0, 1fr); }
+
+  /* Off-canvas needs a way back on-canvas — without this the repo picker and
+     session tree are unreachable at narrow widths. */
+  .sidebar-toggle {
+    display: block;
+    position: fixed;
+    top: 8px;
+    left: 8px;
+    z-index: 11;
+    background: var(--surface2);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    font-size: var(--text-md);
+    line-height: 1;
+    padding: 6px 10px;
+    cursor: pointer;
+  }
+  .sidebar-toggle:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
+  /* Keep the first view row clear of the floating button. */
+  .view { padding-top: 44px; }
 }

--- a/web/static/css/tokens.css
+++ b/web/static/css/tokens.css
@@ -25,11 +25,22 @@
   --warning: #d29922;
   --error: #f85149;
 
+  /* Metric hues — carried from the same palette so cost/speed/risk read
+     apart from status at a glance without inventing new colors. (INT-3402) */
+  --purple: #d2a8ff;
+  --orange: #ffa657;
+  --risk: #ff7b72;
+  --on-fill: #ffffff;
+
   /* Metrics */
   --radius-sm: 6px;
   --radius-md: 8px;
   --radius-lg: 12px;
+  --radius-xl: 16px;
   --radius-pill: 999px;
+
+  /* Cockpit layout */
+  --sidebar-w: 260px;
 
   --font-ui: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;

--- a/web/static/js/api.mjs
+++ b/web/static/js/api.mjs
@@ -10,7 +10,7 @@ export class ApiError extends Error {
 async function request(path, options = {}) {
   const res = await fetch(path, {
     ...options,
-    headers: { 'Content-Type': 'application/json', ...(options.headers ?? {}) },
+    headers: { 'Content-Type': 'application/json', ...options.headers },
   });
   let body = null;
   try {
@@ -24,6 +24,20 @@ async function request(path, options = {}) {
   return body;
 }
 
+/**
+ * For endpoints a daemon may predate: a 404 resolves to null instead of
+ * throwing, so callers branch on data rather than on exception type. Real
+ * failures (500, network) still throw.
+ */
+async function optional(promise) {
+  try {
+    return await promise;
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return null;
+    throw err;
+  }
+}
+
 export const api = {
   health: () => request('/api/health'),
   // The dispatchable repo set — matches dispatchWork's boundary check exactly.
@@ -33,4 +47,12 @@ export const api = {
     request('/api/work', { method: 'POST', body: JSON.stringify({ projectPath, issueIds }) }),
   stages: () => request('/api/stages'),
   quota: () => request('/api/quota'),
+
+  // Cockpit surfaces (INT-3402). `optional` so an older daemon degrades to a
+  // reduced cockpit instead of an error screen.
+  workSessions: (limit) => optional(request(`/api/work/sessions${limit ? `?limit=${limit}` : ''}`)),
+  sessionLog: (taskId) => optional(request(`/api/work/sessions/${encodeURIComponent(taskId)}/log`)),
+  workDiff: (taskId) => optional(request(`/api/work/diff?taskId=${encodeURIComponent(taskId)}`)),
+  projects: () => request('/api/projects'),
+  cancelTask: (taskId) => request(`/api/processes/${encodeURIComponent(taskId)}`, { method: 'DELETE' }),
 };

--- a/web/static/js/diffPanel.mjs
+++ b/web/static/js/diffPanel.mjs
@@ -1,0 +1,135 @@
+// Worktree diff for the selected session. (INT-3402)
+//
+// Renders GET /api/work/diff — the changes an agent has made in its isolated
+// worktree. A minimal unified-diff parser lives here rather than a vendored
+// highlighter: the shape is small and stable, and the page ships no bundler.
+
+/** Split a unified diff into rows the renderer can style. Pure. */
+export function parseUnifiedDiff(text) {
+  const rows = [];
+  for (const line of (text ?? '').split('\n')) {
+    if (line.startsWith('diff --git ') || line.startsWith('index ')) {
+      rows.push({ type: 'file', text: line });
+    } else if (line.startsWith('@@')) {
+      rows.push({ type: 'hunk', text: line });
+    } else if (line.startsWith('+++') || line.startsWith('---')) {
+      rows.push({ type: 'meta', text: line });
+    } else if (line.startsWith('+')) {
+      rows.push({ type: 'add', text: line });
+    } else if (line.startsWith('-')) {
+      rows.push({ type: 'del', text: line });
+    } else {
+      rows.push({ type: 'context', text: line });
+    }
+  }
+  // A trailing newline yields one empty context row — drop it.
+  if (rows.length && rows.at(-1).text === '') rows.pop();
+  return rows;
+}
+
+/** "3 files · +42 −7" from the API's per-file counts. Pure. */
+export function summarizeFiles(files) {
+  if (!files?.length) return 'No file changes';
+  const added = files.reduce((sum, file) => sum + (file.added ?? 0), 0);
+  const deleted = files.reduce((sum, file) => sum + (file.deleted ?? 0), 0);
+  return `${files.length} file${files.length > 1 ? 's' : ''} · +${added} −${deleted}`;
+}
+
+export class DiffPanel {
+  #el;
+  #fetchDiff;
+  #taskId = null;
+  /**
+   * Only the newest request may paint. A taskId comparison is not enough —
+   * re-opening the SAME session starts a second request with the same id, and
+   * a stale failure resolving late would overwrite the newer render.
+   */
+  #requestId = 0;
+
+  constructor(el, { fetchDiff }) {
+    this.#el = el;
+    this.#fetchDiff = fetchDiff;
+  }
+
+  get element() {
+    return this.#el;
+  }
+
+  async load(taskId) {
+    this.#taskId = taskId;
+    const requestId = ++this.#requestId;
+    this.#message('Loading diff…');
+    let payload;
+    try {
+      payload = await this.#fetchDiff(taskId);
+    } catch (err) {
+      // 409 = the worktree exists but git could not read it; anything else is
+      // reported verbatim rather than shown as "no changes".
+      if (requestId === this.#requestId) {
+        this.#message(err?.message ?? 'Could not read the worktree diff.');
+      }
+      return;
+    }
+    if (requestId !== this.#requestId) return; // superseded mid-flight
+    if (!payload) {
+      this.#message('This daemon does not expose worktree diffs.');
+      return;
+    }
+    this.#render(payload);
+  }
+
+  clear() {
+    this.#taskId = null;
+    // Nothing in flight may paint over a cleared panel either.
+    this.#requestId++;
+    this.#el.replaceChildren();
+  }
+
+  #message(text) {
+    const el = document.createElement('div');
+    el.className = 'empty';
+    el.textContent = text;
+    this.#el.replaceChildren(el);
+  }
+
+  #render(payload) {
+    const fragment = document.createDocumentFragment();
+
+    const summary = document.createElement('div');
+    summary.className = 'diff-summary';
+    summary.textContent = summarizeFiles(payload.files);
+    if (payload.branch) summary.textContent += ` · ${payload.branch}`;
+    if (payload.truncated) summary.textContent += ' · truncated';
+    fragment.appendChild(summary);
+
+    for (const file of payload.files ?? []) {
+      const row = document.createElement('div');
+      row.className = 'diff-file';
+      row.textContent = `${file.isNew ? 'new ' : ''}${file.file}  +${file.added ?? 0} −${file.deleted ?? 0}`;
+      fragment.appendChild(row);
+    }
+
+    if (!payload.diff) {
+      // Files with no patch text is a real state (binary, or committed already).
+      const note = document.createElement('div');
+      note.className = 'empty';
+      note.textContent = payload.files?.length
+        ? 'No patch text for these changes.'
+        : 'Working tree is clean.';
+      fragment.appendChild(note);
+      this.#el.replaceChildren(fragment);
+      return;
+    }
+
+    const pre = document.createElement('div');
+    pre.className = 'diff-body';
+    for (const row of parseUnifiedDiff(payload.diff)) {
+      const line = document.createElement('div');
+      line.className = `diff-line ${row.type}`;
+      line.textContent = row.text;
+      pre.appendChild(line);
+    }
+    fragment.appendChild(pre);
+    this.#el.replaceChildren(fragment);
+  }
+}

--- a/web/static/js/format.mjs
+++ b/web/static/js/format.mjs
@@ -1,0 +1,71 @@
+// Display formatting helpers for the cockpit. (INT-3402)
+//
+// Pure and DOM-free so they are unit-testable in Node. Every function takes
+// `now` explicitly rather than reading the clock, so tests never race.
+
+/** "just now" / "5m" / "2h" / "3d" — compact relative age for tree rows. */
+export function formatRelativeTime(timestampMs, nowMs = Date.now()) {
+  if (typeof timestampMs !== 'number' || !Number.isFinite(timestampMs)) return '';
+  const seconds = Math.round((nowMs - timestampMs) / 1000);
+  if (seconds < 0) return 'just now'; // clock skew reads as fresh, never "-3m"
+  if (seconds < 45) return 'just now';
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  if (seconds < 86_400) return `${Math.round(seconds / 3600)}h`;
+  return `${Math.round(seconds / 86_400)}d`;
+}
+
+/** "8s" / "2m 05s" / "1h 12m" — elapsed/duration, distinct from age above. */
+export function formatDuration(ms) {
+  if (typeof ms !== 'number' || !Number.isFinite(ms) || ms < 0) return '';
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) {
+    const m = Math.floor(seconds / 60);
+    return `${m}m ${String(seconds % 60).padStart(2, '0')}s`;
+  }
+  const h = Math.floor(seconds / 3600);
+  return `${h}h ${Math.floor((seconds % 3600) / 60)}m`;
+}
+
+/**
+ * Cost with enough precision to stay honest at both ends: sub-cent runs keep
+ * their magnitude instead of rounding to "$0.00".
+ */
+export function formatCost(usd) {
+  if (typeof usd !== 'number' || !Number.isFinite(usd) || usd < 0) return '';
+  if (usd === 0) return '$0';
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
+/** "1.2k" / "847" — token counts, compact but never misleadingly rounded to 0. */
+export function formatTokens(count) {
+  if (typeof count !== 'number' || !Number.isFinite(count) || count < 0) return '';
+  if (count < 1000) return String(Math.round(count));
+  if (count < 1_000_000) return `${(count / 1000).toFixed(1)}k`;
+  return `${(count / 1_000_000).toFixed(1)}M`;
+}
+
+/**
+ * Shorten a filesystem path for a one-line status bar, keeping the tail (the
+ * part that identifies the worktree) and marking home as `~`.
+ */
+export function shortenPath(path, { home = '', maxSegments = 3 } = {}) {
+  if (typeof path !== 'string' || !path) return '';
+  let text = path;
+  if (home && (text === home || text.startsWith(`${home}/`))) {
+    text = `~${text.slice(home.length)}`;
+  }
+  const segments = text.split('/').filter(Boolean);
+  const leadingTilde = text.startsWith('~');
+  if (segments.length <= maxSegments) return text;
+  const tail = segments.slice(-maxSegments).join('/');
+  return leadingTilde ? `~/…/${tail}` : `…/${tail}`;
+}
+
+/** Truncate to a hard cap with an ellipsis, for titles in fixed-width rows. */
+export function truncate(text, maxChars) {
+  if (typeof text !== 'string') return '';
+  if (!Number.isFinite(maxChars) || maxChars <= 0 || text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars - 1)}…`;
+}

--- a/web/static/js/main.mjs
+++ b/web/static/js/main.mjs
@@ -1,4 +1,5 @@
-// Board bootstrap: wire modules together. (INT-3388)
+// Cockpit bootstrap: wire modules together. Wiring only — behavior lives in
+// the modules so it stays testable. (INT-3388, cockpit shell INT-3402)
 
 import { api } from './api.mjs';
 import { EventStream } from './events.mjs';
@@ -6,6 +7,13 @@ import { RepoPicker } from './repoPicker.mjs';
 import { IssueBoard } from './issueBoard.mjs';
 import { WorkCards } from './workCards.mjs';
 import { QuotaGauge } from './quotaGauge.mjs';
+import { SessionStore } from './sessionStore.mjs';
+import { TranscriptModel } from './transcriptModel.mjs';
+import { TranscriptView } from './transcriptView.mjs';
+import { SessionTree } from './sessionTree.mjs';
+import { SessionPanel } from './sessionPanel.mjs';
+import { Nav } from './nav.mjs';
+import { resolveSelection } from './sessionSelection.mjs';
 
 const statusDot = document.querySelector('#daemon-status .dot');
 const statusLabel = document.querySelector('#daemon-status .label');
@@ -24,7 +32,96 @@ async function pollHealth() {
   }
 }
 
+// ── Models ─────────────────────────────────────────────────────────────
+
+const sessions = new SessionStore();
+const transcripts = new TranscriptModel();
+
+// ── Views ──────────────────────────────────────────────────────────────
+
 const workCards = new WorkCards(document.getElementById('work-cards'));
+
+const nav = new Nav({
+  buttons: [...document.querySelectorAll('.nav-item')],
+});
+
+const transcriptEl = document.createElement('div');
+transcriptEl.className = 'transcript';
+const transcriptView = new TranscriptView(transcriptEl, { model: transcripts });
+
+const sessionPanel = new SessionPanel(document.getElementById('session-body'), {
+  store: sessions,
+  transcripts,
+  transcriptView,
+  fetchLog: (taskId) => api.sessionLog(taskId),
+});
+
+const sessionTree = new SessionTree(document.getElementById('session-tree'), {
+  store: sessions,
+  // The hash is the single source of selection — clicking navigates, and the
+  // nav 'change' handler below does the actual showing.
+  onSelect: (taskId) => nav.show('sessions', taskId),
+});
+
+const sessionCount = document.getElementById('session-count');
+sessions.addEventListener('change', () => {
+  const running = sessions.list().filter((s) => s.phase === 'running').length;
+  const total = sessions.list().length;
+  sessionCount.textContent = total ? `${running} running · ${total} total` : '';
+});
+
+// True once GET /api/work/sessions has answered — until then an unknown deep
+// link is "not loaded yet", not "does not exist".
+let sessionSnapshotLoaded = false;
+
+function showSelectedSession(taskId) {
+  sessionTree.select(taskId);
+  const choice = resolveSelection({
+    hashTaskId: taskId,
+    sessions: sessions.list(),
+    snapshotLoaded: sessionSnapshotLoaded,
+  });
+  if (choice.taskId) void sessionPanel.show(choice.taskId);
+  else sessionPanel.showEmpty(choice.message);
+}
+
+/** Re-ask the selection question with whatever is known now. */
+function reconcileSelection() {
+  const { view, taskId } = nav.current;
+  if (view === 'sessions') showSelectedSession(taskId);
+}
+
+nav.addEventListener('change', (event) => {
+  if (event.detail.view === 'sessions') showSelectedSession(event.detail.taskId);
+});
+
+// Deploy → follow the work: switch to Sessions and open the first session
+// this dispatch produces. Bounded so a session started much later by someone
+// else never hijacks the view.
+const DEPLOY_FOLLOW_WINDOW_MS = 120_000;
+let pendingDeploy = null;
+
+function followDeployedSession(session) {
+  if (!pendingDeploy) return false;
+  if (session.projectPath && session.projectPath !== pendingDeploy.projectPath) return false;
+  if (Date.now() - pendingDeploy.at > DEPLOY_FOLLOW_WINDOW_MS) {
+    pendingDeploy = null;
+    return false;
+  }
+  pendingDeploy = null;
+  nav.show('sessions', session.taskId);
+  return true;
+}
+
+sessions.addEventListener('session:new', (event) => {
+  const session = event.detail.session;
+  if (followDeployedSession(session)) return;
+  const { view, taskId } = nav.current;
+  if (view !== 'sessions') return;
+  // The deep-linked session may only now have appeared, or the view may be
+  // sitting on the placeholder with nothing selected — either way, re-ask.
+  if (session.taskId === taskId || !sessionPanel.taskId) reconcileSelection();
+});
 
 const board = new IssueBoard({
   listEl: document.getElementById('issue-list'),
@@ -32,23 +129,53 @@ const board = new IssueBoard({
   summaryEl: document.getElementById('selection-summary'),
   deployBtn: document.getElementById('deploy-btn'),
   fetchIssues: (path) => api.workIssues(path),
-  dispatch: (path, issueIds) => api.dispatchWork(path, issueIds),
+  dispatch: async (path, issueIds) => {
+    const result = await api.dispatchWork(path, issueIds);
+    if (result?.queued) {
+      pendingDeploy = { projectPath: path, at: Date.now() };
+      // The daemon may have queued and broadcast before this response landed,
+      // so the session:new for our own dispatch can already be behind us —
+      // arming alone would wait for an event that never comes again.
+      const dispatched = new Set(result.items?.filter((i) => i.status === 'queued').map((i) => i.issueId));
+      const existing = sessions.byProject(path).find((s) => dispatched.has(s.taskId));
+      if (existing) followDeployedSession(existing);
+    }
+    return result;
+  },
 });
 
 const picker = new RepoPicker(document.getElementById('repo-picker'), {
-  onSelect: (path) => board.loadFor(path),
+  onSelect: (path) => {
+    board.loadFor(path);
+    nav.show('issues');
+  },
 });
+
+// ── Live stream ────────────────────────────────────────────────────────
 
 const events = new EventStream();
 events
-  .on('pipeline:stage', (data) => workCards.onStage(data))
-  .on('log', (data) => workCards.onLog(data))
+  .on('pipeline:stage', (data) => {
+    workCards.onStage(data);
+    sessions.applyEvent('pipeline:stage', data);
+  })
+  .on('log', (data) => {
+    workCards.onLog(data);
+    transcripts.append(data.taskId, { stage: data.stage, line: data.line, ts: data.ts, seq: data.seq });
+  })
+  .on('task:queued', (data) => sessions.applyEvent('task:queued', data))
+  .on('task:started', (data) => sessions.applyEvent('task:started', data))
+  .on('task:completed', (data) => sessions.applyEvent('task:completed', data))
+  .on('task:cost', (data) => sessions.applyEvent('task:cost', data))
+  .on('pipeline:iteration', (data) => sessions.applyEvent('pipeline:iteration', data))
+  .on('pipeline:escalation', (data) => sessions.applyEvent('pipeline:escalation', data))
   .on('$open', () => pollHealth())
   .on('$down', () => setDaemonStatus('down', 'reconnecting…'));
 // Connect immediately — delaying SSE behind the snapshot fetch opened a
 // live-output blind window. Ordering against the async stage snapshot does
 // not matter: log lines that arrive before their card exists are parked in
-// WorkCards' bounded pending buffer and flushed when the card materializes.
+// WorkCards' bounded pending buffer and flushed when the card materializes,
+// and SessionStore's phase-rank guard makes replay idempotent.
 events.connect();
 
 // Independent of the bootstrap chain: a hanging /api/health request must not
@@ -56,6 +183,8 @@ events.connect();
 // poll is plenty, and the gauge stays hidden until the daemon has actually
 // observed a provider header.
 new QuotaGauge(document.getElementById('quota-gauge'), { fetchQuota: () => api.quota() }).start();
+
+nav.start();
 
 (async () => {
   await pollHealth();
@@ -78,5 +207,18 @@ new QuotaGauge(document.getElementById('quota-gauge'), { fetchQuota: () => api.q
     workCards.seed(Array.isArray(stages) ? stages : stages?.stages);
   } catch {
     // stage snapshot is best-effort — SSE replay still seeds recent cards
+  }
+  // Authoritative session list (null on a daemon that predates the endpoint,
+  // in which case the SSE-derived state above is all we have).
+  try {
+    sessions.seed(await api.workSessions());
+  } catch (err) {
+    console.error('Failed to load sessions', err);
+  } finally {
+    // The hash was read before this answered: a deep link to a session the
+    // store did not know yet showed a placeholder, and an empty view never
+    // adopted the newly-known sessions. Ask again now.
+    sessionSnapshotLoaded = true;
+    reconcileSelection();
   }
 })();

--- a/web/static/js/main.mjs
+++ b/web/static/js/main.mjs
@@ -12,6 +12,7 @@ import { TranscriptModel } from './transcriptModel.mjs';
 import { TranscriptView } from './transcriptView.mjs';
 import { SessionTree } from './sessionTree.mjs';
 import { SessionPanel } from './sessionPanel.mjs';
+import { DiffPanel } from './diffPanel.mjs';
 import { Nav } from './nav.mjs';
 import { resolveSelection } from './sessionSelection.mjs';
 
@@ -49,10 +50,16 @@ const transcriptEl = document.createElement('div');
 transcriptEl.className = 'transcript';
 const transcriptView = new TranscriptView(transcriptEl, { model: transcripts });
 
+const diffEl = document.createElement('div');
+diffEl.className = 'diff-pane';
+diffEl.hidden = true;
+const diffPanel = new DiffPanel(diffEl, { fetchDiff: (taskId) => api.workDiff(taskId) });
+
 const sessionPanel = new SessionPanel(document.getElementById('session-body'), {
   store: sessions,
   transcripts,
   transcriptView,
+  diffPanel,
   fetchLog: (taskId) => api.sessionLog(taskId),
 });
 

--- a/web/static/js/main.mjs
+++ b/web/static/js/main.mjs
@@ -81,6 +81,14 @@ sessions.addEventListener('change', () => {
 // link is "not loaded yet", not "does not exist".
 let sessionSnapshotLoaded = false;
 
+async function reloadSessions() {
+  try {
+    sessions.seed(await api.workSessions());
+  } catch (err) {
+    console.error('Failed to load sessions', err);
+  }
+}
+
 function showSelectedSession(taskId) {
   sessionTree.select(taskId);
   const choice = resolveSelection({
@@ -110,7 +118,7 @@ let pendingDeploy = null;
 
 function followDeployedSession(session) {
   if (!pendingDeploy) return false;
-  if (session.projectPath && session.projectPath !== pendingDeploy.projectPath) return false;
+  if (pendingDeploy.taskIds && !pendingDeploy.taskIds.has(session.taskId)) return false;
   if (Date.now() - pendingDeploy.at > DEPLOY_FOLLOW_WINDOW_MS) {
     pendingDeploy = null;
     return false;
@@ -143,8 +151,12 @@ const board = new IssueBoard({
       // The daemon may have queued and broadcast before this response landed,
       // so the session:new for our own dispatch can already be behind us —
       // arming alone would wait for an event that never comes again.
-      const dispatched = new Set(result.items?.filter((i) => i.status === 'queued').map((i) => i.issueId));
-      const existing = sessions.byProject(path).find((s) => dispatched.has(s.taskId));
+      // Match on the dispatched issue ids, not the path: the picker's value
+      // may be tilde-spelled while the daemon reports an absolute path.
+      pendingDeploy.taskIds = new Set(
+        (result.items ?? []).filter((item) => item.status === 'queued').map((item) => item.issueId),
+      );
+      const existing = sessions.list().find((session) => pendingDeploy.taskIds.has(session.taskId));
       if (existing) followDeployedSession(existing);
     }
     return result;
@@ -168,7 +180,7 @@ events
   })
   .on('log', (data) => {
     workCards.onLog(data);
-    transcripts.append(data.taskId, { stage: data.stage, line: data.line, ts: data.ts, seq: data.seq });
+    transcripts.append(data.taskId, { stage: data.stage, line: data.line, ts: data.ts, seq: data.seq, gen: data.gen });
   })
   .on('task:queued', (data) => sessions.applyEvent('task:queued', data))
   .on('task:started', (data) => sessions.applyEvent('task:started', data))
@@ -176,7 +188,12 @@ events
   .on('task:cost', (data) => sessions.applyEvent('task:cost', data))
   .on('pipeline:iteration', (data) => sessions.applyEvent('pipeline:iteration', data))
   .on('pipeline:escalation', (data) => sessions.applyEvent('pipeline:escalation', data))
-  .on('$open', () => pollHealth())
+  .on('$open', () => {
+    void pollHealth();
+    // A reconnect skips the replay buffer, so anything that happened during
+    // the outage is missing. Re-read the authoritative list.
+    void reloadSessions();
+  })
   .on('$down', () => setDaemonStatus('down', 'reconnecting…'));
 // Connect immediately — delaying SSE behind the snapshot fetch opened a
 // live-output blind window. Ordering against the async stage snapshot does
@@ -190,6 +207,18 @@ events.connect();
 // poll is plenty, and the gauge stays hidden until the daemon has actually
 // observed a provider header.
 new QuotaGauge(document.getElementById('quota-gauge'), { fetchQuota: () => api.quota() }).start();
+
+// Off-canvas sidebar (narrow windows only — the button is display:none above
+// the breakpoint). Selecting anything closes it so the choice is visible.
+const sidebarToggle = document.getElementById('sidebar-toggle');
+function setSidebarOpen(open) {
+  document.body.classList.toggle('sidebar-open', open);
+  sidebarToggle.setAttribute('aria-expanded', String(open));
+}
+sidebarToggle.addEventListener('click', () => {
+  setSidebarOpen(!document.body.classList.contains('sidebar-open'));
+});
+nav.addEventListener('change', () => setSidebarOpen(false));
 
 nav.start();
 
@@ -218,9 +247,7 @@ nav.start();
   // Authoritative session list (null on a daemon that predates the endpoint,
   // in which case the SSE-derived state above is all we have).
   try {
-    sessions.seed(await api.workSessions());
-  } catch (err) {
-    console.error('Failed to load sessions', err);
+    await reloadSessions();
   } finally {
     // The hash was read before this answered: a deep link to a session the
     // store did not know yet showed a placeholder, and an empty view never

--- a/web/static/js/nav.mjs
+++ b/web/static/js/nav.mjs
@@ -1,0 +1,84 @@
+// Hash-based view routing for the cockpit. (INT-3402)
+//
+// No router library and no history rewriting: the hash IS the state, so a
+// reload or a deep link lands on the same view (and, for a session, the same
+// tab). Views live side by side in the DOM and are switched with a single
+// `data-view` attribute on <body>, which keeps CSS in charge of visibility.
+
+export const VIEWS = ['sessions', 'issues'];
+const DEFAULT_VIEW = 'issues';
+
+/** '#/sessions/abc' → { view: 'sessions', taskId: 'abc' }. Unknown → default. */
+export function parseHash(hash) {
+  const raw = (hash ?? '').replace(/^#\/?/, '');
+  const [view, ...rest] = raw.split('/').filter(Boolean);
+  if (!VIEWS.includes(view)) return { view: DEFAULT_VIEW, taskId: null };
+  let taskId = null;
+  if (rest.length) {
+    const encoded = rest.join('/');
+    // A hand-edited or truncated URL can carry a malformed escape ('%', '%zz').
+    // decodeURIComponent throws on those, and this runs inside the bootstrap —
+    // an unguarded throw would leave the page with no view rendered at all.
+    try {
+      taskId = decodeURIComponent(encoded);
+    } catch {
+      taskId = encoded;
+    }
+  }
+  return { view, taskId: view === 'sessions' ? taskId : null };
+}
+
+export function buildHash(view, taskId) {
+  if (view === 'sessions' && taskId) return `#/sessions/${encodeURIComponent(taskId)}`;
+  return `#/${VIEWS.includes(view) ? view : DEFAULT_VIEW}`;
+}
+
+export class Nav extends EventTarget {
+  #root;
+  #buttons;
+  /** Last hash actually rendered — dedupes the hashchange that follows show(). */
+  #applied = null;
+
+  constructor({ root = document.body, buttons = [] } = {}) {
+    super();
+    this.#root = root;
+    this.#buttons = buttons;
+    for (const button of buttons) {
+      button.addEventListener('click', () => this.show(button.dataset.view));
+    }
+    window.addEventListener('hashchange', () => this.#applyFromHash());
+  }
+
+  get current() {
+    return parseHash(window.location.hash);
+  }
+
+  /**
+   * Navigate and render NOW. Writing the hash alone would defer the render to
+   * the hashchange task, so callers could not rely on the view being current
+   * on the next line; the dedupe below makes the trailing event a no-op.
+   */
+  show(view, taskId = null) {
+    window.location.hash = buildHash(view, taskId);
+    this.#applyFromHash({ force: true });
+  }
+
+  /** Render whatever the current hash says — call once at startup. */
+  start() {
+    this.#applyFromHash({ force: true });
+  }
+
+  #applyFromHash({ force = false } = {}) {
+    const hash = window.location.hash;
+    if (!force && hash === this.#applied) return;
+    this.#applied = hash;
+    const { view, taskId } = this.current;
+    this.#root.dataset.view = view;
+    for (const button of this.#buttons) {
+      const active = button.dataset.view === view;
+      button.classList.toggle('active', active);
+      button.setAttribute('aria-current', active ? 'page' : 'false');
+    }
+    this.dispatchEvent(new CustomEvent('change', { detail: { view, taskId } }));
+  }
+}

--- a/web/static/js/sessionPanel.mjs
+++ b/web/static/js/sessionPanel.mjs
@@ -83,13 +83,23 @@ export class SessionPanel {
       // duplicate. Sequence, not timestamp: an agent emits several lines per
       // millisecond, and a ts comparison silently drops the ties.
       const lastSeq = snapshotLines.at(-1)?.seq;
+      const snapshotGen = snapshotLines.at(-1)?.gen ?? snapshot.gen;
       const live = this.#transcripts.rawLines(taskId);
-      const tail = typeof lastSeq === 'number'
-        ? live.filter((entry) => typeof entry.seq === 'number' && entry.seq > lastSeq)
+      const tail = live.filter((entry) => {
+        // A line from a DIFFERENT daemon process is strictly after this
+        // snapshot — the daemon restarted mid-request, and its sequence
+        // restarted with it, so comparing the two numbers would discard real
+        // post-restart output.
+        if (entry.gen && snapshotGen && entry.gen !== snapshotGen) return true;
         // No sequence (daemon predates the stamp): keeping live lines could
         // duplicate the overlap, so the snapshot alone is the honest answer.
-        : [];
-      this.#transcripts.replace(taskId, [...snapshotLines, ...tail]);
+        if (typeof lastSeq !== 'number' || typeof entry.seq !== 'number') return false;
+        return entry.seq > lastSeq;
+      });
+      // Carry the snapshot's generation so the model reconciles against the
+      // right process even if no live line has arrived yet.
+      const stamped = snapshotLines.map((entry) => ({ ...entry, gen: entry.gen ?? snapshot.gen }));
+      this.#transcripts.replace(taskId, [...stamped, ...tail]);
     } catch {
       // Older daemon or expired retention — live lines are all we get.
     }

--- a/web/static/js/sessionPanel.mjs
+++ b/web/static/js/sessionPanel.mjs
@@ -1,0 +1,136 @@
+// The selected session: header, status line, and live transcript. (INT-3402)
+//
+// Transcript history is seeded lazily, on selection, from
+// GET /api/work/sessions/:taskId/log — the daemon's per-task ring holds far
+// more than the SSE replay's global 50 lines. The snapshot and the live
+// stream are merged on the daemon's per-line sequence, so history is complete
+// and no line renders twice.
+
+import { formatCost, formatDuration, formatRelativeTime, shortenPath, formatTokens } from './format.mjs';
+
+const PHASE_LABEL = {
+  queued: 'Queued',
+  running: 'Working',
+  completed: 'Completed',
+  failed: 'Failed',
+  cancelled: 'Cancelled',
+  decomposed: 'Decomposed',
+};
+
+export class SessionPanel {
+  #root;
+  #store;
+  #transcripts;
+  #view;
+  #fetchLog;
+  #taskId = null;
+  #seeded = new Set();
+
+  constructor(root, { store, transcripts, transcriptView, fetchLog }) {
+    this.#root = root;
+    this.#store = store;
+    this.#transcripts = transcripts;
+    this.#view = transcriptView;
+    this.#fetchLog = fetchLog;
+    store.addEventListener('change', (event) => {
+      if (event.detail.session.taskId === this.#taskId) this.#renderHeader();
+    });
+  }
+
+  get taskId() {
+    return this.#taskId;
+  }
+
+  async show(taskId) {
+    this.#taskId = taskId;
+    this.#mount();
+    this.#renderHeader();
+    this.#view.show(taskId);
+    await this.#seedTranscript(taskId);
+  }
+
+  showEmpty(message) {
+    this.#taskId = null;
+    this.#view.clear();
+    const empty = document.createElement('div');
+    empty.className = 'empty';
+    empty.textContent = message;
+    this.#root.replaceChildren(empty);
+  }
+
+  async #seedTranscript(taskId) {
+    // Once per session per page: re-seeding would re-do the merge below for no
+    // gain (and briefly re-render history the user is already reading).
+    if (this.#seeded.has(taskId)) return;
+    this.#seeded.add(taskId);
+    try {
+      const snapshot = await this.#fetchLog(taskId);
+      const snapshotLines = snapshot?.lines ?? [];
+      if (!snapshotLines.length) return;
+
+      // Lines can stream in WHILE the request is in flight. Replacing outright
+      // would drop exactly those. Both sides carry the daemon's own monotonic
+      // sequence (broadcastEvent stamps the ring and the SSE copy together),
+      // so keep live lines after the snapshot's last one — no loss, no
+      // duplicate. Sequence, not timestamp: an agent emits several lines per
+      // millisecond, and a ts comparison silently drops the ties.
+      const lastSeq = snapshotLines.at(-1)?.seq;
+      const live = this.#transcripts.rawLines(taskId);
+      const tail = typeof lastSeq === 'number'
+        ? live.filter((entry) => typeof entry.seq === 'number' && entry.seq > lastSeq)
+        // No sequence (daemon predates the stamp): keeping live lines could
+        // duplicate the overlap, so the snapshot alone is the honest answer.
+        : [];
+      this.#transcripts.replace(taskId, [...snapshotLines, ...tail]);
+    } catch {
+      // Older daemon or expired retention — live lines are all we get.
+    }
+  }
+
+  #mount() {
+    if (this.#root.querySelector('.session-header')) return;
+    const header = document.createElement('div');
+    header.className = 'session-header';
+    const meta = document.createElement('div');
+    meta.className = 'session-meta';
+    this.#root.replaceChildren(header, meta, this.#view.element);
+  }
+
+  #renderHeader() {
+    const session = this.#store.get(this.#taskId);
+    if (!session) return;
+    const header = this.#root.querySelector('.session-header');
+    const meta = this.#root.querySelector('.session-meta');
+    if (!header || !meta) return;
+
+    header.replaceChildren();
+    const identifier = document.createElement('span');
+    identifier.className = 'identifier';
+    identifier.textContent = session.issueIdentifier ?? '';
+    const title = document.createElement('span');
+    title.className = 'title';
+    title.textContent = session.title || session.taskId;
+    const phase = document.createElement('span');
+    phase.className = 'phase';
+    phase.dataset.phase = session.phase;
+    phase.textContent = session.currentStage && session.phase === 'running'
+      ? `${PHASE_LABEL[session.phase]} — ${session.currentStage}`
+      : PHASE_LABEL[session.phase] ?? session.phase;
+    header.append(identifier, title, phase);
+
+    // Right-hand usage strip, vega's usage-meta in one line. Only facts the
+    // daemon actually reported appear.
+    const bits = [
+      session.model,
+      session.branch,
+      session.worktreePath ? shortenPath(session.worktreePath) : '',
+      session.inputTokens ? `${formatTokens(session.inputTokens)} in` : '',
+      formatCost(session.costUsd),
+      formatDuration(session.durationMs),
+      session.completedAt ? formatRelativeTime(session.completedAt) : '',
+      session.failureCause ? `cause: ${session.failureCause}` : '',
+      session.error ?? '',
+    ].filter(Boolean);
+    meta.textContent = bits.join(' · ');
+  }
+}

--- a/web/static/js/sessionPanel.mjs
+++ b/web/static/js/sessionPanel.mjs
@@ -22,15 +22,18 @@ export class SessionPanel {
   #store;
   #transcripts;
   #view;
+  #diff;
   #fetchLog;
   #taskId = null;
+  #tab = 'transcript';
   #seeded = new Set();
 
-  constructor(root, { store, transcripts, transcriptView, fetchLog }) {
+  constructor(root, { store, transcripts, transcriptView, diffPanel, fetchLog }) {
     this.#root = root;
     this.#store = store;
     this.#transcripts = transcripts;
     this.#view = transcriptView;
+    this.#diff = diffPanel;
     this.#fetchLog = fetchLog;
     store.addEventListener('change', (event) => {
       if (event.detail.session.taskId === this.#taskId) this.#renderHeader();
@@ -46,12 +49,17 @@ export class SessionPanel {
     this.#mount();
     this.#renderHeader();
     this.#view.show(taskId);
+    this.#diff?.clear();
+    // Selecting a session always lands on its output; the diff is one click
+    // away and fetched only when asked for.
+    this.#setTab('transcript');
     await this.#seedTranscript(taskId);
   }
 
   showEmpty(message) {
     this.#taskId = null;
     this.#view.clear();
+    this.#diff?.clear();
     const empty = document.createElement('div');
     empty.className = 'empty';
     empty.textContent = message;
@@ -93,7 +101,35 @@ export class SessionPanel {
     header.className = 'session-header';
     const meta = document.createElement('div');
     meta.className = 'session-meta';
-    this.#root.replaceChildren(header, meta, this.#view.element);
+
+    const tabs = document.createElement('div');
+    tabs.className = 'session-tabs';
+    for (const [tab, label] of [['transcript', 'Transcript'], ['diff', 'Diff']]) {
+      if (tab === 'diff' && !this.#diff) continue;
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'session-tab';
+      button.dataset.tab = tab;
+      button.textContent = label;
+      button.addEventListener('click', () => this.#setTab(tab));
+      tabs.appendChild(button);
+    }
+
+    const children = [header, meta, tabs, this.#view.element];
+    if (this.#diff) children.push(this.#diff.element);
+    this.#root.replaceChildren(...children);
+  }
+
+  #setTab(tab) {
+    this.#tab = tab;
+    for (const button of this.#root.querySelectorAll('.session-tab')) {
+      button.classList.toggle('active', button.dataset.tab === tab);
+    }
+    this.#view.element.hidden = tab !== 'transcript';
+    if (!this.#diff) return;
+    this.#diff.element.hidden = tab !== 'diff';
+    // Fetch on demand: a diff is a git call per view, not something to poll.
+    if (tab === 'diff' && this.#taskId) void this.#diff.load(this.#taskId);
   }
 
   #renderHeader() {

--- a/web/static/js/sessionSelection.mjs
+++ b/web/static/js/sessionSelection.mjs
@@ -1,0 +1,25 @@
+// What the Sessions view should show, given the URL and what is known. (INT-3402)
+//
+// Pure so the decision is testable: the tricky part is that the hash is read
+// at startup while the authoritative session list arrives asynchronously, so
+// the same question gets asked again later with more knowledge.
+
+export const EMPTY_MESSAGE = 'Deploy issues to start a session. Live agent output appears here.';
+
+/**
+ * @returns {{ taskId: string } | { message: string }}
+ *   taskId → show that session; message → show this placeholder instead.
+ */
+export function resolveSelection({ hashTaskId, sessions, snapshotLoaded = false }) {
+  if (hashTaskId) {
+    if (sessions.some((session) => session.taskId === hashTaskId)) return { taskId: hashTaskId };
+    // Before the snapshot lands, an unknown id is simply not-known-YET — the
+    // deep link is probably valid and reconciling later will find it. Claiming
+    // it does not exist would be a guess presented as fact.
+    return snapshotLoaded
+      ? { message: `Session ${hashTaskId} is not in this daemon's recent history.` }
+      : { message: 'Loading session…' };
+  }
+  const first = sessions[0];
+  return first ? { taskId: first.taskId } : { message: EMPTY_MESSAGE };
+}

--- a/web/static/js/sessionStore.mjs
+++ b/web/static/js/sessionStore.mjs
@@ -20,8 +20,30 @@ const PHASE_RANK = {
 
 export const TERMINAL_PHASES = new Set(['completed', 'failed', 'cancelled', 'decomposed']);
 
+/**
+ * The ONLY terminal→terminal move history may make. A decomposition reports
+ * `success: true`, so the live event can only say "completed" — history knows
+ * it was really a split. Everything else is a genuine outcome disagreement,
+ * where the newer live event wins (e.g. an older completed run in history must
+ * not overwrite a fresh attempt's failure).
+ */
+function refinesTerminal(from, to) {
+  return from === 'completed' && to === 'decomposed';
+}
+
 function rankOf(phase) {
   return PHASE_RANK[phase] ?? -1;
+}
+
+/**
+ * Repository root for a path that may be a worktree. Stage events report the
+ * ACTIVE directory (`{repo}/worktree/{issueId}` in worktree mode), so using it
+ * as the repository would scatter one repo's sessions across a tree node per
+ * task. Same layout the daemon creates.
+ */
+export function repoRootFromPath(path) {
+  if (typeof path !== 'string' || !path) return path;
+  return path.replace(/\/worktree\/[^/]+\/?$/, '');
 }
 
 export class SessionStore extends EventTarget {
@@ -59,16 +81,24 @@ export class SessionStore extends EventTarget {
       });
     }
     for (const entry of payload?.recent ?? []) {
-      this.#upsert(entry.taskId, {
-        phase: entry.status,
-        issueIdentifier: entry.issueIdentifier,
-        title: entry.title,
-        projectPath: entry.projectPath,
-        costUsd: entry.costUsd,
-        durationMs: entry.durationMs,
-        failureCause: entry.failureCause,
-        completedAt: entry.completedAt,
-      });
+      // History describes a run that already ENDED, so it may refine one
+      // terminal phase into a more specific one ('completed' → 'decomposed'),
+      // which the equal-rank guard would otherwise block. It must not, though,
+      // overwrite metadata a newer attempt has already reported live.
+      this.#upsert(
+        entry.taskId,
+        {
+          phase: entry.status,
+          issueIdentifier: entry.issueIdentifier,
+          title: entry.title,
+          projectPath: entry.projectPath,
+          costUsd: entry.costUsd,
+          durationMs: entry.durationMs,
+          failureCause: entry.failureCause,
+          completedAt: entry.completedAt,
+        },
+        { refineTerminal: true, fillOnly: true },
+      );
     }
   }
 
@@ -120,13 +150,18 @@ export class SessionStore extends EventTarget {
         this.#upsert(taskId, { model: data.toModel });
         break;
 
-      case 'task:completed':
+      case 'task:completed': {
+        const session = this.#sessions.get(taskId);
+        // A reviewer stage failure on the way to success must not linger in
+        // the metadata strip next to a green result.
+        if (data.success && session) session.error = undefined;
         this.#upsert(taskId, {
           phase: data.success ? 'completed' : 'failed',
           durationMs: data.duration,
           completedAt: data.completedAt,
         });
         break;
+      }
 
       case 'task:cost':
         this.#upsert(taskId, {
@@ -151,11 +186,18 @@ export class SessionStore extends EventTarget {
       currentStage: data.stage,
       issueIdentifier: data.issueIdentifier,
       title: data.title,
-      projectPath: data.projectPath,
-      worktreePath: data.worktree,
+      // `worktree` is a short NAME (the issue id), not a path — labelling only.
+      worktreeName: data.worktree,
       branch: data.branch,
       model: data.model,
     };
+    // The stage's projectPath is the active directory, which in worktree mode
+    // IS the worktree. Derive the repository for grouping, and only fill the
+    // full worktree path when the authoritative seed has not supplied one.
+    if (data.projectPath) {
+      patch.projectPath = repoRootFromPath(data.projectPath);
+      if (data.projectPath !== patch.projectPath) patch.worktreePath = data.projectPath;
+    }
     if (data.status === 'fail') {
       // A failed STAGE is not a failed TASK: the pipeline routinely fails a
       // reviewer stage and iterates to success. Only task:completed decides the
@@ -181,7 +223,7 @@ export class SessionStore extends EventTarget {
     });
   }
 
-  #upsert(taskId, patch, { restart = false } = {}) {
+  #upsert(taskId, patch, { restart = false, refineTerminal = false, fillOnly = false } = {}) {
     let session = this.#sessions.get(taskId);
     const isNew = !session;
     if (!session) {
@@ -213,17 +255,22 @@ export class SessionStore extends EventTarget {
         // Rank guard: a replayed 'started' must not resurrect a finished
         // session, and a late 'queued' must not un-run a running one. Terminal
         // is also final against ANOTHER terminal — equal rank — so a replayed
-        // outcome cannot rewrite how a session ended. An explicit restart (see
-        // task:started) is the one sanctioned exception.
+        // outcome cannot rewrite how a session ended. Two sanctioned
+        // exceptions: an explicit restart (task:started), and the daemon's
+        // own history refining one terminal into a more specific one.
         if (!reopening) {
-          const blocked = TERMINAL_PHASES.has(session.phase)
-            ? rankOf(value) <= rankOf(session.phase)
+          const terminal = TERMINAL_PHASES.has(session.phase);
+          const blocked = terminal
+            ? !(refineTerminal && refinesTerminal(session.phase, value)) && rankOf(value) <= rankOf(session.phase)
             : rankOf(value) < rankOf(session.phase);
           if (blocked) continue;
         }
         session.phase = value;
         continue;
       }
+      // A history seed fills gaps; it never overwrites what a newer attempt
+      // already reported live.
+      if (fillOnly && session[key] !== undefined && session[key] !== '') continue;
       session[key] = value;
     }
     session.updatedAt = Date.now();

--- a/web/static/js/sessionStore.mjs
+++ b/web/static/js/sessionStore.mjs
@@ -1,0 +1,242 @@
+// Cockpit session state, folded from the daemon's SSE events. (INT-3402)
+//
+// Adapted from vega-agent's session_runtime.mjs: same EventTarget shape and
+// phase vocabulary, but this store does NOT own a stream — it fans in events
+// from many tasks, so vega's per-stream `generation` guard is replaced by a
+// PHASE RANK guard. Applying any event is idempotent and order-tolerant, which
+// is what makes the SSE replay buffer safe to re-apply on reconnect.
+//
+// DOM-free on purpose: this is the testable core the views render from.
+
+/** Terminal phases share the top rank — a session never leaves one. */
+const PHASE_RANK = {
+  queued: 0,
+  running: 1,
+  completed: 2,
+  failed: 2,
+  cancelled: 2,
+  decomposed: 2,
+};
+
+export const TERMINAL_PHASES = new Set(['completed', 'failed', 'cancelled', 'decomposed']);
+
+function rankOf(phase) {
+  return PHASE_RANK[phase] ?? -1;
+}
+
+export class SessionStore extends EventTarget {
+  #sessions = new Map(); // taskId -> session record
+
+  /** All known sessions, most recently updated first. */
+  list() {
+    return [...this.#sessions.values()].sort((a, b) => b.updatedAt - a.updatedAt);
+  }
+
+  get(taskId) {
+    return this.#sessions.get(taskId) ?? null;
+  }
+
+  byProject(projectPath) {
+    return this.list().filter((session) => session.projectPath === projectPath);
+  }
+
+  /**
+   * Seed from GET /api/work/sessions. Merges rather than replaces: live events
+   * that arrived before the snapshot resolved must not be rolled back.
+   */
+  seed(payload) {
+    for (const entry of payload?.sessions ?? []) {
+      this.#upsert(entry.taskId, {
+        phase: entry.status === 'queued' ? 'queued' : 'running',
+        issueIdentifier: entry.issueIdentifier,
+        title: entry.title,
+        projectPath: entry.projectPath,
+        worktreePath: entry.worktreePath,
+        branch: entry.branch,
+        currentStage: entry.stage,
+        model: entry.model,
+        startedAt: entry.startedAt,
+      });
+    }
+    for (const entry of payload?.recent ?? []) {
+      this.#upsert(entry.taskId, {
+        phase: entry.status,
+        issueIdentifier: entry.issueIdentifier,
+        title: entry.title,
+        projectPath: entry.projectPath,
+        costUsd: entry.costUsd,
+        durationMs: entry.durationMs,
+        failureCause: entry.failureCause,
+        completedAt: entry.completedAt,
+      });
+    }
+  }
+
+  /**
+   * Apply one hub event. Unknown types are ignored, so new daemon events never
+   * break an older page.
+   */
+  applyEvent(type, data) {
+    if (!data || typeof data.taskId !== 'string' || !data.taskId) return;
+    const taskId = data.taskId;
+
+    switch (type) {
+      case 'task:queued':
+        this.#upsert(taskId, {
+          phase: 'queued',
+          title: data.title,
+          projectPath: data.projectPath,
+          issueIdentifier: data.issueIdentifier,
+        });
+        break;
+
+      case 'task:started':
+        // The one event that may re-open a finished session: the daemon
+        // retries a failed issue under the SAME task id, and without this a
+        // retried session would stay "failed" in the cockpit while an agent is
+        // demonstrably working on it. Stage events deliberately do NOT get
+        // this power — a replayed stage would resurrect finished work.
+        this.#upsert(
+          taskId,
+          {
+            phase: 'running',
+            title: data.title,
+            issueIdentifier: data.issueIdentifier,
+            startedAt: data.startedAt,
+          },
+          { restart: true },
+        );
+        break;
+
+      case 'pipeline:stage':
+        this.#applyStage(taskId, data);
+        break;
+
+      case 'pipeline:iteration':
+        this.#upsert(taskId, { iteration: data.iteration });
+        break;
+
+      case 'pipeline:escalation':
+        this.#upsert(taskId, { model: data.toModel });
+        break;
+
+      case 'task:completed':
+        this.#upsert(taskId, {
+          phase: data.success ? 'completed' : 'failed',
+          durationMs: data.duration,
+          completedAt: data.completedAt,
+        });
+        break;
+
+      case 'task:cost':
+        this.#upsert(taskId, {
+          costUsd: data.cost?.costUsd,
+          inputTokens: data.cost?.inputTokens,
+          outputTokens: data.cost?.outputTokens,
+        });
+        break;
+
+      // 'log' belongs to the transcript model; process:* drives the status bar.
+      // Neither participates in session phase.
+      default:
+        break;
+    }
+  }
+
+  #applyStage(taskId, data) {
+    const patch = {
+      // A stage event proves the task is executing even if task:started was
+      // evicted from the replay window.
+      phase: 'running',
+      currentStage: data.stage,
+      issueIdentifier: data.issueIdentifier,
+      title: data.title,
+      projectPath: data.projectPath,
+      worktreePath: data.worktree,
+      branch: data.branch,
+      model: data.model,
+    };
+    if (data.status === 'fail') {
+      // A failed STAGE is not a failed TASK: the pipeline routinely fails a
+      // reviewer stage and iterates to success. Only task:completed decides the
+      // session's outcome — treating a stage failure as terminal both lied
+      // mid-run and let a replayed stage overwrite a finished session's
+      // result. Keep the error for display.
+      patch.error = data.error;
+    }
+    const session = this.#upsert(taskId, patch);
+    if (!session) return;
+
+    // Stages fold into a map keyed by stage name, so replaying is idempotent.
+    const previous = session.stages.get(data.stage);
+    session.stages.set(data.stage, {
+      stage: data.stage,
+      status: data.status,
+      durationMs: data.durationMs ?? previous?.durationMs,
+      costUsd: data.costUsd ?? previous?.costUsd,
+      summary: data.summary ?? previous?.summary,
+      decision: data.decision ?? previous?.decision,
+      filesChanged: data.filesChanged ?? previous?.filesChanged,
+      error: data.error ?? previous?.error,
+    });
+  }
+
+  #upsert(taskId, patch, { restart = false } = {}) {
+    let session = this.#sessions.get(taskId);
+    const isNew = !session;
+    if (!session) {
+      session = {
+        taskId,
+        phase: 'queued',
+        title: '',
+        stages: new Map(),
+        updatedAt: 0,
+      };
+      this.#sessions.set(taskId, session);
+    }
+
+    // A retry is a NEW attempt on the same id: drop the previous attempt's
+    // outcome so the panel does not show last run's error next to live work.
+    const reopening = restart && !isNew && TERMINAL_PHASES.has(session.phase);
+    if (reopening) {
+      session.stages = new Map();
+      session.error = undefined;
+      session.failureCause = undefined;
+      session.completedAt = undefined;
+      session.durationMs = undefined;
+    }
+
+    const previousPhase = session.phase;
+    for (const [key, value] of Object.entries(patch)) {
+      if (value === undefined || value === null || value === '') continue;
+      if (key === 'phase') {
+        // Rank guard: a replayed 'started' must not resurrect a finished
+        // session, and a late 'queued' must not un-run a running one. Terminal
+        // is also final against ANOTHER terminal — equal rank — so a replayed
+        // outcome cannot rewrite how a session ended. An explicit restart (see
+        // task:started) is the one sanctioned exception.
+        if (!reopening) {
+          const blocked = TERMINAL_PHASES.has(session.phase)
+            ? rankOf(value) <= rankOf(session.phase)
+            : rankOf(value) < rankOf(session.phase);
+          if (blocked) continue;
+        }
+        session.phase = value;
+        continue;
+      }
+      session[key] = value;
+    }
+    session.updatedAt = Date.now();
+
+    if (isNew) this.#emit('session:new', session);
+    if (session.phase !== previousPhase) {
+      this.#emit('session:phase', session, { previousPhase });
+    }
+    this.#emit('change', session);
+    return session;
+  }
+
+  #emit(type, session, extra = {}) {
+    this.dispatchEvent(new CustomEvent(type, { detail: { session, ...extra } }));
+  }
+}

--- a/web/static/js/sessionTree.mjs
+++ b/web/static/js/sessionTree.mjs
@@ -1,0 +1,99 @@
+// Sidebar list of sessions, grouped by repository. (INT-3402)
+//
+// Mirrors Orca's project > session tree. Renders only what the store actually
+// knows — no placeholder rows for work the daemon never reported.
+
+import { formatRelativeTime, truncate } from './format.mjs';
+
+const PHASE_GLYPH = {
+  queued: '·',
+  running: '▸',
+  completed: '✓',
+  failed: '✗',
+  cancelled: '⊘',
+  decomposed: '⑂',
+};
+
+export class SessionTree {
+  #el;
+  #store;
+  #onSelect;
+  #selectedId = null;
+
+  constructor(el, { store, onSelect }) {
+    this.#el = el;
+    this.#store = store;
+    this.#onSelect = onSelect;
+    store.addEventListener('change', () => this.render());
+  }
+
+  select(taskId) {
+    this.#selectedId = taskId;
+    this.render();
+  }
+
+  render(nowMs = Date.now()) {
+    const sessions = this.#store.list();
+    if (!sessions.length) {
+      const empty = document.createElement('div');
+      empty.className = 'tree-empty';
+      empty.textContent = 'No sessions yet.';
+      this.#el.replaceChildren(empty);
+      return;
+    }
+
+    const byProject = new Map();
+    for (const session of sessions) {
+      const key = session.projectPath || 'unknown';
+      if (!byProject.has(key)) byProject.set(key, []);
+      byProject.get(key).push(session);
+    }
+
+    const fragment = document.createDocumentFragment();
+    for (const [projectPath, group] of byProject) {
+      const head = document.createElement('div');
+      head.className = 'tree-project';
+      head.textContent = projectPath.split('/').filter(Boolean).pop() ?? projectPath;
+      head.title = projectPath;
+
+      const runningCount = group.filter((s) => s.phase === 'running').length;
+      if (runningCount) {
+        const badge = document.createElement('span');
+        badge.className = 'tree-badge';
+        badge.textContent = String(runningCount);
+        badge.title = `${runningCount} running`;
+        head.appendChild(badge);
+      }
+      fragment.appendChild(head);
+
+      for (const session of group) fragment.appendChild(this.#renderRow(session, nowMs));
+    }
+    this.#el.replaceChildren(fragment);
+  }
+
+  #renderRow(session, nowMs) {
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = 'tree-session';
+    row.dataset.phase = session.phase;
+    row.dataset.taskId = session.taskId;
+    if (session.taskId === this.#selectedId) row.classList.add('selected');
+
+    const glyph = document.createElement('span');
+    glyph.className = 'glyph';
+    glyph.textContent = PHASE_GLYPH[session.phase] ?? '·';
+
+    const label = document.createElement('span');
+    label.className = 'label';
+    label.textContent = session.issueIdentifier || truncate(session.title || session.taskId, 18);
+
+    const time = document.createElement('span');
+    time.className = 'time';
+    time.textContent = formatRelativeTime(session.completedAt ?? session.startedAt ?? session.updatedAt, nowMs);
+
+    row.append(glyph, label, time);
+    row.title = `${session.issueIdentifier ? `${session.issueIdentifier} — ` : ''}${session.title ?? ''}`;
+    row.addEventListener('click', () => this.#onSelect(session.taskId));
+    return row;
+  }
+}

--- a/web/static/js/transcriptModel.mjs
+++ b/web/static/js/transcriptModel.mjs
@@ -10,17 +10,36 @@
 
 export const TRANSCRIPT_MAX_ENTRIES = 500;
 
+/**
+ * A single tool group is ONE entry, so a long uninterrupted run of tool calls
+ * would escape the entry cap entirely and grow the DOM without bound (the view
+ * re-renders the whole group per line). Cap the run; the next call opens a new
+ * group, which the entry cap then governs.
+ */
+export const TRANSCRIPT_MAX_GROUP_LINES = 50;
+
 // Daemon line prefixes. Kept in one place: the emitters may change glyphs, and
 // a stale copy would silently mis-style every line.
 const THINKING_PREFIX = '💭';
 const TOOL_PREFIX = '🔧';
 
+/**
+ * pairPipeline wraps every streamed line as `[${prefix}] ${line}`, so the
+ * glyph is NOT at the start — without stripping it, real worker and reviewer
+ * output all classifies as plain and tool runs never collapse.
+ */
+const TASK_PREFIX_RE = /^\s*\[[^\]]*\]\s*/;
+
+function stripTaskPrefix(line) {
+  return line.replace(TASK_PREFIX_RE, '').trimStart();
+}
+
 /** 'thinking' | 'tool' | 'plain' — drives styling, not behavior. */
 export function classifyLine(line) {
   if (typeof line !== 'string') return 'plain';
-  const trimmed = line.trimStart();
-  if (trimmed.startsWith(THINKING_PREFIX)) return 'thinking';
-  if (trimmed.startsWith(TOOL_PREFIX)) return 'tool';
+  const body = stripTaskPrefix(line.trimStart());
+  if (body.startsWith(THINKING_PREFIX)) return 'thinking';
+  if (body.startsWith(TOOL_PREFIX)) return 'tool';
   return 'plain';
 }
 
@@ -40,7 +59,8 @@ export function summarizeToolGroup(lines) {
 }
 
 function stripToolPrefix(line) {
-  return line.trimStart().slice(TOOL_PREFIX.length).trim() || line.trim();
+  const body = stripTaskPrefix(line.trimStart());
+  return body.slice(TOOL_PREFIX.length).trim() || body || line.trim();
 }
 
 /** First token of a tool line, e.g. "🔧 read_file: src/a.ts" → "read_file". */
@@ -64,9 +84,31 @@ export class TranscriptModel extends EventTarget {
   #byTask = new Map();
   #maxEntries;
 
-  constructor({ maxEntries = TRANSCRIPT_MAX_ENTRIES } = {}) {
+  #maxGroupLines;
+  /** Daemon instance the current sequence numbers belong to. */
+  #generation = null;
+
+  constructor({ maxEntries = TRANSCRIPT_MAX_ENTRIES, maxGroupLines = TRANSCRIPT_MAX_GROUP_LINES } = {}) {
     super();
     this.#maxEntries = maxEntries;
+    this.#maxGroupLines = maxGroupLines;
+  }
+
+  /**
+   * The daemon's sequence counter is process-local and restarts at 1, so a
+   * page that kept its high-water marks across a restart would discard every
+   * new line until the fresh counter passed the old mark.
+   *
+   * The generation rides on each line, so this needs no health round trip and
+   * cannot lose a race with reconnecting SSE delivery — dropping the marks the
+   * moment a line from a different process arrives is enough. History stays.
+   */
+  #applyGeneration(generation) {
+    if (!generation || generation === this.#generation) return;
+    const first = this.#generation === null;
+    this.#generation = generation;
+    if (first) return;
+    for (const state of this.#byTask.values()) state.maxSeq = 0;
   }
 
   entries(taskId) {
@@ -99,8 +141,9 @@ export class TranscriptModel extends EventTarget {
     this.dispatchEvent(new CustomEvent('replace', { detail: { taskId } }));
   }
 
-  append(taskId, { stage, line, ts, seq }, { silent = false } = {}) {
+  append(taskId, { stage, line, ts, seq, gen }, { silent = false } = {}) {
     if (typeof line !== 'string' || !line) return;
+    this.#applyGeneration(gen);
     let state = this.#byTask.get(taskId);
     if (!state) {
       state = { entries: [], raw: [], lastStage: null, openTools: null, maxSeq: 0 };
@@ -118,7 +161,7 @@ export class TranscriptModel extends EventTarget {
       state.maxSeq = seq;
     }
 
-    state.raw.push({ stage, line, ts, seq });
+    state.raw.push({ stage, line, ts, seq, gen });
     while (state.raw.length > this.#maxEntries) state.raw.shift();
 
     if (stage && stage !== state.lastStage) {
@@ -129,6 +172,9 @@ export class TranscriptModel extends EventTarget {
 
     const type = classifyLine(line);
     if (type === 'tool') {
+      if (state.openTools && state.openTools.lines.length >= this.#maxGroupLines) {
+        state.openTools = null; // cap the run so the entry cap can govern it
+      }
       if (state.openTools) {
         state.openTools.lines.push(line);
       } else {

--- a/web/static/js/transcriptModel.mjs
+++ b/web/static/js/transcriptModel.mjs
@@ -1,0 +1,153 @@
+// Per-session transcript: classification, tool grouping, bounded history.
+// (INT-3402)
+//
+// The data half of the work-card console (INT-3397), generalized for the
+// cockpit: same ring bound and stage boundaries, plus vega's activity-row
+// idea — consecutive tool lines collapse into one summarized group instead of
+// scrolling the reasoning off screen.
+//
+// DOM-free; transcriptView renders the entries this produces.
+
+export const TRANSCRIPT_MAX_ENTRIES = 500;
+
+// Daemon line prefixes. Kept in one place: the emitters may change glyphs, and
+// a stale copy would silently mis-style every line.
+const THINKING_PREFIX = '💭';
+const TOOL_PREFIX = '🔧';
+
+/** 'thinking' | 'tool' | 'plain' — drives styling, not behavior. */
+export function classifyLine(line) {
+  if (typeof line !== 'string') return 'plain';
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith(THINKING_PREFIX)) return 'thinking';
+  if (trimmed.startsWith(TOOL_PREFIX)) return 'tool';
+  return 'plain';
+}
+
+/**
+ * Summarize a run of tool lines: "Read 4 files" when they share a verb,
+ * "7 tool calls" when mixed. Mirrors vega's activity-row vocabulary.
+ */
+export function summarizeToolGroup(lines) {
+  const count = lines.length;
+  if (count === 1) return stripToolPrefix(lines[0]);
+  const verbs = new Set(lines.map(toolVerb).filter(Boolean));
+  if (verbs.size === 1) {
+    const verb = [...verbs][0];
+    return `${verb} ×${count}`;
+  }
+  return `${count} tool calls`;
+}
+
+function stripToolPrefix(line) {
+  return line.trimStart().slice(TOOL_PREFIX.length).trim() || line.trim();
+}
+
+/** First token of a tool line, e.g. "🔧 read_file: src/a.ts" → "read_file". */
+function toolVerb(line) {
+  const body = stripToolPrefix(line);
+  const match = body.match(/^([A-Za-z_][\w-]*)/);
+  return match ? match[1] : '';
+}
+
+/**
+ * Entries are one of:
+ *   { kind: 'stage',  stage }                      — a stage boundary marker
+ *   { kind: 'line',   type: 'thinking'|'plain', text, stage }
+ *   { kind: 'tools',  lines: string[], stage }     — a collapsible run
+ *
+ * A tool group stays OPEN (appendable) until a non-tool line or a stage change
+ * flushes it, so a burst of calls renders as one row.
+ */
+export class TranscriptModel extends EventTarget {
+  // taskId -> { entries, raw, lastStage, openTools, maxSeq }
+  #byTask = new Map();
+  #maxEntries;
+
+  constructor({ maxEntries = TRANSCRIPT_MAX_ENTRIES } = {}) {
+    super();
+    this.#maxEntries = maxEntries;
+  }
+
+  entries(taskId) {
+    return this.#byTask.get(taskId)?.entries ?? [];
+  }
+
+  /**
+   * Flat {stage, line, ts, seq} history, in arrival order — the shape `replace`
+   * accepts. Lets a caller reconcile a server snapshot with lines that
+   * streamed in while the request was in flight instead of dropping them.
+   */
+  rawLines(taskId) {
+    return this.#byTask.get(taskId)?.raw ?? [];
+  }
+
+  has(taskId) {
+    return this.#byTask.has(taskId);
+  }
+
+  clear(taskId) {
+    this.#byTask.delete(taskId);
+  }
+
+  /** Replace a task's history wholesale (REST snapshot wins over live noise). */
+  replace(taskId, lines) {
+    this.#byTask.delete(taskId);
+    for (const entry of lines ?? []) {
+      this.append(taskId, entry, { silent: true });
+    }
+    this.dispatchEvent(new CustomEvent('replace', { detail: { taskId } }));
+  }
+
+  append(taskId, { stage, line, ts, seq }, { silent = false } = {}) {
+    if (typeof line !== 'string' || !line) return;
+    let state = this.#byTask.get(taskId);
+    if (!state) {
+      state = { entries: [], raw: [], lastStage: null, openTools: null, maxSeq: 0 };
+      this.#byTask.set(taskId, state);
+    }
+
+    // Idempotent on the daemon's per-line sequence. The same line can reach us
+    // more than once — the SSE replay buffer on connect, a snapshot merge, a
+    // reconnect that replays — and rendering it twice is a visible lie about
+    // what the agent did. Sequences arrive in order within a task, so the
+    // high-water mark is enough; lines from a daemon that stamps none fall
+    // through unchanged.
+    if (typeof seq === 'number') {
+      if (seq <= state.maxSeq) return;
+      state.maxSeq = seq;
+    }
+
+    state.raw.push({ stage, line, ts, seq });
+    while (state.raw.length > this.#maxEntries) state.raw.shift();
+
+    if (stage && stage !== state.lastStage) {
+      state.lastStage = stage;
+      state.openTools = null; // a new stage always starts a fresh group
+      state.entries.push({ kind: 'stage', stage });
+    }
+
+    const type = classifyLine(line);
+    if (type === 'tool') {
+      if (state.openTools) {
+        state.openTools.lines.push(line);
+      } else {
+        state.openTools = { kind: 'tools', lines: [line], stage: state.lastStage };
+        state.entries.push(state.openTools);
+      }
+    } else {
+      state.openTools = null;
+      state.entries.push({ kind: 'line', type, text: line, stage: state.lastStage });
+    }
+
+    // Evict whole entries — never half a tool group.
+    while (state.entries.length > this.#maxEntries) {
+      const dropped = state.entries.shift();
+      if (dropped === state.openTools) state.openTools = null;
+    }
+
+    if (!silent) {
+      this.dispatchEvent(new CustomEvent('append', { detail: { taskId } }));
+    }
+  }
+}

--- a/web/static/js/transcriptView.mjs
+++ b/web/static/js/transcriptView.mjs
@@ -58,15 +58,22 @@ export class TranscriptView {
     }
 
     // Full re-render: bounded at the model's ring size, and it keeps the DOM
-    // an exact projection of the model (no incremental drift to debug).
+    // an exact projection of the model (no incremental drift to debug). Groups
+    // the reader expanded must survive it — collapsing them on every incoming
+    // line would make an open group unreadable during live output.
+    const openGroups = new Set();
+    this.#el.querySelectorAll('details.activity-row[open]').forEach((el) => {
+      if (el.dataset.groupKey) openGroups.add(el.dataset.groupKey);
+    });
+
     const fragment = document.createDocumentFragment();
-    for (const entry of entries) fragment.appendChild(this.#renderEntry(entry));
+    entries.forEach((entry, index) => fragment.appendChild(this.#renderEntry(entry, index, openGroups)));
     this.#el.replaceChildren(fragment);
 
     if (following) this.#el.scrollTop = this.#el.scrollHeight;
   }
 
-  #renderEntry(entry) {
+  #renderEntry(entry, index, openGroups) {
     if (entry.kind === 'stage') {
       const el = document.createElement('div');
       el.className = 'transcript-stage';
@@ -76,6 +83,10 @@ export class TranscriptView {
     if (entry.kind === 'tools') {
       const details = document.createElement('details');
       details.className = 'activity-row';
+      // Index is a stable key while entries only append/evict from the front;
+      // an evicted head shifts keys, which at worst re-collapses a group.
+      details.dataset.groupKey = String(index);
+      if (openGroups?.has(String(index))) details.open = true;
       const summary = document.createElement('summary');
       // Vocabulary lives with the model so labels have one owner.
       summary.textContent = summarizeToolGroup(entry.lines);

--- a/web/static/js/transcriptView.mjs
+++ b/web/static/js/transcriptView.mjs
@@ -1,0 +1,101 @@
+// Renders a session's transcript entries. (INT-3402)
+//
+// Scroll contract (vega INT-1411): follow the tail only while the viewer is
+// already near the bottom, and never `scroll-behavior: smooth` — smooth
+// scrolling fires intermediate scroll events that make "am I at the bottom?"
+// unanswerable, so the view would keep yanking a reader back down.
+
+import { summarizeToolGroup } from './transcriptModel.mjs';
+
+const FOLLOW_THRESHOLD_PX = 80;
+
+export class TranscriptView {
+  #el;
+  #model;
+  #taskId = null;
+
+  constructor(el, { model }) {
+    this.#el = el;
+    this.#model = model;
+    model.addEventListener('append', (event) => {
+      if (event.detail.taskId === this.#taskId) this.render();
+    });
+    model.addEventListener('replace', (event) => {
+      if (event.detail.taskId === this.#taskId) this.render({ toBottom: true });
+    });
+  }
+
+  get taskId() {
+    return this.#taskId;
+  }
+
+  /** The scroll container, so a host panel can mount it in its own layout. */
+  get element() {
+    return this.#el;
+  }
+
+  show(taskId) {
+    this.#taskId = taskId;
+    this.render({ toBottom: true });
+  }
+
+  clear() {
+    this.#taskId = null;
+    this.#el.replaceChildren();
+  }
+
+  render({ toBottom = false } = {}) {
+    if (!this.#taskId) return;
+    const following = toBottom || this.#isFollowing();
+    const entries = this.#model.entries(this.#taskId);
+
+    if (!entries.length) {
+      const empty = document.createElement('div');
+      empty.className = 'empty';
+      empty.textContent = 'No output captured for this session yet.';
+      this.#el.replaceChildren(empty);
+      return;
+    }
+
+    // Full re-render: bounded at the model's ring size, and it keeps the DOM
+    // an exact projection of the model (no incremental drift to debug).
+    const fragment = document.createDocumentFragment();
+    for (const entry of entries) fragment.appendChild(this.#renderEntry(entry));
+    this.#el.replaceChildren(fragment);
+
+    if (following) this.#el.scrollTop = this.#el.scrollHeight;
+  }
+
+  #renderEntry(entry) {
+    if (entry.kind === 'stage') {
+      const el = document.createElement('div');
+      el.className = 'transcript-stage';
+      el.textContent = `── ${entry.stage} ──`;
+      return el;
+    }
+    if (entry.kind === 'tools') {
+      const details = document.createElement('details');
+      details.className = 'activity-row';
+      const summary = document.createElement('summary');
+      // Vocabulary lives with the model so labels have one owner.
+      summary.textContent = summarizeToolGroup(entry.lines);
+      details.appendChild(summary);
+      for (const line of entry.lines) {
+        const child = document.createElement('div');
+        child.className = 'activity-line';
+        child.textContent = line;
+        details.appendChild(child);
+      }
+      return details;
+    }
+    const el = document.createElement('div');
+    el.className = `transcript-line ${entry.type}`;
+    el.textContent = entry.text;
+    return el;
+  }
+
+  #isFollowing() {
+    const distance = this.#el.scrollHeight - this.#el.scrollTop - this.#el.clientHeight;
+    return distance <= FOLLOW_THRESHOLD_PX;
+  }
+}


### PR DESCRIPTION
## TL;DR

이슈 보드가 **콕핏**이 된다. 좌측 사이드바에 저장소별 세션 트리, Sessions 뷰에 선택한 에이전트의 라이브 트랜스크립트, 해시 라우팅으로 세션이 링크 가능·리로드 생존. Issues 보드는 그대로 nav 항목 뒤로 이동하고, 배포하면 Sessions로 따라간다.

## 모듈 (가능한 한 DOM-free — 동작이 테스트 가능하도록)

- **sessionStore** — vega `session_runtime` 개작. phase rank 가드로 리플레이 멱등. **터미널은 다른 터미널에 대해서도 최종**이라 리플레이된 결과가 종료 방식을 다시 쓰지 못한다. `task:started`만 재진입 허용 — 데몬이 같은 id로 재시도하므로 재시도 세션이 "failed"로 굳으면 안 된다.
- **transcriptModel** — 라인 분류, 연속 도구 호출을 한 줄로 접기, 바운드 히스토리, **데몬 per-line 시퀀스 기반 중복 제거**(두 번 배달돼도 한 번만 렌더).
- sessionPanel / transcriptView / sessionTree / nav / format / sessionSelection.

## 리뷰 게이트가 잡아낸 실결함 (7라운드)

1. **stage 실패 ≠ task 실패** — 파이프라인은 reviewer stage를 실패시키고 반복해 성공하는 게 정상. task:completed만 결과를 결정하도록 수정
2. **터미널 덮어쓰기** — 리플레이된 stage fail이 완료된 세션을 failed로 뒤집음
3. **재시도 재진입 불가** — 같은 id 재시도가 영원히 failed로 표시
4. **스냅샷 페치 중 라인 유실** — `replace()`가 in-flight 도착 라인을 버림 → 시퀀스 병합
5. **ms 동률 유실** — ts 비교는 같은 밀리초 라인을 떨굼 → 단조 시퀀스로 교체
6. **SSE 리플레이 중복** — seq를 찍어놓고 dedupe에 안 씀
7. **딥링크 미재조정** — 해시는 스냅샷 도착 전에 읽히는데 이후 재확인이 없음 (+ `decodeURIComponent` 던짐이 부트스트랩 전체를 죽임, jsdom engines가 선언된 Node 범위와 불일치)

## 검증

- **jsdom 도입**(Node 범위 맞춰 ^26 고정) — "Sessions 뷰가 실제로 렌더된다"를 브라우저 스팟체크가 아니라 CI에서 검사
- web 테스트 67건 · 전체 **293 files green** · 커버리지 게이트 통과 · tsc/oxlint clean
- 커밋 게이트 **APPROVE**
- 브라우저 실측(확장 연결 시점): 뷰 전환·딥링크·Issues 무회귀(레포 선택→이슈 10건→2건 선택→arm까지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)