### PR TITLE
chore(docker): modernize stale Docker packaging into a verified deployable image (AGT-3997)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,62 +1,45 @@
-# Dependencies
+# Dependencies (rebuilt inside the image)
 node_modules/
 
-# Build artifacts
+# Host build artifacts — the image builds its own dist; a stale host dist
+# copied over it would mask build failures.
+dist/
 build/
 *.tgz
 
-# Environment & secrets
+# Secrets and local state. config.yaml routinely embeds tokens via env
+# interpolation defaults; the runtime mounts it instead.
 .env
 .env.*
+config.yaml
+config.yml
+config.json
+.openswarm/
+.coverage/
 
-# IDE & OS
+# VCS / editor / OS
+.git/
+.gitignore
 .vscode/
 .idea/
 *.swp
-*.swo
-*~
 .DS_Store
-Thumbs.db
 
-# Git & Docker (self-referential)
-.git/
-.gitignore
+# Docker (self-referential)
 Dockerfile*
 docker-compose*
 .dockerignore
 
-# Logs & runtime
+# Tests, docs, CI — not part of the runtime image
+coverage/
+docs/
+benchmarks/
+desktop/
+web-e2e/
+.github/
+.claude/
+testing/
+trash/
 logs/
 *.log
-pids/
-*.pid
-*.pid.lock
-*.seed
-
-# Testing & coverage
-coverage/
-.nyc_output/
-__tests__/
-*.test.js
-*.test.ts
-
-# Documentation
-README.md
-docs/
-CHANGELOG.md
-
-# Claude Code
-.claude/
-
-# Development config
-.github/
-vitest.config.ts
-
-# Data (mounted as volumes)
-data/
-tmp/
-temp/
-trash/
-
-# Subprojects
-openclaw/
+plan.md

--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -1,0 +1,41 @@
+# Build (never push) the production image when the Docker packaging changes.
+#
+# The packaging rotted silently once before — a pre-rename Dockerfile kept
+# "working" in the repo for months while npx tsc drifted from npm run build and
+# the image stopped containing the dashboard. Scoped to packaging paths so
+# ordinary PRs do not pay the multi-minute image build.
+name: Docker Build Check
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'docker-compose.yml'
+      - '.github/workflows/docker-build-check.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: production
+          push: false
+          load: true
+          tags: openswarm:pr-check
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Smoke — CLI and bundled assets
+        run: |
+          docker run --rm openswarm:pr-check openswarm --version
+          docker run --rm openswarm:pr-check sh -c 'test -d /app/dist/web-static && test -x /app/dist/cli.js'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,61 @@
+# Build and publish the OpenSwarm daemon image to GHCR.
+#
+# Triggered by the GitHub release that release.yml creates after an npm
+# publish, so the image version always matches a published npm version.
+# workflow_dispatch exists for rebuilding an image (base-image CVE, Dockerfile
+# fix) without cutting a new release.
+name: Docker Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/openswarm
+          # On a release event this yields the semver tags (0.21.1 / 0.21 / latest);
+          # a manual dispatch from a branch yields a branch tag instead of
+          # clobbering latest.
+          # latest=auto attaches `latest` to semver tags only — pinned here so
+          # a future metadata-action default change cannot silently stop
+          # updating `latest` on releases.
+          flavor: |
+            latest=auto
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: production
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,102 +1,97 @@
-# Multi-stage build for OpenSwarm
-# Stage 1: Builder (using Alpine for smaller image)
-FROM node:22-alpine AS builder
+# ============================================
+# OpenSwarm - deployable daemon image
+# ============================================
+#
+# Two stages on the SAME libc (node:22-slim / glibc): the native addons
+# (better-sqlite3, lancedb) are compiled once in the builder and copied into
+# the runtime, so the runtime stage needs no toolchain and cannot drift from
+# what was built. The previous Alpine(musl) builder + slim(glibc) runtime pair
+# forced a second, toolchain-less rebuild in the runtime stage that only worked
+# while every native dependency happened to ship a prebuilt binary.
+#
+# The image runs the headless daemon (web dashboard on 3847) and bundles the
+# `openswarm` CLI. Provider CLIs (claude/codex/cursor) are NOT baked in — the
+# default codex-responses adapter runs OpenSwarm's own tool loop against
+# mounted OAuth state (~/.openswarm, ~/.codex). See README "Run with Docker".
 
-# Install build dependencies for native modules
-RUN apk add --no-cache \
-    python3 \
-    make \
-    g++ \
-    cairo-dev \
-    jpeg-dev \
-    pango-dev \
-    musl-dev \
-    giflib-dev \
-    pixman-dev \
-    pangomm-dev \
-    libjpeg-turbo-dev \
-    freetype-dev
+# ---- Stage 1: build ----
+FROM node:22-slim AS builder
+
+# Toolchain for native-addon source builds when a prebuilt binary is missing.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 make g++ ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-# Copy package files for dependency installation
 COPY package*.json ./
