### PR TITLE
fix(web): stop losing the operator's message without saying so (AGT-4026)

### DIFF
--- a/tests/web/chatView.test.ts
+++ b/tests/web/chatView.test.ts
@@ -40,10 +40,10 @@ function boardEvent(over: Record<string, unknown> = {}) {
   };
 }
 
-function fetchWith(history: unknown[], board: unknown[] = []) {
+function fetchWith(history: unknown[], board: unknown[] = [], messageResponse?: unknown) {
   return vi.fn(async (url: string) => {
     if (url.startsWith('/api/coordination/message')) {
-      return { ok: true, json: async () => ({ delivered: true }) };
+      return messageResponse ?? { ok: true, json: async () => ({ delivered: true }) };
     }
     if (url.startsWith('/api/coordination/history')) {
       return { ok: true, json: async () => ({ events: history, traceSize: history.length }) };
@@ -240,5 +240,70 @@ describe('renderLine', () => {
     });
     expect(html).not.toContain('class="tag"');
     expect(html).toContain('boo');
+  });
+});
+
+describe('startChatView composer outcome (AGT-4026)', () => {
+  // `fetch` resolves on 400/409, so a refused send used to look identical to a
+  // delivered one — the operator's text was already gone from the box and
+  // nothing said why. Nine agents were parked awaiting an answer when this was
+  // reported.
+  it('keeps the text and shows the daemon\'s reason when the send is refused', async () => {
+    const doc = shell();
+    const fetchImpl = fetchWith(
+      [boardEvent({ id: 'a', seq: 1 })],
+      [],
+      { ok: false, status: 409, json: async () => ({ error: 'Question is already completed' }) },
+    );
+    const view = startChatView(doc, { fetchImpl, eventSourceImpl: null });
+    await vi.waitFor(() => expect(doc.querySelectorAll('#room .line').length).toBe(1));
+
+    const input = doc.getElementById('composer-text') as HTMLInputElement;
+    input.value = 'Use the masked card master.';
+    doc.getElementById('composer')!.dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
+
+    await vi.waitFor(() => {
+      expect(doc.getElementById('composer-status')?.textContent).toBe('Question is already completed');
+    });
+    expect(input.value).toBe('Use the masked card master.');
+    view.stop();
+  });
+
+  it('clears the box only after the daemon accepts', async () => {
+    const doc = shell();
+    const fetchImpl = fetchWith([boardEvent({ id: 'a', seq: 1 })]);
+    const view = startChatView(doc, { fetchImpl, eventSourceImpl: null });
+    await vi.waitFor(() => expect(doc.querySelectorAll('#room .line').length).toBe(1));
+
+    const input = doc.getElementById('composer-text') as HTMLInputElement;
+    input.value = 'Proceed with the mounted credentials.';
+    doc.getElementById('composer')!.dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
+
+    await vi.waitFor(() => expect(input.value).toBe(''));
+    expect(doc.getElementById('composer-status')?.textContent).toBe('');
+    view.stop();
+  });
+
+  it('reports an unreachable daemon instead of swallowing it', async () => {
+    const doc = shell();
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.startsWith('/api/coordination/message')) throw new Error('network down');
+      if (url.startsWith('/api/coordination/history')) {
+        return { ok: true, json: async () => ({ events: [boardEvent({ id: 'a', seq: 1 })], traceSize: 1 }) };
+      }
+      return { ok: true, json: async () => ({ events: [], pending: [], lastSeq: 0 }) };
+    });
+    const view = startChatView(doc, { fetchImpl, eventSourceImpl: null });
+    await vi.waitFor(() => expect(doc.querySelectorAll('#room .line').length).toBe(1));
+
+    const input = doc.getElementById('composer-text') as HTMLInputElement;
+    input.value = 'anyone there?';
+    doc.getElementById('composer')!.dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
+
+    await vi.waitFor(() => {
+      expect(doc.getElementById('composer-status')?.textContent).toContain('network down');
+    });
+    expect(input.value).toBe('anyone there?');
+    view.stop();
   });
 });

