### PR TITLE
fix(linear): report a failed issue lookup instead of calling it "not found" (AGT-4012)

### DIFF
--- a/src/automation/workRunner.lookup.test.ts
+++ b/src/automation/workRunner.lookup.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// dispatchWork checks the project path exists before any lookup, so the test
+// needs a real directory rather than a placeholder string.
+const repo = mkdtempSync(join(tmpdir(), 'work-dispatch-'));
+afterAll(() => rmSync(repo, { recursive: true, force: true }));
+
+const linear = vi.hoisted(() => ({
+  isLinearInitialized: vi.fn(() => true),
+  lookupIssue: vi.fn(),
+  getIssue: vi.fn(),
+  updateIssueState: vi.fn(async () => true),
+}));
+vi.mock('../linear/linear.js', () => linear);
+vi.mock('../support/repoMetadata.js', () => ({
+  loadRepoMetadata: vi.fn(async () => ({ linear: { projectId: 'proj-1' } })),
+}));
+vi.mock('../orchestration/decisionEngine.js', () => ({
+  linearIssueToTask: (issue: { id: string; title: string }) => ({ id: issue.id, title: issue.title }),
+  normalizeProjectPath: (path: string) => path,
+}));
+
+const { dispatchWork } = await import('./workRunner.js');
+
+// dispatchWork probes the runner with an empty batch first, to fail fast when
+// the daemon is not configured for queued work.
+const runner = {
+  getAllowedProjects: () => [repo],
+  enqueueIssues: vi.fn(async () => undefined),
+} as never;
+
+describe('dispatchWork lookup reporting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    linear.isLinearInitialized.mockReturnValue(true);
+    linear.updateIssueState.mockResolvedValue(true);
+  });
+
+  it('names the credential failure instead of blaming the issue', async () => {
+    // An expired token used to surface as "not found", which sent the operator
+    // looking for a missing issue that was there the whole time.
+    linear.lookupIssue.mockResolvedValue({
+      ok: false,
+      error: 'Authentication required, not authenticated',
+    });
+
+    const result = await dispatchWork(runner, { issueIds: ['AGT-1'], projectPath: repo });
+
+    expect(result.items[0]).toMatchObject({ issueId: 'AGT-1', status: 'skipped' });
+    expect(result.items[0].reason).toContain('Linear lookup failed');
+    expect(result.items[0].reason).toContain('Authentication required');
+    expect(result.queued).toBe(0);
+  });
+
+  it('still reports a genuinely missing issue as not found', async () => {
+    linear.lookupIssue.mockResolvedValue({ ok: true, issue: null });
+
+    const result = await dispatchWork(runner, { issueIds: ['AGT-2'], projectPath: repo });
+
+    expect(result.items[0].reason).toBe('not found');
+  });
+});

--- a/src/automation/workRunner.test.ts
+++ b/src/automation/workRunner.test.ts
@@ -2,13 +2,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { homedir } from 'node:os';
 import type { AutonomousRunner } from './autonomousRunner.js';
 
