### PR TITLE
fix(adapters): prove process-group ownership before any group signal (AGT-4011)

### DIFF
--- a/src/adapters/base.spawn.test.ts
+++ b/src/adapters/base.spawn.test.ts
@@ -23,7 +23,9 @@ describe('CLI process tree termination', () => {
     const processKill = vi.spyOn(process, 'kill').mockImplementation(() => true);
     const directKill = vi.fn(() => true);
 
-    terminateCliProcessTree({ pid: 7654, kill: directKill } as never, 'linux');
+    // The lookup answers "7654 leads its own group and is our child": only
+    // then may the whole group be signalled.
+    terminateCliProcessTree({ pid: 7654, kill: directKill } as never, 'linux', () => ({ pgid: 7654, ppid: process.pid }));
 
     expect(processKill).toHaveBeenCalledWith(-7654, 'SIGKILL');
     expect(directKill).not.toHaveBeenCalled();
@@ -35,7 +37,7 @@ describe('CLI process tree termination', () => {
     });
     const directKill = vi.fn(() => true);
 
-    terminateCliProcessTree({ pid: 7655, kill: directKill } as never, 'linux');
+    terminateCliProcessTree({ pid: 7655, kill: directKill } as never, 'linux', () => ({ pgid: 7655, ppid: process.pid }));
 
     expect(directKill).toHaveBeenCalledWith('SIGKILL');
   });
@@ -126,11 +128,11 @@ describe('CLI process tree termination', () => {
     process.emit('SIGINT', 'SIGINT');
 
     expect(gracefulShutdown).toHaveBeenCalledOnce();
-    expect(processKill).toHaveBeenCalledWith(-7659, 'SIGKILL');
+    expect(processKill).not.toHaveBeenCalledWith(-7659, 'SIGKILL');
     expect(processKill).not.toHaveBeenCalledWith(process.pid, 'SIGINT');
   });
 