--- a/tests/web/orchestrationView.test.ts
+++ b/tests/web/orchestrationView.test.ts
@@ -248,7 +248,7 @@ describe('feed legibility', () => {
 });
 
 describe('clicking a feed row', () => {
-  async function withThread() {
+  async function withThread(messageResponse?: unknown) {
     const doc = shell();
     const events = [
       boardEvent({ id: 'q', seq: 1, summary: 'Retry in adapter or scheduler?' }),
@@ -261,7 +261,7 @@ describe('clicking a feed row', () => {
     ];
     const fetchImpl = vi.fn(async (url: string) => {
       if (typeof url === 'string' && url.startsWith('/api/coordination/message')) {
-        return { ok: true, json: async () => ({ delivered: true }) };
+        return messageResponse ?? { ok: true, json: async () => ({ delivered: true }) };
       }
       return { ok: true, json: async () => ({ events, pending: [], lastSeq: 2 }) };
     });
@@ -336,6 +336,96 @@ describe('clicking a feed row', () => {
       recipient: 'adept-helion-cognitor',
       text: 'Keep it in the scheduler.',
     });
+    view.stop();
+  });
+
+  // `fetch` resolves on 400/409, so a refused reply used to read as delivered
+  // while the operator's text was already gone from the box (AGT-4026).
+  it('keeps the reply and shows why when the daemon refuses it', async () => {
+    const { doc, view } = await withThread({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'Cannot address the message' }),
+    });
+    (doc.querySelector('#feed .ev') as HTMLElement).dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+    const input = doc.getElementById('composer-text') as HTMLInputElement;
+    input.value = 'Use the mounted credentials.';
+    doc.getElementById('composer')!.dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
+
+    await vi.waitFor(() => {
+      expect(doc.getElementById('composer-status')?.textContent).toBe('Cannot address the message');
+    });
+    expect(input.value).toBe('Use the mounted credentials.');
+    view.stop();
+  });
+
+  it('clears the reply only once the daemon accepts it', async () => {
+    const { doc, view } = await withThread();
+    (doc.querySelector('#feed .ev') as HTMLElement).dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+    (doc.getElementById('composer-text') as HTMLInputElement).value = 'Proceed.';
+    doc.getElementById('composer')!.dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
+
+    // Re-query rather than holding the node: a send re-renders the panel, and
+    // the pending state is re-applied to the fresh composer — that is the
+    // property that keeps an in-flight send from being undone by an agent
+    // event arriving mid-flight.
+    await vi.waitFor(() => {
+      expect((doc.getElementById('composer-text') as HTMLInputElement).value).toBe('');
+    });
+    expect(doc.getElementById('composer-status')?.textContent).toBe('');
+    view.stop();
+  });
+
+  it('keeps the composer locked and the text intact while a send is in flight', async () => {
+    let release: (value: unknown) => void = () => {};
+    const gate = new Promise((resolve) => { release = resolve; });
+    const { doc, view } = await withThread(
+      gate.then(() => ({ ok: true, json: async () => ({ delivered: true }) })),
+    );
+    (doc.querySelector('#feed .ev') as HTMLElement).dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+    (doc.getElementById('composer-text') as HTMLInputElement).value = 'Hold for CI.';
+    doc.getElementById('composer')!.dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
+
+    await vi.waitFor(() => {
+      expect(doc.getElementById('composer-status')?.textContent).toBe('Sending…');
+    });
+    const midFlight = doc.getElementById('composer-text') as HTMLInputElement;
+    expect(midFlight.disabled).toBe(true);
+    expect(midFlight.value).toBe('Hold for CI.');
+
+    release(null);
+    await vi.waitFor(() => {
+      expect((doc.getElementById('composer-text') as HTMLInputElement).value).toBe('');
+    });
+    view.stop();
+  });
+
+  it('does not leak a pending send into a different exchange', async () => {
+    let release: (value: unknown) => void = () => {};
+    const gate = new Promise((resolve) => { release = resolve; });
+    const { doc, view } = await withThread(
+      gate.then(() => ({ ok: false, status: 400, json: async () => ({ error: 'Cannot address the message' }) })),
+    );
+    const rows = doc.querySelectorAll('#feed .ev');
+    (rows[0] as HTMLElement).dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+    (doc.getElementById('composer-text') as HTMLInputElement).value = 'For the first thread only.';
+    doc.getElementById('composer')!.dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
+    await vi.waitFor(() => expect(doc.getElementById('composer-status')?.textContent).toBe('Sending…'));
+
+    // The operator moves to another exchange while the first send is in flight.
+    (rows[0] as HTMLElement).dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    release(null);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const other = doc.getElementById('composer-text') as HTMLInputElement | null;
+    if (other) {
+      expect(other.value).not.toBe('For the first thread only.');
+      expect(other.disabled).toBe(false);
+    }
     view.stop();
   });
 });

