### PR TITLE
fix(task-state): free a lock whose owner cannot be probed across a restart (AGT-4023)

### DIFF
--- a/src/taskState/store.test.ts
+++ b/src/taskState/store.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { existsSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, unlinkSync, utimesSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
@@ -359,5 +359,48 @@ describe('task state store', () => {
 
     expect(() => getTaskState('ISSUE-CORRUPT')).toThrow(/Task state store is corrupt/);
     expect(readFileSync(stateFile, 'utf8')).toBe('{not-json');
+  });
+
+  describe('stale lock reclamation (AGT-4023)', () => {
+    // Measured on vela: a container recreate left a well-formed lock behind,
+    // the new daemon came up on the SAME pid (a container assigns it
+    // deterministically), so the pid probe answered "alive" for the daemon's
+    // own ghost. Fifteen straight heartbeats died on it, zero tasks ran for 75
+    // minutes, and a manual rm was the only way out.
+    const lockFile = () => `${stateFile}.lock`;
+
+    it('reclaims a well-formed lock left at our own pid once it is long expired', () => {
+      writeFileSync(lockFile(), JSON.stringify({ pid: process.pid, token: 'ghost-token' }), 'utf8');
+      const longAgo = new Date(Date.now() - 900_000);
+      utimesSync(lockFile(), longAgo, longAgo);
+
+      upsertTaskState('ISSUE-LOCK-1', { execution: { status: 'todo', retryCount: 0 } });
+
+      expect(getTaskState('ISSUE-LOCK-1')?.execution.status).toBe('todo');
+      expect(existsSync(lockFile())).toBe(false);
+    });
+
+    it('respects a well-formed lock right up to the expiry, on its own clock', () => {
+      // Pins the policy from below: a lock older than the 30s malformed clock
+      // but inside the 10-minute one is still someone's — it may belong to a
+      // live writer in another pid namespace sharing the mounted state file.
+      // Shortening LOCK_ABANDON_MS toward LOCK_STALE_MS fails here.
+      writeFileSync(lockFile(), JSON.stringify({ pid: process.pid, token: 'possibly-live' }), 'utf8');
+      const almostExpired = new Date(Date.now() - 570_000);
+      utimesSync(lockFile(), almostExpired, almostExpired);
+
+      expect(() => upsertTaskState('ISSUE-LOCK-2', { execution: { status: 'todo', retryCount: 0 } }))
+        .toThrow(/Timed out waiting for task state lock/);
+    });
+
+    it('still ages out a lock with no readable owner on the shorter clock', () => {
+      writeFileSync(lockFile(), 'not-json-at-all', 'utf8');
+      const longAgo = new Date(Date.now() - 120_000);
+      utimesSync(lockFile(), longAgo, longAgo);
+
+      upsertTaskState('ISSUE-LOCK-4', { execution: { status: 'todo', retryCount: 0 } });
+
+      expect(getTaskState('ISSUE-LOCK-4')?.execution.status).toBe('todo');
+    });
   });
 });

--- a/src/taskState/store.ts
+++ b/src/taskState/store.ts
@@ -105,6 +105,7 @@ type TaskStateStore = z.infer<typeof TaskStateStoreSchema>;
 let cache: TaskStateStore | null = null;
 let cacheStamp: string | null = null;
 const LOCK_STALE_MS = 30_000;
+const LOCK_ABANDON_MS = 600_000;
 const LOCK_WAIT_MS = 10;
 const LOCK_TIMEOUT_MS = 5_000;
 const lockWaitBuffer = new Int32Array(new SharedArrayBuffer(4));
