### PR TITLE
fix(web): send the operator's orchestration reply as a POST (AGT-4029)

### DIFF
--- a/tests/web/orchestrationView.test.ts
+++ b/tests/web/orchestrationView.test.ts
@@ -429,3 +429,41 @@ describe('clicking a feed row', () => {
     view.stop();
   });
 });
+
+describe('the default fetcher (AGT-4029)', () => {
+  // Every other test injects fetchImpl, so the fetcher a real browser uses was
+  // never exercised — and it dropped the request init, turning each POST into a
+  // GET the daemon answered 404. Drive the view with no fetchImpl so the
+  // default path is the one under test.
+  it('forwards method and body, so a send is a POST and not a GET', async () => {
+    const doc = shell();
+    const events = [
+      boardEvent({ id: 'q', seq: 1, summary: 'Retry in adapter or scheduler?' }),
+    ];
+    const calls: Array<[string, RequestInit | undefined]> = [];
+    const original = globalThis.fetch;
+    globalThis.fetch = ((url: string, init?: RequestInit) => {
+      calls.push([url, init]);
+      return Promise.resolve({ ok: true, json: async () => ({ events, pending: [], lastSeq: 1 }) } as Response);
+    }) as typeof fetch;
+
+    try {
+      const view = startOrchestrationView(doc, { eventSourceImpl: null, pollMs: 1e9 });
+      await vi.waitFor(() => expect(doc.querySelectorAll('#feed .ev').length).toBe(1));
+      (doc.querySelector('#feed .ev') as HTMLElement).dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+      (doc.getElementById('composer-text') as HTMLInputElement).value = 'Ship it.';
+      doc.getElementById('composer')!.dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
+
+      await vi.waitFor(() => {
+        expect(calls.some(([url]) => url === '/api/coordination/message')).toBe(true);
+      });
+      const [, init] = calls.find(([url]) => url === '/api/coordination/message')!;
+      expect(init?.method).toBe('POST');
+      expect(JSON.parse(String(init?.body))).toMatchObject({ text: 'Ship it.' });
+      view.stop();
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});

--- a/web/static/js/orchestrationView.mjs
+++ b/web/static/js/orchestrationView.mjs
@@ -363,7 +363,11 @@ export function renderThread(doc, thread, onSend, pending = null) {
 
 /** Entry point: fetch, render, then keep live via SSE with a polling backstop. */
 export function startOrchestrationView(doc, { fetchImpl, eventSourceImpl, pollMs = 30_000 } = {}) {
-  const fetcher = fetchImpl ?? ((url) => fetch(url));
+  // Forward the init: every send passes {method:'POST', headers, body} as the
+  // second argument, and dropping it turned each one into a GET — a path with
+  // no GET route, so the daemon answered 404 and the operator's reply never
+  // left the browser (AGT-4029).
+  const fetcher = fetchImpl ?? ((url, init) => fetch(url, init));
   const byId = new Map();
   let selected = null;
   let focusedEventId = null;


### PR DESCRIPTION
## The bug

```js
const fetcher = fetchImpl ?? ((url) => fetch(url));   // init dropped
```

Every send passes `{ method: 'POST', headers, body }` as the second argument. The default fetcher threw it away, so in a browser the operator's reply went out as a **GET** — and that path has no GET route:

```
GET  /api/coordination/message → 404 Not Found     (measured, live)
POST /api/coordination/message → 400 / 409 / 202   (measured, live)
```

`chatView.mjs` already forwarded it, which is exactly why the operator hit this only in the orchestration view.

This is the root cause of the original report — *typing a reply does nothing*. AGT-4026 stopped the composer swallowing failures, which turned the silence into a visible `The daemon refused the message (404)` and pointed straight here.

## Why no test caught it

Every existing test injects `fetchImpl`, so the fetcher a browser uses was never exercised. The tests assert the POST init the view *builds* — what was untested is whether anything forwards it.

The new test drives the view with **no** `fetchImpl`, stubs `globalThis.fetch`, and asserts the method and body arrive. Mutation-verified: restoring the old one-liner fails it.

## Test plan

`npx tsc --noEmit` clean, `tests/web` **166/166**, `openswarm review` APPROVE.

## Linear

Closes AGT-4029