-
-# Install dependencies (including devDependencies for build)
 RUN npm ci --include=dev
 
-# Copy all source code
 COPY . .
 
-# Build the TypeScript project
-RUN npx tsc
+# Full build script, not bare tsc: postbuild sets the CLI exec bit and copies
+# web/static into dist/web-static — without it the dashboard serves nothing.
+RUN npm run build
 
-# Stage 2: Production (use slim instead of alpine for better compatibility)
+# Drop devDependencies in place so the runtime copies exactly the node_modules
+# the build compiled (natives included), nothing more.
+RUN npm prune --omit=dev && npm cache clean --force
+
+# ---- Stage 2: runtime ----
 FROM node:22-slim AS production
 
-# Install runtime dependencies for native modules and ONNX
+# git + gh: workers commit and open PRs. bubblewrap: the verify sandbox —
+# fail-closed under Docker's default seccomp profile; see README for the flags
+# that enable it. curl: healthcheck. dumb-init: PID-1 signal handling.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        dumb-init \
-        python3 \
-        ca-certificates \
-        curl \
-        gnupg \
-        git \
-        && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install GitHub CLI
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
-        dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+        dumb-init ca-certificates curl git bubblewrap gnupg && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | \
-        tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list && \
     apt-get update && \
-    apt-get install -y gh && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends gh && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Claude CLI
-RUN npm install -g @anthropic-ai/claude-code && \
-    npm cache clean --force
-
-# Create app user for security
-RUN groupadd --gid 1001 nodejs && \
-    useradd --uid 1001 --gid nodejs --shell /bin/bash --create-home claude
+RUN groupadd --gid 1001 openswarm && \
+    useradd --uid 1001 --gid openswarm --shell /bin/bash --create-home openswarm
 
 WORKDIR /app
 
-# Copy package files and install production dependencies
-COPY package*.json ./
-RUN npm ci --omit=dev --include=optional && \
-    npm cache clean --force
+COPY --from=builder --chown=openswarm:openswarm /app/node_modules ./node_modules
+COPY --from=builder --chown=openswarm:openswarm /app/dist ./dist
+COPY --chown=openswarm:openswarm package.json config.example.yaml ./
+COPY --chown=openswarm:openswarm templates ./templates
+COPY --chown=openswarm:openswarm .codeql ./.codeql
 
-# Copy built application from builder stage
-COPY --from=builder /app/dist ./dist
+# The CLI on PATH; node resolves modules from the symlink target, so this is
+# equivalent to a global install without a second copy of the package.
+RUN ln -s /app/dist/cli.js /usr/local/bin/openswarm
 
-# Copy example config (actual config.yaml should be mounted as volume)
-COPY config.example.yaml ./config.example.yaml
+# /work is where repositories are mounted; ~/.openswarm holds daemon state and
+# must be a volume or every restart forgets task state, auth profiles, and the
+# coordination board.
+RUN mkdir -p /work /home/openswarm/.openswarm && \
+    chown -R openswarm:openswarm /work /home/openswarm
 
-# Create necessary directories and set permissions
-RUN mkdir -p /app/config /app/logs /app/data /home/claude/dev && \
-    ln -sf /app /home/claude/dev/openswarm && \
-    chown -R claude:nodejs /app && \
-    chown -R claude:nodejs /home/claude
+USER openswarm
+ENV HOME=/home/openswarm \
+    NODE_ENV=production
 
-# Switch to non-root user
-USER claude
+# Mounted repositories belong to arbitrary host UIDs; without this every git
+# operation inside /work dies with "dubious ownership". The container's whole
+# job is operating on mounted repos, so the blanket opt-in is the intent.
+RUN git config --global safe.directory '*'
 
-# Expose web dashboard port
 EXPOSE 3847
 
-# Health check via web API
+# /api/health is the token-less diagnostics endpoint (INT-3388) — /api/* reads
+# are otherwise auth-gated, so a healthcheck against them reports auth policy,
+# not process health.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD curl -f http://localhost:3847/api/stats || exit 1
+    CMD curl -fsS http://localhost:3847/api/health || exit 1
 
-# Use dumb-init for proper signal handling
 ENTRYPOINT ["dumb-init", "--"]
-
-# Start the application
 CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -451,6 +451,36 @@ openswarm dash                # open the web dashboard (:3847)
 
 > **From source / development** (contributors): clone the repo and use the `npm run …` scripts (`npm run dev`, `npm start`, `npm run service:install` for a macOS launchd service, `docker compose up -d`). See [CONTRIBUTING.md](CONTRIBUTING.md).
 
