### PR TITLE
fix(security): classify unsupported CodeQL coverage

### DIFF
--- a/src/agents/pairPipeline.verify.test.ts
+++ b/src/agents/pairPipeline.verify.test.ts
@@ -109,7 +109,12 @@ beforeEach(() => {
   discoverVerifyCommands.mockResolvedValue([]);
   resolveBaseRef.mockResolvedValue({ remote: 'origin', branch: 'main', ref: 'origin/main' });
   listTrackedSecurityFiles.mockResolvedValue(['src/example.ts']);
-  runSecurityAudit.mockResolvedValue({ status: 'passed', codeqlLanguages: ['javascript'], findings: [] });
+  runSecurityAudit.mockResolvedValue({
+    status: 'passed',
+    codeqlLanguages: ['javascript'],
+    skippedCodeqlLanguages: [],
+    findings: [],
+  });
 });
 
 afterEach(() => {
@@ -117,12 +122,38 @@ afterEach(() => {
 });
 
 describe('PairPipeline deterministic tester (INT-2662)', () => {
+  it('fails closed when a detected CodeQL language has only partial coverage', async () => {
+    runSecurityAudit.mockResolvedValueOnce({
+      status: 'partial',
+      codeqlLanguages: ['javascript', 'swift'],
+      skippedCodeqlLanguages: ['swift'],
+      findings: [],
+      detail: 'Swift does not support build-mode=none.',
+    });
+
+    const { result } = await runPipeline({
+      stages: ['worker', 'reviewer'],
+      securityAudit: { enabled: true, maxThreads: 2 },
+    });
+
+    expect(result).toMatchObject({ success: false, finalStatus: 'infra_error' });
+    expect(runSecurityAudit).toHaveBeenCalledOnce();
+    expect(runWorker).not.toHaveBeenCalled();
+    expect(runReviewer).not.toHaveBeenCalled();
+  });
+
   it('blocks new CodeQL findings even when the tester stage is not configured', async () => {
     runSecurityAudit
-      .mockResolvedValueOnce({ status: 'passed', codeqlLanguages: ['javascript'], findings: [] })
+      .mockResolvedValueOnce({
+        status: 'passed',
+        codeqlLanguages: ['javascript'],
+        skippedCodeqlLanguages: [],
+        findings: [],
+      })
       .mockResolvedValueOnce({
         status: 'findings',
         codeqlLanguages: ['javascript'],
+        skippedCodeqlLanguages: [],
         findings: [{
           ruleId: 'codeql/js/file-access-to-http', level: 'error', message: 'outbound file data', filePath: 'src/new.ts', line: 12,
         }],

--- a/src/agents/securityAuditGate.ts
+++ b/src/agents/securityAuditGate.ts
@@ -27,7 +27,9 @@ async function runConfiguredSecurityAudit(projectPath: string, config: SecurityA
   } catch (error) {
     throw new SecurityAuditInfrastructureError(undefined, error instanceof Error ? error.message : String(error));
   }
-  if (result.status === 'failed' || result.status === 'unavailable') throw new SecurityAuditInfrastructureError(result);
+  if (result.status === 'failed' || result.status === 'unavailable' || result.status === 'partial') {
+    throw new SecurityAuditInfrastructureError(result);
+  }
   return result;
 }
 

--- a/src/cli/reviewMaxCommand.tsx
+++ b/src/cli/reviewMaxCommand.tsx
@@ -566,8 +566,16 @@ export async function runReviewMaxCommand(opts: ReviewMaxOptions = {}): Promise<
   const refreshSecurityAudit = async (): Promise<SecurityFinding[]> => {
     try {
       const result = await runSecurityAudit(workCwd, await listTrackedSecurityFiles(workCwd), securityAuditConfig);
-      console.log(c.dim(`  CodeQL refresh: ${result.status}, ${result.findings.length} finding(s).`));
-      return result.findings;
+      const skipped = result.skippedCodeqlLanguages.length > 0
+        ? `; skipped no-build-unsupported language(s): ${result.skippedCodeqlLanguages.join(', ')}`
+        : '';
+      console.log(c.dim(`  CodeQL refresh: ${result.status}, ${result.findings.length} finding(s)${skipped}.`));
+      if (result.status !== 'partial') return result.findings;
+      return [...result.findings, {
+        ruleId: 'openswarm/security-codeql-coverage',
+        level: 'error',
+        message: result.detail ?? `CodeQL coverage is partial for: ${result.skippedCodeqlLanguages.join(', ')}.`,
+      }];
     } catch (error) {
       return [{ ruleId: 'openswarm/security-codeql-refresh', level: 'error', message: `CodeQL refresh failed: ${error instanceof Error ? error.message : String(error)}` }];
     }

--- a/src/verify/securityAudit.test.ts
+++ b/src/verify/securityAudit.test.ts
@@ -84,9 +84,9 @@ describe('security audit primitives', () => {
 describe('runSecurityAudit', () => {
   it('does not require CodeQL for a disabled or source-free audit', async () => {
     await expect(runSecurityAudit('/repo', ['src/a.ts'], { enabled: false, maxThreads: 2 }))
-      .resolves.toEqual({ status: 'disabled', codeqlLanguages: [], findings: [] });
+      .resolves.toEqual({ status: 'disabled', codeqlLanguages: [], skippedCodeqlLanguages: [], findings: [] });
     await expect(runSecurityAudit('/repo', ['README.md'], DEFAULT_SECURITY_AUDIT_CONFIG))
-      .resolves.toEqual({ status: 'passed', codeqlLanguages: [], findings: [] });
+      .resolves.toEqual({ status: 'passed', codeqlLanguages: [], skippedCodeqlLanguages: [], findings: [] });
     expect(execFileMock).not.toHaveBeenCalled();
   });
 
@@ -133,6 +133,100 @@ describe('runSecurityAudit', () => {
       expect.arrayContaining(['database', 'create']),
       expect.arrayContaining(['database', 'analyze']),
     ]));
+  });
+
+  it('preserves contained file URI locations and rejects locations outside the snapshot', async () => {
+    fsMock.readFile.mockResolvedValue(JSON.stringify({
+      version: '2.1.0',
+      runs: [{ results: [
+        {
+          ruleId: 'js/xss-through-dom',
+          message: { text: 'contained location' },
+          locations: [{ physicalLocation: {
+            artifactLocation: { uri: 'file:///snapshot/web/main.js' },
+            region: { startLine: 85 },
+          } }],
+        },
+        {
+          ruleId: 'js/path-injection',
+          message: { text: 'external location' },
+          locations: [{ physicalLocation: {
+            artifactLocation: { uri: 'file:///etc/passwd' },
+            region: { startLine: 1 },
+          } }],
+        },
+      ] }],
+    }));
+
+    const audit = await runSecurityAudit('/repo', ['web/main.js']);
+
+    expect(audit.findings).toEqual([
+      expect.objectContaining({ filePath: 'web/main.js', line: 85 }),
+      expect.objectContaining({ filePath: undefined, line: 1 }),
+    ]);
+  });
+
+  it('records an exact unsupported none-build response as an explicit coverage skip', async () => {
+    execFileMock
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockRejectedValueOnce(Object.assign(new Error('unsupported build mode'), {
+        code: 2,
+        stderr: 'Swift does not support the none build mode. Please try using one of the following build modes instead: autobuild, manual.',
+      }));
+
+    const audit = await runSecurityAudit('/repo', ['host/App.swift']);
+
+    expect(audit).toMatchObject({
+      status: 'partial',
+      codeqlLanguages: ['swift'],
+      skippedCodeqlLanguages: ['swift'],
+      findings: [],
+    });
+    expect(audit.detail).toContain('build-mode=none: swift');
+  });
+
+  it('keeps unrelated database creation failures fail-closed', async () => {
+    execFileMock
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockRejectedValueOnce(Object.assign(new Error('database failed'), {
+        code: 1,
+        stderr: 'extractor crashed while importing source',
+      }));
+
+    const audit = await runSecurityAudit('/repo', ['host/App.swift']);
+
+    expect(audit).toMatchObject({
+      status: 'failed',
+      skippedCodeqlLanguages: [],
+      findings: [{ ruleId: 'openswarm/security-codeql-swift-database' }],
+    });
+  });
+
+  it('keeps partial coverage visible when another language also has findings', async () => {
+    fsMock.readFile.mockResolvedValue(JSON.stringify({
+      version: '2.1.0',
+      runs: [{ results: [{
+        ruleId: 'js/xss-through-dom',
+        message: { text: 'untrusted data reaches a DOM sink' },
+      }] }],
+    }));
+    execFileMock
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockRejectedValueOnce(Object.assign(new Error('unsupported build mode'), {
+        code: 2,
+        stderr: 'Swift does not support the none build mode. Please try using one of the following build modes instead: autobuild, manual.',
+      }));
+
+    const audit = await runSecurityAudit('/repo', ['web/main.js', 'host/App.swift']);
+
+    expect(audit).toMatchObject({
+      status: 'partial',
+      codeqlLanguages: ['javascript', 'swift'],
+      skippedCodeqlLanguages: ['swift'],
+      findings: [{ ruleId: 'codeql/js/xss-through-dom' }],
+    });
   });
 
   it('fails closed when SARIF cannot be parsed', async () => {

--- a/src/verify/securityAudit.ts
+++ b/src/verify/securityAudit.ts
@@ -47,8 +47,10 @@ export interface SecurityFinding {
 }
 
 export interface SecurityAuditResult {
-  status: 'passed' | 'findings' | 'unavailable' | 'failed' | 'disabled';
+  status: 'passed' | 'partial' | 'findings' | 'unavailable' | 'failed' | 'disabled';
   codeqlLanguages: string[];
+  /** Languages detected in the repository but not scanned because the installed extractor rejects build-mode=none. */
+  skippedCodeqlLanguages: string[];
   findings: SecurityFinding[];
   detail?: string;
 }
@@ -91,9 +93,27 @@ function shortened(value: string, limit = 700): string {
   return compact.length <= limit ? compact : `${compact.slice(0, limit)}…`;
 }
 
+function rejectsNoBuildMode(output: string, language: string): boolean {
+  const escapedLanguage = language.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(
+    `(?:^|\\s)${escapedLanguage} does not support the none build mode\\. Please try using one of the following build modes instead:`,
+    'i',
+  ).test(output);
+}
+
 function inside(root: string, candidate: string): boolean {
   const path = relative(root, candidate);
   return path !== '' && path !== '..' && !path.startsWith(`..${sep}`) && !isAbsolute(path);
+}
+
+function sarifArtifactPath(snapshotRoot: string, uri: string | undefined): string | undefined {
+  if (!uri) return undefined;
+  try {
+    const candidate = uri.startsWith('file:') ? fileURLToPath(uri) : resolve(snapshotRoot, uri);
+    return inside(snapshotRoot, candidate) ? relative(snapshotRoot, candidate).split(sep).join('/') : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 async function findSystemExecutable(name: string): Promise<string | undefined> {
@@ -187,8 +207,7 @@ function parseSarif(text: string, snapshotRoot: string): SecurityFinding[] {
       const physical = ((result.locations as Array<Record<string, unknown>> | undefined)?.[0]?.physicalLocation ?? {}) as Record<string, unknown>;
       const artifact = (physical.artifactLocation ?? {}) as Record<string, unknown>;
       const uri = typeof artifact.uri === 'string' ? artifact.uri : undefined;
-      const candidate = uri && !uri.startsWith('file:') ? resolve(snapshotRoot, uri) : undefined;
-      const filePath = candidate && inside(snapshotRoot, candidate) ? relative(snapshotRoot, candidate).split(sep).join('/') : undefined;
+      const filePath = sarifArtifactPath(snapshotRoot, uri);
       const region = (physical.region ?? {}) as Record<string, unknown>;
       const line = typeof region.startLine === 'number' && Number.isSafeInteger(region.startLine) && region.startLine > 0
         ? region.startLine
@@ -209,12 +228,12 @@ export async function runSecurityAudit(
   sourceFiles: readonly string[],
   config: SecurityAuditConfig = DEFAULT_SECURITY_AUDIT_CONFIG,
 ): Promise<SecurityAuditResult> {
-  if (!config.enabled) return { status: 'disabled', codeqlLanguages: [], findings: [] };
+  if (!config.enabled) return { status: 'disabled', codeqlLanguages: [], skippedCodeqlLanguages: [], findings: [] };
   const codeqlLanguages = detectCodeqlLanguages(sourceFiles);
-  if (codeqlLanguages.length === 0) return { status: 'passed', codeqlLanguages, findings: [] };
+  if (codeqlLanguages.length === 0) return { status: 'passed', codeqlLanguages, skippedCodeqlLanguages: [], findings: [] };
   const executable = await findSystemExecutable('codeql');
   if (!executable) {
-    return { status: 'unavailable', codeqlLanguages, findings: [{
+    return { status: 'unavailable', codeqlLanguages, skippedCodeqlLanguages: [], findings: [{
       ruleId: 'openswarm/security-codeql-unavailable', level: 'error', message: 'CodeQL is not installed or available on an absolute PATH entry.',
     }] };
   }
@@ -225,7 +244,7 @@ export async function runSecurityAudit(
     const packs = codeqlLanguages.map((language) => QUERY_PACK_BY_LANGUAGE[language]).filter((pack): pack is string => Boolean(pack));
     const download = await run(executable, ['pack', 'download', '--', ...packs], snapshot.root);
     if (download.exitCode !== 0) {
-      return { status: 'failed', codeqlLanguages, findings: [{
+      return { status: 'failed', codeqlLanguages, skippedCodeqlLanguages: [], findings: [{
         ruleId: 'openswarm/security-codeql-query-pack', level: 'error', message: 'CodeQL query packs could not be prepared.',
       }], detail: shortened(download.stderr || download.stdout) };
     }
@@ -239,19 +258,20 @@ export async function runSecurityAudit(
       try {
         await access(OPENSWARM_SECURITY_SUITE, constants.R_OK);
       } catch {
-        return { status: 'failed', codeqlLanguages, findings: [{
+        return { status: 'failed', codeqlLanguages, skippedCodeqlLanguages: [], findings: [{
           ruleId: 'openswarm/security-codeql-suite', level: 'error', message: 'OpenSwarm CodeQL security suite is unavailable from this installation.',
         }] };
       }
       const install = await run(executable, ['pack', 'install'], dirname(OPENSWARM_SECURITY_SUITE));
       if (install.exitCode !== 0) {
-        return { status: 'failed', codeqlLanguages, findings: [{
+        return { status: 'failed', codeqlLanguages, skippedCodeqlLanguages: [], findings: [{
           ruleId: 'openswarm/security-codeql-suite', level: 'error', message: 'OpenSwarm CodeQL security suite dependencies could not be prepared.',
         }], detail: shortened(install.stderr || install.stdout) };
       }
     }
 
     const findings: SecurityFinding[] = [];
+    const skippedCodeqlLanguages: string[] = [];
     let infrastructureFailure = false;
     for (const language of codeqlLanguages) {
       const pack = QUERY_PACK_BY_LANGUAGE[language];
@@ -263,6 +283,10 @@ export async function runSecurityAudit(
         `--source-root=${snapshot.root}`, `--threads=${config.maxThreads}`,
       ], snapshot.root);
       if (create.exitCode !== 0) {
+        if (rejectsNoBuildMode(create.stderr || create.stdout, language)) {
+          skippedCodeqlLanguages.push(language);
+          continue;
+        }
         infrastructureFailure = true;
         findings.push({ ruleId: `openswarm/security-codeql-${language}-database`, level: 'error', message: 'CodeQL could not create its no-build security database.' });
         continue;
@@ -286,9 +310,23 @@ export async function runSecurityAudit(
         findings.push({ ruleId: `openswarm/security-codeql-${language}-sarif`, level: 'error', message: `CodeQL SARIF was invalid: ${shortened(error instanceof Error ? error.message : String(error))}` });
       }
     }
-    return { status: infrastructureFailure ? 'failed' : findings.length === 0 ? 'passed' : 'findings', codeqlLanguages, findings };
+    return {
+      status: infrastructureFailure
+        ? 'failed'
+        : skippedCodeqlLanguages.length > 0
+          ? 'partial'
+          : findings.length > 0
+            ? 'findings'
+            : 'passed',
+      codeqlLanguages,
+      skippedCodeqlLanguages,
+      findings,
+      ...(skippedCodeqlLanguages.length > 0
+        ? { detail: `Skipped languages whose installed CodeQL extractor does not support build-mode=none: ${skippedCodeqlLanguages.join(', ')}.` }
+        : {}),
+    };
   } catch (error) {
-    return { status: 'failed', codeqlLanguages, findings: [{
+    return { status: 'failed', codeqlLanguages, skippedCodeqlLanguages: [], findings: [{
       ruleId: 'openswarm/security-codeql-runtime', level: 'error', message: `CodeQL security audit failed: ${shortened(error instanceof Error ? error.message : String(error))}`,
     }] };
   } finally {


### PR DESCRIPTION
## Summary
- classify exact CodeQL `build-mode=none` extractor rejections as explicit partial coverage instead of vulnerability findings
- keep partial coverage fail-closed in the pair pipeline and `review --max --fix`
- preserve contained `file:` SARIF locations while rejecting paths outside the audit snapshot

## Verification
- `npm test -- --run` — 4,137 passed, 1 skipped
- `npm run typecheck`
- `npm run lint`
- live de-artifact audit — JavaScript/Python/Rust scanned with 0 findings; Swift reported as explicit partial coverage
- `openswarm review --path .` — APPROVE

Linear: AGT-3965