### PR TITLE
fix(worker): let a scoped task write its own tests (AGT-4014)

### DIFF
--- a/src/agents/worker.scope.test.ts
+++ b/src/agents/worker.scope.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { reconcileWorkerFiles } from './worker.js';
+
+const scope = ['src/support/web.ts'];
+
+describe('worker file scope', () => {
+  it('admits the tests for a file the worker may already rewrite', () => {
+    // A task scoped to one source file, whose completion criteria demand tests,
+    // otherwise rejects the worker for writing them — and the retry writes them
+    // again. A real run burned all five iterations on exactly this.
+    const { outsideScope } = reconcileWorkerFiles([
+      'src/support/web.ts',
+      'src/support/web.test.ts',
+      'src/support/web.githubRepos.test.ts',
+      'src/support/web.spec.ts',
+    ], scope);
+    expect(outsideScope).toEqual([]);
+  });
+
+  it('does not admit a test for a different file in the same directory', () => {
+    const { outsideScope } = reconcileWorkerFiles(['src/support/staticAssets.test.ts'], scope);
+    expect(outsideScope).toEqual(['src/support/staticAssets.test.ts']);
+  });
+
+  it('does not admit a same-named test in another directory', () => {
+    const { outsideScope } = reconcileWorkerFiles(['tests/web.test.ts'], scope);
+    expect(outsideScope).toEqual(['tests/web.test.ts']);
+  });
+
+  it('does not admit a non-test neighbour that merely shares the base name', () => {
+    const { outsideScope } = reconcileWorkerFiles([
+      'src/support/web.helpers.ts',
+      'src/support/webSocket.ts',
+    ], scope);
+    expect(outsideScope).toEqual(['src/support/web.helpers.ts', 'src/support/webSocket.ts']);
+  });
+
+  it('keeps directory scope working', () => {
+    const { outsideScope } = reconcileWorkerFiles(
+      ['src/coordination/store.ts', 'src/agents/worker.ts'],
+      ['src/coordination'],
+    );
+    expect(outsideScope).toEqual(['src/agents/worker.ts']);
+  });
+
+  it('treats an empty scope as unrestricted, as before', () => {
+    const { outsideScope } = reconcileWorkerFiles(['anything.ts'], []);
+    expect(outsideScope).toEqual([]);
+  });
+
+  it('reports every changed file regardless of scope', () => {
+    const { filesChanged } = reconcileWorkerFiles(['src/support/web.ts', 'other.ts'], scope);
+    expect(filesChanged).toEqual(['src/support/web.ts', 'other.ts']);
+  });
+});

--- a/src/agents/worker.scope.test.ts
+++ b/src/agents/worker.scope.test.ts
@@ -22,6 +22,19 @@ describe('worker file scope', () => {
     expect(outsideScope).toEqual(['src/support/staticAssets.test.ts']);
   });
 