-  it.skipIf(process.platform === 'win32')('kills the POSIX process group on AbortSignal and removes parent hooks', async () => {
+  it.skipIf(process.platform === 'win32')('refuses the group signal for an unverifiable pid on AbortSignal and removes parent hooks', async () => {
     const proc = Object.assign(new EventEmitter(), {
       pid: 7658,
       stdout: new PassThrough(),
@@ -167,7 +169,12 @@ describe('CLI process tree termination', () => {
     controller.abort(new Error('cancelled by test'));
 
     await expect(running).rejects.toThrow('cancelled by test');
-    expect(processKill).toHaveBeenCalledWith(-7658, 'SIGKILL');
+    // 7658 is fabricated: the ownership lookup cannot verify it leads a group,
+    // so the group signal must NOT be sent — kill(-fakepid, SIGKILL) from this
+    // very suite once wiped the operator's login session. The direct handle is
+    // still killed.
+    expect(processKill).not.toHaveBeenCalledWith(-7658, 'SIGKILL');
+    expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
     expect(process.listenerCount('SIGINT')).toBe(beforeSigint);
     expect(process.listenerCount('SIGTERM')).toBe(beforeSigterm);
   });
@@ -270,7 +277,10 @@ describe('argv-safe adapter spawning', () => {
     await expect(spawnCli(adapter, { prompt: 'hello', cwd: process.cwd() }))
       .resolves.toMatchObject({ exitCode: 0 });
     expect(Date.now() - started).toBeLessThan(2_000);
-    expect(processKill).toHaveBeenCalledWith(-125, 'SIGKILL');
+    // Unverifiable pid: the tree teardown must fall back to the direct handle
+    // instead of signalling a group it cannot prove it owns.
+    expect(processKill).not.toHaveBeenCalledWith(-125, 'SIGKILL');
+    expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
   });
 
   it('hard-times-out command construction that ignores AbortSignal and handles its late rejection', async () => {

--- a/src/adapters/codexUserMcp.test.ts
+++ b/src/adapters/codexUserMcp.test.ts
@@ -108,16 +108,27 @@ describe('codex inherited MCP isolation (AGT-3990)', () => {
     const pidFile = join(root, 'pid');
     try {
       mkdirSync(bin);
-      writeFileSync(executable, '#!/bin/sh\ntrap "" TERM\necho $$ > "$MCP_PID_FILE"\nwhile :; do sleep 1; done\n');
+      writeFileSync(executable, [
+        '#!/bin/sh',
+        '[ -n "$MCP_WARMUP" ] && exit 0',
+        'trap "" TERM',
+        'echo $$ > "$MCP_PID_FILE"',
+        'while :; do sleep 1; done',
+        '',
+      ].join('\n'));
       chmodSync(executable, 0o755);
+      // macOS scans a freshly written executable on its first exec (measured
+      // 200-400ms), longer than the timeout under test — the fixture would be
+      // killed before it even starts. One throwaway exec warms that cache.
+      execFileSync(executable, { env: { ...process.env, MCP_WARMUP: '1' } });
       const childEnv = {
         ...process.env,
         PATH: `${bin}:${process.env.PATH ?? ''}`,
         MCP_PID_FILE: pidFile,
       };
 
-      await expect(runCodexMcpListJson(root, childEnv, undefined, 100)).rejects.toThrow(
-        'codex mcp list timed out after 100ms',
+      await expect(runCodexMcpListJson(root, childEnv, undefined, 500)).rejects.toThrow(
+        'codex mcp list timed out after 500ms',
       );
       expect(existsSync(pidFile)).toBe(true);
       const pid = Number.parseInt(readFileSync(pidFile, 'utf-8'), 10);

--- a/src/adapters/processTree.groupSafety.test.ts
+++ b/src/adapters/processTree.groupSafety.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import {
+  signalCliProcessTree,
+  terminateCliProcessTree,
+  trackCliProcessTree,
+  untrackCliProcessTree,
+} from './processTree.js';
+
+// What went wrong: unit tests handed fabricated pids (1, 321) to the close
+// handler, which group-killed them via process.kill(-pid, SIGKILL). kill(-1)
+// addresses every process the user may signal — it wiped the operator's whole
+// login session twice and severed the SSH connection running the suite on a
+// remote host. These tests pin the ownership proof that prevents it.
+
+afterEach(() => vi.restoreAllMocks());
+
+function proc(pid: number | undefined) {
+  return { pid, kill: vi.fn(() => true) } as never;
+}
+
+describe('process-group signalling ownership proof', () => {
+  it('never addresses pid 1 as a group, even if a lookup claims it leads one', () => {
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const target = proc(1);
+    signalCliProcessTree(target, 'SIGKILL', 'linux', () => ({ pgid: 1, ppid: process.pid }));
+    expect(kill).not.toHaveBeenCalled();
+    expect((target as { kill: ReturnType<typeof vi.fn> }).kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('never group-signals our own process', () => {
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const self = proc(process.pid);
+    signalCliProcessTree(self, 'SIGTERM', 'linux', () => ({ pgid: process.pid, ppid: 1 }));
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('refuses the group when the pid does not lead it', () => {
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const target = proc(4242);
+    // The OS says 4242 belongs to group 999: killing -4242 would address
+    // whoever owns that number now, not our child.
+    signalCliProcessTree(target, 'SIGKILL', 'linux', () => ({ pgid: 999, ppid: process.pid }));
+    expect(kill).not.toHaveBeenCalled();
+    expect((target as { kill: ReturnType<typeof vi.fn> }).kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('refuses a live group leader that is not our child', () => {
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const target = proc(4248);
+    // A fabricated pid can collide with a real, unrelated session leader.
+    // Leading a group is not enough — the process must also be OUR child.
+    signalCliProcessTree(target, 'SIGKILL', 'linux', () => ({ pgid: 4248, ppid: 1 }));
+    expect(kill).not.toHaveBeenCalled();
+    expect((target as { kill: ReturnType<typeof vi.fn> }).kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('refuses an exited pid that was never tracked as our detached leader', () => {
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const target = proc(4243);
+    signalCliProcessTree(target, 'SIGKILL', 'linux', () => null);
+    expect(kill).not.toHaveBeenCalled();
+    expect((target as { kill: ReturnType<typeof vi.fn> }).kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('group-kills a verified detached child', () => {
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    terminateCliProcessTree(proc(4244), 'linux', () => ({ pgid: 4244, ppid: process.pid }));
+    expect(kill).toHaveBeenCalledWith(-4244, 'SIGKILL');
+  });
+
+  it('sweeps an exited leader\'s orphans individually, never by group signal', () => {
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const target = proc(4246);
+    // Track time: alive, leads its own group, our direct child.
+    trackCliProcessTree(target, () => ({ pgid: 4246, ppid: process.pid }));
+    try {
+      // Kill time: the leader already exited (the OS has nothing to report),
+      // but its orphaned descendants keep the group id reserved. They are
+      // signalled one pid at a time; kill(-pgid) must never fire post-mortem.
+      const listMembers = vi.fn()
+        .mockReturnValueOnce([
+          { pid: 6001, elapsedMs: 60_000 },
+          { pid: 6002, elapsedMs: 45_000 },
+        ])
+        .mockReturnValue([]);
+      signalCliProcessTree(target, 'SIGKILL', 'linux', () => null, listMembers);
+      expect(kill).toHaveBeenCalledWith(6001, 'SIGKILL');
+      expect(kill).toHaveBeenCalledWith(6002, 'SIGKILL');
+      expect(kill).not.toHaveBeenCalledWith(-4246, 'SIGKILL');
+      // Second enumeration catches descendants forked mid-sweep.
+      expect(listMembers).toHaveBeenCalledTimes(2);
+    } finally {
+      untrackCliProcessTree(target);
+    }
+  });
+
+  it('skips group members younger than the leader\'s death (recycled group id)', () => {
+    vi.useFakeTimers();
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const exitListeners: Array<() => void> = [];
+    const target = {
+      pid: 4249,
+      kill: vi.fn(() => true),
+      once: (event: string, listener: () => void) => {
+        if (event === 'exit') exitListeners.push(listener);
+      },
+    } as never;
+    trackCliProcessTree(target, () => ({ pgid: 4249, ppid: process.pid }));
+    try {
+      for (const listener of exitListeners) listener();
+      // The kill arrives 10s after the leader died. A member only 4s old was
+      // born after that death: the group id was recycled — leak, never misfire.
+      vi.setSystemTime(Date.now() + 10_000);
+      signalCliProcessTree(target, 'SIGKILL', 'linux', () => null, () => [
+        { pid: 6100, elapsedMs: 4_000 },
+      ]);
+      expect(kill).not.toHaveBeenCalled();
+      expect((target as { kill: ReturnType<typeof vi.fn> }).kill).toHaveBeenCalledWith('SIGKILL');
+    } finally {
+      untrackCliProcessTree(target);
+      vi.useRealTimers();
+    }
+  });
+
+  it('still sweeps a member that predates the leader\'s death long after it', () => {
+    vi.useFakeTimers();
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const exitListeners: Array<() => void> = [];
+    const target = {
+      pid: 4250,
+      kill: vi.fn(() => true),
+      once: (event: string, listener: () => void) => {
+        if (event === 'exit') exitListeners.push(listener);
+      },
+    } as never;
+    trackCliProcessTree(target, () => ({ pgid: 4250, ppid: process.pid }));
+    try {
+      for (const listener of exitListeners) listener();
+      vi.setSystemTime(Date.now() + 10_000);
+      const listMembers = vi.fn()
+        .mockReturnValueOnce([{ pid: 6200, elapsedMs: 30_000 }])
+        .mockReturnValue([]);
+      signalCliProcessTree(target, 'SIGKILL', 'linux', () => null, listMembers);
+      expect(kill).toHaveBeenCalledWith(6200, 'SIGKILL');
+      expect(kill).not.toHaveBeenCalledWith(-4250, 'SIGKILL');
+    } finally {
+      untrackCliProcessTree(target);
+      vi.useRealTimers();
+    }
+  });
+
+  it('records no track-time ownership for a child that is not ours', () => {
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const target = proc(4247);
+    trackCliProcessTree(target, () => ({ pgid: 4247, ppid: 999 }));
+    try {
+      signalCliProcessTree(target, 'SIGKILL', 'linux', () => null);
+      expect(kill).not.toHaveBeenCalled();
+      expect((target as { kill: ReturnType<typeof vi.fn> }).kill).toHaveBeenCalledWith('SIGKILL');
+    } finally {
+      untrackCliProcessTree(target);
+    }
+  });
+});

--- a/src/adapters/processTree.ts
+++ b/src/adapters/processTree.ts
@@ -1,4 +1,6 @@
 import type { ChildProcess } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { win32 } from 'node:path';
 
@@ -334,8 +336,35 @@ const relayParentSignal = (signal: NodeJS.Signals): void => {
 const onParentSigint = (): void => relayParentSignal('SIGINT');
 const onParentSigterm = (): void => relayParentSignal('SIGTERM');
 
-export function trackCliProcessTree(proc: KillableProcess): void {
+// Group ownership proven while the child was alive. A detached child leads its
+// own group (pgid == pid) and is our direct child (ppid == us); once that
+// leader exits, /proc and ps(1) have nothing left to report, yet its orphaned
+// descendants keep the group id reserved and are reachable only by the group
+// signal. Keyed by the handle in a WeakMap so callers that untrack before
+// terminating (codexUserMcp does) cannot drop the record. exitedAt marks when
+// the leader died: any group member started before that instant predates any
+// possible reuse of the pid, which is what the kill path re-verifies.
+interface DetachedLeaderRecord {
+  pid: number;
+  exitedAt?: number;
+}
+const verifiedDetachedLeaders = new WeakMap<KillableProcess, DetachedLeaderRecord>();
+
+export function trackCliProcessTree(
+  proc: KillableProcess,
+  lookupOwnership: (pid: number) => ProcessOwnership | null = lookupProcessOwnership,
+): void {
   if (process.platform === 'win32') return;
+  if (proc.pid && proc.pid > 1 && proc.pid !== process.pid) {
+    const owner = lookupOwnership(proc.pid);
+    if (owner && owner.pgid === proc.pid && owner.ppid === process.pid) {
+      const record: DetachedLeaderRecord = { pid: proc.pid };
+      verifiedDetachedLeaders.set(proc, record);
+      (proc as Partial<ChildProcess>).once?.('exit', () => {
+        record.exitedAt = Date.now();
+      });
+    }
+  }
   if (activeCliProcessTrees.size === 0) {
     sigintInstalledWithoutOtherHandler = process.listenerCount('SIGINT') === 0;
     sigtermInstalledWithoutOtherHandler = process.listenerCount('SIGTERM') === 0;
@@ -356,11 +385,138 @@ export function untrackCliProcessTree(proc: KillableProcess): void {
   }
 }
 
+/** Where a pid sits in the process tree: its group and its parent. */
+export interface ProcessOwnership {
+  pgid: number;
+  ppid: number;
+}
+
+/**
+ * The group and parent of a pid, or null when the process no longer exists.
+ *
+ * Node has no getpgid()/getppid(pid), so ask the OS: /proc on Linux, ps(1)
+ * elsewhere. Runs at spawn and kill time, which is per-stage, not per-event.
+ */
+export function lookupProcessOwnership(pid: number): ProcessOwnership | null {
+  try {
+    if (process.platform === 'linux') {
+      // /proc/<pid>/stat: pid (comm) state ppid pgrp ... — comm may contain
+      // spaces/parens, so parse from the LAST ')'.
+      const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+      const rest = stat.slice(stat.lastIndexOf(')') + 2).split(' ');
+      const ppid = Number(rest[1]);
+      const pgid = Number(rest[2]);
+      if (!Number.isSafeInteger(ppid) || !Number.isSafeInteger(pgid) || pgid <= 0) return null;
+      return { pgid, ppid };
+    }
+    const out = execFileSync('ps', ['-o', 'ppid=,pgid=', '-p', String(pid)], { encoding: 'utf8' });
+    const [ppid, pgid] = out.trim().split(/\s+/).map(Number);
+    if (!Number.isSafeInteger(ppid) || !Number.isSafeInteger(pgid) || pgid <= 0) return null;
+    return { pgid, ppid };
+  } catch {
+    return null;
+  }
+}
+
+/** A live process in some group, with how long ago it started. */
+export interface ProcessGroupMember {
+  pid: number;
+  elapsedMs: number;
+}
+
+/**
+ * Every live member of the given process group with its age. Empty on any
+ * enumeration failure: refusing to enumerate means refusing to sweep — leak,
+ * never misfire.
+ */
+function listProcessGroupMembers(pgid: number): ProcessGroupMember[] {
+  const members: ProcessGroupMember[] = [];
+  try {
+    if (process.platform === 'linux') {
+      // starttime (field 22 of /proc/<pid>/stat) counts in USER_HZ ticks since
+      // boot; USER_HZ is 100 on mainstream Linux and the sweep's clock fuzz
+      // absorbs any rounding. Avoids depending on ps(1) in slim containers.
+      const uptimeSec = Number(readFileSync('/proc/uptime', 'utf8').split(' ')[0]);
+      for (const entry of readdirSync('/proc')) {
+        if (!/^\d+$/.test(entry)) continue;
+        try {
+          const stat = readFileSync(`/proc/${entry}/stat`, 'utf8');
+          const rest = stat.slice(stat.lastIndexOf(')') + 2).split(' ');
+          if (Number(rest[2]) !== pgid) continue;
+          members.push({ pid: Number(entry), elapsedMs: (uptimeSec - Number(rest[19]) / 100) * 1_000 });
+        } catch {
+          // The process exited mid-scan; keep scanning.
+        }
+      }
+      return members;
+    }
+    const out = execFileSync('ps', ['-A', '-o', 'pid=,pgid=,etime='], { encoding: 'utf8' });
+    for (const line of out.split('\n')) {
+      // etime is [[dd-]hh:]mm:ss.
+      const match = line.trim().match(/^(\d+)\s+(\d+)\s+(?:(\d+)-)?(?:(\d+):)?(\d+):(\d+)$/);
+      if (!match || Number(match[2]) !== pgid) continue;
+      members.push({
+        pid: Number(match[1]),
+        elapsedMs: (Number(match[3] ?? 0) * 86_400 + Number(match[4] ?? 0) * 3_600
+          + Number(match[5]) * 60 + Number(match[6])) * 1_000,
+      });
+    }
+    return members;
+  } catch {
+    return [];
+  }
+}
+
+// Absorbs the measurement granularity of process ages plus clock skew against
+// our Date.now() exit stamp: /proc starttime ticks at 10ms on Linux, ps etime
+// truncates to whole seconds on macOS. Any acceptance rule must include this
+// band or it leaks legitimate orphans born just before the leader died; a
+// group id recycled inside the band would require the kernel to exhaust its
+// entire pid space within it.
+const GROUP_AGE_CLOCK_FUZZ_MS = process.platform === 'linux' ? 250 : 1_500;
+
+/**
+ * Kill the orphaned descendants of an exited detached leader one pid at a
+ * time. kill(-pgid) is off the table here: with the leader dead, nothing can
+ * re-verify the group as a whole, and the id could belong to a recycled group.
+ * Instead, only members that started BEFORE the leader died are signalled —
+ * POSIX reserves the group id while any original member lives, so a member
+ * predating the leader's death is provably one of its descendants, while every
+ * member of a recycled group is younger than that. What remains is the same
+ * per-pid check-then-signal window the live path already carries.
+ */
+function sweepOrphanedGroupMembers(
+  pgid: number,
+  leaderExitedAt: number,
+  signal: NodeJS.Signals,
+  listMembers: (pgid: number) => ProcessGroupMember[],
+): void {
+  // Second pass catches a descendant forked between enumeration and the kill
+  // of its parent (it still predates the leader's death only if it does).
+  for (let pass = 0; pass < 2; pass += 1) {
+    const sinceExitMs = Date.now() - leaderExitedAt;
+    let signalled = false;
+    for (const member of listMembers(pgid)) {
+      if (member.pid <= 1 || member.pid === process.pid) continue;
+      if (member.elapsedMs < sinceExitMs - GROUP_AGE_CLOCK_FUZZ_MS) continue;
+      try {
+        process.kill(member.pid, signal);
+        signalled = true;
+      } catch {
+        // Already gone.
+      }
+    }
+    if (!signalled) return;
+  }
+}
+
 /** Send one signal to a CLI wrapper and every descendant it launched. */
 export function signalCliProcessTree(
   proc: KillableProcess,
   signal: NodeJS.Signals,
   platform: NodeJS.Platform = process.platform,
+  lookupOwnership?: (pid: number) => ProcessOwnership | null,
+  listGroupMembers?: (pgid: number) => ProcessGroupMember[],
 ): void {
   if (platform === 'win32') {
     // ChildProcess.kill() uses the process handle Node retained at spawn time.
@@ -369,21 +525,65 @@ export function signalCliProcessTree(
     proc.kill(signal);
     return;
   }
-  if (proc.pid) {
-    try {
-      process.kill(-proc.pid, signal);
-      return;
-    } catch {
-      // The process may have exited before the signal or failed to form a group.
+  // Prove ownership before signalling a whole group. kill(-1) addresses every
+  // process on the host, our own group would take the daemon down with the
+  // child, and a stale or fabricated pid addresses whoever holds that group
+  // now. All three are real: unit tests handed fake pids (1, 321) to the close
+  // handler, and the resulting kill(-1, SIGKILL) wiped every application in
+  // the operator's login session and severed the SSH connection running the
+  // suite on a remote host. Only a child we spawned detached — one that leads
+  // its own group (pgid == pid) and is our direct child (ppid == us) — may be
+  // group-killed.
+  if (proc.pid && proc.pid > 1 && proc.pid !== process.pid && proc.pid !== ownProcessGroup()) {
+    const owner = (lookupOwnership ?? lookupProcessOwnership)(proc.pid);
+    if (owner) {
+      // The leader is alive, so the OS can vouch for it directly, and the
+      // group id is guaranteed unrecycled while it lives.
+      if (owner.pgid === proc.pid && owner.ppid === process.pid) {
+        try {
+          process.kill(-proc.pid, signal);
+          return;
+        } catch {
+          // The group drained between lookup and kill.
+        }
+      }
+    } else {
+      // The leader already exited. Never group-signal here — sweep only the
+      // members that provably predate the leader's death, one pid at a time.
+      const record = verifiedDetachedLeaders.get(proc);
+      if (record?.pid === proc.pid) {
+        // A kill can observe the death before the 'exit' event has fired
+        // (abort handlers run in the same loop turn as the reap). This first
+        // observation of the death is then the tightest stamp available.
+        record.exitedAt ??= Date.now();
+        sweepOrphanedGroupMembers(
+          proc.pid,
+          record.exitedAt,
+          signal,
+          listGroupMembers ?? listProcessGroupMembers,
+        );
+      }
     }
   }
   proc.kill(signal);
+}
+
+let cachedOwnProcessGroup: number | null | undefined;
+function ownProcessGroup(): number | null {
+  // Our own pgid cannot change: Node exposes no setpgid/setsid for a running
+  // process, so one lookup per process lifetime is enough.
+  if (cachedOwnProcessGroup === undefined) {
+    cachedOwnProcessGroup = lookupProcessOwnership(process.pid)?.pgid ?? null;
+  }
+  return cachedOwnProcessGroup;
 }
 
 /** Force-kill a CLI process tree. */
 export function terminateCliProcessTree(
   proc: KillableProcess,
   platform: NodeJS.Platform = process.platform,
+  lookupOwnership?: (pid: number) => ProcessOwnership | null,
+  listGroupMembers?: (pgid: number) => ProcessGroupMember[],
 ): void {
-  signalCliProcessTree(proc, 'SIGKILL', platform);
+  signalCliProcessTree(proc, 'SIGKILL', platform, lookupOwnership, listGroupMembers);
 }


### PR DESCRIPTION
## TL;DR

`signalCliProcessTree` ran `process.kill(-proc.pid, signal)` unconditionally. Unit tests hand fabricated pids (`1`, `321`) to close handlers, so the resulting `kill(-1, SIGKILL)` signalled **every process the user may signal**: it wiped the operator's macOS login session twice, severed the SSH connection running the suite on a remote host, and killed the GitHub runner mid-suite — the cause of `Tests=CANCELLED` on #421–#424.

## Design: three-layer ownership proof

1. **Live leader path** — `kill(-pgid)` fires only after the OS confirms *at kill time* that the pid leads its own group (`pgid == pid`) **and** is our direct child (`ppid == process.pid`), via `/proc/<pid>/stat` on Linux and `ps -o ppid=,pgid=` elsewhere. Pid 1, our own pid, and our own group are refused before any lookup.
2. **Track-time record** — `trackCliProcessTree` proves the same ownership right after spawn (the only moment it is provable: a detached child is a live leader whose parent is us) and stamps the leader's death with `once('exit')`. The record lives in a WeakMap keyed by the handle, so callers that untrack before terminating (codexUserMcp) cannot drop it.
3. **Post-mortem sweep** — once the leader is dead, `kill(-pgid)` is **never** used (a recycled group id cannot be re-verified). Orphaned members are enumerated with their ages (`/proc` starttime on Linux, `ps -A -o pid=,pgid=,etime=` on macOS) and signalled one pid at a time, only when their age proves they started before the leader died — every member of a recycled group is younger than that. Clock fuzz matches measurement granularity (250ms Linux / 1500ms macOS). Enumeration or verification failure means **leak, never misfire**.

Residual risk: a recycled group id inside the fuzz band would require the kernel to exhaust its entire pid space within it (≥131k forks/s on Linux at the 32768 floor). What remains is the same per-pid check-then-signal window the live path — and every kill-by-pid tool — already carries.

## Also in this PR

- `codexUserMcp.test.ts`: on macOS a freshly written script takes 200–400ms to first-exec (measured; Gatekeeper scan), longer than the old 100ms timeout — the fixture was killed before it started. A warm-up exec + 500ms timeout keeps the assertion (a TERM-ignoring child must die) intact.
- `processTree.groupSafety.test.ts` (new): 10 tests pinning the ownership proof — fabricated pids, non-leaders, dead pids, recycled groups, per-pid orphan sweep.
- `base.spawn.test.ts`: injection contract updated to ownership objects; one test renamed to match what it now asserts.

## Verification

- 58/58 across the 4 affected test files on macOS, including two real-process e2e paths (post-mortem sweep via real `ps`, live-path group kill of a TERM-ignoring child); `tsc --noEmit` clean.
- `/proc` field indices (ppid/pgrp/starttime) and elapsed-time math verified empirically on Linux (vela).
- Review gate: tier-1 `openswarm review` ×3 (REVISE, converging on the pid-recycle residual) → tier-2 independent subagent: **APPROVE**, with the residual risk explicitly quantified and accepted; its one Low finding (misleading test name) is fixed in this PR.

Closes AGT-4011.