-const linear = vi.hoisted(() => ({
+const linear = vi.hoisted(() => {
+  const getIssue = vi.fn(async (_id: string): Promise<Record<string, unknown> | null> => null);
+  return {
   isLinearInitialized: vi.fn(() => true),
-  getIssue: vi.fn(async (_id: string): Promise<Record<string, unknown> | null> => null),
+  getIssue,
+  // Dispatch resolves issues through `lookupIssue` so a failed lookup is
+  // reported as such rather than as a missing issue. These cases all exercise
+  // successful lookups, so delegate and keep asserting on `getIssue`; the
+  // failure branch has its own suite.
+  lookupIssue: vi.fn(async (id: string) => ({ ok: true as const, issue: await getIssue(id) })),
   updateIssueState: vi.fn(async () => true),
   fetchIssuesForStates: vi.fn(async () => ({ nodes: [] as Array<Record<string, unknown>> })),
   getClient: vi.fn(() => ({}) as never),
-}));
+  };
+});
 vi.mock('../linear/linear.js', () => linear);
 
 const { loadRepoMetadataImpl } = vi.hoisted(() => ({

--- a/src/automation/workRunner.ts
+++ b/src/automation/workRunner.ts
@@ -203,7 +203,15 @@ export async function dispatchWork(
   const claimedByUs = new Map<string, 'Todo' | 'Backlog'>();
 
   for (const rawId of request.issueIds) {
-    const issue = await linear.getIssue(rawId);
+    // Distinguish a missing issue from a failed lookup: an expired Linear
+    // token used to be reported as `not found`, pointing the operator at the
+    // issue instead of at the credential.
+    const lookup = await linear.lookupIssue(rawId);
+    if (!lookup.ok) {
+      items.push({ issueId: rawId, status: 'skipped', reason: `Linear lookup failed: ${lookup.error}` });
+      continue;
+    }
+    const issue = lookup.issue;
     if (!issue) {
       items.push({ issueId: rawId, status: 'skipped', reason: 'not found' });
       continue;

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -748,13 +748,48 @@ export async function getMyIssues(
 }
 
 /**
+ * Outcome of an issue lookup, separating "this issue does not exist" from "the
+ * lookup could not be performed".
+ *
+ * `getIssue` collapses both into `null`, which reads as "no such issue" at
+ * every call site. An expired Linear token then surfaced to the operator as
+ * `skipped: not found` on dispatch — a report that points at the issue instead
+ * of at the credential that actually failed.
+ */
+export type IssueLookup =
+  | { ok: true; issue: LinearIssueInfo | null }
+  | { ok: false; error: string };
+
+/**
+ * Get a specific issue by ID or identifier, reporting lookup failures instead
+ * of folding them into a missing issue. Prefer this over `getIssue` wherever
+ * the distinction reaches a human.
+ */
+export async function lookupIssue(issueIdOrIdentifier: string): Promise<IssueLookup> {
+  if (!isLinearInitialized()) return { ok: false, error: 'Linear client is not initialized' };
+  try {
+    return { ok: true, issue: await fetchIssue(issueIdOrIdentifier) };
+  } catch (error) {
+    // Fixed first argument: the id is user-supplied (reachable from the
+    // /api/work HTTP surface), and console's printf-style formatting must
+    // never receive a tainted format string (CodeQL js/tainted-format-string).
+    console.error('[Linear] getIssue error:', issueIdOrIdentifier, error);
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
  * Get a specific issue by ID or identifier
  */
 export async function getIssue(issueIdOrIdentifier: string): Promise<LinearIssueInfo | null> {
-  if (!isLinearInitialized()) return null;
+  const result = await lookupIssue(issueIdOrIdentifier);
+  return result.ok ? result.issue : null;
+}
+
+async function fetchIssue(issueIdOrIdentifier: string): Promise<LinearIssueInfo | null> {
   const linear = getClient();
 
-  try {
+  {
     // Check if it's an identifier format (e.g., LIN-123)
     const isIdentifier = /^[A-Z]+-\d+$/.test(issueIdOrIdentifier);
 
@@ -822,12 +857,6 @@ export async function getIssue(issueIdOrIdentifier: string): Promise<LinearIssue
       blockedBy: blockedBy.size > 0 ? [...blockedBy] : undefined,
       createdAt: issue.createdAt instanceof Date ? issue.createdAt.toISOString() : undefined,
     };
-  } catch (error) {
-    // Fixed first argument: the id is user-supplied (reachable from the
-    // /api/work HTTP surface), and console's printf-style formatting must
-    // never receive a tainted format string (CodeQL js/tainted-format-string).
-    console.error('[Linear] getIssue error:', issueIdOrIdentifier, error);
-    return null;
   }
 }
 


### PR DESCRIPTION
## Why

The daemon's Linear OAuth token expired on the container deployment. Every dispatch then returned:

```json
{"issueId": "AGT-4008", "status": "skipped", "reason": "not found"}
```

The issue existed the whole time. Finding that out took reading the daemon's stderr, where the real error was sitting:

```
[Linear] getIssue error: AGT-4008 Error: Authentication required, not authenticated
```

`getIssue` catches every API error and returns `null`, and `null` is indistinguishable from a missing issue at the call site. So an expired credential was reported as a missing issue — pointing the operator at Linear's contents rather than at the daemon's authentication. For an autonomous loop this is the difference between "someone deleted my ticket" and "re-authenticate".

## What changed

- `lookupIssue` returns `{ ok: true, issue }` or `{ ok: false, error }`, separating "no such issue" from "the lookup could not be performed".
- `getIssue` delegates to it and keeps its `null` contract, so callers that only need presence are untouched.
- `dispatchWork` uses `lookupIssue` and reports `Linear lookup failed: <cause>`.

## Verification

- 2 new tests: a lookup failure names the credential error rather than the issue; a genuinely missing issue still reports `not found`.
- `vitest run src/automation/workRunner`: 25 passed. The existing dispatch suite mocked `getIssue`, so its mock now provides `lookupIssue` delegating to it — the assertions on `getIssue` are unchanged and still exercise the production path.
- `vitest run src/linear/`: 20 passed.
- oxlint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)