+### Run with Docker
+
+The repository ships a production image for the headless daemon (web dashboard on `:3847`, `openswarm` CLI on `PATH`). Published images live at `ghcr.io/unohee/openswarm` (tagged per release); building locally works the same way:
+
+```bash
+# Pull a release, or build from the repo
+docker pull ghcr.io/unohee/openswarm:latest   # or: docker compose build
+
+cp config.example.yaml config.yaml            # edit adapter/projects/keys
+export OPENSWARM_WEB_TOKEN=$(openssl rand -hex 24)  # required to expose the dashboard
+docker compose up -d
+curl http://localhost:3847/api/health         # daemon health (token-less)
+```
+
+Without `OPENSWARM_WEB_TOKEN` the dashboard binds only inside the container — an unauthenticated `0.0.0.0` bind is refused by design — so the published port answers nothing while the daemon itself keeps running. With the token set, browser/API access from the host sends it as the `X-OpenSwarm-Token` header (`/api/health` stays token-less).
+
+The compose file wires the three mounts that matter:
+
+| Mount | Purpose |
+|---|---|
+| `./config.yaml → /app/config.yaml` | daemon configuration (read-only) |
+| `openswarm-state → /home/openswarm/.openswarm` | task state, auth profiles, coordination board — **must persist**, and one container per state volume (two daemons sharing it would fight over locks and double-process issues) |
+| `./workspace → /work` | the repositories the daemon works on; point `autonomous.allowedProjects` at `/work/<repo>` |
+
+Notes:
+
+- **Provider CLIs are not baked in.** The default `codex-responses` adapter runs OpenSwarm's own tool loop against OAuth state — log in on the host (`openswarm auth login`) and mount `~/.codex` / reuse the state volume. For the delegated CLI adapters (`claude`, `codex`, `cursor`), derive your own image: `FROM ghcr.io/unohee/openswarm` + `npm install -g <cli>`.
+- **Git identity**: mount `~/.gitconfig` or set `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL` (and `GH_TOKEN` for `gh`) so worker commits and PRs attribute correctly.
+- **Verify sandbox**: `bubblewrap` is installed but fail-closed under Docker's default seccomp profile. Enabling it requires `security_opt: [seccomp=unconfined]` + `cap_add: [SYS_ADMIN]` (commented in `docker-compose.yml`) — weigh that against your threat model.
+
 ---
 
 ## Architecture

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+# OpenSwarm daemon — single instance per state volume. Two containers sharing
+# one openswarm-state volume would fight over the daemon's pid/lock files and
+# double-process the same tracker issues.
 services:
   openswarm:
     build:
@@ -8,83 +11,65 @@ services:
     container_name: openswarm
     restart: unless-stopped
 
-    # Environment variables
     environment:
-      - NODE_ENV=production
-      - ONNX_WEB=1
-      - USE_ONNXRUNTIME_WEB=1
       - TZ=Asia/Seoul
-      - HOME=/home/claude
-      - PROJECT_PATH=/app
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      # The dashboard binds 127.0.0.1 (container-internal) unless a token is
+      # set — an unauthenticated 0.0.0.0 bind is refused by design. Without
+      # this, the published port below answers nothing; the daemon itself and
+      # the in-container healthcheck still work. Reads/mutations from outside
+      # then require the X-OpenSwarm-Token header (/api/health stays open).
+      - OPENSWARM_WEB_TOKEN=${OPENSWARM_WEB_TOKEN:-}
+      # Provider/API keys come from .env (see env_file) or the shell:
+      #   LINEAR_API_KEY, LINEAR_TEAM_ID, DISCORD_TOKEN, DISCORD_CHANNEL_ID,
+      #   ATLASCLOUD_API_KEY, OPENROUTER_API_KEY, ...
 
-    # Load environment from file
+    # Optional: create .env next to this file. Missing file is not an error.
     env_file:
-      - .env
+      - path: .env
+        required: false
 
-    # Port mapping
     ports:
-      - "3002:3847"
+      - "3847:3847"
 
-    # Volume mounts
     volumes:
-      # Configuration files (read-only)
-      - ./config:/app/config:ro
-      # Logs directory (read-write)
-      - ./logs:/app/logs:rw
-      # Data persistence
-      - openswarm-data:/app/data:rw
-      # Config file (if exists)
+      # Daemon configuration — run `cp config.example.yaml config.yaml` BEFORE
+      # `docker compose up`: if the file does not exist, Docker creates a
+      # directory at this path and the daemon fails with an unreadable-config
+      # error instead of a clear "file missing" one.
       - ./config.yaml:/app/config.yaml:ro
