### PR TITLE
fix(trace): keep the durable trace out of the operator's database in tests (AGT-4015)

### DIFF
--- a/src/adapters/processTree.windows.test.ts
+++ b/src/adapters/processTree.windows.test.ts
@@ -67,7 +67,10 @@ describe.runIf(process.platform === 'win32')('Windows Job Object process ownersh
     expect(Buffer.concat(stderr).toString('utf8')).toBe('');
     expect(code).toBe(0);
     expect(JSON.parse(Buffer.concat(stdout).toString('utf8'))).toEqual(expectedArgs);
-  }, 15_000);
+  // Three process starts deep (supervisor -> .cmd shim -> node) on a Windows
+  // runner: 15s is the observed edge, not a budget. This timed out at 15017ms
+  // in CI and passed on rerun, blocking unrelated pull requests each time.
+  }, 60_000);
 
   it('drains a large native stdout stream without truncating its tail', async () => {
     const outputBytes = 2 * 1024 * 1024;

--- a/src/coordination/coordinationTrace.test.ts
+++ b/src/coordination/coordinationTrace.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -85,9 +85,23 @@ describe('coordination trace', () => {
     expect(queryTrace({ actor: 'worker-a' }).map((item) => item.id).sort()).toEqual(['a', 'b']);
   });
 
+  it('creates the state directory rather than degrading on a fresh install', () => {
+    // better-sqlite3 will not create the parent directory, and ~/.openswarm
+    // does not exist before the first run — without the mkdir the trace was
+    // silently unavailable on exactly the deployments that had recorded
+    // nothing yet.
+    resetTraceDbForTests();
+    process.env.OPENSWARM_AUTOMATION_DB = join(root, 'never-created', 'automation.db');
+    recordTraceEvent(event({ id: 'fresh' }));
+    expect(queryTrace().map((item) => item.id)).toEqual(['fresh']);
+  });
+
   it('returns an empty trace instead of throwing when the database cannot open', () => {
     resetTraceDbForTests();
-    process.env.OPENSWARM_AUTOMATION_DB = join(root, 'missing-dir', 'automation.db');
+    // A path whose parent is a regular file: mkdir cannot fix that, so the
+    // trace has to degrade rather than take the publish down with it.
+    writeFileSync(join(root, 'blocker'), 'not a directory');
+    process.env.OPENSWARM_AUTOMATION_DB = join(root, 'blocker', 'automation.db');
     expect(() => recordTraceEvent(event())).not.toThrow();
     expect(queryTrace()).toEqual([]);
   });

--- a/src/coordination/coordinationTrace.ts
+++ b/src/coordination/coordinationTrace.ts
@@ -15,8 +15,9 @@
 // The trace is an archive, not a control path: a failure to record must never
 // fail the publish that produced the event.
 
+import { mkdirSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { defaultAutomationDbPath } from '../automation/automationDbPath.js';
 import { enableWalWithRetry } from '../support/sqliteWal.js';
 import type Database from 'better-sqlite3';
@@ -88,7 +89,13 @@ export function getTraceDb(): Database.Database | null {
   if (unavailable) return null;
   try {
     const Sqlite = require('better-sqlite3') as typeof Database;
-    const handle = new Sqlite(defaultAutomationDbPath());
+    const path = defaultAutomationDbPath();
+    // better-sqlite3 will not create the parent directory, and the state
+    // directory does not exist on a fresh install — without this the trace
+    // silently degrades to unavailable on exactly the deployments that have
+    // never recorded anything.
+    mkdirSync(dirname(path), { recursive: true });
+    const handle = new Sqlite(path);
     handle.pragma('busy_timeout = 5000');
     enableWalWithRetry(handle, 5000);
     migrate(handle);

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -11,3 +11,9 @@ process.env.OPENSWARM_CHAT_DIR = join(tmpdir(), 'openswarm-test-chat');
 // without this they append fixture events to the operator's live
 // ~/.openswarm/coordination.json.
 process.env.OPENSWARM_COORDINATION_FILE = join(tmpdir(), 'openswarm-test-coordination', 'events.json');
+
+// The board mirrors every published event into the automation database, so the
+// same suites that write fixture events would otherwise append them to the
+// operator's live ~/.openswarm/automation.db — and pay a synchronous SQLite
+// write for each one, which is slow enough at suite scale to matter.
+process.env.OPENSWARM_AUTOMATION_DB = join(tmpdir(), 'openswarm-test-automation', 'automation.db');


### PR DESCRIPTION
## Why

Two CI problems, both blocking unrelated pull requests.

**1. The trace writes to the operator's real database during tests.** The board mirrors every published event into the automation database (#417), and `vitest.setup.ts` redirects the coordination board but not that database. Suites exercising the real store therefore appended fixture events to the live `~/.openswarm/automation.db`. Measured on this machine:

```
coordination_trace rows in the real DB: 327
  repo: /a
  repo: /b
  repo: /repo
  repo: /var/folders/.../osw-review-job-NSpyl9
```

Each of those is a synchronous SQLite write on a hot path the suite hits repeatedly — a plausible contributor to `Tests` reaching its 20-minute wall on #411 and #421, which is what sent me looking.

**2. The trace never opened on a fresh install.** better-sqlite3 does not create the parent directory and `~/.openswarm` does not exist before a first run, so the trace silently degraded to `unavailable` on exactly the deployments that had recorded nothing yet. The run ledger already creates it; the trace did not.

## What changed

- `vitest.setup.ts` redirects `OPENSWARM_AUTOMATION_DB` to a temp path, the same way it already redirects the board.
- `getTraceDb` creates the state directory before opening.
- The Windows shim round-trip test gets 60s. It failed at 15017ms against its own 15s budget on a PR touching nothing it exercises, and passed on rerun — twice this week. It starts three processes in sequence (supervisor → `.cmd` shim → node), so 15s is the observed edge, not a budget its assertions depend on.

## Verification

Measured before and after a coordination + pipeline run:

| | real `~/.openswarm/automation.db` | temp database |
|---|---|---|
| before | 327 rows | — |
| after | 327 rows | 41 rows |

- New test: a database path whose directory does not exist now records and reads back, instead of degrading.
- The existing degradation test now uses a path whose parent is a regular file, which `mkdir` genuinely cannot fix — the old path was one `mkdir` away from working and no longer proved anything.
- `vitest run src/coordination/ src/agents/pairPipeline`: 130 passed.
- oxlint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)