### PR TITLE
fix(security-audit): report why the audit failed instead of just "failed" (AGT-4010)

### DIFF
--- a/src/agents/securityAuditGate.diagnostics.test.ts
+++ b/src/agents/securityAuditGate.diagnostics.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { SecurityAuditInfrastructureError } from './securityAuditGate.js';
+import type { SecurityAuditResult } from '../verify/securityAudit.js';
+
+function result(over: Partial<SecurityAuditResult> = {}): SecurityAuditResult {
+  return {
+    status: 'failed',
+    codeqlLanguages: ['javascript-typescript'],
+    skippedCodeqlLanguages: [],
+    findings: [],
+    ...over,
+  } as SecurityAuditResult;
+}
+
+describe('SecurityAuditInfrastructureError', () => {
+  it('prefers an explicit detail', () => {
+    expect(new SecurityAuditInfrastructureError(result({ detail: 'pack download refused' })).message)
+      .toBe('security-audit-infra: pack download refused');
+  });
+
+  it('falls back to the recorded error finding rather than the bare status', () => {
+    // Without this the operator saw "security-audit-infra: failed" and had no
+    // way to tell a missing extractor from an unreadable source file.
+    const error = new SecurityAuditInfrastructureError(result({
+      findings: [{ ruleId: 'openswarm/security-codeql-runtime', level: 'error', message: 'CodeQL security audit failed: EACCES /work' }],
+    }));
+    expect(error.message).toBe('security-audit-infra: CodeQL security audit failed: EACCES /work');
+  });
+
+  it('ignores non-error findings when choosing a cause', () => {
+    const error = new SecurityAuditInfrastructureError(result({
+      status: 'unavailable',
+      findings: [{ ruleId: 'note', level: 'warning', message: 'informational' }],
+    }));
+    expect(error.message).toBe('security-audit-infra: unavailable');
+  });
+
+  it('still reports something when there is no result at all', () => {
+    expect(new SecurityAuditInfrastructureError(undefined).message).toBe('security-audit-infra: no result');
+  });
+});

--- a/src/agents/securityAuditGate.ts
+++ b/src/agents/securityAuditGate.ts
@@ -10,7 +10,11 @@ import type { PipelineContext } from './pairPipelineTypes.js';
 
 export class SecurityAuditInfrastructureError extends Error {
   constructor(result: SecurityAuditResult | undefined, detail?: string) {
-    super(`security-audit-infra: ${result?.detail ?? detail ?? result?.status ?? 'no result'}`);
+    // Fall through to the findings before giving up on a cause: a failing audit
+    // records why it failed as a finding, and reporting only `status` told the
+    // operator "failed" with nothing to act on.
+    const fromFindings = result?.findings?.find((finding) => finding.level === 'error')?.message;
+    super(`security-audit-infra: ${result?.detail ?? detail ?? fromFindings ?? result?.status ?? 'no result'}`);
     this.name = 'SecurityAuditInfrastructureError';
   }
 }

--- a/src/verify/securityAudit.ts
+++ b/src/verify/securityAudit.ts
@@ -326,9 +326,14 @@ export async function runSecurityAudit(
         : {}),
     };
   } catch (error) {
+    // Carry the cause in `detail` as well as the finding: callers that gate on
+    // this result report `detail`, so leaving it unset turned every unexpected
+    // failure into a bare "failed" with no way to tell a missing extractor from
+    // an unreadable source file.
+    const cause = shortened(error instanceof Error ? error.message : String(error));
     return { status: 'failed', codeqlLanguages, skippedCodeqlLanguages: [], findings: [{
-      ruleId: 'openswarm/security-codeql-runtime', level: 'error', message: `CodeQL security audit failed: ${shortened(error instanceof Error ? error.message : String(error))}`,
-    }] };
+      ruleId: 'openswarm/security-codeql-runtime', level: 'error', message: `CodeQL security audit failed: ${cause}`,
+    }], detail: cause };
   } finally {
     await snapshot?.cleanup();
   }


### PR DESCRIPTION
## Why

A swarm run on the live vela deployment stopped with exactly this:

```
Pipeline infra error (not counted toward STUCK): security-audit-infra: failed
[Runner] PR not created for AGT-4008: Pipeline failed (infra_error)
```

That word is the entire diagnosis. CodeQL itself was healthy — I reproduced `codeql database create` (660 files extracted) and `codeql database analyze` (105 queries, SARIF written) inside the same container by hand, both clean — so the operator is told the audit failed while every visible signal says it should not have.

## Cause

The cause is recorded and then dropped twice:

1. `runSecurityAudit`'s catch-all writes the real error into `findings[0].message` but leaves `detail` unset.
2. `SecurityAuditInfrastructureError` builds its message from `result.detail`, then falls through to `result.status` — skipping the findings entirely. With `detail` unset, `status` is `'failed'`, and that is what reaches the log.

Every other failure path in `runSecurityAudit` sets `detail`, which is why only unexpected exceptions surface this way — exactly the failures where a cause matters most.

## What changed

- The catch-all sets `detail` to the same cause it puts in the finding.
- The gate consults the first error-level finding before settling for `status`.

## Verification

- 4 new tests covering the precedence chain: explicit detail wins, an error finding is used when detail is absent, non-error findings are ignored, and a missing result still yields a message.
- `vitest run src/verify/securityAudit`: 15 passed (unchanged).
- Pre-commit gate: oxlint + typecheck clean.

Note: this makes the underlying AGT-4008 failure diagnosable; it does not claim to fix it. The next run will name the actual cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)