### PR TITLE
fix(docker): install python3 so the security audit can analyse Python (AGT-4011)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,14 @@ FROM node:22-slim AS production
 # git + gh: workers commit and open PRs. bubblewrap: the verify sandbox —
 # fail-closed under Docker's default seccomp profile; see README for the flags
 # that enable it. curl: healthcheck. dumb-init: PID-1 signal handling.
+# python3 is a runtime dependency, not a build one: the security-audit gate runs
+# CodeQL over every language present in the analysed repository, and CodeQL's
+# Python extractor shells out to an interpreter. Without it a single tracked
+# .py file makes `codeql database create --build-mode=none` fail, which the
+# pipeline reports as an infra error and parks the task.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        dumb-init ca-certificates curl git bubblewrap gnupg && \
+        dumb-init ca-certificates curl git bubblewrap gnupg python3 && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=builder --chown=openswarm:openswarm /app/node_modules ./node_modules
 COPY --from=builder --chown=openswarm:openswarm /app/dist ./dist
 COPY --chown=openswarm:openswarm package.json config.example.yaml ./
 COPY --chown=openswarm:openswarm templates ./templates
+# The repository's CodeQL *configuration*. The CodeQL CLI itself is not shipped:
+# the bundle is roughly a gigabyte and would be carried by every pull, so the
+# image expects it to be provided by the deployment. Without it the security
+# audit reports `unavailable` and the pipeline parks the task rather than
+# skipping the gate — mount a bundle and put it on PATH, e.g.
+#   volumes: [ /opt/codeql-bundle:/opt/codeql:ro ]
+#   environment: [ "PATH=/opt/codeql:/usr/local/bin:/usr/bin:/bin" ]
 COPY --chown=openswarm:openswarm .codeql ./.codeql
 
 # The CLI on PATH; node resolves modules from the symlink target, so this is


### PR DESCRIPTION
## Why

Every swarm task on the container deployment parked at the security gate:

```
Pipeline infra error (not counted toward STUCK): security-audit-infra: failed
[Runner] PR not created for AGT-4008: Pipeline failed (infra_error)
```

The gate fails closed, so this stopped the autonomous loop before the worker stage ever ran. No agent reached the board, which is why the orchestration view had nothing real to show.

## Cause

CodeQL was healthy — inside the same container I ran `codeql database create` (660 files extracted) and `codeql database analyze` (105 queries, SARIF written) by hand, both clean.

Reproducing `runSecurityAudit` itself and reading its findings named the real cause:

```
error | openswarm/security-codeql-python-database | CodeQL could not create its no-build security database.
```

The audit analyses every language present in the repository. This repository tracks one `.py` file (`src/task_state_model.py`), so CodeQL runs its Python extractor — and that extractor shells out to an interpreter which a `node:22-slim` runtime does not ship. `which python3` in the container returned nothing.

The builder stage already installs `python3` (for native module builds); the runtime stage did not.

## Verification

Installed `python3` into the running container and re-ran the identical audit:

| | before | after |
|---|---|---|
| status | `failed` | `findings` |
| infrastructure findings | `openswarm/security-codeql-python-database` | none |

`findings` is the healthy outcome — the audit completed and reported real code findings rather than an infrastructure failure.

## Related

PR #419 (merged) is what made this diagnosable: the cause was recorded in the findings but discarded before reaching the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)