### PR TITLE
build: ship uv and Python 3.12 so agents can verify Python work (AGT-4032)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,12 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends gh && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# uv, for repositories that are uv projects. Copied from the official image
+# rather than piped from an installer, and pinned by digest rather than tag —
+# a tag can be repointed, so only the digest makes this build reproducible.
+# The digest is the multi-arch index for v0.5.11; bump both together.
+COPY --from=ghcr.io/astral-sh/uv@sha256:0ac957607303916420297a4c9c213bb33fbd3c888f9cd7f4f7273596ebf42b85 /uv /uvx /usr/local/bin/
+
 RUN groupadd --gid 1001 openswarm && \
     useradd --uid 1001 --gid openswarm --shell /bin/bash --create-home openswarm
 
@@ -90,7 +96,16 @@ RUN mkdir -p /work /home/openswarm/.openswarm && \
 
 USER openswarm
 ENV HOME=/home/openswarm \
-    NODE_ENV=production
+    NODE_ENV=production \
+    UV_PYTHON_INSTALL_DIR=/home/openswarm/.local/share/uv/python
+
+# Bake the interpreter in rather than letting uv fetch it on first use: that
+# download lands under $HOME, which is not a mounted volume, so every container
+# recreate would pay for it again — and an agent whose first act is a 30 MB
+# fetch looks like a hung task. The distribution `python3` above stays: CodeQL's
+# Python extractor shells out to it, and that is a separate need from a project
+# runtime (Debian ships 3.11, and repositories here are on 3.12).
+RUN uv python install 3.12
 
 # Mounted repositories belong to arbitrary host UIDs; without this every git
 # operation inside /work dies with "dubious ownership". The container's whole


### PR DESCRIPTION
## Why

Measured in the running container:

```
which uv          → (nothing)
python3 --version → Python 3.11.2
```

cgf-portal is a `uv` project on Python 3.12 whose `db.py` uses PEP 695 syntax that 3.11 cannot compile. An agent there can write code but cannot run one check — the exact failure mode this whole chain exists to prevent. One agent is parked on `uv: command not found`.

## What changed

* `uv` and `uvx` copied from the official image, **pinned by digest**. A tag can be repointed, so only the digest makes the build reproducible — the review round that caught this was right.
* `uv python install 3.12` at build time, not on first use. That download lands under `$HOME`, which is not a mounted volume, so every container recreate would pay for it again — and an agent whose first act is a 30 MB fetch looks like a hung task.
* The distribution `python3` **stays**. It is there for CodeQL's Python extractor; without it a single tracked `.py` file fails `codeql database create` and parks the task as an infra error. That is a separate need from a project runtime.

## Verified in the built image (on the deployment host)

```
uv 0.5.11
uvx: uv-tool-uvx 0.5.11
system python3 (CodeQL): Python 3.11.2
uv-managed: cpython-3.12.8-linux-x86_64-gnu
PEP 695 compile check on 3.12: pep695 ok
```

Rebuilt after the digest pin and re-verified. `openswarm review`: APPROVE (it independently confirmed the digest resolves to a multi-arch index and that the non-root user owns the install dir before the install runs).

## Linear

Closes AGT-4032