### PR TITLE
fix(dashboard): stop long metadata values from scrolling the feed sideways (AGT-4006)

### DIFF
--- a/tests/web/orchestrationView.test.ts
+++ b/tests/web/orchestrationView.test.ts
@@ -179,6 +179,9 @@ describe('feed legibility', () => {
     const row = doc.querySelector('#feed .ev')!;
     expect(row.querySelector('.ev-line')!.textContent).toBe('OpenSwarm daemon (daemon) loaded the rule set');
     expect(row.querySelector('.ev-meta')!.textContent).toContain('digest');
+    // The chip truncates visually, so the full value has to survive somewhere
+    // the operator can still reach — otherwise a digest is unreadable.
+    expect(row.querySelector('.chip')!.getAttribute('title')).toBe('digest: c480ceccd832');
     view.stop();
   });
 
@@ -202,6 +205,24 @@ describe('feed legibility', () => {
     expect(feed.querySelector('script')).toBeNull();
     expect(feed.querySelector('img')).toBeNull();
     expect(feed.querySelector('iframe')).toBeNull();
+    view.stop();
+  });
+
+  it('escapes metadata that reaches the chip tooltip', async () => {
+    const doc = shell();
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        events: [boardEvent({ id: 'm', metadata: { 'a"b': '"><img src=x onerror=alert(1)>' } })],
+        pending: [], lastSeq: 1,
+      }),
+    }));
+    const view = startOrchestrationView(doc, { fetchImpl, eventSourceImpl: null, pollMs: 1e9 });
+    await vi.waitFor(() => expect(doc.querySelector('#feed .chip')).not.toBeNull());
+
+    expect(doc.getElementById('feed')!.querySelector('img')).toBeNull();
+    expect(doc.querySelector('#feed .chip')!.getAttribute('title'))
+      .toBe('a"b: "><img src=x onerror=alert(1)>');
     view.stop();
   });
 });

