### PR TITLE
feat(hitl): let the operator actually answer a parked agent (AGT-4030)

### DIFF
--- a/src/coordination/coordinationRoutes.test.ts
+++ b/src/coordination/coordinationRoutes.test.ts
@@ -93,6 +93,105 @@ describe('POST /api/coordination/message', () => {
     expect(delivered).toMatchObject({ recipient: 'worker-a', detail: 'Use the existing SQLite file.' });
   });
 
+  it('answers the recipient\'s open question even when the client names another exchange', async () => {
+    // The dashboard sees a window over a ring buffer, so a question older than
+    // that window is invisible to it and it names the newest exchange instead.
+    // Filing that as a note would leave the agent parked forever (AGT-4030).
+    const store = await boardAt('events.json');
+    const question = await store.publish({
+      repository: '/repo', taskId: 't-park', actor: 'sable', actorName: 'Sable', actorRole: 'worker',
+      kind: 'human-question', status: 'waiting', summary: 'uv is missing — install it or run elsewhere?',
+    });
+    const laterStage = await store.publish({
+      repository: '/repo', taskId: 't-park', actor: 'sable', actorName: 'Sable', actorRole: 'worker',
+      recipient: 'reviewer-1', kind: 'delegation-result', status: 'failed', summary: 'Did not pass',
+    });
+
+    const result = await post('/api/coordination/message', {
+      correlationId: laterStage.correlationId,
+      recipient: 'sable',
+      repository: '/repo',
+      taskId: 't-park',
+      text: 'uv is installed now — retry.',
+    });
+
+    expect(result.status).toBe(202);
+    expect(result.body.mode).toBe('answer');
+    // The answer must ride the QUESTION's exchange — that is the id the next
+    // run replays by — not the stage exchange the client named.
+    const answer = store.list({ repository: '/repo', taskId: 't-park' })
+      .find((event) => event.kind === 'human-answer');
+    expect(answer).toMatchObject({
+      correlationId: question.correlationId,
+      recipient: 'sable',
+      detail: 'uv is installed now — retry.',
+    });
+    expect(answer?.correlationId).not.toBe(laterStage.correlationId);
+  });
+
+  it('answers the question the agent is actually parked on when several are open', async () => {
+    // A run stops at the question it just asked, so the newest unsettled one is
+    // the live blocker — and the one the operator is reading.
+    const store = await boardAt('events.json');
+    const older = await store.publish({
+      repository: '/repo', taskId: 't-two', actor: 'worker-q', actorRole: 'worker',
+      kind: 'human-question', status: 'waiting', summary: 'Which database?',
+    });
+    const newer = await store.publish({
+      repository: '/repo', taskId: 't-two', actor: 'worker-q', actorRole: 'worker',
+      kind: 'human-question', status: 'waiting', summary: 'Which credentials?',
+    });
+
+    const result = await post('/api/coordination/message', {
+      recipient: 'worker-q', repository: '/repo', taskId: 't-two', text: 'Use the mounted ones.',
+    });
+
+    expect(result.body.mode).toBe('answer');
+    const answer = store.list({ repository: '/repo', taskId: 't-two' })
+      .find((event) => event.kind === 'human-answer');
+    expect(answer?.correlationId).toBe(newer.correlationId);
+    expect(answer?.correlationId).not.toBe(older.correlationId);
+  });
+
+  it('refuses to answer a same-named agent on a different task', async () => {
+    // Agents choose their own display names, so "sable" is not unique across
+    // concurrent work. Without the task scope this would unpark the wrong
+    // agent with an answer meant for someone else.
+    const store = await boardAt('events.json');
+    const theirs = await store.publish({
+      repository: '/other-repo', taskId: 't-other', actor: 'sable', actorName: 'Sable', actorRole: 'worker',
+      kind: 'human-question', status: 'waiting', summary: 'Ship the migration separately?',
+    });
+    const mine = await store.publish({
+      repository: '/repo', taskId: 't-mine', actor: 'sable', actorName: 'Sable', actorRole: 'worker',
+      recipient: 'reviewer-1', kind: 'advice-request', status: 'open', summary: 'Where does retry live?',
+    });
+
+    const result = await post('/api/coordination/message', {
+      correlationId: mine.correlationId, recipient: 'sable',
+      repository: '/repo', taskId: 't-mine', text: 'Scheduler owns retries.',
+    });
+
+    expect(result.body.mode).toBe('note');
+    expect(store.findQuestion(theirs.correlationId)).toBeDefined();
+  });
+
+  it('does not turn a note into an answer when the recipient has nothing open', async () => {
+    const store = await boardAt('events.json');
+    const opening = await store.publish({
+      repository: '/repo', taskId: 't-plain', actor: 'worker-z', actorName: 'Worker Z', actorRole: 'worker',
+      recipient: 'reviewer-z', kind: 'advice-request', status: 'open', summary: 'Which retry policy?',
+    });
+
+    const result = await post('/api/coordination/message', {
+      correlationId: opening.correlationId, recipient: 'worker-z',
+      repository: '/repo', taskId: 't-plain', text: 'Scheduler owns it.',
+    });
+
+    expect(result.status).toBe(202);
+    expect(result.body.mode).toBe('note');
+  });
+
   it('addresses a free-standing note to the agent that last spoke in the thread', async () => {
     const store = await boardAt('events.json');
     const opening = await store.publish({

--- a/src/coordination/coordinationRoutes.ts
+++ b/src/coordination/coordinationRoutes.ts
@@ -86,11 +86,23 @@ export async function tryHandleCoordinationRoutes(
     const correlationId = typeof body.correlationId === 'string' ? body.correlationId : undefined;
     const store = getCoordinationStore();
 
-    if (correlationId) {
-      const question = store.findQuestion(correlationId);
+    // Prefer answering over chatting. The client names the exchange it believes
+    // is open, but it only sees a window over the board's ring buffer — so when
+    // that lookup misses, fall back to the question that recipient is parked on,
+    // which only the server can see (AGT-4030).
+    const recipientHint = typeof body.recipient === 'string' && body.recipient ? body.recipient : undefined;
+    const scopeHint = {
+      ...(typeof body.repository === 'string' && body.repository ? { repository: body.repository } : {}),
+      ...(typeof body.taskId === 'string' && body.taskId ? { taskId: body.taskId } : {}),
+    };
+    const resolvedQuestion = (correlationId ? store.findQuestion(correlationId) : undefined)
+      ?? (recipientHint ? store.findOpenQuestionFor(recipientHint, scopeHint) : undefined);
+
+    {
+      const question = resolvedQuestion;
       if (question) {
         const { answerHumanQuestion } = await import('./humanQuestions.js');
-        const answered = await answerHumanQuestion(correlationId, text, 'operator-dashboard');
+        const answered = await answerHumanQuestion(question.correlationId, text, 'operator-dashboard');
         if (!answered.accepted) {
           writeJson(res, 409, { error: answered.reason ?? 'Question is no longer answerable' });
           return true;

--- a/src/coordination/coordinationStore.ts
+++ b/src/coordination/coordinationStore.ts
@@ -275,6 +275,46 @@ export class CoordinationStore {
       event.correlationId === correlationId && event.kind === 'human-question' && event.status === 'waiting');
   }
 
+  /**
+   * The blocking question an agent is still parked on.
+   *
+   * The dashboard can only reason about the events it has loaded, which is a
+   * window over a ring buffer — a question older than that window is invisible
+   * to it, and an operator's reply would be filed as an ordinary note while the
+   * agent stayed blocked. The retained board is here, so the decision belongs
+   * here (AGT-4030).
+   *
+   * The newest unsettled question wins when several are open: a run stops at
+   * the question it asked, so the latest is what the agent is parked on and
+   * what the operator is reading.
+   */
+  findOpenQuestionFor(
+    actor: string,
+    scope: { repository?: string; taskId?: string } = {},
+  ): CoordinationEvent | undefined {
+    // An address is not unique on its own: agents name themselves, so two on
+    // different tasks can both answer to "sable". The caller passes the task it
+    // is speaking into, and without one this refuses rather than guessing —
+    // answering the wrong task's blocking question would unpark an agent with
+    // an answer meant for someone else.
+    if (!scope.taskId && !scope.repository) return undefined;
+    const repository = scope.repository ? resolve(scope.repository) : undefined;
+    const events = this.load().events;
+    const settled = new Set(events
+      .filter((event) => ['completed', 'expired', 'failed'].includes(event.status))
+      .map((event) => event.correlationId));
+    for (let i = events.length - 1; i >= 0; i -= 1) {
+      const event = events[i];
+      if (event.kind === 'human-question'
+        && event.status === 'waiting'
+        && event.actor === actor
+        && (!repository || event.repository === repository)
+        && (!scope.taskId || event.taskId === scope.taskId)
+        && !settled.has(event.correlationId)) return event;
+    }
+    return undefined;
+  }
+
   async consume(consumer: string, options: { repository?: string; taskId?: string; includeAll?: boolean }): Promise<CoordinationEvent[]> {
     return this.mutate((state) => {
       const seen = new Set(state.consumed[consumer] ?? []);

--- a/tests/web/chatView.test.ts
+++ b/tests/web/chatView.test.ts
@@ -307,3 +307,69 @@ describe('startChatView composer outcome (AGT-4026)', () => {
     view.stop();
   });
 });
+
+describe('answering a parked agent from chat (AGT-4030)', () => {
+  // Ten agents sat on human-question with no way to answer them: the composer
+  // addressed the newest stage exchange, so the daemon filed the reply as a
+  // note and nothing unparked.
+  const parked = () => [
+    boardEvent({ id: 'stage', seq: 9, correlationId: 'stage:abc:worker:2', actor: 'sable', actorName: 'Sable' }),
+    boardEvent({
+      id: 'q', seq: 10, kind: 'human-question', status: 'waiting',
+      correlationId: 'hq-9', repository: '/work/repo', taskId: 'task-9',
+      actor: 'sable', actorName: 'Sable', actorRole: 'worker',
+      recipient: 'human', recipientName: 'Operator', recipientRole: 'human',
+      summary: 'uv is missing — install it or run elsewhere?',
+    }),
+  ];
+
+  it('sends on the question\'s exchange, not the newest one', async () => {
+    const doc = shell();
+    const fetchImpl = fetchWith(parked());
+    const view = startChatView(doc, { fetchImpl, eventSourceImpl: null });
+    await vi.waitFor(() => expect(doc.querySelectorAll('#room .line').length).toBe(2));
+
+    const input = doc.getElementById('composer-text') as HTMLInputElement;
+    input.value = 'uv is installed now — retry.';
+    doc.getElementById('composer')!.dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
+
+    await vi.waitFor(() => expect(fetchImpl.mock.calls.some((c) => c[0] === '/api/coordination/message')).toBe(true));
+    const [, init] = fetchImpl.mock.calls.find((c) => c[0] === '/api/coordination/message')!;
+    expect(JSON.parse((init as { body: string }).body)).toEqual({
+      correlationId: 'hq-9',
+      recipient: 'sable',
+      repository: '/work/repo',
+      taskId: 'task-9',
+      text: 'uv is installed now — retry.',
+    });
+    view.stop();
+  });
+
+  it('says it is answering, and what', async () => {
+    const doc = shell();
+    const view = startChatView(doc, { fetchImpl: fetchWith(parked()), eventSourceImpl: null });
+    await vi.waitFor(() => expect(doc.querySelectorAll('#room .line').length).toBe(2));
+
+    const input = doc.getElementById('composer-text') as HTMLInputElement;
+    expect(input.placeholder).toContain('Answer Sable');
+    expect(input.placeholder).toContain('uv is missing');
+    view.stop();
+  });
+
+  it('still just talks when nobody is waiting on an answer', async () => {
+    const doc = shell();
+    const fetchImpl = fetchWith([boardEvent({ id: 'a', seq: 1, correlationId: 'c-plain' })]);
+    const view = startChatView(doc, { fetchImpl, eventSourceImpl: null });
+    await vi.waitFor(() => expect(doc.querySelectorAll('#room .line').length).toBe(1));
+
+    const input = doc.getElementById('composer-text') as HTMLInputElement;
+    expect(input.placeholder).toContain('Message ');
+    input.value = 'just chatting';
+    doc.getElementById('composer')!.dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
+
+    await vi.waitFor(() => expect(fetchImpl.mock.calls.some((c) => c[0] === '/api/coordination/message')).toBe(true));
+    const [, init] = fetchImpl.mock.calls.find((c) => c[0] === '/api/coordination/message')!;
+    expect(JSON.parse((init as { body: string }).body).correlationId).toBe('c-plain');
+    view.stop();
+  });
+});

--- a/tests/web/conversationModel.test.ts
+++ b/tests/web/conversationModel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 // @ts-expect-error - plain ESM module served to the browser
-import { buildChatLines, buildThreads, chatLineOf, isUtterance, latestAddressable, metadataPairs, taskLabelOf, threadFor } from '../../web/static/js/conversationModel.mjs';
+import { buildChatLines, buildThreads, chatLineOf, isUtterance, latestAddressable, metadataPairs, openQuestionFor, taskLabelOf, threadFor } from '../../web/static/js/conversationModel.mjs';
 
 function event(overrides: Record<string, unknown> = {}) {
   return {
@@ -177,5 +177,49 @@ describe('latestAddressable', () => {
     expect(latestAddressable([
       event({ actor: 'operator-dashboard', actorRole: 'human' }),
     ])).toBeNull();
+  });
+});
+
+describe('openQuestionFor (AGT-4030)', () => {
+  const question = (over: Record<string, unknown> = {}) => event({
+    kind: 'human-question', status: 'waiting', correlationId: 'hq-1',
+    actor: 'sable', actorRole: 'worker', recipient: 'human', seq: 5, ...over,
+  });
+
+  it('finds the question an agent is still parked on', () => {
+    expect(openQuestionFor([event({ seq: 1 }), question()], 'sable', { taskId: 'uuid-1234-5678-9012' })?.correlationId).toBe('hq-1');
+  });
+
+  it('ignores a question that has since been answered', () => {
+    const answered = event({
+      kind: 'human-answer', status: 'completed', correlationId: 'hq-1',
+      actor: 'operator-dashboard', actorRole: 'human', recipient: 'sable', seq: 6,
+    });
+    expect(openQuestionFor([question(), answered], 'sable', { taskId: 'uuid-1234-5678-9012' })).toBeNull();
+  });
+
+  it('keeps an older open question when a newer one was already answered', () => {
+    // An agent can ask twice; answering the second must not hide the first.
+    const older = question({ id: 'q1', correlationId: 'hq-1', seq: 5 });
+    const newer = question({ id: 'q2', correlationId: 'hq-2', seq: 7 });
+    const answeredNewer = event({
+      id: 'a2', kind: 'human-answer', status: 'completed', correlationId: 'hq-2',
+      actor: 'operator-dashboard', actorRole: 'human', recipient: 'sable', seq: 8,
+    });
+    expect(openQuestionFor([older, newer, answeredNewer], 'sable', { taskId: 'uuid-1234-5678-9012' })?.correlationId).toBe('hq-1');
+  });
+
+  it('is null for a different agent, and for none', () => {
+    const scope = { taskId: 'uuid-1234-5678-9012' };
+    expect(openQuestionFor([question()], 'worker-3f2a', scope)).toBeNull();
+    expect(openQuestionFor([question()], undefined, scope)).toBeNull();
+    expect(openQuestionFor([event({ seq: 1 })], 'sable', scope)).toBeNull();
+  });
+
+  it('will not cross tasks, and refuses when given no scope at all', () => {
+    // Self-chosen names are not unique and the room shows every task at once.
+    const theirs = question({ taskId: 'another-task', correlationId: 'hq-other' });
+    expect(openQuestionFor([theirs], 'sable', { taskId: 'uuid-1234-5678-9012' })).toBeNull();
+    expect(openQuestionFor([theirs], 'sable', {})).toBeNull();
   });
 });

--- a/web/static/js/chatView.mjs
+++ b/web/static/js/chatView.mjs
@@ -8,7 +8,7 @@
 // (`/api/coordination/history`), live updates from the same SSE channel the
 // orchestration view uses, with the board snapshot as a polling backstop.
 
-import { buildChatLines, latestAddressable } from './conversationModel.mjs';
+import { buildChatLines, latestAddressable, openQuestionFor } from './conversationModel.mjs';
 import { ROLE_COLORS } from './orchestrationView.mjs';
 
 const PENDING = new Set(['open', 'waiting', 'running']);
@@ -89,14 +89,21 @@ export function startChatView(doc, { fetchImpl, eventSourceImpl, pollMs = 30_000
     // The composer can only address an agent that exists; without one the
     // POST would be unroutable (the API requires repository/taskId/recipient).
     const target = latestAddressable(events);
+    const question = target
+      ? openQuestionFor(events, target.actor, { repository: target.repository, taskId: target.taskId })
+      : null;
     if (input) {
       // A send takes seconds under load (AGT-4027) and agent events keep
       // arriving, so a redraw lands mid-flight — it must not re-enable the box
       // the send just locked.
       input.disabled = !target || sending;
-      input.placeholder = target
-        ? `Message ${target.actorName || target.actor}…`
-        : 'No agent to address yet';
+      // Say which of the two things the next message will do: unpark an agent
+      // that is waiting, or just speak into the room.
+      input.placeholder = !target
+        ? 'No agent to address yet'
+        : question
+          ? `Answer ${target.actorName || target.actor}: ${(question.summary || '').slice(0, 60)}…`
+          : `Message ${target.actorName || target.actor}…`;
     }
     if (button) button.disabled = !target || sending;
     if (stick) room.scrollTop = room.scrollHeight;
@@ -116,18 +123,24 @@ export function startChatView(doc, { fetchImpl, eventSourceImpl, pollMs = 30_000
   // resolves happily on 400/409 — the server's own "cannot address this" and
   // "already answered" both arrive that way (AGT-4026).
   const send = async (text) => {
-    const target = latestAddressable([...byId.values()]);
+    const events = [...byId.values()];
+    const target = latestAddressable(events);
     if (!target) return 'No agent is addressable yet.';
+    // Answering beats chatting: if this agent is parked on a question, the
+    // message has to ride that exchange or the daemon files it as a note and
+    // the agent stays blocked (AGT-4030).
+    const question = openQuestionFor(events, target.actor, { repository: target.repository, taskId: target.taskId });
+    const exchange = question ?? target;
     let response;
     try {
       response = await fetcher('/api/coordination/message', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          correlationId: target.correlationId,
+          correlationId: exchange.correlationId,
           recipient: target.actor,
-          repository: target.repository,
-          taskId: target.taskId,
+          repository: exchange.repository,
+          taskId: exchange.taskId,
           text,
         }),
       });

--- a/web/static/js/conversationModel.mjs
+++ b/web/static/js/conversationModel.mjs
@@ -152,6 +152,39 @@ export function buildChatLines(events) {
  * actual utterance. A daemon's instruction snapshot is not a speaker, and the
  * operator cannot address themselves.
  */
+/**
+ * The blocking question an agent is still parked on, if any.
+ *
+ * An operator writing to an agent that is waiting on them means "here is your
+ * answer" — but the daemon only turns a message into a `human-answer` when its
+ * correlation id names a pending question. Addressing the newest exchange
+ * instead files a note the agent never unparks on, which is what left ten
+ * agents waiting with no way to reply (AGT-4030).
+ */
+export function openQuestionFor(events, actorAddress, scope = {}) {
+  if (!actorAddress) return null;
+  // An address is not unique: agents name themselves, so two on different tasks
+  // can both answer to "sable", and the room shows every task at once. Without
+  // the task this would offer to answer someone else's blocking question.
+  if (!scope.taskId && !scope.repository) return null;
+  // A later terminal event on the same exchange means the question was answered
+  // or expired since; the board keeps both. Settle each candidate before
+  // picking, not after — an agent can be parked on an older question while a
+  // newer one has already been resolved, and taking the newest first would
+  // report "nothing open" and file the reply as a note.
+  const open = events
+    .filter((event) => event.kind === 'human-question'
+      && event.status === 'waiting'
+      && event.actor === actorAddress
+      && (!scope.repository || event.repository === scope.repository)
+      && (!scope.taskId || event.taskId === scope.taskId))
+    .filter((question) => !events.some((event) => event.correlationId === question.correlationId
+      && event.seq > question.seq
+      && ['completed', 'expired', 'failed'].includes(event.status)))
+    .sort((a, b) => a.seq - b.seq);
+  return open[open.length - 1] ?? null;
+}
+
 export function latestAddressable(events) {
   const spoken = events.filter(isUtterance).sort((a, b) => a.seq - b.seq);
   for (let i = spoken.length - 1; i >= 0; i -= 1) {

--- a/web/static/js/orchestrationView.mjs
+++ b/web/static/js/orchestrationView.mjs
@@ -10,7 +10,7 @@
 import { buildOrchestrationModel, dominantKind, KIND_COLORS } from './orchestrationModel.mjs';
 import { layoutTiers } from './tierLayout.mjs';
 import {
-  buildThreads, chatLineOf, isUtterance, metadataPairs, taskLabelOf, threadFor,
+  buildThreads, chatLineOf, isUtterance, metadataPairs, openQuestionFor, taskLabelOf, threadFor,
 } from './conversationModel.mjs';
 
 export const ROLE_COLORS = {
@@ -398,16 +398,23 @@ export function startOrchestrationView(doc, { fetchImpl, eventSourceImpl, pollMs
   };
 
   const publish = async (thread, text) => {
+    // Answering beats chatting: an agent parked on a question needs the message
+    // on THAT exchange, or the daemon files it as a note and it stays blocked
+    // (AGT-4030).
+    const question = openQuestionFor([...byId.values()], thread.replyTo?.address, {
+      repository: thread.events[0]?.repository,
+      taskId: thread.taskId,
+    });
     let response;
     try {
       response = await fetcher('/api/coordination/message', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          correlationId: thread.correlationId,
+          correlationId: question?.correlationId ?? thread.correlationId,
           recipient: thread.replyTo?.address,
-          repository: thread.events[0]?.repository,
-          taskId: thread.taskId,
+          repository: question?.repository ?? thread.events[0]?.repository,
+          taskId: question?.taskId ?? thread.taskId,
           text,
         }),
       });


### PR DESCRIPTION
## Why

Ten agents were sitting on `human-question` with *awaiting your answer* next to them, and **neither surface could answer one**. The composer addressed the newest exchange, so the daemon — which only converts a message into a `human-answer` when its correlation id names a pending question — filed the reply as an ordinary note. Nothing unparked.

This is the last of three defects that together left human-in-the-loop with no working entry point: AGT-4029 (the orchestration composer sent GETs), AGT-4026 (failures were swallowed silently), and this one (replies went to the wrong exchange).

## What changed

**The decision moved to the server.** The dashboard reasons only over the events it has loaded — a window on a ring buffer — so a question older than that window is invisible to it. The retained board is on the server, so `findOpenQuestionFor` lives there and the route prefers it when the client's named exchange is not a pending question.

**The client still resolves it too**, so the composer can say *which* question the next message will answer instead of leaving the operator guessing.

**Both lookups are scoped to a repository/task, and refuse when given neither.** Agents name themselves, so two on different tasks can both answer to `sable`, and the chat room shows every task at once — unscoped, an operator could unpark the wrong agent with an answer meant for someone else.

**Newest open question wins.** A run stops at the question it asked, so the latest unsettled one is what the agent is parked on and what the operator is reading.

## Verified

Answer replay does *not* depend on the mailbox address — `humanQuestionCorrelation` hashes (repository, taskId, question), so the next run of a task finds the recorded answer by correlation id, and the `waiting_on_operator` handler already re-admits the task on a backoff timer. That is why routing the reply onto the question's exchange is sufficient to unpark it.

## Test plan

`npx tsc --noEmit` clean, lint clean, **231/231** across `src/coordination` and `tests/web` — including answering past a stale client hint, refusing a same-named agent on another task, picking the newest of several open questions, and leaving an ordinary note alone.

`openswarm review`: 7 rounds → APPROVE (rounds found the settled-newest miss, the ring-buffer window, cross-task collision on both sides, and a comment that contradicted the code).

## Linear

Closes AGT-4030