+  it('does not admit a subdirectory ride on a dotted infix', () => {
+    // `.+` in the infix would have let a crafted path escape the directory:
+    // src/support/web.x/evil/deep.test.ts matched a scope of src/support/web.ts.
+    const { outsideScope } = reconcileWorkerFiles([
+      'src/support/web.x/evil/deep.test.ts',
+      'src/support/web.helpers/inner.spec.ts',
+    ], scope);
+    expect(outsideScope).toEqual([
+      'src/support/web.x/evil/deep.test.ts',
+      'src/support/web.helpers/inner.spec.ts',
+    ]);
+  });
+
   it('does not admit a same-named test in another directory', () => {
     const { outsideScope } = reconcileWorkerFiles(['tests/web.test.ts'], scope);
     expect(outsideScope).toEqual(['tests/web.test.ts']);

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -141,7 +141,9 @@ function isTestForScopedFile(file: string, scoped: string): boolean {
   if (!match) return false;
   const [, dir, base, ext] = match;
   const escape = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp(`^${escape(dir)}${escape(base)}(\\..+)?\\.(test|spec)\\.${escape(ext)}$`).test(file);
+  // [^/] keeps the infix inside the same directory: `.+` would let
+  // `src/a.x/evil/deep.test.ts` ride on a scope of `src/a.ts`.
+  return new RegExp(`^${escape(dir)}${escape(base)}(\\.[^/]+)?\\.(test|spec)\\.${escape(ext)}$`).test(file);
 }
 
 export function reconcileWorkerFiles(

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -123,14 +123,38 @@ export function loadWorkerRepoRules(projectPath: string): string {
 }
 
 /** Keep Git as the sole changed-file authority and enforce planner scope. */
+/**
+ * Does `file` test `scoped`?
+ *
+ * A task scoped to `src/support/web.ts` whose completion criteria demand tests
+ * has nowhere to put them: the test file is outside the declared scope, the
+ * worker is rejected for writing it, and the retry writes it again. That
+ * contradiction burned every iteration of a real run without ever reaching the
+ * reviewer.
+ *
+ * The allowance is deliberately narrow — same directory, same base name, a
+ * `.test`/`.spec` suffix, same extension — so it admits the tests for a file
+ * the worker may already rewrite, and nothing else.
+ */
+function isTestForScopedFile(file: string, scoped: string): boolean {
+  const match = scoped.match(/^(.*?)([^/]+)\.([cm]?[jt]sx?)$/);
+  if (!match) return false;
+  const [, dir, base, ext] = match;
+  const escape = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^${escape(dir)}${escape(base)}(\\..+)?\\.(test|spec)\\.${escape(ext)}$`).test(file);
+}
+
 export function reconcileWorkerFiles(
   gitChangedFiles: string[],
   fileScope: string[] = [],
 ): { filesChanged: string[]; outsideScope: string[] } {
   const filesChanged = [...gitChangedFiles];
   const scope = fileScope.map((file) => file.replace(/^\.\//, '').replace(/\/$/, ''));
-  const outsideScope = scope.length === 0 ? [] : filesChanged.filter((file) =>
-    !scope.some((allowed) => file === allowed || file.startsWith(`${allowed}/`)));
+  const inScope = (file: string): boolean => scope.some((allowed) =>
+    file === allowed
+    || file.startsWith(`${allowed}/`)
+    || isTestForScopedFile(file, allowed));
+  const outsideScope = scope.length === 0 ? [] : filesChanged.filter((file) => !inScope(file));
   return { filesChanged, outsideScope };
 }
 


### PR DESCRIPTION
## Why

A live run of AGT-4008 on the vela deployment spent every one of its five iterations on the same rejection, then failed:

```
Worker failed, retrying... (worker-scope: changed files outside declared fileScope: src/support/web.githubRepos.test.ts)
Iteration 3/5 … Iteration 5/5
Max iterations (5) exceeded
Total cost: 423.3k in / 6.8k out (351.7k cached) | 177.5s
[Runner] PR not created for AGT-4008: Pipeline failed (failed)
```

The issue's completion criteria demand tests ("Automated tests cover the required status/error/security cases"). Its declared `fileScope` is `src/support/web.ts` and nothing else. So the worker wrote the test, was rejected for writing it, retried with an escalated model, wrote it again — five times, never once reaching the reviewer.

The task could not converge. Not because the work was hard: because its scope contradicted its own requirements. Any decomposed sub-issue that asks for tests hits this.

## What changed

Treat the tests for an in-scope source file as in scope.

The allowance is deliberately narrow — same directory, same base name, a `.test`/`.spec` suffix, same extension — so it admits exactly the tests for a file the worker is already permitted to rewrite. `src/support/web.ts` in scope admits `web.test.ts`, `web.spec.ts`, and `web.githubRepos.test.ts`; it does not admit `staticAssets.test.ts`, `tests/web.test.ts`, `web.helpers.ts`, or `webSocket.ts`.

## Verification

- 7 new tests, four of which assert the boundary stays closed: a test for a different file, a same-named test in another directory, a non-test neighbour sharing the base name, and directory-scope behaviour unchanged. Empty scope stays unrestricted, and every changed file is still reported regardless of scope.
- `vitest run src/agents/worker`: 101 passed.
- oxlint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)