--- a/web/static/js/orchestrationView.mjs
+++ b/web/static/js/orchestrationView.mjs
@@ -218,9 +218,12 @@ function messageBody(event) {
   const detail = event.detail && event.detail !== event.summary
     ? `<div class="ev-detail">${escapeHtml(event.detail)}</div>`
     : '';
+  // Metadata values are frequently long opaque tokens (a content digest, a
+  // correlation id). Rendered raw they force the whole feed to scroll
+  // sideways, so the chip truncates and keeps the full value in its tooltip.
   const meta = pairs.length
     ? `<div class="ev-meta">${pairs.map(([key, value]) =>
-        `<span class="chip"><b>${escapeHtml(key)}</b>${escapeHtml(value)}</span>`).join('')}</div>`
+        `<span class="chip" title="${escapeHtml(`${key}: ${value}`)}"><b>${escapeHtml(key)}</b>${escapeHtml(value)}</span>`).join('')}</div>`
     : '';
   return `<div class="ev-summary">${escapeHtml(event.summary)}</div>${detail}${meta}`;
 }

--- a/web/static/orchestration.html
+++ b/web/static/orchestration.html
@@ -27,12 +27,21 @@
     #legend .row { display: flex; align-items: center; gap: 6px; margin: 2px 0; }
     #legend .swatch { width: 10px; height: 10px; border-radius: 50%; }
     #legend .line { width: 14px; height: 2px; }
-    aside { width: 400px; border-left: 1px solid var(--border); display: flex; flex-direction: column; min-height: 0; }
+    aside { width: 400px; min-width: 0; border-left: 1px solid var(--border); display: flex; flex-direction: column; min-height: 0; }
+    aside > div { min-width: 0; }
+    /* Thin, self-coloured scrollbars: the default chrome is heavy against the
+       dark panel and reads as a defect rather than an affordance. */
+    #feed, .transcript, .ev-detail { scrollbar-width: thin; scrollbar-color: #2a3140 transparent; }
+    #feed::-webkit-scrollbar, .transcript::-webkit-scrollbar, .ev-detail::-webkit-scrollbar { width: 6px; height: 0; }
+    #feed::-webkit-scrollbar-thumb, .transcript::-webkit-scrollbar-thumb, .ev-detail::-webkit-scrollbar-thumb { background: #2a3140; border-radius: 3px; }
+    #feed::-webkit-scrollbar-track, .transcript::-webkit-scrollbar-track, .ev-detail::-webkit-scrollbar-track { background: transparent; }
     aside h2 { font-size: 11px; letter-spacing: 1px; color: var(--dim); padding: 10px 12px 6px; }
     #detail { border-bottom: 1px solid var(--border); padding: 0 12px 10px; font-size: 12px; min-height: 84px; }
     #detail .name { color: var(--cyan); font-weight: 700; }
     #detail .meta { color: var(--dim); font-size: 11px; margin-top: 2px; }
-    #feed { flex: 1 1 40%; overflow-y: auto; padding: 0 6px 10px; min-height: 120px; }
+    /* Long opaque values (digests, ids) must never widen the panel: the feed
+       scrolls vertically only, and its rows are free to break anywhere. */
+    #feed { flex: 1 1 40%; overflow-y: auto; overflow-x: hidden; padding: 0 6px 10px; min-height: 120px; }
     .ev { padding: 6px; border-bottom: 1px solid var(--border); cursor: pointer; border-left: 2px solid transparent; }
     .ev:hover { background: #10141c; }
     .ev.focused { border-left-color: var(--white); background: #131926; }
@@ -40,17 +49,18 @@
     .ev .status { font-weight: 700; }
     .task-chip { color: var(--cyan); border: 1px solid var(--border); border-radius: 3px; padding: 0 4px; font-size: 9px; }
     .clock { color: var(--dim); margin-left: auto; font-variant-numeric: tabular-nums; }
-    .ev-line { font-size: 11px; margin-top: 3px; color: var(--white); }
-    .ev-summary { font-size: 11px; margin-top: 2px; color: #b6bdcc; }
-    .ev-detail { font-size: 10px; margin-top: 3px; color: var(--dim); white-space: pre-wrap; max-height: 6.5em; overflow-y: auto; }
-    .ev-meta { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
-    .chip { font-size: 9px; color: var(--dim); border: 1px solid var(--border); border-radius: 3px; padding: 0 4px; }
+    .ev-line { font-size: 11px; margin-top: 3px; color: var(--white); overflow-wrap: anywhere; }
+    .ev-summary { font-size: 11px; margin-top: 2px; color: #b6bdcc; overflow-wrap: anywhere; }
+    .ev-detail { font-size: 10px; margin-top: 3px; color: var(--dim); white-space: pre-wrap; overflow-wrap: anywhere; max-height: 6.5em; overflow-y: auto; }
+    .ev-meta { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; min-width: 0; }
+    .chip { font-size: 9px; color: var(--dim); border: 1px solid var(--border); border-radius: 3px; padding: 0 4px;
+            max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .chip b { color: #7d879b; font-weight: 600; margin-right: 3px; }
     #thread { flex: 1 1 60%; display: flex; flex-direction: column; min-height: 0; border-top: 1px solid var(--border); }
     .thread-head { display: flex; align-items: center; gap: 6px; padding: 6px 12px; font-size: 10px; border-bottom: 1px solid var(--border); }
     .thread-head .participants { color: var(--dim); margin-left: auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .await-chip { color: #0d1117; background: var(--amber, #e8b339); border-radius: 3px; padding: 0 4px; font-weight: 700; }
-    .transcript { flex: 1; overflow-y: auto; padding: 6px 12px; }
+    .transcript { flex: 1; overflow-y: auto; overflow-x: hidden; padding: 6px 12px; }
     .msg { padding: 6px 0; border-bottom: 1px solid var(--border); }
     .msg.from-operator { border-left: 2px solid #e5484d; padding-left: 6px; }
     .msg-head { display: flex; gap: 6px; align-items: baseline; font-size: 10px; }


### PR DESCRIPTION
## Why

Reported from the live vela dashboard: the event feed had a horizontal scrollbar under it.

Cause: metadata chips rendered their value raw, and a content digest is a 64-character unbreakable token — one `instruction-snapshot` row was wider than the sidebar and dragged the whole feed sideways.

## What changed

- Chips truncate with an ellipsis and keep the full `key: value` in their `title`, so the digest is still readable on hover rather than lost.
- Feed and transcript scroll vertically only (`overflow-x: hidden`), and their flex children are pinned to `min-width: 0` — without that, `min-width: auto` lets one long word widen the panel and the ellipsis never applies.
- Long words in the summary/detail lines break (`overflow-wrap: anywhere`) instead of pushing.
- The remaining vertical scrollbars are thin and panel-coloured; the default chrome read as a defect against the dark surface.

## Verification

- `vitest run tests/web/orchestrationView.test.ts`: 12 passed, including a new case asserting the tooltip is HTML-escaped (metadata is event-fed, so it is untrusted).
- Pre-commit gate: oxlint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)