### PR TITLE
test(adapters): cover the cc-router and cursor adapters (AGT-3993 follow-up)

### DIFF
--- a/src/adapters/ccRouter.test.ts
+++ b/src/adapters/ccRouter.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execFileMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ execFile: execFileMock }));
+
+import { CcRouterAdapter } from './ccRouter.js';
+
+// The adapter awaits promisify(execFile); the generic promisify wrapper
+// resolves with the callback's first success value, so the mock hands back the
+// { stdout } object the real promisified execFile would.
+type ExecCb = (err: Error | null, result?: { stdout: string; stderr: string }) => void;
+function statusReply(payload: unknown): void {
+  execFileMock.mockImplementation((_c: string, _a: string[], _o: unknown, cb: ExecCb) =>
+    cb(null, { stdout: JSON.stringify(payload), stderr: '' }));
+}
+
+const ENV_KEYS = ['CC_ROUTER_TOKEN', 'CC_ROUTER_BASE_URL', 'CC_ROUTER_MODEL'] as const;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) { saved[key] = process.env[key]; delete process.env[key]; }
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe('CcRouterAdapter availability', () => {
+  it('requires an ok status AND the openAIResponses capability, not mere reachability', async () => {
+    // A cc-router that answers but cannot serve the Responses API would accept
+    // the route and then fail every call — that is an unavailable primary.
+    statusReply({ status: 'ok', operational: { capabilities: { openAIResponses: true } } });
+    await expect(new CcRouterAdapter().isAvailable()).resolves.toBe(true);
+
+    statusReply({ status: 'ok', operational: { capabilities: { openAIResponses: false } } });
+    await expect(new CcRouterAdapter().isAvailable()).resolves.toBe(false);
+
+    statusReply({ status: 'degraded', operational: { capabilities: { openAIResponses: true } } });
+    await expect(new CcRouterAdapter().isAvailable()).resolves.toBe(false);
+  });
+
+  it('reports unavailable on a missing binary or non-JSON status', async () => {
+    execFileMock.mockImplementation((_c: string, _a: string[], _o: unknown, cb: ExecCb) =>
+      cb(new Error('ENOENT')));
+    await expect(new CcRouterAdapter().isAvailable()).resolves.toBe(false);
+
+    execFileMock.mockImplementation((_c: string, _a: string[], _o: unknown, cb: ExecCb) =>
+      cb(null, { stdout: 'not json', stderr: '' }));
+    await expect(new CcRouterAdapter().isAvailable()).resolves.toBe(false);
+  });
+});
+
+describe('CcRouterAdapter model discovery', () => {
+  it('lists model ids from /v1/models with the bearer token when configured', async () => {
+    process.env.CC_ROUTER_TOKEN = 'router-secret';
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: 'gpt-5.6-terra' }, { notAnId: 1 }, { id: 'gpt-5.6-sol' }] })));
+
+    const adapter = new CcRouterAdapter();
+    await expect(adapter.listModels()).resolves.toEqual(['gpt-5.6-terra', 'gpt-5.6-sol']);
+    await expect(adapter.getDefaultModel()).resolves.toBe('gpt-5.6-terra');
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }];
+    expect(url).toBe('http://127.0.0.1:3456/v1/models');
+    expect(init.headers).toEqual({ Authorization: 'Bearer router-secret' });
+  });
+
+  it('falls back through env model to the hardcoded default when listing fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('down'));
+    await expect(new CcRouterAdapter().getDefaultModel()).resolves.toBe('gpt-5.6-terra');
+
+    process.env.CC_ROUTER_MODEL = 'my-model';
+    await expect(new CcRouterAdapter().getDefaultModel()).resolves.toBe('my-model');
+  });
+
+  it('normalizes a configured base URL whether or not it already ends in /v1', async () => {
+    process.env.CC_ROUTER_BASE_URL = 'http://10.0.0.5:9999/v1/';
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ data: [] })));
+    await new CcRouterAdapter().listModels();
+    expect(fetchMock.mock.calls[0][0]).toBe('http://10.0.0.5:9999/v1/models');
+  });
+
+  it('returns no models on a non-OK response instead of throwing into the router', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('nope', { status: 503 }));
+    await expect(new CcRouterAdapter().listModels()).resolves.toEqual([]);
+  });
+});
+
+describe('CcRouterAdapter request identity', () => {
+  // The protected overrides are the entire point of the subclass: no ChatGPT
+  // account id, optional local bearer token, and the loopback-only egress
+  // guard. Exercise them through a test-local subclass.
+  class Probe extends CcRouterAdapter {
+    headersFor(options: Parameters<CcRouterAdapter['authHeaders']>[0]) { return this.authHeaders(options); }
+    credentialsFor(options: Parameters<CcRouterAdapter['credentials']>[0]) { return this.credentials(options); }
+    url() { return this.responsesUrl(); }
+    prepare(payload: unknown) { return this.prepareRequest(payload); }
+  }
+  const runOptions = { prompt: 'p', cwd: '/repo' };
+
+  it('sends a bearer header only when CC_ROUTER_TOKEN is set, never an account id', async () => {
+    const probe = new Probe();
+    expect(probe.headersFor(runOptions)).toEqual({});
+    await expect(probe.credentialsFor(runOptions)).resolves.toEqual({ accessToken: '', accountId: '' });
+
+    process.env.CC_ROUTER_TOKEN = 'router-secret';
+    expect(probe.headersFor(runOptions)).toEqual({ Authorization: 'Bearer router-secret' });
+    await expect(probe.credentialsFor(runOptions)).resolves.toEqual({ accessToken: 'router-secret', accountId: '' });
+  });
+
+  it('targets the local /v1/responses endpoint through the loopback egress guard', () => {
+    const probe = new Probe();
+    expect(probe.url()).toBe('http://127.0.0.1:3456/v1/responses');
+    // The egress guard admits the loopback origin and would reject a remote one.
+    expect(() => probe.prepare({ model: 'm' })).not.toThrow();
+    process.env.CC_ROUTER_BASE_URL = 'https://evil.example.com';
+    expect(() => new Probe().prepare({ model: 'm' })).toThrow();
+  });
+});

