### PR TITLE
fix(ledger): asking the operator a question is not the repository failing (AGT-4037)

### DIFF
--- a/src/automation/runLedger.test.ts
+++ b/src/automation/runLedger.test.ts
@@ -516,6 +516,53 @@ describe('RunLedger claim and fencing races', () => {
     ledger.close();
   });
 
+  it('does not let an agent asking the operator a question close the repository', () => {
+    // A run that stops on `ask_human` has not broken anything — it is waiting on
+    // a human. Counting it as a repository failure means a handful of polite
+    // questions shuts every other task out: measured on vela, six questions and
+    // one real failure opened the circuit at 7/6 and idled the daemon for an
+    // hour, which is the opposite of what a working human-in-the-loop should do.
+    const ledger = new RunLedger(createDbPath());
+    for (const id of ['ASK-1', 'ASK-2', 'ASK-3']) register(ledger, id, '/asking-repo');
+
+    for (const [index, id] of ['ASK-1', 'ASK-2'].entries()) {
+      const held = claim(ledger, id, 'daemon', 2_000 + index, 3);
+      expect(ledger.recordAttemptResult(held, {
+        success: false,
+        finalStatus: 'waiting_on_operator',
+        maxFailuresPerHour: 1,
+        circuitCooldownMs: 60_000,
+      }, 2_100 + index)).toBe(true);
+    }
+
+    expect(ledger.getMetrics(2_200).openCircuits).toBe(0);
+    // And the next task on that repository can still start.
+    expect(ledger.claimRun('ASK-3', {
+      ownerInstanceId: 'daemon', leaseMs: 1_000, now: 2_300,
+      maxActiveForProject: 3, maxFailuresPerHour: 1,
+    })).not.toBeNull();
+    ledger.close();
+  });
+
+  it('still opens the circuit for failures that are the repository\'s own', () => {
+    // The guard is about what a question means, not about disabling the circuit.
+    const ledger = new RunLedger(createDbPath());
+    for (const id of ['REAL-1', 'REAL-2']) register(ledger, id, '/breaking-repo');
+    const held = claim(ledger, 'REAL-1', 'daemon', 2_000, 2);
+    expect(ledger.recordAttemptResult(held, {
+      success: false,
+      finalStatus: 'failed',
+      maxFailuresPerHour: 1,
+      circuitCooldownMs: 60_000,
+    }, 2_100)).toBe(true);
+
+    expect(ledger.claimRun('REAL-2', {
+      ownerInstanceId: 'daemon', leaseMs: 1_000, now: 2_200,
+      maxActiveForProject: 2, maxFailuresPerHour: 1,
+    })).toBeNull();
+    ledger.close();
+  });
+
   it('preserves remediated attempts while excluding them from the failure circuit', () => {
     const ledger = new RunLedger(createDbPath());
     register(ledger, 'FIXED-1', '/fixed-repo');

--- a/src/automation/runLedger.ts
+++ b/src/automation/runLedger.ts
@@ -25,6 +25,29 @@ import type {
 } from './runLedgerTypes.js';
 
 export { AUTOMATION_SCHEMA_VERSION, RUN_STATES } from './runLedgerTypes.js';
+
+/**
+ * Outcomes that are not the repository failing, and so must not trip its circuit.
+ *
+ * `waiting_on_operator` is the one that matters most and was missing: an agent
+ * that stops to ask a question has not broken anything, and counting it as a
+ * failure means a run of polite questions closes the whole repository to every
+ * other task — measured on vela, six questions and one real failure opened the
+ * circuit at 7/6 and idled the daemon for an hour. The better the human-in-the-
+ * loop path works, the faster that would happen.
+ *
+ * Kept in one place because the three call sites had already drifted: the
+ * in-memory guard was missing `operator_remediated` that both SQL copies had.
+ */
+export const NON_FAILURE_RESULT_STATUSES: readonly string[] = [
+  'cancelled',
+  'superseded',
+  'rate_limited',
+  'publication_reconcile',
+  'operator_remediated',
+  'waiting_on_operator',
+];
+
 export type {
   AttemptResultInput,
   ClaimOptions,
@@ -458,11 +481,8 @@ export class RunLedger {
           FROM automation_attempts a
           JOIN automation_runs r ON r.issue_id = a.issue_id
           WHERE r.project_path = ? AND a.started_at >= ? AND a.success = 0
-            AND COALESCE(a.result_status, '') NOT IN (
-              'cancelled', 'superseded', 'rate_limited', 'publication_reconcile',
-              'operator_remediated'
-            )
-        `).get(row.project_path, hourAgo) as { count: number }).count;
+            AND COALESCE(a.result_status, '') NOT IN (${placeholders(NON_FAILURE_RESULT_STATUSES)})
+        `).get(row.project_path, hourAgo, ...NON_FAILURE_RESULT_STATUSES) as { count: number }).count;
         if (failures >= Math.max(1, options.maxFailuresPerHour)) {
           openCircuit(`failure circuit open: ${failures}/${options.maxFailuresPerHour} in 1h`);
           return null;
@@ -623,7 +643,7 @@ export class RunLedger {
       if (updated.changes !== 1) return false;
 
       const countsAsFailure = !input.success
-        && !['cancelled', 'superseded', 'rate_limited', 'publication_reconcile'].includes(input.finalStatus);
+        && !NON_FAILURE_RESULT_STATUSES.includes(input.finalStatus);
       if (countsAsFailure && input.maxFailuresPerHour != null) {
         const run = this.db.prepare('SELECT project_path FROM automation_runs WHERE issue_id = ?')
           .get(claim.issueId) as { project_path: string };
@@ -632,11 +652,8 @@ export class RunLedger {
           FROM automation_attempts a
           JOIN automation_runs r ON r.issue_id = a.issue_id
           WHERE r.project_path = ? AND a.started_at >= ? AND a.success = 0
-            AND COALESCE(a.result_status, '') NOT IN (
-              'cancelled', 'superseded', 'rate_limited', 'publication_reconcile',
-              'operator_remediated'
-            )
-        `).get(run.project_path, now - 60 * 60_000) as { count: number }).count;
+            AND COALESCE(a.result_status, '') NOT IN (${placeholders(NON_FAILURE_RESULT_STATUSES)})
+        `).get(run.project_path, now - 60 * 60_000, ...NON_FAILURE_RESULT_STATUSES) as { count: number }).count;
         if (failures >= Math.max(1, input.maxFailuresPerHour)) {
           const cooldownMs = Math.max(60_000, input.circuitCooldownMs ?? 60 * 60_000);
           const reason = `failure circuit open: ${failures}/${input.maxFailuresPerHour} in 1h`;


### PR DESCRIPTION
## What happened

Six agents stopped to ask the operator a question. That closed the whole cgf-portal repository for an hour.

From the live ledger on vela:

```
=== attempts in the last hour that COUNT as failures ===
  waiting_on_operator          6
  failed                       1
  TOTAL counted as failures: 7      → circuit opens at 7/6

=== repo circuits ===
  /work/cgf-portal
    reason: failure circuit open: 7/6 in 1h
    open for another 42.5 min
```

One of the seven was a real failure.

`waiting_on_operator` was missing from the set of outcomes the failure circuit ignores (`runLedger.ts:461`), so a run that halted on `ask_human` counted against the repository hosting it. Once the circuit was open, every other task there was refused a claim — including the ones with nothing to wait for.

## Why this was worth chasing

It is the reason the loop looked broken today, and it explains every symptom:

| Symptom | Cause |
|---|---|
| container at 0.09% CPU, 164 MiB of 16 GiB | every claim on the repo refused |
| 6 hours, zero completions | nothing could start |
| raising `maxConcurrentTasks` 2 → 6 changed nothing | slots were never binding |
| 88 `Task superseded` lines | each refused claim reports as one — the second defect that hid this (AGT-4036) |

Two things made it urgent rather than merely wrong.

**It gets worse as the human-in-the-loop path gets better.** AGT-4026/4029/4030 made operator questions actually reach the operator, and AGT-4033 makes answers resume the run promptly. The more reliably agents ask, the faster they lock the repository.

**And answering did not help while it was open.** The circuit refuses the claim, so the run never reached the code that would have replayed the answer.

## The change

`waiting_on_operator` joins the exclusion set. The three copies of that set had already drifted — the in-memory guard at `:626` was missing `operator_remediated` that both SQL copies had — so they are now one exported constant, bound as parameters rather than interpolated into the SQL.

The circuit is not weakened. A genuine `failed` outcome still opens it on the same threshold, and the second test pins exactly that, so this cannot quietly become "the circuit never fires".

## Verification

Two tests, and the fix is mutation-checked: removing `'waiting_on_operator'` from the constant fails the first and only the first.

- a repository whose agents are asking questions stays claimable, and the next task on it still starts
- a repository with a real failure still trips at the same threshold

`tsc --noEmit`, `oxlint`, and the changed suites pass — 707 tests across `src/automation/`, `src/coordination/`, `src/taskState/`.

Review gate: **APPROVE** on round 1.

## Note on the diagnosis

Two earlier readings of this were wrong and are corrected in AGT-4036: a deferred claim does *not* escalate the backoff ladder (it is a flat 30 s and does not touch the attempt counter), and open-PR overlap accounted for 2 of the 88 supersessions, not most of them. The measurements that led here are in the issue.

Closes AGT-4037.