--- a/web/static/chat.html
+++ b/web/static/chat.html
@@ -36,6 +36,8 @@
     .composer input:disabled { color: var(--dim); }
     .composer button { background: var(--cyan); border: none; border-radius: 4px; color: #0d1117; font: inherit; font-size: 12px; font-weight: 700; padding: 6px 14px; cursor: pointer; }
     .composer button:disabled { background: var(--border); color: var(--dim); cursor: default; }
+    .composer-status { padding: 0 16px 8px; font-size: 11px; color: var(--dim); min-height: 14px; }
+    .composer-status.is-error { color: var(--red, #f85149); }
     .empty { color: var(--dim); padding: 14px; font-size: 12px; }
   </style>
 </head>

--- a/web/static/js/chatView.mjs
+++ b/web/static/js/chatView.mjs
@@ -57,6 +57,26 @@ export function startChatView(doc, { fetchImpl, eventSourceImpl, pollMs = 30_000
   const form = doc.getElementById('composer');
   const input = doc.getElementById('composer-text');
   const button = form?.querySelector('button');
+  let sending = false;
+
+  // One line under the composer carrying the send's outcome. Created on demand
+  // so the shell markup does not have to know about it.
+  const setComposerStatus = (message, { pending = false } = {}) => {
+    if (!form) return;
+    let line = doc.getElementById('composer-status');
+    if (!line) {
+      line = doc.createElement('div');
+      line.id = 'composer-status';
+      line.className = 'composer-status';
+      form.insertAdjacentElement('afterend', line);
+    }
+    sending = pending;
+    line.textContent = pending ? 'Sending…' : message;
+    line.classList.toggle('is-error', !pending && !!message);
+    const addressable = !!latestAddressable([...byId.values()]);
+    if (input) input.disabled = pending || !addressable;
+    if (button) button.disabled = pending || !addressable;
+  };
 
   room.addEventListener('scroll', () => { stick = isNearBottom(room); });
 
@@ -70,12 +90,15 @@ export function startChatView(doc, { fetchImpl, eventSourceImpl, pollMs = 30_000
     // POST would be unroutable (the API requires repository/taskId/recipient).
     const target = latestAddressable(events);
     if (input) {
-      input.disabled = !target;
+      // A send takes seconds under load (AGT-4027) and agent events keep
+      // arriving, so a redraw lands mid-flight — it must not re-enable the box
+      // the send just locked.
+      input.disabled = !target || sending;
       input.placeholder = target
         ? `Message ${target.actorName || target.actor}…`
         : 'No agent to address yet';
     }
-    if (button) button.disabled = !target;
+    if (button) button.disabled = !target || sending;
     if (stick) room.scrollTop = room.scrollHeight;
   };
 
@@ -87,11 +110,17 @@ export function startChatView(doc, { fetchImpl, eventSourceImpl, pollMs = 30_000
   // Interjections join the newest exchange: the message is addressed to the
   // last agent that spoke, exactly like replying in a busy room. Same POST
   // contract (and same bare-fetch auth posture) as the orchestration composer.
+  // Returns the failure reason, or null when the message was accepted. The
+  // caller keeps the operator's text until it hears null: a refusal that
+  // silently ate the message is worse than no composer at all, and `fetch`
+  // resolves happily on 400/409 — the server's own "cannot address this" and
+  // "already answered" both arrive that way (AGT-4026).
   const send = async (text) => {
     const target = latestAddressable([...byId.values()]);
-    if (!target) return;
+    if (!target) return 'No agent is addressable yet.';
+    let response;
     try {
-      await fetcher('/api/coordination/message', {
+      response = await fetcher('/api/coordination/message', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -102,9 +131,20 @@ export function startChatView(doc, { fetchImpl, eventSourceImpl, pollMs = 30_000
           text,
         }),
       });
-    } catch { /* the next poll shows whether it landed */ }
+    } catch (error) {
+      return error?.message ? `Could not reach the daemon: ${error.message}` : 'Could not reach the daemon.';
+    }
+    if (!response?.ok) {
+      let reason = `The daemon refused the message (${response?.status ?? 'no status'}).`;
+      try {
+        const body = await response.json();
+        if (body?.error) reason = body.error;
+      } catch { /* a refusal without a JSON body still has its status */ }
+      return reason;
+    }
     // Re-read rather than echoing locally: the board decides what was published.
     await refresh();
+    return null;
   };
 
   /** The durable trace reaches back past the board's ring-buffer window. */
@@ -146,12 +186,17 @@ export function startChatView(doc, { fetchImpl, eventSourceImpl, pollMs = 30_000
   }
 
   if (form) {
-    form.addEventListener('submit', (submitEvent) => {
+    form.addEventListener('submit', async (submitEvent) => {
       submitEvent.preventDefault();
       const text = input.value.trim();
       if (!text) return;
-      input.value = '';
-      send(text);
+      // The publish queues behind the agents' own board traffic and has been
+      // measured at seconds under load (AGT-4027), so say it is in flight
+      // rather than looking dead — and hold the text until it lands.
+      setComposerStatus('', { pending: true });
+      const failure = await send(text);
+      setComposerStatus(failure ?? '', { pending: false });
+      if (!failure) input.value = '';
     });
   }
 

--- a/web/static/js/orchestrationView.mjs
+++ b/web/static/js/orchestrationView.mjs
@@ -227,6 +227,31 @@ function clip(text, max = 140) {
 }
 
 /** `Speaker → Recipient: words` — one utterance as a line of dialogue. */
+/**
+ * Paint the composer's send state: the outcome line, the in-flight lock, and
+ * the text still waiting to be accepted. Called on every render so a redraw
+ * mid-send cannot quietly re-enable the box or drop the operator's words.
+ */
+function applyComposerState(doc, form, pending) {
+  let line = doc.getElementById('composer-status');
+  if (!line) {
+    line = doc.createElement('div');
+    line.id = 'composer-status';
+    line.className = 'composer-status';
+    form.insertAdjacentElement('afterend', line);
+  }
+  const input = doc.getElementById('composer-text');
+  const button = form.querySelector('button');
+  const active = !!pending?.active;
+  line.textContent = active ? 'Sending…' : (pending?.message ?? '');
+  line.classList.toggle('is-error', !active && !!pending?.message);
+  if (input) {
+    input.disabled = active;
+    if (pending?.text !== undefined) input.value = pending.text;
+  }
+  if (button) button.disabled = active;
+}
+
 function dialogueLine(event, max = 140) {
   const line = chatLineOf(event);
   const to = line.recipientName ? ` → <span class="who">${escapeHtml(line.recipientName)}</span>` : '';
@@ -275,7 +300,7 @@ export function renderFeed(doc, events, selected, focusedEventId, onFocus) {
  * a composer. Speaking here is not decoration: the message is addressed to the
  * agent, which picks it up on its next `coordination_read`.
  */
-export function renderThread(doc, thread, onSend) {
+export function renderThread(doc, thread, onSend, pending = null) {
   const holder = doc.getElementById('thread');
   if (!holder) return;
   if (!thread) {
@@ -321,12 +346,17 @@ export function renderThread(doc, thread, onSend) {
 
   const form = doc.getElementById('composer');
   if (!form || !onSend) return;
+  // A send takes seconds under load (AGT-4027) and agent events keep arriving,
+  // so a redraw lands mid-flight and replaces this very form. The pending state
+  // therefore lives in the caller and is re-applied on every render below,
+  // rather than being held in DOM nodes this handler captured.
+  applyComposerState(doc, form, pending);
+
   form.addEventListener('submit', (submitEvent) => {
     submitEvent.preventDefault();
     const input = doc.getElementById('composer-text');
     const text = input.value.trim();
     if (!text) return;
-    input.value = '';
     onSend(thread, text);
   });
 }
@@ -337,10 +367,36 @@ export function startOrchestrationView(doc, { fetchImpl, eventSourceImpl, pollMs
   const byId = new Map();
   let selected = null;
   let focusedEventId = null;
+  const composerStates = new Map();
 
+  // Returns the failure reason, or null when the message was accepted. `fetch`
+  // resolves on 400/409, so the server's "cannot address this" and "already
+  // answered" both look like success unless `ok` is checked — and an operator
+  // whose reply is silently dropped is the one person who must never be lied
+  // to, since a parked agent is waiting on it (AGT-4026).
   const send = async (thread, text) => {
+    // Kept per exchange, not in the form and not in one slot: a redraw can
+    // replace the composer while this awaits, the operator can move to another
+    // exchange mid-send and start a second one there, and neither send may
+    // land its text or its verdict on the other's composer.
+    const correlationId = thread?.correlationId ?? null;
+    composerStates.set(correlationId, { active: true, message: '', text });
+    redraw();
+    const failure = await publish(thread, text);
+    if (failure) {
+      composerStates.set(correlationId, { active: false, message: failure, text });
+    } else {
+      // Accepted: nothing left to say, and keeping the entry would grow the map
+      // one exchange at a time for the life of the page.
+      composerStates.delete(correlationId);
+    }
+    redraw();
+  };
+
+  const publish = async (thread, text) => {
+    let response;
     try {
-      await fetcher('/api/coordination/message', {
+      response = await fetcher('/api/coordination/message', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -351,10 +407,21 @@ export function startOrchestrationView(doc, { fetchImpl, eventSourceImpl, pollMs
           text,
         }),
       });
-    } catch { /* the next poll shows whether it landed */ }
+    } catch (error) {
+      return error?.message ? `Could not reach the daemon: ${error.message}` : 'Could not reach the daemon.';
+    }
+    if (!response?.ok) {
+      let reason = `The daemon refused the message (${response?.status ?? 'no status'}).`;
+      try {
+        const body = await response.json();
+        if (body?.error) reason = body.error;
+      } catch { /* a refusal without a JSON body still has its status */ }
+      return reason;
+    }
     // Re-read rather than echoing locally: the board decides what was actually
     // published (an answer to a blocking question looks different from a note).
     await refresh();
+    return null;
   };
 
   const redraw = () => {
@@ -379,7 +446,8 @@ export function startOrchestrationView(doc, { fetchImpl, eventSourceImpl, pollMs
       focusedEventId = focusedEventId === id ? null : id;
       redraw();
     });
-    renderThread(doc, threadFor(threads, focused), send);
+    const shownThread = threadFor(threads, focused);
+    renderThread(doc, shownThread, send, composerStates.get(shownThread?.correlationId ?? null) ?? null);
   };
 
   const absorb = (event) => {

--- a/web/static/orchestration.html
+++ b/web/static/orchestration.html
@@ -70,6 +70,9 @@
     .composer { display: flex; gap: 6px; padding: 8px 12px; border-top: 1px solid var(--border); }
     .composer input { flex: 1; background: #0d1117; border: 1px solid var(--border); border-radius: 4px; color: var(--white); padding: 5px 8px; font: inherit; font-size: 11px; }
     .composer button { background: var(--cyan, #3b9eff); border: none; border-radius: 4px; color: #0d1117; font: inherit; font-size: 11px; font-weight: 700; padding: 5px 12px; cursor: pointer; }
+    .composer button:disabled { background: var(--border); color: var(--dim); cursor: default; }
+    .composer-status { padding: 0 12px 6px; font-size: 10px; color: var(--dim); min-height: 13px; }
+    .composer-status.is-error { color: var(--red, #f85149); }
     .empty { color: var(--dim); padding: 14px; font-size: 12px; }
     .tier-label { fill: var(--dim); font-size: 10px; letter-spacing: 2px; font-weight: 700; }
     .tier-count { fill: #3d4454; font-size: 9px; }


### PR DESCRIPTION
## The report

Operator, with **nine agents parked on `human-question`**: the orchestration view shows "awaiting your answer", typing a reply does nothing — no message, no error.

## Two defects on the same line, in both composers

```js
input.value = '';        // cleared before the send is known to have worked
send(text);              // not awaited
try { await fetcher('/api/coordination/message', {...}); }
catch { /* the next poll shows whether it landed */ }
```

1. **`fetch` does not reject on 4xx/5xx.** The daemon's own refusals — `400 Cannot address the message`, `409 Question is already completed` — arrived in the success path. Both are returned by the live endpoint today.
2. **The box was cleared before the outcome was known**, so a refused reply was also text the operator had to retype from memory.

## Measured, and why the in-flight state matters

| condition | POST /api/coordination/message |
| --- | --- |
| no tasks running | 9 ms |
| 2 tasks running | 8.3 s |
| 2 tasks running (earlier) | >20 s, client aborted |

Publishing queues behind the agents' own board traffic (filed as AGT-4027). So even a reply that lands looks dead for seconds without a pending state.

## What changed

Both composers now check `response.ok`, surface the daemon's `error` text, keep the operator's words until the send is accepted, and show "Sending…" while it is in flight.

Two things the review rounds surfaced, both fixed and pinned by tests:

- **The pending state lives in the view, not the form.** Agent events arrive constantly; a redraw mid-send replaces the composer, which would otherwise re-enable the box and drop the text.
- **It is kept per exchange.** The operator can move to another thread while a send is running and start a second there; one completing must not land its verdict on the other's composer.

## Test plan

`npx tsc --noEmit` clean, oxlint clean, `tests/web` **165/165** — including a refused send (keeps text + shows reason), an unreachable daemon, a gated in-flight send (locked box, text intact), and a cross-exchange leak check.

Gate: `openswarm review` 4 rounds → APPROVE (rounds 1–3 found the redraw race, the thread-scoping, and the concurrent-send overwrite).

## Linear

Closes AGT-4026