### PR TITLE
fix(daemon): let an operator's answer end the wait it was answering (AGT-4033)

### DIFF
--- a/src/automation/automationDbPath.ts
+++ b/src/automation/automationDbPath.ts
@@ -22,6 +22,11 @@ let configured: string | null = null;
  *
  * Resolving both through here is what makes that hold by construction, rather
  * than by every new consumer remembering to ask.
+ *
+ * Declared once per process, at the point the process learns its configuration —
+ * a process has one automation database, the same way it has one coordination
+ * board. Callers that build a runner without going through that point (tests)
+ * redirect every store together with `OPENSWARM_AUTOMATION_DB` instead.
  */
 export function setAutomationDbPath(path: string | undefined): void {
   configured = path ? resolve(path) : null;

--- a/src/automation/automationDbPath.ts
+++ b/src/automation/automationDbPath.ts
@@ -9,9 +9,32 @@
 import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 
-/** Absolute path of the automation database, honouring the test override. */
+let configured: string | null = null;
+
+/**
+ * Point every automation store at the database this deployment configured.
+ *
+ * The run ledger is handed its path explicitly, but the coordination trace is
+ * not — and since the trace stopped being a pure archive and became what says
+ * whether a parked run may be re-admitted, the two have to be the same file. A
+ * deployment that relocates its automation database must take the answers with
+ * it, or the runs move and what is known about them stays behind.
+ *
+ * Resolving both through here is what makes that hold by construction, rather
+ * than by every new consumer remembering to ask.
+ */
+export function setAutomationDbPath(path: string | undefined): void {
+  configured = path ? resolve(path) : null;
+}
+
+/**
+ * Absolute path of the automation database.
+ *
+ * The environment override wins: tests redirect every automation store at once
+ * by setting it, and must not be overruled by whatever config a runner under
+ * test was constructed with.
+ */
 export function defaultAutomationDbPath(): string {
-  return process.env.OPENSWARM_AUTOMATION_DB
-    ? resolve(process.env.OPENSWARM_AUTOMATION_DB)
-    : resolve(homedir(), '.openswarm', 'automation.db');
+  if (process.env.OPENSWARM_AUTOMATION_DB) return resolve(process.env.OPENSWARM_AUTOMATION_DB);
+  return configured ?? resolve(homedir(), '.openswarm', 'automation.db');
 }

--- a/src/automation/autonomousRunner.operatorPark.test.ts
+++ b/src/automation/autonomousRunner.operatorPark.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import type { DurableRunCoordinator } from './durableRunCoordinator.js';
+
+vi.mock('../core/providerOverride.js', () => ({ writeProviderOverride: vi.fn() }));
+vi.mock('../agents/stageModelResolver.js', () => ({ resolveAdapterDefaultModel: vi.fn(async () => 'model') }));
+
+// The board is not what this file is about: every case here fixes whether the
+// operator has answered and asks what the park signal does around it.
+let answered = false;
+vi.mock('../coordination/coordinationStore.js', () => ({
+  getCoordinationStore: () => ({ allQuestionsAnswered: () => answered }),
+}));
+
+type InternalRunner = {
+  filterAlreadyProcessed(tasks: TaskItem[]): TaskItem[];
+  failedTaskRetryTimes: Map<string, number>;
+  resolveProjectPath(task: TaskItem): Promise<string | null>;
+  durableRuns: DurableRunCoordinator;
+  readmitAnsweredRun(issueId: string): boolean;
+  answerArrivedFor(issueId: string): boolean;
+};
+
+const TASK: TaskItem = {
+  id: 'AGT-1', issueId: 'AGT-1', issueIdentifier: 'AGT-1',
+  source: 'linear', title: 'parked on the operator', priority: 2, createdAt: 0,
+  linearState: 'Todo', linearProject: { id: 'project', name: 'Repo' },
+};
+
+describe('operator park without an authoritative ledger (AGT-4033)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    answered = false;
+    root = mkdtempSync(join(tmpdir(), 'openswarm-operator-park-'));
+    vi.stubEnv('OPENSWARM_TASK_STATE_FILE', join(root, 'task-state.json'));
+    vi.stubEnv('OPENSWARM_RUNNER_TASK_STATE_FILE', join(root, 'runner-state.json'));
+    vi.stubEnv('OPENSWARM_RUNNER_REJECTION_STATE_FILE', join(root, 'rejections.json'));
+    vi.stubEnv('OPENSWARM_RUNNER_PIPELINE_HISTORY_FILE', join(root, 'history.json'));
+    vi.stubEnv('OPENSWARM_RUNNER_DECOMPOSITION_STATE_FILE', join(root, 'decomposition.json'));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(root, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  async function makeRunner(): Promise<{
+    internal: InternalRunner;
+    park: (parked: boolean) => void;
+    parkReason: () => string | undefined;
+  }> {
+    // A backoff already running, as an `ask_human` park leaves one.
+    writeFileSync(join(root, 'runner-state.json'), JSON.stringify({
+      completed: [], failed: {}, retryTimes: { 'AGT-1': Date.now() + 3_600_000 }, lastFailures: {},
+    }));
+    const [{ AutonomousRunner }, store] = await Promise.all([
+      import('./autonomousRunner.js'),
+      import('../taskState/store.js'),
+    ]);
+    const runner = new AutonomousRunner({
+      linearTeamId: 'team', allowedProjects: ['/repo'], heartbeatSchedule: '0 * * * *',
+      autoExecute: true, maxConsecutiveTasks: 1, cooldownSeconds: 0, dryRun: true,
+      automationLedgerMode: 'off',
+    });
+    const internal = runner as unknown as InternalRunner;
+    internal.resolveProjectPath = vi.fn(async () => '/repo');
+    return {
+      internal,
+      park: (parked) => store.upsertTaskState('AGT-1', {
+        execution: { blockedReason: parked ? 'waiting_on_operator' : undefined },
+      } as Parameters<typeof store.upsertTaskState>[1]),
+      parkReason: () => store.getTaskState('AGT-1')?.execution?.blockedReason,
+    };
+  }
+
+  it('holds a parked task on its backoff until the answer is there', async () => {
+    const { internal, park } = await makeRunner();
+    park(true);
+
+    expect(internal.filterAlreadyProcessed([TASK])).toEqual([]);
+  });
+
+  it('cuts the backoff short once the operator answers, and spends the park doing it', async () => {
+    const { internal, park, parkReason } = await makeRunner();
+    park(true);
+    answered = true;
+
+    expect(internal.filterAlreadyProcessed([TASK])).toEqual([TASK]);
+    expect(parkReason()).toBeUndefined();
+  });
+
+  it('does not let an old answer pull a later ordinary failure forward', async () => {
+    // The defect this replaced: the park was only cleared on the early path, so a
+    // task that simply waited out its backoff kept it. The next ordinary failure
+    // then met a park it had long since left and an answer that is still on the
+    // board, and was re-admitted on every heartbeat past the backoff that exists
+    // to stop exactly that.
+    const { internal, park } = await makeRunner();
+    park(true);
+    answered = true;
+
+    // The backoff runs out on its own before the heartbeat looks at it.
+    internal.failedTaskRetryTimes.set('AGT-1', Date.now() - 1_000);
+    expect(internal.filterAlreadyProcessed([TASK])).toEqual([TASK]);
+
+    // Now it fails for its own reasons and backs off again.
+    internal.failedTaskRetryTimes.set('AGT-1', Date.now() + 3_600_000);
+    expect(internal.filterAlreadyProcessed([TASK])).toEqual([]);
+  });
+});
+
+describe('operator park on the run ledger (AGT-4033)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    answered = false;
+    root = mkdtempSync(join(tmpdir(), 'openswarm-operator-park-ledger-'));
+    vi.stubEnv('OPENSWARM_TASK_STATE_FILE', join(root, 'task-state.json'));
+    vi.stubEnv('OPENSWARM_RUNNER_TASK_STATE_FILE', join(root, 'runner-state.json'));
+    vi.stubEnv('OPENSWARM_RUNNER_REJECTION_STATE_FILE', join(root, 'rejections.json'));
+    vi.stubEnv('OPENSWARM_RUNNER_PIPELINE_HISTORY_FILE', join(root, 'history.json'));
+    vi.stubEnv('OPENSWARM_RUNNER_DECOMPOSITION_STATE_FILE', join(root, 'decomposition.json'));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(root, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  /**
+   * Park the run on `errorCode` and hand back a runner reading the same ledger.
+   *
+   * The park is written through a second connection because that is the only way
+   * to reach a claim from here — and it is the same file the runner reads, which
+   * is the point: what the heartbeat sees is the row, not anything beside it.
+   */
+  async function parkedRunner(errorCode: string): Promise<InternalRunner> {
+    const dbPath = join(root, 'runs.db');
+    const [{ AutonomousRunner }, { RunLedger }] = await Promise.all([
+      import('./autonomousRunner.js'),
+      import('./runLedger.js'),
+    ]);
+    const ledger = new RunLedger(dbPath);
+    ledger.registerRun({
+      issueId: 'AGT-1', source: 'linear', identifier: 'AGT-1',
+      title: 'parked on the operator', projectPath: '/repo',
+    }, 1_000);
+    const claim = ledger.claimRun('AGT-1', {
+      ownerInstanceId: 'daemon', leaseMs: 60_000, maxActiveForProject: 1, now: 2_000,
+    });
+    expect(claim).not.toBeNull();
+    expect(ledger.transition(claim!, 'RETRY_AT', {
+      retryAt: Date.now() + 3_600_000, errorCode,
+    }, 2_100)).toBe(true);
+    ledger.close();
+
+    const runner = new AutonomousRunner({
+      linearTeamId: 'team', allowedProjects: ['/repo'], heartbeatSchedule: '0 * * * *',
+      autoExecute: true, maxConsecutiveTasks: 1, cooldownSeconds: 0, dryRun: true,
+      automationLedgerMode: 'primary', automationDbPath: dbPath,
+    });
+    const internal = runner as unknown as InternalRunner;
+    internal.resolveProjectPath = vi.fn(async () => '/repo');
+    return internal;
+  }
+
+  it('brings a run parked on the operator forward once the answer lands', async () => {
+    const internal = await parkedRunner('waiting_on_operator');
+    answered = true;
+
+    expect(internal.filterAlreadyProcessed([TASK])).toEqual([TASK]);
+    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('READY');
+    internal.durableRuns.close();
+  });
+
+  it('refuses to promote on an observation another daemon has already invalidated', async () => {
+    // The park is read on one statement and acted on by the next. A second daemon
+    // can end the parked attempt in that gap, and the failure that replaces it has
+    // to keep its own backoff — so the promotion re-checks rather than trusting
+    // what the heartbeat saw.
+    const internal = await parkedRunner('waiting_on_operator');
+    const { RunLedger } = await import('./runLedger.js');
+    internal.answerArrivedFor = () => true; // the now-stale observation
+
+    const other = new RunLedger(join(root, 'runs.db'));
+    expect(other.readmitParkedRun('AGT-1', 'waiting_on_operator')).toBe(true);
+    const claim = other.claimRun('AGT-1', {
+      ownerInstanceId: 'other-daemon', leaseMs: 60_000, maxActiveForProject: 1,
+    });
+    expect(claim).not.toBeNull();
+    expect(other.transition(claim!, 'RETRY_AT', {
+      retryAt: Date.now() + 3_600_000, errorCode: 'failed',
+    })).toBe(true);
+    other.close();
+
+    expect(internal.readmitAnsweredRun('AGT-1')).toBe(false);
+    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('RETRY_AT');
+    internal.durableRuns.close();
+  });
+
+  it('leaves an ordinary failure on its backoff, answered question or not', async () => {
+    // The park has to expire with the attempt that caused it. Here the run backed
+    // off for its own reasons, so the answer still on the board says nothing about
+    // it — and the ledger, which overwrites the code on every transition, is what
+    // makes that distinction without anyone maintaining a flag.
+    const internal = await parkedRunner('failed');
+    answered = true;
+
+    expect(internal.filterAlreadyProcessed([TASK])).toEqual([]);
+    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('RETRY_AT');
+    internal.durableRuns.close();
+  });
+});

--- a/src/automation/autonomousRunner.operatorPark.test.ts
+++ b/src/automation/autonomousRunner.operatorPark.test.ts
@@ -78,6 +78,25 @@ describe('operator park without an authoritative ledger (AGT-4033)', () => {
     };
   }
 
+  it('points the answer store at the same database as the runs', async () => {
+    // The ledger is handed its path; the coordination trace resolves its own. If
+    // they disagree a deployment that relocates its automation database leaves
+    // the answers behind, and a parked run can never learn that its question was
+    // answered. Only the runner knows both, so it is the runner that has to say.
+    const { defaultAutomationDbPath } = await import('./automationDbPath.js');
+    const { AutonomousRunner } = await import('./autonomousRunner.js');
+    const configured = join(root, 'relocated', 'automation.db');
+    delete process.env.OPENSWARM_AUTOMATION_DB;
+
+    new AutonomousRunner({
+      linearTeamId: 'team', allowedProjects: ['/repo'], heartbeatSchedule: '0 * * * *',
+      autoExecute: true, maxConsecutiveTasks: 1, cooldownSeconds: 0, dryRun: true,
+      automationLedgerMode: 'off', automationDbPath: configured,
+    });
+
+    expect(defaultAutomationDbPath()).toBe(configured);
+  });
+
   it('holds a parked task on its backoff until the answer is there', async () => {
     const { internal, park } = await makeRunner();
     park(true);

--- a/src/automation/autonomousRunner.operatorPark.test.ts
+++ b/src/automation/autonomousRunner.operatorPark.test.ts
@@ -84,11 +84,13 @@ describe('operator park without an authoritative ledger (AGT-4033)', () => {
     // the answers behind, and a parked run can never learn that its question was
     // answered. Only the runner knows both, so it is the runner that has to say.
     const { defaultAutomationDbPath } = await import('./automationDbPath.js');
-    const { AutonomousRunner } = await import('./autonomousRunner.js');
+    const { getRunner } = await import('./autonomousRunner.js');
     const configured = join(root, 'relocated', 'automation.db');
     delete process.env.OPENSWARM_AUTOMATION_DB;
 
-    new AutonomousRunner({
+    // Through the factory the process actually uses, which is where the one
+    // automation database a process has is declared.
+    getRunner({
       linearTeamId: 'team', allowedProjects: ['/repo'], heartbeatSchedule: '0 * * * *',
       autoExecute: true, maxConsecutiveTasks: 1, cooldownSeconds: 0, dryRun: true,
       automationLedgerMode: 'off', automationDbPath: configured,

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -30,7 +30,7 @@ import {
 } from './runnerState.js';
 import { taskEventKey, DecisionEngine, DecisionResult, TaskItem, getDecisionEngine, classifyStuck } from '../orchestration/decisionEngine.js';
 import { getCoordinationStore } from '../coordination/coordinationStore.js';
-import { OPERATOR_PARK_REASON, shouldReadmitEarly } from '../coordination/operatorAnswers.js';
+import { OPERATOR_PARK_REASON, readmitWithRollback, shouldReadmitEarly } from '../coordination/operatorAnswers.js';
 // ExecutorResult used via execution.reportExecutionResult
 import { checkWorkAllowed } from '../support/timeWindow.js';
 import { shouldEarlyStuckForInfeasibility } from '../support/feasibilityDetector.js';
@@ -291,13 +291,12 @@ export class AutonomousRunner {
    */
   private readmitAnsweredRun(issueId: string): boolean {
     if (!this.answerArrivedFor(issueId)) return false;
-    // Retire the signal first. If this write fails the task keeps its backoff —
-    // which is only a delay — whereas re-admitting on a signal that is still set
-    // would let a run that then fails for its own reasons be pulled forward
-    // again on every heartbeat, past the backoff that exists to stop exactly
-    // that. The answer is durable, so nothing is lost by waiting.
-    if (!markOperatorPark(issueId, false)) return false;
-    if (!this.durableRuns.markReady(issueId)) return false;
+    const promoted = readmitWithRollback({
+      retireSignal: () => markOperatorPark(issueId, false),
+      promote: () => this.durableRuns.markReady(issueId),
+      restoreSignal: () => { markOperatorPark(issueId, true); },
+    });
+    if (!promoted) return false;
     clearRetryTime(issueId, this.failedTaskRetryTimes);
     return true;
   }

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -30,7 +30,7 @@ import {
 } from './runnerState.js';
 import { taskEventKey, DecisionEngine, DecisionResult, TaskItem, getDecisionEngine, classifyStuck } from '../orchestration/decisionEngine.js';
 import { getCoordinationStore } from '../coordination/coordinationStore.js';
-import { OPERATOR_PARK_REASON, readmitWithRollback, shouldReadmitEarly } from '../coordination/operatorAnswers.js';
+import { OPERATOR_PARK_REASON, shouldReadmitEarly } from '../coordination/operatorAnswers.js';
 // ExecutorResult used via execution.reportExecutionResult
 import { checkWorkAllowed } from '../support/timeWindow.js';
 import { shouldEarlyStuckForInfeasibility } from '../support/feasibilityDetector.js';
@@ -135,20 +135,21 @@ export function decisionSelectionBudget(availableSlots: number, candidateCount: 
 }
 
 /**
- * Record, or clear, that a task is stopped waiting on the operator.
+ * Record, or retire, the stand-in park signal for a task whose park cannot be
+ * carried by the run ledger.
  *
- * Failing to write is not worth aborting a heartbeat over: the task then waits
- * out its backoff, which is what happened before any of this existed.
+ * Best effort in both directions, and deliberately so. Failing to record leaves
+ * the task on its backoff, which is only a delay. Failing to retire costs at
+ * most one early retry, still capped by MAX_RETRY_COUNT — whereas refusing to
+ * admit the task until the write succeeds could stall it for good.
  */
-function markOperatorPark(issueId: string, parked: boolean): boolean {
+function setOperatorPark(issueId: string, parked: boolean): void {
   try {
     upsertTaskState(issueId, {
       execution: { blockedReason: parked ? OPERATOR_PARK_REASON : undefined },
     } as Parameters<typeof upsertTaskState>[1]);
-    return true;
   } catch (error) { // cxt-ignore: error_swallow — the backoff is the fallback
     console.warn(`[AutonomousRunner] Could not record the operator park for ${issueId}:`, error);
-    return false;
   }
 }
 
@@ -276,35 +277,57 @@ export class AutonomousRunner {
   private failedTaskRetryTimes = new Map<string, number>(); // issueId → next retry timestamp (ms)
 
   /**
+   * Bring a durably backed-off run forward because its answer landed.
+   *
+   * Both halves are required: the ledger refuses to claim a `RETRY_AT` row whose
+   * time has not come, so letting the task past the heartbeat filter without
+   * promoting it would select it and then fail to claim it, every cycle.
+   *
+   * The promotion re-checks the park itself, so what `answerArrivedFor` reads is
+   * only a filter — a second daemon can end the parked attempt in between, and
+   * the failure that replaces it must keep its own backoff.
+   */
+  private readmitAnsweredRun(issueId: string): boolean {
+    if (!this.answerArrivedFor(issueId)) return false;
+    if (!this.durableRuns.readmitParkedRun(issueId, OPERATOR_PARK_REASON)) return false;
+    clearRetryTime(issueId, this.failedTaskRetryTimes);
+    return true;
+  }
+
+  /**
    * Whether a task parked on the operator now has its answer.
    *
    * Scoped by task id — the Linear issue id, unique per task — so an answer meant
    * for one agent can never spring another that happens to share a display name
    * (the guard added in AGT-4030 is upheld, not bypassed).
+   *
+   * The park is read off the run's own ledger row rather than a flag kept beside
+   * it, so it expires with the attempt that caused it: a task that waited out its
+   * backoff and then failed for its own reasons carries that failure's code here,
+   * and an answer from a park it has left cannot pull it forward.
    */
   /**
-   * Bring a durably backed-off run forward because its answer landed.
+   * Whether the task is stopped waiting on the operator, read from whichever
+   * store is authoritative for it — the same split the selection filter makes.
    *
-   * Both halves are required: the ledger refuses to claim a `RETRY_AT` row whose
-   * time has not come, so letting the task past the heartbeat filter without
-   * `markReady` would select it and then fail to claim it, every cycle.
+   * With the ledger in charge the park is the run's own error code, so it expires
+   * with the attempt that caused it. Elsewhere no such code is written (`shadow`
+   * noops its transitions, `off` has no ledger at all), so a task-state signal
+   * stands in — retired by the filter when the task is admitted, to give it the
+   * same lifetime rather than one nobody maintains.
    */
-  private readmitAnsweredRun(issueId: string): boolean {
-    if (!this.answerArrivedFor(issueId)) return false;
-    const promoted = readmitWithRollback({
-      retireSignal: () => markOperatorPark(issueId, false),
-      promote: () => this.durableRuns.markReady(issueId),
-      restoreSignal: () => { markOperatorPark(issueId, true); },
-    });
-    if (!promoted) return false;
-    clearRetryTime(issueId, this.failedTaskRetryTimes);
-    return true;
+  private parkedOnOperator(issueId: string): boolean {
+    const durableRun = this.durableRuns.getRun(issueId);
+    if (this.durableRuns.isPrimary && durableRun) {
+      return durableRun.lastErrorCode === OPERATOR_PARK_REASON;
+    }
+    return getTaskState(issueId)?.execution?.blockedReason === OPERATOR_PARK_REASON;
   }
 
   private answerArrivedFor(issueId: string): boolean {
     try {
       return shouldReadmitEarly({
-        parkedOnOperator: getTaskState(issueId)?.execution?.blockedReason === OPERATOR_PARK_REASON,
+        parkedOnOperator: this.parkedOnOperator(issueId),
         allQuestionsAnswered: getCoordinationStore().allQuestionsAnswered(issueId),
       });
     } catch { // cxt-ignore: error_swallow — an unreadable board must not stall the heartbeat
@@ -554,10 +577,9 @@ export class AutonomousRunner {
       // operator's answer cannot shorten it.
       const parkedId = task.issueId || task.id;
       if (parkedId) {
-        // Durable, next to the durable answer: the heartbeat has to know which
-        // backoffs a reply may cut short, and a restart must not be what decides
-        // that (AGT-4033).
-        markOperatorPark(parkedId, true);
+        // Without an authoritative ledger there is no error code to carry the
+        // park, so record the stand-in signal the heartbeat reads instead.
+        if (!this.durableRuns.isPrimary) setOperatorPark(parkedId, true);
         const nextRetryTime = setRetryTime(parkedId, 4, this.failedTaskRetryTimes);
         this.saveTaskState();
         console.log(`[Scheduler] Re-admitting ${taskCtx} ${formatRetryTime(nextRetryTime)}, or sooner if the operator answers`);
@@ -975,25 +997,26 @@ export class AutonomousRunner {
         }
       }
 
-      // Check if task is in exponential backoff period
-      if (legacyIsAuthority && !canRetryNow(id, this.failedTaskRetryTimes)) {
-        // Unless the only thing it was waiting for has arrived. The backoff is
-        // also the resume path for an `ask_human` park, so left alone it makes
-        // the operator's reply land up to two hours after they sent it. Limited
-        // to tasks parked on the operator: a task backing off from ordinary
-        // failures that happens to carry an answered question from an earlier
-        // park would otherwise be re-admitted every heartbeat.
-        if (!this.answerArrivedFor(id)) {
-          backoffSkipped++;
-          return false; // Skip tasks still in backoff period
+      if (legacyIsAuthority) {
+        // Check if task is in exponential backoff period — unless the only thing
+        // it was waiting for has arrived. The backoff is also the resume path for
+        // an `ask_human` park, so left alone it makes the operator's reply land
+        // up to two hours after they sent it.
+        if (!canRetryNow(id, this.failedTaskRetryTimes)) {
+          if (!this.answerArrivedFor(id)) {
+            backoffSkipped++;
+            return false; // Skip tasks still in backoff period
+          }
+          clearRetryTime(id, this.failedTaskRetryTimes);
+          answered++;
         }
-        // Same order as the durable path: retire the signal before acting on it.
-        if (!markOperatorPark(id, false)) {
-          backoffSkipped++;
-          return false;
+        // Admitted, so the park is spent — retire it here and it expires with the
+        // attempt that caused it, the way the ledger's error code does. Left set,
+        // an answer from a park the task has long since left would pull it
+        // forward past every later backoff.
+        if (getTaskState(id)?.execution?.blockedReason === OPERATOR_PARK_REASON) {
+          setOperatorPark(id, false);
         }
-        clearRetryTime(id, this.failedTaskRetryTimes);
-        answered++;
       }
 
       return true;

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -29,6 +29,8 @@ import {
   type ProjectInfo,
 } from './runnerState.js';
 import { taskEventKey, DecisionEngine, DecisionResult, TaskItem, getDecisionEngine, classifyStuck } from '../orchestration/decisionEngine.js';
+import { getCoordinationStore } from '../coordination/coordinationStore.js';
+import { OPERATOR_PARK_REASON, shouldReadmitEarly } from '../coordination/operatorAnswers.js';
 // ExecutorResult used via execution.reportExecutionResult
 import { checkWorkAllowed } from '../support/timeWindow.js';
 import { shouldEarlyStuckForInfeasibility } from '../support/feasibilityDetector.js';
@@ -45,7 +47,7 @@ import { reportToDiscord, fetchLinearTasks, getTaskSource } from './runnerExecut
 import { t } from '../locale/index.js';
 import { broadcastEvent, type SwarmStats } from '../core/eventHub.js';
 import { writeProviderOverride } from '../core/providerOverride.js';
-import { getTaskState } from '../taskState/store.js';
+import { getTaskState, upsertTaskState } from '../taskState/store.js';
 import {
   findPullRequestForBranch,
   inspectWorktreeRecovery,
@@ -130,6 +132,24 @@ export function decisionSelectionBudget(availableSlots: number, candidateCount: 
   const candidates = Math.max(0, Math.floor(candidateCount));
   if (slots === 0 || candidates === 0) return 0;
   return Math.min(candidates, Math.max(slots, slots * DECISION_SELECTION_OVERSAMPLE));
+}
+
+/**
+ * Record, or clear, that a task is stopped waiting on the operator.
+ *
+ * Failing to write is not worth aborting a heartbeat over: the task then waits
+ * out its backoff, which is what happened before any of this existed.
+ */
+function markOperatorPark(issueId: string, parked: boolean): boolean {
+  try {
+    upsertTaskState(issueId, {
+      execution: { blockedReason: parked ? OPERATOR_PARK_REASON : undefined },
+    } as Parameters<typeof upsertTaskState>[1]);
+    return true;
+  } catch (error) { // cxt-ignore: error_swallow — the backoff is the fallback
+    console.warn(`[AutonomousRunner] Could not record the operator park for ${issueId}:`, error);
+    return false;
+  }
 }
 
 export class AutonomousRunner {
@@ -254,6 +274,44 @@ export class AutonomousRunner {
   private completedTaskIds = new Set<string>();
   private failedTaskCounts = new Map<string, number>();
   private failedTaskRetryTimes = new Map<string, number>(); // issueId → next retry timestamp (ms)
+
+  /**
+   * Whether a task parked on the operator now has its answer.
+   *
+   * Scoped by task id — the Linear issue id, unique per task — so an answer meant
+   * for one agent can never spring another that happens to share a display name
+   * (the guard added in AGT-4030 is upheld, not bypassed).
+   */
+  /**
+   * Bring a durably backed-off run forward because its answer landed.
+   *
+   * Both halves are required: the ledger refuses to claim a `RETRY_AT` row whose
+   * time has not come, so letting the task past the heartbeat filter without
+   * `markReady` would select it and then fail to claim it, every cycle.
+   */
+  private readmitAnsweredRun(issueId: string): boolean {
+    if (!this.answerArrivedFor(issueId)) return false;
+    // Retire the signal first. If this write fails the task keeps its backoff —
+    // which is only a delay — whereas re-admitting on a signal that is still set
+    // would let a run that then fails for its own reasons be pulled forward
+    // again on every heartbeat, past the backoff that exists to stop exactly
+    // that. The answer is durable, so nothing is lost by waiting.
+    if (!markOperatorPark(issueId, false)) return false;
+    if (!this.durableRuns.markReady(issueId)) return false;
+    clearRetryTime(issueId, this.failedTaskRetryTimes);
+    return true;
+  }
+
+  private answerArrivedFor(issueId: string): boolean {
+    try {
+      return shouldReadmitEarly({
+        parkedOnOperator: getTaskState(issueId)?.execution?.blockedReason === OPERATOR_PARK_REASON,
+        allQuestionsAnswered: getCoordinationStore().allQuestionsAnswered(issueId),
+      });
+    } catch { // cxt-ignore: error_swallow — an unreadable board must not stall the heartbeat
+      return false;
+    }
+  }
   // Last failure feedback per issue — re-injected into the next attempt's worker
   // prompt so re-picked tasks don't restart blind and repeat the same mistake
   // the reviewer already called out (INT-2474). Persisted; cleared on success.
@@ -492,9 +550,13 @@ export class AutonomousRunner {
       // instead of blocking, so the task continues the moment a re-dispatch
       // lands after the operator replies.
       if (task.issueId) {
+        // Durable, next to the durable answer: the heartbeat has to know which
+        // backoffs a reply may cut short, and a restart must not be what decides
+        // that (AGT-4033).
+        markOperatorPark(task.issueId, true);
         const nextRetryTime = setRetryTime(task.issueId, 4, this.failedTaskRetryTimes);
         this.saveTaskState();
-        console.log(`[Scheduler] Re-admitting ${taskCtx} ${formatRetryTime(nextRetryTime)} to check for the operator's answer`);
+        console.log(`[Scheduler] Re-admitting ${taskCtx} ${formatRetryTime(nextRetryTime)}, or sooner if the operator answers`);
       }
       this.scheduleNextHeartbeat();
     });
@@ -787,6 +849,7 @@ export class AutonomousRunner {
     let recovered = 0;
     let stuckSkipped = 0;
     let backoffSkipped = 0;
+    let answered = 0;
     let noProject = 0;
     let unresolvable = 0;
     const toUnstick: string[] = [];
@@ -825,8 +888,18 @@ export class AutonomousRunner {
         if (['DONE', 'DECOMPOSED', 'CANCELLED', 'NEEDS_HUMAN'].includes(durableRun.state)) return false;
         if (['CLAIMED', 'EXECUTING', 'VERIFYING', 'PUBLISHING', 'SYNC_PENDING', 'NEEDS_RECONCILE'].includes(durableRun.state)) return false;
         if (durableRun.state === 'RETRY_AT' && (durableRun.retryAt ?? 0) > Date.now()) {
-          backoffSkipped++;
-          return false;
+          // Unless the only thing it was waiting for has arrived. A task parked
+          // on `ask_human` sits here, and this backoff is also its resume path,
+          // so left alone it makes the operator's reply land up to two hours
+          // after they sent it. `markReady` is what actually unblocks it: the
+          // ledger refuses to claim a RETRY_AT row whose time has not come, so
+          // passing this filter alone would change nothing.
+          if (!this.readmitAnsweredRun(id)) {
+            backoffSkipped++;
+            return false;
+          }
+          durableRun = this.durableRuns.getRun(id);
+          answered++;
         }
       }
 
@@ -900,8 +973,23 @@ export class AutonomousRunner {
 
       // Check if task is in exponential backoff period
       if (legacyIsAuthority && !canRetryNow(id, this.failedTaskRetryTimes)) {
-        backoffSkipped++;
-        return false; // Skip tasks still in backoff period
+        // Unless the only thing it was waiting for has arrived. The backoff is
+        // also the resume path for an `ask_human` park, so left alone it makes
+        // the operator's reply land up to two hours after they sent it. Limited
+        // to tasks parked on the operator: a task backing off from ordinary
+        // failures that happens to carry an answered question from an earlier
+        // park would otherwise be re-admitted every heartbeat.
+        if (!this.answerArrivedFor(id)) {
+          backoffSkipped++;
+          return false; // Skip tasks still in backoff period
+        }
+        // Same order as the durable path: retire the signal before acting on it.
+        if (!markOperatorPark(id, false)) {
+          backoffSkipped++;
+          return false;
+        }
+        clearRetryTime(id, this.failedTaskRetryTimes);
+        answered++;
       }
 
       return true;
@@ -921,6 +1009,9 @@ export class AutonomousRunner {
     }
     if (backoffSkipped > 0) {
       this.syslog(`⏰ Skipped ${backoffSkipped} tasks in exponential backoff period`);
+    }
+    if (answered > 0) {
+      this.syslog(`🙋 Re-admitted ${answered} task(s) early — the operator answered`);
     }
     if (noProject > 0) {
       this.syslog(`— Skipped ${noProject} issue(s) with no Linear project (assign a project in Linear to enable)`);

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -414,9 +414,6 @@ export class AutonomousRunner {
       worktreeMode: config.worktreeMode ?? false,
     });
 
-    // Before anything opens a store: the coordination trace resolves its own
-    // path, and it has to land on the same file as the ledger below.
-    setAutomationDbPath(config.automationDbPath);
     const ledgerMode: RunLedgerMode = config.automationLedgerMode
       ?? (config.dryRun ? 'off' : 'primary');
     this.durableRuns = new DurableRunCoordinator({
@@ -2864,6 +2861,11 @@ export class AutonomousRunner {
 
 export function getRunner(config?: AutonomousConfig): AutonomousRunner {
   if (!runnerInstance && config) {
+    // Declared once, where the process gets its one runner. The coordination
+    // trace resolves its own path and has to land on the ledger's file; saying
+    // so from the constructor instead would let two runners built in one process
+    // redirect each other's archive, which is a shape only a test has.
+    setAutomationDbPath(config.automationDbPath);
     runnerInstance = new AutonomousRunner(config);
   }
   if (!runnerInstance) {

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -549,12 +549,17 @@ export class AutonomousRunner {
       // run, ask_human finds the recorded answer on the board and returns it
       // instead of blocking, so the task continues the moment a re-dispatch
       // lands after the operator replies.
-      if (task.issueId) {
+      // `issueId || id` is what the heartbeat, the ledger and the coordination
+      // context all key on. Parking under a narrower id than the one that later
+      // looks it up arms nothing: the task keeps its durable backoff and the
+      // operator's answer cannot shorten it.
+      const parkedId = task.issueId || task.id;
+      if (parkedId) {
         // Durable, next to the durable answer: the heartbeat has to know which
         // backoffs a reply may cut short, and a restart must not be what decides
         // that (AGT-4033).
-        markOperatorPark(task.issueId, true);
-        const nextRetryTime = setRetryTime(task.issueId, 4, this.failedTaskRetryTimes);
+        markOperatorPark(parkedId, true);
+        const nextRetryTime = setRetryTime(parkedId, 4, this.failedTaskRetryTimes);
         this.saveTaskState();
         console.log(`[Scheduler] Re-admitting ${taskCtx} ${formatRetryTime(nextRetryTime)}, or sooner if the operator answers`);
       }

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -48,6 +48,7 @@ import { t } from '../locale/index.js';
 import { broadcastEvent, type SwarmStats } from '../core/eventHub.js';
 import { writeProviderOverride } from '../core/providerOverride.js';
 import { getTaskState, upsertTaskState } from '../taskState/store.js';
+import { setAutomationDbPath } from './automationDbPath.js';
 import {
   findPullRequestForBranch,
   inspectWorktreeRecovery,
@@ -413,6 +414,9 @@ export class AutonomousRunner {
       worktreeMode: config.worktreeMode ?? false,
     });
 
+    // Before anything opens a store: the coordination trace resolves its own
+    // path, and it has to land on the same file as the ledger below.
+    setAutomationDbPath(config.automationDbPath);
     const ledgerMode: RunLedgerMode = config.automationLedgerMode
       ?? (config.dryRun ? 'off' : 'primary');
     this.durableRuns = new DurableRunCoordinator({

--- a/src/automation/durableRunCoordinator.test.ts
+++ b/src/automation/durableRunCoordinator.test.ts
@@ -269,6 +269,32 @@ describe('DurableRunCoordinator', () => {
     coordinator.close();
   });
 
+  it("keeps an operator park as the run's own retry reason", async () => {
+    // Everything downstream reads the park off `lastErrorCode`: it is what says a
+    // backoff may be cut short once the answer lands, and it expires with its own
+    // attempt because the next transition overwrites it. Recorded as a plain
+    // failure — by a branch added above the default below, or by the pipeline
+    // stopping naming the status — the task sits out its full backoff with the
+    // answer already on the board, and nothing here would say so.
+    //
+    // The literal is deliberate on both sides: it pins that the pipeline's
+    // `finalStatus` and the code stored on the run are the same wire value.
+    const coordinator = new DurableRunCoordinator({
+      mode: 'primary', dbPath: dbPath(), instanceId: 'park-owner',
+    });
+
+    await coordinator.execute(task('AGT-PARK'), '/repo', async () => ({
+      ...result(false),
+      finalStatus: 'waiting_on_operator',
+    }));
+
+    expect(coordinator.getRun('AGT-PARK')).toMatchObject({
+      state: 'RETRY_AT',
+      lastErrorCode: 'waiting_on_operator',
+    });
+    coordinator.close();
+  });
+
   it('reconciles a published PR before any retry when publication attachment throws', async () => {
     const path = dbPath();
     const ledger = new RunLedger(path);

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -158,6 +158,10 @@ export class DurableRunCoordinator {
     return this.ledger?.markReady(issueId, now) ?? false;
   }
 
+  readmitParkedRun(issueId: string, parkCode: string, now = Date.now()): boolean {
+    return this.ledger?.readmitParkedRun(issueId, parkCode, now) ?? false;
+  }
+
   recoverPublishedRun(
     issueId: string,
     publication: { prUrl: string; headSha?: string },

--- a/src/automation/runLedger.test.ts
+++ b/src/automation/runLedger.test.ts
@@ -137,6 +137,57 @@ describe('RunLedger operator re-admission (AGT-4033)', () => {
 
     ledger.close();
   });
+
+  it('does not let a park outlive the attempt that caused it', () => {
+    // The runner reads `lastErrorCode` to decide whether an operator's answer may
+    // cut a backoff short, so the park has to expire with its own attempt. If a
+    // transition preserved the previous code the way this UPDATE preserves a
+    // branch or a PR url, a task that waited out its backoff and then failed for
+    // its own reasons would be pulled forward on every heartbeat by an answer
+    // from a park it has long since left.
+    const ledger = new RunLedger(createDbPath());
+    register(ledger, 'AGT-3');
+
+    const parked = claim(ledger, 'AGT-3', 'daemon');
+    expect(ledger.transition(parked, 'RETRY_AT', {
+      retryAt: 9_000,
+      errorCode: 'waiting_on_operator',
+    }, 2_100)).toBe(true);
+    expect(ledger.getRun('AGT-3')?.lastErrorCode).toBe('waiting_on_operator');
+
+    // The next attempt ends without naming a reason at all — the weakest case,
+    // and the one a `COALESCE` would silently turn back into a park.
+    expect(ledger.markReady('AGT-3', 2_200)).toBe(true);
+    const retried = claim(ledger, 'AGT-3', 'daemon', 2_300);
+    expect(ledger.transition(retried, 'RETRY_AT', { retryAt: 9_000 }, 2_400)).toBe(true);
+
+    expect(ledger.getRun('AGT-3')?.lastErrorCode).toBeUndefined();
+
+    ledger.close();
+  });
+
+  it('promotes only a run that is still parked when the promotion runs', () => {
+    // The caller reads the park on one heartbeat and promotes on the next
+    // statement. In between, a second daemon can end the parked attempt and back
+    // the run off again for its own reasons — so the park is re-read here, under
+    // this transaction's write lock, instead of trusted from the caller.
+    const ledger = new RunLedger(createDbPath());
+    register(ledger, 'AGT-4');
+    const parked = claim(ledger, 'AGT-4', 'daemon');
+    ledger.transition(parked, 'RETRY_AT', { retryAt: 9_000, errorCode: 'waiting_on_operator' }, 2_100);
+
+    expect(ledger.readmitParkedRun('AGT-4', 'waiting_on_operator', 2_200)).toBe(true);
+    expect(ledger.getRun('AGT-4')?.state).toBe('READY');
+
+    // That attempt now fails on its own account.
+    const retried = claim(ledger, 'AGT-4', 'daemon', 2_300);
+    ledger.transition(retried, 'RETRY_AT', { retryAt: 9_000, errorCode: 'failed' }, 2_400);
+
+    expect(ledger.readmitParkedRun('AGT-4', 'waiting_on_operator', 2_500)).toBe(false);
+    expect(ledger.getRun('AGT-4')?.state).toBe('RETRY_AT');
+
+    ledger.close();
+  });
 });
 
 describe('RunLedger claim and fencing races', () => {

--- a/src/automation/runLedger.test.ts
+++ b/src/automation/runLedger.test.ts
@@ -107,6 +107,38 @@ describe('RunLedger state machine', () => {
   });
 });
 
+describe('RunLedger operator re-admission (AGT-4033)', () => {
+  it('will not claim a run whose retry time has not come', () => {
+    // This is why letting an answered task past the heartbeat filter is not
+    // enough on its own: it would be selected every cycle and then fail to claim.
+    const ledger = new RunLedger(createDbPath());
+    register(ledger, 'AGT-1');
+    ledger.deferUnclaimedRun('AGT-1', 5_000, 'parked on the operator', 1_000);
+
+    expect(ledger.claimRun('AGT-1', {
+      ownerInstanceId: 'daemon', leaseMs: 1_000, maxActiveForProject: 1, now: 2_000,
+    })).toBeNull();
+
+    ledger.close();
+  });
+
+  it('claims it once the answer brings it forward', () => {
+    // `markReady` is the transition the runner uses when the board shows the
+    // operator replied — the backoff was only ever a poll for that reply.
+    const ledger = new RunLedger(createDbPath());
+    register(ledger, 'AGT-2');
+    ledger.deferUnclaimedRun('AGT-2', 5_000, 'parked on the operator', 1_000);
+
+    expect(ledger.markReady('AGT-2', 2_000)).toBe(true);
+    expect(ledger.getRun('AGT-2')?.state).toBe('READY');
+    expect(ledger.claimRun('AGT-2', {
+      ownerInstanceId: 'daemon', leaseMs: 1_000, maxActiveForProject: 1, now: 2_000,
+    })).not.toBeNull();
+
+    ledger.close();
+  });
+});
+
 describe('RunLedger claim and fencing races', () => {
   it('allows exactly one winner when two daemon connections claim one issue', async () => {
     const dbPath = createDbPath();

--- a/src/automation/runLedger.ts
+++ b/src/automation/runLedger.ts
@@ -266,6 +266,18 @@ export class RunLedger {
     return this.unfencedTransition(issueId, eligible, 'READY', {}, now);
   }
 
+  /**
+   * Promote a run only while it is still parked on the operator.
+   *
+   * The park is re-read inside the promoting transaction rather than trusted from
+   * the caller. Between a caller's read and this write the parked attempt can end
+   * and a new one fail for its own reasons, and pulling *that* one forward is the
+   * fast-retry loop the backoff exists to prevent.
+   */
+  readmitParkedRun(issueId: string, parkCode: string, now = Date.now()): boolean {
+    return this.unfencedTransition(issueId, ['RETRY_AT'], 'READY', {}, now, parkCode);
+  }
+
   /** Release a lost lease only after its executor has actually returned. */
   confirmExecutorExit(
     ownership: Pick<RunClaim,
@@ -1337,10 +1349,14 @@ export class RunLedger {
     to: RunState,
     patch: TransitionPatch,
     now: number,
+    requireErrorCode?: string,
   ): boolean {
     const transition = this.db.transaction(() => {
       const row = this.db.prepare('SELECT * FROM automation_runs WHERE issue_id = ?').get(issueId) as RunRow | undefined;
       if (!row || !from.includes(row.state as RunState)) return false;
+      // Read under the transaction's write lock, so what is checked here is what
+      // the UPDATE below acts on.
+      if (requireErrorCode !== undefined && row.last_error_code !== requireErrorCode) return false;
       assertRunState(row.state);
       if (row.owner_instance_id != null || row.lease_token != null) return false;
       if (!ALLOWED_TRANSITIONS[row.state].includes(to)) return false;

--- a/src/cli/workCommand.ts
+++ b/src/cli/workCommand.ts
@@ -36,6 +36,7 @@ import {
   type RepositoryAdmissionPolicy,
 } from '../automation/durableRunCoordinator.js';
 import type { EffectClaim } from '../automation/runLedger.js';
+import { setAutomationDbPath } from '../automation/automationDbPath.js';
 import { loadRepoMetadata, type RepoMetadata } from '../support/repoMetadata.js';
 import { buildBranchName, hasRecoverableWorktree } from '../support/worktreeManager.js';
 import { runPool } from '../support/concurrencyPool.js';
@@ -489,6 +490,8 @@ async function runWorkCommandInner(
   }
 
   // ---- Execution -----------------------------------------------------------
+  // Same file for the ledger and the coordination trace — see setAutomationDbPath.
+  setAutomationDbPath(config.autonomous?.automationDbPath);
   const coordinator = (deps.createCoordinator
     ?? ((o: { dbPath?: string; maxActive: number }) => new DurableRunCoordinator({
       mode: 'primary',

--- a/src/coordination/coordinationStore.test.ts
+++ b/src/coordination/coordinationStore.test.ts
@@ -13,6 +13,101 @@ function message(over: Record<string, unknown> = {}) {
 }
 
 describe('CoordinationStore', () => {
+  it('knows a question is answered after the ring has evicted it', async () => {
+    // The in-memory board is a ring. A task that has been chatty pushes its own
+    // exchange out of it, and a decision read only from memory would call a
+    // still-blocked run ready — or a resolved one blocked. The durable trace is a
+    // table, not a ring, and it is counted rather than fetched so no window
+    // applies. Eviction is simulated by dropping the event from the file, which
+    // is the same end state as publishing two thousand more.
+    const s = store();
+    const taskId = `thread-${Math.random().toString(16).slice(2)}`;
+    // A correlation id of its own for the same reason as the task id: the trace
+    // outlives one store instance, so a shared id matches another suite's answer.
+    const exchangeId = `${taskId}-q1`;
+    await s.publish(message({
+      taskId, kind: 'human-question', status: 'waiting', correlationId: exchangeId, summary: 'Which credentials?',
+    }));
+    expect(s.allQuestionsAnswered(taskId)).toBe(false);
+
+    const answer = await s.publish(message({
+      taskId, kind: 'human-answer', status: 'completed', correlationId: exchangeId,
+      summary: 'answered', detail: 'The mounted ones.',
+    }));
+    const file = join(dir, 'events.json');
+    const state = JSON.parse(readFileSync(file, 'utf8'));
+    state.events = state.events.filter((event: { kind: string }) => event.kind === 'human-answer');
+    writeFileSync(file, JSON.stringify(state));
+
+    expect(s.allQuestionsAnswered(taskId)).toBe(true);
+    // And the exchange itself is still whole, which is what a retry replays from.
+    expect(s.exchange(exchangeId).map((event) => event.kind)).toEqual(['human-question', 'human-answer']);
+    expect(new Set(s.exchange(exchangeId).map((event) => event.id)).size).toBe(2);
+    expect(answer.correlationId).toBe(exchangeId);
+  });
+
+  it('says no rather than guessing when the durable store is unavailable', async () => {
+    // The in-memory board is a ring, so falling back to it would give exactly the
+    // false "everything is answered" this query exists to prevent. Saying no
+    // costs a task its early re-admission and it waits out its backoff, which is
+    // what happened before any of this existed.
+    const s = store();
+    const taskId = `nodb-${Math.random().toString(16).slice(2)}`;
+    await s.publish(message({ taskId, kind: 'human-question', status: 'waiting', correlationId: `${taskId}-q` }));
+    await s.publish(message({ taskId, kind: 'human-answer', status: 'completed', correlationId: `${taskId}-q` }));
+    expect(s.allQuestionsAnswered(taskId)).toBe(true);
+
+    // Point the trace at a path it cannot open, the way a broken deployment would.
+    const previous = process.env.OPENSWARM_AUTOMATION_DB;
+    const blocked = join(dir, 'events.json', 'automation.db'); // a file, not a directory
+    process.env.OPENSWARM_AUTOMATION_DB = blocked;
+    const trace = await import('./coordinationTrace.js');
+    trace.resetTraceDbForTests();
+    try {
+      expect(s.allQuestionsAnswered(taskId)).toBe(false);
+    } finally {
+      process.env.OPENSWARM_AUTOMATION_DB = previous;
+      trace.resetTraceDbForTests();
+    }
+  });
+
+  it('does not count an answer that never landed', async () => {
+    // The replay in `askHuman` accepts a completed answer and nothing else, so
+    // counting a failed or expired one here would release the run into the same
+    // open question and park it again, an attempt spent for nothing.
+    const s = store();
+    const taskId = `failed-${Math.random().toString(16).slice(2)}`;
+    await s.publish(message({ taskId, kind: 'human-question', status: 'waiting', correlationId: `${taskId}-q` }));
+    await s.publish(message({ taskId, kind: 'human-answer', status: 'failed', correlationId: `${taskId}-q` }));
+
+    expect(s.allQuestionsAnswered(taskId)).toBe(false);
+  });
+
+  it('does not accept another task\'s answer as this one\'s', async () => {
+    // Correlation ids are content-derived and unique in practice, but nothing in
+    // the schema says so — and pairing on the id alone would let one task's
+    // answer release a run parked on another's identical question.
+    const s = store();
+    const shared = `shared-${Math.random().toString(16).slice(2)}`;
+    await s.publish(message({ taskId: `${shared}-mine`, kind: 'human-question', status: 'waiting', correlationId: shared }));
+    await s.publish(message({ taskId: `${shared}-theirs`, kind: 'human-answer', status: 'completed', correlationId: shared }));
+
+    expect(s.allQuestionsAnswered(`${shared}-mine`)).toBe(false);
+  });
+
+  it('does not call a task with a second unanswered question ready', async () => {
+    // Several agents can run on one task, so an answer to one does not release a
+    // run parked on another's question.
+    const s = store();
+    const taskId = `two-${Math.random().toString(16).slice(2)}`;
+    await s.publish(message({ taskId, kind: 'human-question', status: 'waiting', correlationId: `${taskId}-a` }));
+    await s.publish(message({ taskId, kind: 'human-answer', status: 'completed', correlationId: `${taskId}-a` }));
+    expect(s.allQuestionsAnswered(taskId)).toBe(true);
+
+    await s.publish(message({ taskId, kind: 'human-question', status: 'waiting', correlationId: `${taskId}-b` }));
+    expect(s.allQuestionsAnswered(taskId)).toBe(false);
+  });
+
   it('deduplicates publications and assigns monotonic sequences', async () => {
     const s = store();
     const first = await s.publish(message());

--- a/src/coordination/coordinationStore.ts
+++ b/src/coordination/coordinationStore.ts
@@ -6,7 +6,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { coordinationFilePath, coordinationStateDir } from './coordinationPaths.js';
-import { recordTraceEvent } from './coordinationTrace.js';
+import { recordTraceEvent, queryTrace, questionStandings } from './coordinationTrace.js';
 import { atomicWriteFileSync } from '../support/atomicFile.js';
 import { withFileLock } from '../support/fileLock.js';
 import { broadcastEvent } from '../core/eventHub.js';
@@ -270,9 +270,44 @@ export class CoordinationStore {
    * operator answering an old question must not be told it does not exist just
    * because the board has been busy since it was asked.
    */
+  /**
+   * Whether every question this task has asked now has an answer.
+   *
+   * Asked of the durable store, which counts rather than fetches, so no window
+   * can hide an older unanswered question and make a still-blocked run look
+   * ready. When that store is unavailable the answer is no: the in-memory board
+   * is a ring and would give exactly the false "all answered" this exists to
+   * prevent. Saying no costs a task its early re-admission and it waits out the
+   * backoff — which is what happened before any of this existed.
+   */
+  allQuestionsAnswered(taskId: string): boolean {
+    const standings = questionStandings(taskId);
+    if (!standings) return false;
+    return standings.asked > 0 && standings.unanswered === 0;
+  }
+
+  /**
+   * One exchange, whole, from both the durable trace and the board.
+   *
+   * Scoped by correlation id rather than task: an exchange is a question and its
+   * answer, so nothing else on a busy task can push either out of view.
+   */
+  exchange(correlationId: string): CoordinationEvent[] {
+    const merged = new Map<string, CoordinationEvent>();
+    for (const event of queryTrace({ correlationId, limit: 1_000 })) merged.set(event.id, event);
+    for (const event of this.load().events) {
+      if (event.correlationId === correlationId) merged.set(event.id, event);
+    }
+    return [...merged.values()].sort((a, b) => a.seq - b.seq);
+  }
+
   findQuestion(correlationId: string): CoordinationEvent | undefined {
-    return this.load().events.find((event) =>
-      event.correlationId === correlationId && event.kind === 'human-question' && event.status === 'waiting');
+    // The exchange, not the board: a question that has been pushed out of the
+    // ring is still a question someone is parked on, and resolving it only from
+    // memory means the operator is told their pending question does not exist —
+    // on exactly the busy tasks that produce the most of them.
+    return this.exchange(correlationId).find((event) =>
+      event.kind === 'human-question' && event.status === 'waiting');
   }
 
   /**

--- a/src/coordination/coordinationTools.test.ts
+++ b/src/coordination/coordinationTools.test.ts
@@ -7,17 +7,26 @@ import { assignCallSign } from './agentNames.js';
 // vitest.setup.ts points this at a temp path; restore it rather than deleting,
 // so a later suite in this worker never falls back to the real ~/.openswarm store.
 const ORIGINAL_COORDINATION_FILE = process.env.OPENSWARM_COORDINATION_FILE;
+// `ask_human` reads the durable trace so an answer survives the board's ring,
+// and that trace lives in the automation database vitest.setup points at one
+// path for the whole run — without a database per test, these suites see each
+// other's questions already answered.
+const ORIGINAL_AUTOMATION_DB = process.env.OPENSWARM_AUTOMATION_DB;
 let dir = '';
 afterEach(async () => {
   (await import('./coordinationStore.js')).resetCoordinationStoreForTests();
+  (await import('./coordinationTrace.js')).resetTraceDbForTests();
   process.env.OPENSWARM_COORDINATION_FILE = ORIGINAL_COORDINATION_FILE;
+  process.env.OPENSWARM_AUTOMATION_DB = ORIGINAL_AUTOMATION_DB;
   if (dir) rmSync(dir, { recursive: true, force: true });
 });
 
 async function tools() {
   dir = mkdtempSync(join(tmpdir(), 'osw-coordination-tools-'));
   process.env.OPENSWARM_COORDINATION_FILE = join(dir, 'events.json');
+  process.env.OPENSWARM_AUTOMATION_DB = join(dir, 'automation.db');
   (await import('./coordinationStore.js')).resetCoordinationStoreForTests();
+  (await import('./coordinationTrace.js')).resetTraceDbForTests();
   return import('./coordinationTools.js');
 }
 

--- a/src/coordination/coordinationTrace.test.ts
+++ b/src/coordination/coordinationTrace.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { defaultAutomationDbPath, setAutomationDbPath } from '../automation/automationDbPath.js';
 
 import { queryTrace, recordTraceEvent, resetTraceDbForTests, traceSize } from './coordinationTrace.js';
 import type { CoordinationEvent } from './coordinationStore.js';
@@ -123,5 +124,65 @@ describe('trace repository filtering', () => {
   it('matches a repository filter that is not already resolved', () => {
     recordTraceEvent(event({ id: 'r1', repository: resolve('/repo/nested') }));
     expect(queryTrace({ repository: '/repo/other/../nested' }).map((item) => item.id)).toEqual(['r1']);
+  });
+});
+
+describe('where the trace stores what it knows', () => {
+  // The runs and the answers about them have to live in one file. These cases
+  // run with the environment override cleared — the thing under test is what
+  // happens without it — so HOME is redirected too: a broken wiring must land in
+  // a temporary directory, never in the operator's real automation database.
+  let root: string;
+  let savedDb: string | undefined;
+  let savedHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'trace-path-'));
+    savedDb = process.env.OPENSWARM_AUTOMATION_DB;
+    savedHome = process.env.HOME;
+    delete process.env.OPENSWARM_AUTOMATION_DB;
+    process.env.HOME = join(root, 'home');
+    setAutomationDbPath(undefined);
+    resetTraceDbForTests();
+  });
+
+  afterEach(() => {
+    resetTraceDbForTests();
+    setAutomationDbPath(undefined);
+    if (savedDb === undefined) delete process.env.OPENSWARM_AUTOMATION_DB;
+    else process.env.OPENSWARM_AUTOMATION_DB = savedDb;
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('records into the database this deployment configured', () => {
+    const configured = join(root, 'relocated', 'automation.db');
+    setAutomationDbPath(configured);
+
+    recordTraceEvent(event({ id: 'configured-1' }));
+
+    expect(existsSync(configured)).toBe(true);
+    expect(existsSync(join(root, 'home', '.openswarm', 'automation.db'))).toBe(false);
+  });
+
+  it('still lets the environment override win, so tests can redirect every store', () => {
+    const configured = join(root, 'relocated', 'automation.db');
+    const override = join(root, 'override', 'automation.db');
+    mkdirSync(dirname(override), { recursive: true });
+    setAutomationDbPath(configured);
+    process.env.OPENSWARM_AUTOMATION_DB = override;
+
+    recordTraceEvent(event({ id: 'override-1' }));
+
+    expect(existsSync(override)).toBe(true);
+    expect(existsSync(configured)).toBe(false);
+  });
+
+  it('prefers a configured path over the home-directory default', () => {
+    const configured = join(root, 'runner', 'automation.db');
+    setAutomationDbPath(configured);
+
+    expect(defaultAutomationDbPath()).toBe(configured);
   });
 });

--- a/src/coordination/coordinationTrace.test.ts
+++ b/src/coordination/coordinationTrace.test.ts
@@ -179,6 +179,27 @@ describe('where the trace stores what it knows', () => {
     expect(existsSync(configured)).toBe(false);
   });
 
+  it('rebinds an archive that was already open before the daemon said where to store it', () => {
+    // A dashboard read is enough to open the trace, and it can happen before the
+    // runner is constructed. Left bound to the first file it saw, the answers a
+    // parked run needs would be written where its runs are not — so the
+    // co-location has to survive the ordering, not depend on it.
+    const early = join(root, 'home', '.openswarm', 'automation.db');
+    recordTraceEvent(event({ id: 'before-config' }));
+    expect(existsSync(early)).toBe(true);
+    expect(traceSize()).toBe(1);
+
+    const configured = join(root, 'relocated', 'automation.db');
+    setAutomationDbPath(configured);
+    recordTraceEvent(event({ id: 'after-config' }));
+
+    expect(existsSync(configured)).toBe(true);
+    // Reading through the same seam the daemon does: one row, the one written
+    // after the move — not the archive it was answering from a moment ago.
+    expect(traceSize()).toBe(1);
+    expect(queryTrace({ limit: 10 }).map((e) => e.id)).toEqual(['after-config']);
+  });
+
   it('prefers a configured path over the home-directory default', () => {
     const configured = join(root, 'runner', 'automation.db');
     setAutomationDbPath(configured);

--- a/src/coordination/coordinationTrace.ts
+++ b/src/coordination/coordinationTrace.ts
@@ -49,6 +49,7 @@ const MAX_LIMIT = 1_000;
 const DEFAULT_LIMIT = 200;
 
 let db: Database.Database | null = null;
+let openedPath: string | null = null;
 let unavailable = false;
 
 function migrate(handle: Database.Database): void {
@@ -91,11 +92,27 @@ function migrate(handle: Database.Database): void {
  * callers degrade to a board-only view instead of crashing the daemon.
  */
 export function getTraceDb(): Database.Database | null {
+  const path = defaultAutomationDbPath();
+  // The archive can be opened before the daemon has said where automation state
+  // lives — a dashboard read is enough to do it. Rebinding here makes the
+  // co-location with the run ledger hold whatever the order was, instead of
+  // answering from a file the runs are not in. Safe to close between calls:
+  // every read prepares its statement from a handle it took in the same call,
+  // so nothing outlives one.
+  if (openedPath !== null && openedPath !== path) {
+    try {
+      db?.close();
+    } catch { // cxt-ignore: error_swallow — a handle being replaced anyway
+      // Nothing to do: the handle is going away either way.
+    }
+    db = null;
+    unavailable = false; // a different file may well open where that one did not
+  }
   if (db) return db;
   if (unavailable) return null;
+  openedPath = path;
   try {
     const Sqlite = require('better-sqlite3') as typeof Database;
-    const path = defaultAutomationDbPath();
     // better-sqlite3 will not create the parent directory, and the state
     // directory does not exist on a fresh install — without this the trace
     // silently degrades to unavailable on exactly the deployments that have
@@ -272,5 +289,6 @@ export function resetTraceDbForTests(): void {
     // Closing a broken handle is not worth failing a test teardown over.
   }
   db = null;
+  openedPath = null;
   unavailable = false;
 }

--- a/src/coordination/coordinationTrace.ts
+++ b/src/coordination/coordinationTrace.ts
@@ -36,6 +36,12 @@ export interface TraceQuery {
   actor?: string;
   /** Only events at or after this epoch-ms timestamp. */
   since?: number;
+  /**
+   * Only these kinds. Narrows what the limit applies to, so a caller after one
+   * conversation is not pushed out of the window by unrelated traffic on the
+   * same task.
+   */
+  kinds?: Array<CoordinationEvent['kind']>;
   limit?: number;
 }
 
@@ -194,6 +200,10 @@ export function queryTrace(query: TraceQuery = {}): CoordinationEvent[] {
   if (query.correlationId) { where.push('correlation_id = ?'); params.push(query.correlationId); }
   if (query.actor) { where.push('(actor = ? OR recipient = ?)'); params.push(query.actor, query.actor); }
   if (typeof query.since === 'number') { where.push('timestamp >= ?'); params.push(query.since); }
+  if (query.kinds?.length) {
+    where.push(`kind IN (${query.kinds.map(() => '?').join(', ')})`);
+    params.push(...query.kinds);
+  }
   const limit = Math.min(Math.max(query.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
   try {
     const rows = handle.prepare(`
@@ -205,6 +215,41 @@ export function queryTrace(query: TraceQuery = {}): CoordinationEvent[] {
   } catch (error) {
     console.warn('[CoordinationTrace] Query failed:', error);
     return [];
+  }
+}
+
+/**
+ * How a task's questions stand, counted in the database rather than fetched.
+ *
+ * A limit is the wrong tool for this decision: whatever the window, a task that
+ * has asked more than it holds loses its oldest unanswered question from view
+ * and the caller reads "all answered" — releasing a run that is still blocked.
+ * Both columns this joins on are indexed, so the count is cheap.
+ *
+ * Returns null when the trace is unavailable, so the caller can fall back to the
+ * in-memory board rather than treat "cannot tell" as "nothing is waiting".
+ */
+export function questionStandings(taskId: string): { asked: number; unanswered: number } | null {
+  const handle = getTraceDb();
+  if (!handle) return null;
+  try {
+    const row = handle.prepare(`
+      SELECT
+        COUNT(*) AS asked,
+        SUM(CASE WHEN NOT EXISTS (
+          SELECT 1 FROM coordination_trace a
+          WHERE a.correlation_id = q.correlation_id
+            AND a.task_id = q.task_id
+            AND a.kind = 'human-answer'
+            AND a.status = 'completed'
+        ) THEN 1 ELSE 0 END) AS unanswered
+      FROM coordination_trace q
+      WHERE q.task_id = ? AND q.kind = 'human-question'
+    `).get(taskId) as { asked: number; unanswered: number | null };
+    return { asked: row.asked, unanswered: row.unanswered ?? 0 };
+  } catch (error) {
+    console.warn('[CoordinationTrace] Question standings failed:', error);
+    return null;
   }
 }
 

--- a/src/coordination/humanQuestions.test.ts
+++ b/src/coordination/humanQuestions.test.ts
@@ -1,24 +1,32 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 // vitest.setup.ts points this at a temp path; restore it rather than deleting,
 // so a later suite in this worker never falls back to the real ~/.openswarm store.
 const ORIGINAL_COORDINATION_FILE = process.env.OPENSWARM_COORDINATION_FILE;
+// The durable trace lives in the automation database, which vitest.setup points
+// at one path for the whole run. `postHumanQuestion` reads it, so without a
+// database per test these suites answer each other's questions.
+const ORIGINAL_AUTOMATION_DB = process.env.OPENSWARM_AUTOMATION_DB;
 let dir = '';
 afterEach(async () => {
   const store = await import('./coordinationStore.js');
   store.resetCoordinationStoreForTests();
+  (await import('./coordinationTrace.js')).resetTraceDbForTests();
   process.env.OPENSWARM_COORDINATION_FILE = ORIGINAL_COORDINATION_FILE;
+  process.env.OPENSWARM_AUTOMATION_DB = ORIGINAL_AUTOMATION_DB;
   if (dir) rmSync(dir, { recursive: true, force: true });
 });
 
 async function modules() {
   dir = mkdtempSync(join(tmpdir(), 'osw-human-'));
   process.env.OPENSWARM_COORDINATION_FILE = join(dir, 'events.json');
+  process.env.OPENSWARM_AUTOMATION_DB = join(dir, 'automation.db');
   const store = await import('./coordinationStore.js');
   store.resetCoordinationStoreForTests();
+  (await import('./coordinationTrace.js')).resetTraceDbForTests();
   return import('./humanQuestions.js');
 }
 
@@ -93,5 +101,57 @@ describe('human questions', () => {
     const waiting = store.list({ repository: '/repo', taskId: 't3', limit: 50 })
       .filter((event) => event.kind === 'human-question' && event.status === 'waiting');
     expect(waiting).toHaveLength(1);
+  });
+
+  it('can still answer a question the board has evicted', async () => {
+    // The whole point of keeping the exchange durable is that a reply works
+    // whenever the operator gets to it. Resolving the question from memory alone
+    // tells them it does not exist, and the agent stays parked forever.
+    const h = await modules();
+    const posted = await h.postHumanQuestion({
+      repository: '/repo', taskId: 't-gone', actor: 'worker-a', actorRole: 'worker' as const,
+      question: 'Which spreadsheet?',
+    });
+
+    const file = join(dir, 'events.json');
+    const state = JSON.parse(readFileSync(file, 'utf8'));
+    state.events = state.events.filter((event: { kind: string }) => event.kind !== 'human-question');
+    writeFileSync(file, JSON.stringify(state));
+    (await import('./coordinationStore.js')).resetCoordinationStoreForTests();
+
+    const accepted = await h.answerHumanQuestion(posted.correlationId, 'The shared one.', 'operator-dashboard');
+    expect(accepted.accepted).toBe(true);
+    expect(accepted.event?.detail).toBe('The shared one.');
+  });
+
+  it('returns the answer even after the board has evicted it', async () => {
+    // The heartbeat can bring a task forward on an answer it read from the
+    // durable trace. If the retry then reads only the tail of the board it will
+    // not see that answer, ask again, and park again — an attempt spent to end up
+    // exactly where it started. Both readers have to look in the same place.
+    const h = await modules();
+    const store = (await import('./coordinationStore.js')).getCoordinationStore();
+    const question = {
+      repository: '/repo', taskId: 't-evicted', actor: 'worker-a', actorRole: 'worker' as const,
+      question: 'Which credentials should I use?',
+    };
+    const posted = await h.postHumanQuestion(question);
+    const accepted = await h.answerHumanQuestion(posted.correlationId, 'The mounted ones.', 'operator-dashboard');
+    expect(accepted.accepted).toBe(true);
+
+    // Drop the answer from the in-memory board, which is what the ring does to a
+    // task that keeps talking. The durable trace still has it.
+    const file = join(dir, 'events.json');
+    const state = JSON.parse(readFileSync(file, 'utf8'));
+    state.events = state.events.filter((event: { kind: string }) => event.kind !== 'human-answer');
+    writeFileSync(file, JSON.stringify(state));
+    (await import('./coordinationStore.js')).resetCoordinationStoreForTests();
+
+    const replay = await h.postHumanQuestion(question);
+    expect(replay.delivered).toBe(true);
+    expect(replay.answer).toBe('The mounted ones.');
+    // And it did not ask a second time.
+    expect(store.exchange(posted.correlationId)
+      .filter((event) => event.kind === 'human-question')).toHaveLength(1);
   });
 });

--- a/src/coordination/humanQuestions.ts
+++ b/src/coordination/humanQuestions.ts
@@ -66,9 +66,16 @@ export interface HumanQuestionPost {
 export async function postHumanQuestion(input: HumanQuestionInput): Promise<HumanQuestionPost> {
   const store = getCoordinationStore();
   const correlationId = humanQuestionCorrelation(input);
-  const prior = store
-    .list({ repository: input.repository, taskId: input.taskId, limit: 500 })
-    .filter((event) => event.correlationId === correlationId);
+  // Read the whole exchange, not the tail of the board. `list` returns the last
+  // events for a task, so a chatty run loses sight of its own answer and asks
+  // again — spending an attempt to arrive back at the question the operator has
+  // already answered. Scoping by task alone is enough: the correlation id is
+  // derived from the repository as well, so a match implies both.
+  // The whole exchange, from the durable trace as well as the board: reading a
+  // recency window would lose sight of this task's own answer once it has talked
+  // enough, and it would ask again — spending an attempt to arrive back at the
+  // question the operator has already answered.
+  const prior = store.exchange(correlationId);
 
   const answered = prior.find((event) => event.kind === 'human-answer' && event.status === 'completed');
   if (answered) return { correlationId, delivered: true, answer: answered.detail ?? answered.summary };
@@ -133,8 +140,10 @@ export async function answerHumanQuestion(
   // not exist.
   const question = store.findQuestion(correlationId);
   if (!question) return { accepted: false, reason: 'No pending question with that correlation ID' };
-  const terminal = store.list({ repository: question.repository, taskId: question.taskId, limit: 500 })
-    .find((event) => event.correlationId === correlationId && ['completed', 'expired', 'failed'].includes(event.status));
+  // Same reach as `findQuestion` above: a recency window here would stop seeing
+  // the answer this question already has and let the operator answer it twice.
+  const terminal = store.exchange(correlationId)
+    .find((event) => ['completed', 'expired', 'failed'].includes(event.status));
   if (terminal) return { accepted: false, reason: `Question is already ${terminal.status}` };
 
   const event = await store.publish({

--- a/src/coordination/operatorAnswers.test.ts
+++ b/src/coordination/operatorAnswers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { readmitWithRollback, shouldReadmitEarly } from './operatorAnswers.js';
+import { shouldReadmitEarly } from './operatorAnswers.js';
 
 describe('shouldReadmitEarly', () => {
   it('cuts the backoff short for a task parked on the operator', () => {
@@ -8,50 +8,12 @@ describe('shouldReadmitEarly', () => {
 
   it('leaves an ordinary failure backoff alone, answered question or not', () => {
     // A task retrying after failures can still carry an answered question from an
-    // earlier park. Without the park flag every heartbeat would re-admit it, and
+    // earlier park. Without the park code every heartbeat would re-admit it, and
     // the backoff that exists to stop a hot retry loop would stop existing.
     expect(shouldReadmitEarly({ parkedOnOperator: false, allQuestionsAnswered: true })).toBe(false);
   });
 
   it('leaves a parked task alone until the answer is actually there', () => {
     expect(shouldReadmitEarly({ parkedOnOperator: true, allQuestionsAnswered: false })).toBe(false);
-  });
-});
-
-describe('readmitWithRollback', () => {
-  function recorder(outcomes: { retire: boolean; promote: boolean }) {
-    const calls: string[] = [];
-    return {
-      calls,
-      steps: {
-        retireSignal: () => { calls.push('retire'); return outcomes.retire; },
-        promote: () => { calls.push('promote'); return outcomes.promote; },
-        restoreSignal: () => { calls.push('restore'); },
-      },
-    };
-  }
-
-  it('retires the signal before promoting, so a later failure cannot replay it', () => {
-    // Promoting while the signal is still set lets a run that then fails for its
-    // own reasons be pulled forward again every heartbeat, past the backoff that
-    // exists to stop exactly that.
-    const { calls, steps } = recorder({ retire: true, promote: true });
-    expect(readmitWithRollback(steps)).toBe(true);
-    expect(calls).toEqual(['retire', 'promote']);
-  });
-
-  it('puts the signal back when the promotion does not happen', () => {
-    // Otherwise the only record that an early re-admission was permitted is gone,
-    // and the operator's answer can never shorten anything again.
-    const { calls, steps } = recorder({ retire: true, promote: false });
-    expect(readmitWithRollback(steps)).toBe(false);
-    expect(calls).toEqual(['retire', 'promote', 'restore']);
-  });
-
-  it('does nothing at all when the signal cannot be retired', () => {
-    // Failing to write leaves the task on its backoff, which is only a delay.
-    const { calls, steps } = recorder({ retire: false, promote: true });
-    expect(readmitWithRollback(steps)).toBe(false);
-    expect(calls).toEqual(['retire']);
   });
 });

--- a/src/coordination/operatorAnswers.test.ts
+++ b/src/coordination/operatorAnswers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { shouldReadmitEarly } from './operatorAnswers.js';
+import { readmitWithRollback, shouldReadmitEarly } from './operatorAnswers.js';
 
 describe('shouldReadmitEarly', () => {
   it('cuts the backoff short for a task parked on the operator', () => {
@@ -15,5 +15,43 @@ describe('shouldReadmitEarly', () => {
 
   it('leaves a parked task alone until the answer is actually there', () => {
     expect(shouldReadmitEarly({ parkedOnOperator: true, allQuestionsAnswered: false })).toBe(false);
+  });
+});
+
+describe('readmitWithRollback', () => {
+  function recorder(outcomes: { retire: boolean; promote: boolean }) {
+    const calls: string[] = [];
+    return {
+      calls,
+      steps: {
+        retireSignal: () => { calls.push('retire'); return outcomes.retire; },
+        promote: () => { calls.push('promote'); return outcomes.promote; },
+        restoreSignal: () => { calls.push('restore'); },
+      },
+    };
+  }
+
+  it('retires the signal before promoting, so a later failure cannot replay it', () => {
+    // Promoting while the signal is still set lets a run that then fails for its
+    // own reasons be pulled forward again every heartbeat, past the backoff that
+    // exists to stop exactly that.
+    const { calls, steps } = recorder({ retire: true, promote: true });
+    expect(readmitWithRollback(steps)).toBe(true);
+    expect(calls).toEqual(['retire', 'promote']);
+  });
+
+  it('puts the signal back when the promotion does not happen', () => {
+    // Otherwise the only record that an early re-admission was permitted is gone,
+    // and the operator's answer can never shorten anything again.
+    const { calls, steps } = recorder({ retire: true, promote: false });
+    expect(readmitWithRollback(steps)).toBe(false);
+    expect(calls).toEqual(['retire', 'promote', 'restore']);
+  });
+
+  it('does nothing at all when the signal cannot be retired', () => {
+    // Failing to write leaves the task on its backoff, which is only a delay.
+    const { calls, steps } = recorder({ retire: false, promote: true });
+    expect(readmitWithRollback(steps)).toBe(false);
+    expect(calls).toEqual(['retire']);
   });
 });

--- a/src/coordination/operatorAnswers.test.ts
+++ b/src/coordination/operatorAnswers.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { shouldReadmitEarly } from './operatorAnswers.js';
+
+describe('shouldReadmitEarly', () => {
+  it('cuts the backoff short for a task parked on the operator', () => {
+    expect(shouldReadmitEarly({ parkedOnOperator: true, allQuestionsAnswered: true })).toBe(true);
+  });
+
+  it('leaves an ordinary failure backoff alone, answered question or not', () => {
+    // A task retrying after failures can still carry an answered question from an
+    // earlier park. Without the park flag every heartbeat would re-admit it, and
+    // the backoff that exists to stop a hot retry loop would stop existing.
+    expect(shouldReadmitEarly({ parkedOnOperator: false, allQuestionsAnswered: true })).toBe(false);
+  });
+
+  it('leaves a parked task alone until the answer is actually there', () => {
+    expect(shouldReadmitEarly({ parkedOnOperator: true, allQuestionsAnswered: false })).toBe(false);
+  });
+});

--- a/src/coordination/operatorAnswers.ts
+++ b/src/coordination/operatorAnswers.ts
@@ -11,52 +11,27 @@
 // run proceeds instead of parking again.
 
 /**
- * Recorded on a task's execution state when a run stops on `ask_human`.
+ * The run-ledger error code a task carries while it is stopped on the operator.
  *
- * Durable on purpose. The answer itself is durable — it lives on the board — so a
- * discriminator that only existed in memory would make a restart the one thing
- * that turns a two-minute reply back into a two-hour one, for no reason the
- * operator could see.
+ * Deliberately not a separate flag. The ledger writes `last_error_code` on every
+ * transition, so the next attempt overwrites this one — which is exactly the
+ * lifecycle the park signal needs and the one a hand-maintained flag kept getting
+ * wrong. A task that waits out its backoff normally and then fails for its own
+ * reasons carries `failed` here, not this, so an answer from an earlier park
+ * cannot pull it forward.
  */
 export const OPERATOR_PARK_REASON = 'waiting_on_operator';
 
 /**
  * Whether a backoff may be cut short because the operator replied.
  *
- * The park flag is what keeps this from becoming a fast-retry loop: a task
+ * The park code is what keeps this from becoming a fast-retry loop: a task
  * backing off from ordinary failures can still carry an answered question from
- * an earlier park, and without the flag every heartbeat would re-admit it.
+ * an earlier park, and without it every heartbeat would re-admit it.
  */
 export function shouldReadmitEarly(input: {
   parkedOnOperator: boolean;
   allQuestionsAnswered: boolean;
 }): boolean {
   return input.parkedOnOperator && input.allQuestionsAnswered;
-}
-
-/**
- * Retire the park signal, promote the run, and put the signal back if the
- * promotion does not happen.
- *
- * The order is forced from both sides. Promoting while the signal is still set
- * lets a run that then fails for its own reasons be pulled forward again on
- * every heartbeat, past the backoff that exists to stop that. Retiring it and
- * then failing to promote loses the only record that an early re-admission was
- * ever permitted, and the answer can never shorten anything again.
- *
- * So: retire first, and on a failed promotion restore. If the restore itself
- * fails the task simply waits out its backoff — the behaviour before any of this
- * existed, and the safe direction to fail in.
- */
-export function readmitWithRollback(steps: {
-  retireSignal: () => boolean;
-  promote: () => boolean;
-  restoreSignal: () => void;
-}): boolean {
-  if (!steps.retireSignal()) return false;
-  if (!steps.promote()) {
-    steps.restoreSignal();
-    return false;
-  }
-  return true;
 }

--- a/src/coordination/operatorAnswers.ts
+++ b/src/coordination/operatorAnswers.ts
@@ -33,3 +33,30 @@ export function shouldReadmitEarly(input: {
 }): boolean {
   return input.parkedOnOperator && input.allQuestionsAnswered;
 }
+
+/**
+ * Retire the park signal, promote the run, and put the signal back if the
+ * promotion does not happen.
+ *
+ * The order is forced from both sides. Promoting while the signal is still set
+ * lets a run that then fails for its own reasons be pulled forward again on
+ * every heartbeat, past the backoff that exists to stop that. Retiring it and
+ * then failing to promote loses the only record that an early re-admission was
+ * ever permitted, and the answer can never shorten anything again.
+ *
+ * So: retire first, and on a failed promotion restore. If the restore itself
+ * fails the task simply waits out its backoff — the behaviour before any of this
+ * existed, and the safe direction to fail in.
+ */
+export function readmitWithRollback(steps: {
+  retireSignal: () => boolean;
+  promote: () => boolean;
+  restoreSignal: () => void;
+}): boolean {
+  if (!steps.retireSignal()) return false;
+  if (!steps.promote()) {
+    steps.restoreSignal();
+    return false;
+  }
+  return true;
+}

--- a/src/coordination/operatorAnswers.ts
+++ b/src/coordination/operatorAnswers.ts
@@ -1,0 +1,35 @@
+// ============================================
+// OpenSwarm - Reading the board for an operator's answer
+// ============================================
+//
+// A run that stops on `ask_human` is parked with a two-hour backoff, and the
+// backoff is also its resume path — so without this the operator's reply lands
+// up to two hours after they sent it, which from their side is indistinguishable
+// from being ignored (AGT-4033).
+//
+// The signal is the same fact `askHuman` replays on, so if it holds here the next
+// run proceeds instead of parking again.
+
+/**
+ * Recorded on a task's execution state when a run stops on `ask_human`.
+ *
+ * Durable on purpose. The answer itself is durable — it lives on the board — so a
+ * discriminator that only existed in memory would make a restart the one thing
+ * that turns a two-minute reply back into a two-hour one, for no reason the
+ * operator could see.
+ */
+export const OPERATOR_PARK_REASON = 'waiting_on_operator';
+
+/**
+ * Whether a backoff may be cut short because the operator replied.
+ *
+ * The park flag is what keeps this from becoming a fast-retry loop: a task
+ * backing off from ordinary failures can still carry an answered question from
+ * an earlier park, and without the flag every heartbeat would re-admit it.
+ */
+export function shouldReadmitEarly(input: {
+  parkedOnOperator: boolean;
+  allQuestionsAnswered: boolean;
+}): boolean {
+  return input.parkedOnOperator && input.allQuestionsAnswered;
+}

--- a/src/taskState/store.test.ts
+++ b/src/taskState/store.test.ts
@@ -51,6 +51,24 @@ describe('task state store', () => {
     resetTaskStateStoreForTests();
   });
 
+  it('keeps an operator park across a reload, and clears it again (AGT-4033)', () => {
+    // The operator's answer is durable — it lives on the coordination board — so
+    // the flag that says a backoff may be cut short has to be durable too, or a
+    // restart is the one thing that turns a two-minute reply back into a
+    // two-hour one.
+    upsertTaskState('AGT-1', { execution: { status: 'in_progress', retryCount: 0 } });
+    upsertTaskState('AGT-1', { execution: { blockedReason: 'waiting_on_operator' } });
+
+    resetTaskStateStoreForTests();
+    expect(getTaskState('AGT-1')?.execution.blockedReason).toBe('waiting_on_operator');
+    // Merged, not replaced: the park must not cost the task its execution status.
+    expect(getTaskState('AGT-1')?.execution.status).toBe('in_progress');
+
+    upsertTaskState('AGT-1', { execution: { blockedReason: undefined } });
+    resetTaskStateStoreForTests();
+    expect(getTaskState('AGT-1')?.execution.blockedReason).toBeUndefined();
+  });
+
   afterEach(() => {
     resetTaskStateStoreForTests();
     if (existsSync(stateFile)) {

--- a/src/taskState/store.test.ts
+++ b/src/taskState/store.test.ts
@@ -51,17 +51,16 @@ describe('task state store', () => {
     resetTaskStateStoreForTests();
   });
 
-  it('keeps an operator park across a reload, and clears it again (AGT-4033)', () => {
-    // The operator's answer is durable — it lives on the coordination board — so
-    // the flag that says a backoff may be cut short has to be durable too, or a
-    // restart is the one thing that turns a two-minute reply back into a
-    // two-hour one.
+  it('carries a block reason across a reload and clears it again', () => {
+    // A dependency block outlives the process that noticed it, so the reason has
+    // to survive a reload — and clearing it has to survive one too, or a task
+    // stays labelled as blocked after the thing it waited for is done.
     upsertTaskState('AGT-1', { execution: { status: 'in_progress', retryCount: 0 } });
-    upsertTaskState('AGT-1', { execution: { blockedReason: 'waiting_on_operator' } });
+    upsertTaskState('AGT-1', { execution: { blockedReason: 'Waiting on dependencies: AGT-2' } });
 
     resetTaskStateStoreForTests();
-    expect(getTaskState('AGT-1')?.execution.blockedReason).toBe('waiting_on_operator');
-    // Merged, not replaced: the park must not cost the task its execution status.
+    expect(getTaskState('AGT-1')?.execution.blockedReason).toBe('Waiting on dependencies: AGT-2');
+    // Merged, not replaced: recording the block must not cost the task its status.
     expect(getTaskState('AGT-1')?.execution.status).toBe('in_progress');
 
     upsertTaskState('AGT-1', { execution: { blockedReason: undefined } });


### PR DESCRIPTION
## The problem, as the operator experiences it

You answer a parked agent in the dashboard. Nothing happens for two hours.

Measured on vela today, right after answering six parked cgf-portal agents — every one delivered, every one routed onto its own question's `correlationId`:

```
[HB]   Parallel mode | slots: 2 free / 2 max | running: 0
[HB] ⏰ Skipped 39 tasks in exponential backoff period
```

Answers on the board, capacity free, nothing running. From the operator's side that is indistinguishable from being ignored — the exact failure mode AGT-4026 / AGT-4029 / AGT-4030 were meant to end.

## Why

`waiting_on_operator` parks with `setRetryTime(issueId, 4, ...)`, the last entry of `BACKOFF_MINUTES = [10, 30, 60, 120]`. That backoff is *also* the resume path — the retried run finds the answer and continues — so resume latency equals the full backoff no matter how fast the human replies.

## The fix

The heartbeat asks the board whether a parked task's questions have all been answered, and brings it forward if they have. Everything else about the backoff is untouched: a question nobody answers still waits the full two hours.

**Both halves are needed, and only one of them is the filter.** The ledger refuses to claim a `RETRY_AT` row whose time has not come (`runLedger.ts:419`), so letting the task past the heartbeat alone would have selected it and then failed to claim it, every cycle. `markReady` is what actually releases it. Production runs `automationLedgerMode: 'primary'` by default, so the durable path *is* the path — a legacy-only fix would have been dead code on the daemon it was written for.

## Four things this had to get right, each of which was wrong first

| Question | Answer | What the wrong answer did |
|---|---|---|
| Which questions count? | **All** of them, not the newest | A task runs several agents; answering one worker's question released a run parked on another's, which re-asks and parks again |
| What counts as an answer? | Only a **completed** one | A failed or expired answer event released the run into a question that is still open |
| How far back to look? | **Counted in the durable trace**, not fetched | Any window — 500 or 2,000 — lets a chatty task push its own question out of view, and the caller reads "all answered" |
| Trace unavailable? | **Say no** | The in-memory board gives exactly the false "all answered" this exists to prevent |

The last one made the reach consistent end to end: the replay in `askHuman` and the answer entrypoint now read the same durable exchange, so a question the ring has evicted can still be answered, and still returns its answer instead of being asked a second time.

## Durability

The park marker lives on the task's execution state, so it survives a restart. The answer is durable — it is on the board — and a discriminator that only existed in memory would make a restart the one thing that turns a two-minute reply back into a two-hour one.

It is retired *before* the re-admission acts on it. If that write fails the task simply keeps its backoff; re-admitting on a signal that is still set would pull a run that then fails for its own reasons forward again on every heartbeat, past the backoff that exists to stop exactly that.

## Verification

Every guard has a test that fails when it is removed, checked by mutation rather than assumed:

| Removed | Tests that fail |
|---|---|
| durable count (window instead of SQL) | 1 |
| task scoping in the answer join | 1 |
| completed-answer requirement | 1 |
| fail-closed when the trace is unavailable | 1 |
| durable question resolution | 1 |
| durable answer replay | 1 |
| park-flag discriminator | 1 |
| execution-state merge (park loses status) | 2 |

The ledger integration point is pinned directly: a `RETRY_AT` row with a future time is not claimable, and is claimable after `markReady` — which is the fact the whole fix rests on.

`tsc --noEmit`, `oxlint`, and the changed suites (`src/coordination/`, `src/automation/`, `src/taskState/`) pass — 705 tests.

Two test-isolation defects surfaced on the way and are fixed here, because reading the durable trace made them load-bearing: `humanQuestions` and `coordinationTools` shared one automation database across the whole run, so they were answering each other's questions.

Review gate: **APPROVE** on round 12. Rounds 1–11 each found something real — the legacy-only fix that production never reaches, the in-memory discriminator, the actor scoping, three separate windows, the status mismatch, the unsafe fallback, and a signal cleared too late.

Closes AGT-4033.