-      # Claude CLI auth and git config (uncomment and configure as needed)
-      # - ~/.claude:/home/claude/.claude:ro
-      # - ~/.gitconfig:/home/claude/.gitconfig:ro
+      # Daemon state: task state, auth profiles, coordination board, logs.
+      # Must persist or every restart forgets everything.
+      - openswarm-state:/home/openswarm/.openswarm
+      # Repositories the daemon works on. Point allowedProjects at /work/<repo>.
+      - ${OPENSWARM_WORKSPACE:-./workspace}:/work
+      # Git identity for worker commits (or set GIT_AUTHOR_* env instead).
+      # - ~/.gitconfig:/home/openswarm/.gitconfig:ro
+      # ChatGPT-OAuth (codex-responses adapter) state from a host login:
+      # - ~/.codex:/home/openswarm/.codex
 
-    # Resource limits
-    deploy:
-      resources:
-        limits:
-          cpus: '2.0'
-          memory: 1G
-        reservations:
-          cpus: '0.5'
-          memory: 256M
-
-    # Health check
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3847/api/stats"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:3847/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
 
-    # Logging configuration
     logging:
       driver: json-file
       options:
         max-size: "10m"
         max-file: "3"
 
-    # Network
-    networks:
-      - openswarm-network
-
-    # Security options
     security_opt:
       - no-new-privileges:true
 
-    # Read-only root filesystem (except for volumes)
-    read_only: false  # Set to true if app doesn't need to write to filesystem
+    # The verify sandbox (bubblewrap) is fail-closed under Docker's default
+    # seccomp profile. To enable it, uncomment — and understand — the following:
+    # security_opt:
+    #   - seccomp=unconfined
+    # cap_add:
+    #   - SYS_ADMIN
 
-# Named volumes
 volumes:
-  openswarm-data:
+  openswarm-state:
     driver: local
-
-# Networks
-networks:
-  openswarm-network:
-    driver: bridge
-    ipam:
-      config:
-        - subnet: 172.25.0.0/24


### PR DESCRIPTION
## TL;DR

The Docker packaging predated the OpenSwarm rename and had silently rotted — the image built a dashboard-less daemon with no CLI exec bit, health-checked an auth-gated endpoint, and persisted no state. This PR rewrites it into a locally build- and boot-verified deployable image, with a GHCR publish path and a packaging-scoped PR build check so it cannot rot silently again.

Closes AGT-3997.

## Changes

| File | Change |
|---|---|
| `Dockerfile` | Both stages `node:22-slim` (one libc — natives compiled once in the builder, copied to runtime; no runtime toolchain); `npm run build` (postbuild: CLI exec bit + `dist/web-static`); prod-pruned `node_modules`; git+gh+bubblewrap+dumb-init; non-root; `openswarm` on PATH; `/api/health` healthcheck; `safe.directory` for mounted repos |
| `docker-compose.yml` | `openswarm-state` volume (`~/.openswarm`), `/work` repos mount, `OPENSWARM_WEB_TOKEN` passthrough (dashboard binds container-internal without it — by design), config bind-mount footgun documented, ONNX/cairo-era leftovers removed |
| `.dockerignore` | Excludes `config.yaml`/`.env`/`dist`/state — secrets and stale host builds stay out of the build context |
| `.github/workflows/docker-publish.yml` | GHCR publish on release published + manual dispatch; buildx amd64+arm64; semver + pinned `latest=auto` tags |
| `.github/workflows/docker-build-check.yml` | PR build check scoped to packaging paths (build + CLI/assets smoke, never pushes) |
| `README.md` | "Run with Docker": quick start, mount matrix, token requirement, provider-CLI derivation, verify-sandbox flags |

## Verification (local, actual runs)

- `docker build` → success, 1.16GB (arm64; CI builds amd64+arm64)
- Container smoke: `openswarm --version` → 0.21.1; git/gh/bubblewrap present; non-root user
- Daemon boot on a minimal config → `/api/health` 200 (token-less), dashboard `/` 200, `/static/js/api.mjs` 200
- Auth posture: `/api/coordination` 403 without token, 200 with `X-OpenSwarm-Token`
- Docker `HEALTHCHECK` → `healthy`; state dir written by the native sqlite addon (glibc prebuild works)
- `docker compose config` clean; workflow YAML parse clean
- Commit gate: `openswarm review` → **APPROVE** (0 issues; 3 suggestions all applied: `latest` flavor pinned, PR build check added, config-mount footgun documented)

Note: image is 1.16GB vs the 1GB aspiration — the bulk is the dependency set (transformers/onnx/arrow/lancedb), not packaging overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)