--- a/src/adapters/cursor.test.ts
+++ b/src/adapters/cursor.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const execFileMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ execFile: execFileMock }));
+
 import { CursorCliAdapter, extractCursorFinalText } from './cursor.js';
+
+// promisify(execFile)'s generic wrapper resolves with the callback's first
+// success value, so the mock hands back the { stdout } object.
+type ExecCb = (err: Error | null, result?: { stdout: string; stderr: string }) => void;
+
+afterEach(() => vi.clearAllMocks());
 
 describe('CursorCliAdapter', () => {
   it('runs headlessly in the selected workspace without force/yolo', () => {
@@ -21,5 +31,71 @@ describe('CursorCliAdapter', () => {
   it('extracts the last textual stream event', () => {
     const stream = [JSON.stringify({ type: 'assistant', text: 'first' }), JSON.stringify({ type: 'result', result: 'final' })].join('\n');
     expect(extractCursorFinalText(stream)).toBe('final');
+  });
+});
+
+describe('CursorCliAdapter CLI probes', () => {
+  it('is available exactly when cursor-agent status answers', async () => {
+    execFileMock.mockImplementation((_c: string, _a: string[], _o: unknown, cb: ExecCb) =>
+      cb(null, { stdout: 'ok', stderr: '' }));
+    await expect(new CursorCliAdapter().isAvailable()).resolves.toBe(true);
+
+    execFileMock.mockImplementation((_c: string, _a: string[], _o: unknown, cb: ExecCb) =>
+      cb(new Error('ENOENT')));
+    await expect(new CursorCliAdapter().isAvailable()).resolves.toBe(false);
+  });
+
+  it('parses the model list, skipping the banner line, and defaults to the first', async () => {
+    execFileMock.mockImplementation((_c: string, _a: string[], _o: unknown, cb: ExecCb) =>
+      cb(null, { stdout: 'Available models:\n gpt-5\ncomposer-1\n\n', stderr: '' }));
+    const adapter = new CursorCliAdapter();
+    await expect(adapter.listModels()).resolves.toEqual(['gpt-5', 'composer-1']);
+    await expect(adapter.getDefaultModel()).resolves.toBe('gpt-5');
+  });
+
+  it("falls back to 'auto' when the CLI cannot list models", async () => {
+    execFileMock.mockImplementation((_c: string, _a: string[], _o: unknown, cb: ExecCb) =>
+      cb(new Error('down')));
+    await expect(new CursorCliAdapter().getDefaultModel()).resolves.toBe('auto');
+  });
+});
+
+describe('CursorCliAdapter stream and result parsing', () => {
+  it('logs each complete stream event and returns the partial line as the next buffer', () => {
+    const logged: string[] = [];
+    const adapter = new CursorCliAdapter();
+    const chunk = `${JSON.stringify({ type: 'assistant', text: 'thinking' })}\n{"type":"assis`;
+    const remainder = adapter.parseStreamingChunk(chunk, (line) => logged.push(line));
+    expect(logged).toEqual(['thinking']);
+    expect(remainder).toBe('{"type":"assis');
+
+    // The buffered partial completes on the next chunk — no event is lost or duplicated.
+    const logged2: string[] = [];
+    const rest = adapter.parseStreamingChunk('tant","text":"done"}\n', (line) => logged2.push(line), remainder);
+    expect(logged2).toEqual(['done']);
+    expect(rest).toBe('');
+  });
+
+  it('parses worker output from the final stream event and merges executed commands', () => {
+    const raw = {
+      exitCode: 0,
+      stdout: JSON.stringify({ type: 'result', result: '{"success": true, "summary": "edited", "filesChanged": ["a.ts"], "commands": ["npm test"]}' }),
+      stderr: '',
+      durationMs: 1,
+      executedCommands: ['npm test', 'npm run lint'],
+    };
+    const result = new CursorCliAdapter().parseWorkerOutput(raw);
+    expect(result.success).toBe(true);
+    expect(result.commands).toEqual(expect.arrayContaining(['npm test', 'npm run lint']));
+  });
+
+  it('parses a reviewer verdict from the final stream event', () => {
+    const raw = {
+      exitCode: 0,
+      stdout: JSON.stringify({ type: 'result', result: '{"decision": "approve", "feedback": "clean", "issues": [], "suggestions": []}' }),
+      stderr: '',
+      durationMs: 1,
+    };
+    expect(new CursorCliAdapter().parseReviewerOutput(raw).decision).toBe('approve');
   });
 });


### PR DESCRIPTION
## TL;DR

The AGT-3993 merge landed `cc-router` with **zero** function coverage and `cursor` at 3/11, dropping global function coverage to 89.67% — under the 90% gate. Main's CI is red and every open PR (including #413) is blocked on it. This adds the missing adapter tests; coverage recovers to **90.45%**.

The PR-side Tests check on #412 was misread as green because the job registered late while the merge decision was taken — the gate itself was correct. Process note recorded; the fix here is the tests the new code should have shipped with.

## What's covered

- **cc-router availability contract**: `ok` status AND `openAIResponses` capability required — a reachable router that can't serve the Responses API is an unusable primary, and capability routing depends on this probe being strict
- **Identity**: bearer token only when `CC_ROUTER_TOKEN` is set, never a ChatGPT account id
- **Egress guard**: local `/v1/responses` admitted, remote base URL rejected
- **Model discovery**: id extraction, banner filtering (cursor), env/hardcoded fallbacks, non-OK → `[]`
- **Cursor streaming**: partial-line buffering across chunks (no lost or duplicated events), worker/reviewer result parsing with executed-command merge

## Verification

- `npm run test:coverage`: functions **90.45%** (2357/2606), 311 files / 4,217 tests green
- lint 0/0, pre-commit typecheck clean
- Tests-only diff — per the commit-gate policy the tier-1 review is not required for it

🤖 Generated with [Claude Code](https://claude.com/claude-code)