@@ -194,9 +195,30 @@ function withStoreLock<T>(operation: () => T): T {
       if (code !== 'EEXIST') throw error;
       try {
         const owner = readStoreLockOwner(lockPath);
-        const staleMalformedLock = !owner && Date.now() - statSync(lockPath).mtimeMs > LOCK_STALE_MS;
+        const lockAgeMs = Date.now() - statSync(lockPath).mtimeMs;
+        const staleMalformedLock = !owner && lockAgeMs > LOCK_STALE_MS;
         const abandonedLock = owner !== null && !isProcessAlive(owner.pid);
-        if (staleMalformedLock || abandonedLock) {
+        // A pid probe cannot see past its own namespace, and a container
+        // assigns the daemon the same pid every start — so a lock left behind
+        // by a killed container reads as "alive" against the new daemon
+        // itself, and nothing ever frees it (AGT-4023: 15 straight heartbeats
+        // dead, zero tasks for 75 minutes, manual rm the only exit). Age is
+        // the one signal that stays true across namespaces and generations.
+        //
+        // What this buys and what it costs. The guarded work is synchronous —
+        // read, parse, write, fsync, rename, measured at tens of milliseconds
+        // — and an out-of-space write fails fast rather than blocking, so
+        // reaching this threshold takes a frozen process (SIGSTOP, docker
+        // pause, uninterruptible I/O) or a wall-clock jump, since mtime is
+        // compared against a non-monotonic clock. A process frozen that long
+        // is serving nothing anyway. If one is evicted and later resumes, it
+        // overwrites with its own snapshot: a lost update, never a torn file
+        // (persistStore renames atomically) and never a cascade (the exit
+        // unlink is token-guarded). The run ledger — not this projection —
+        // owns leases and remote effects, so a rollback here cannot
+        // double-execute anything, and the next Linear sync re-derives it.
+        const expiredLock = lockAgeMs > LOCK_ABANDON_MS;
+        if (staleMalformedLock || abandonedLock || expiredLock) {
           unlinkSync(lockPath);
           continue;
         }

--- a/src/taskState/store.ts
+++ b/src/taskState/store.ts
@@ -195,7 +195,8 @@ function withStoreLock<T>(operation: () => T): T {
       if (code !== 'EEXIST') throw error;
       try {
         const owner = readStoreLockOwner(lockPath);
-        const lockAgeMs = Date.now() - statSync(lockPath).mtimeMs;
+        const judgedMtimeMs = statSync(lockPath).mtimeMs;
+        const lockAgeMs = Date.now() - judgedMtimeMs;
         const staleMalformedLock = !owner && lockAgeMs > LOCK_STALE_MS;
         const abandonedLock = owner !== null && !isProcessAlive(owner.pid);
         // A pid probe cannot see past its own namespace, and a container
@@ -219,7 +220,18 @@ function withStoreLock<T>(operation: () => T): T {
         // double-execute anything, and the next Linear sync re-derives it.
         const expiredLock = lockAgeMs > LOCK_ABANDON_MS;
         if (staleMalformedLock || abandonedLock || expiredLock) {
-          unlinkSync(lockPath);
+          // Reclaim only the lock that was actually judged. Between the
+          // judgement above and this unlink the holder can release and a third
+          // process can take a fresh lock; deleting THAT one would put two
+          // writers in the store. Re-reading identity here narrows the window
+          // to a pair of syscalls — it does not close it, because POSIX has no
+          // compare-and-unlink for a regular file. Closing it needs a
+          // kernel-owned mutex (AGT-4024).
+          const currentMtimeMs = statSync(lockPath).mtimeMs;
+          const currentOwner = readStoreLockOwner(lockPath);
+          const sameLock = currentMtimeMs === judgedMtimeMs
+            && currentOwner?.token === owner?.token;
+          if (sameLock) unlinkSync(lockPath);
           continue;
         }
       } catch (statError) {


### PR DESCRIPTION
## The incident (measured, on vela)

A container recreate killed the daemon mid-operation and left a well-formed lock at `~/.openswarm/task-state.json.lock` — `{"pid":7,...}` — on the bind-mounted state volume. A container assigns the daemon **the same pid every start**, so `isProcessAlive(7)` probed the *new* daemon and answered "held". Nothing could ever free it.

Measured: **15 consecutive heartbeats** failed with `Timed out waiting for task state lock`, the daemon fetched **zero** tasks for **75 minutes**, `runningTasks=0`, and a manual `rm` was the only recovery. Confirmed after removal: next heartbeat fetched 755 tasks and started work.

## Fix

Identity cannot settle this. A pid-namespace boundary makes "my pid from an earlier generation" and "a live process elsewhere sharing the mounted state file" indistinguishable — an instance-id scheme was tried and withdrawn for exactly that reason. Age is the one signal true across namespaces and generations: a lock older than `LOCK_ABANDON_MS` (10 min) is released regardless of its owner field. The two pre-existing rules are unchanged.

## The tradeoff, stated rather than claimed away

The code comment now says what this actually costs instead of asserting it is free:

- Eviction requires a process **frozen for ten minutes** (SIGSTOP / docker pause / uninterruptible I/O) or a wall-clock jump. The guarded work is synchronous — read, parse, write, fsync, rename, measured at tens of ms — and an out-of-space write fails fast rather than blocking.
- If an evicted holder resumes it overwrites with its own snapshot: **a lost update, never a torn file** (`persistStore` renames atomically) and **never a cascade** (the exit unlink is token-guarded).
- The **run ledger owns leases and remote effects**, not this projection, so a rollback here cannot double-execute anything; the next Linear sync re-derives it.

Against a *certain, measured* 75-minute outage needing a human.

## Review

The tier-1 gate raised mutual exclusion four times. An independent tier-2 review adjudicated it with evidence — ENOSPC returns an error rather than blocking (so the cited trigger releases in ms), `upsertTaskState` is the sole `withStoreLock` caller and is fully synchronous, and `runLedger.importRun` is insert-only for leases — and **approved the design unchanged**, asking only for three mechanical fixes, all applied:

- the comment no longer overclaims (it now names the frozen-process and non-monotonic-clock exposure);
- a test pins the threshold **from below** so it cannot quietly collapse into the 30s malformed clock — mutation-verified: setting 600s → 60s fails the suite;
- a duplicate 5s test was dropped (suite 10.9s → 5.9s).

Follow-up filed separately for the kernel-owned SQLite mutex (`serviceInstanceLock.ts` pattern), which removes thresholds entirely but needs a CLI/daemon migration story.

## Test plan

`npx tsc --noEmit` clean; `LC_ALL=C npx vitest run src/taskState` 17/17 including the two-process serialization test; oxlint clean.

## Linear

Closes AGT-4023