### PR TITLE
build: let agents validate a compose file (AGT-4039)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,25 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends gh && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# The docker CLI and its compose plugin, for repositories whose gates validate a
+# compose file. `docker compose config` renders and interpolates the YAML from
+# disk and never opens a socket, so the CLI alone is what those gates need.
+#
+# Deliberately no /var/run/docker.sock: mounting it would give every agent
+# control of the host's containers, which is a container escape by another name.
+# Subcommands that do need a daemon (up, build, ps) will fail to connect — that
+# is the boundary, not a bug to be fixed by mounting the socket.
+RUN apt-get update && apt-get install -y --no-install-recommends gnupg && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg \
+        -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+        > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # uv, for repositories that are uv projects. Copied from the official image
 # rather than piped from an installer, and pinned by digest rather than tag —
 # a tag can be repointed, so only the digest makes this build reproducible.


### PR DESCRIPTION
Repository gates that run `docker compose config` failed in the daemon image with `docker: command not found`, and the tasks behind them parked asking the operator to run the command by hand.

What those gates need is the CLI, not a daemon: `config` renders and interpolates the compose file from disk and never opens a socket. So this adds `docker-ce-cli` and `docker-compose-plugin` in the runtime stage, using the same signed-apt-repo pattern the image already uses for `gh`.

**Deliberately no `/var/run/docker.sock`.** Mounting it would hand every agent control of the host's containers, which is a container escape by another name. Subcommands that do need a daemon fail to connect, and the Dockerfile says why so that is not "fixed" later by mounting the socket.

## Verified on the deployment host (amd64)

Built from this branch and run against the real cgf-portal checkout:

| check | result |
|---|---|
| the gate command — `cd infra/nas && docker compose --env-file .env.example config --quiet` | exit 0 |
| a malformed compose file | exit 1, `go-yaml load error in parser …` |
| `docker ps` (needs the daemon) | fails to connect — no socket, boundary intact |
| `docker --version` / `docker compose version` | 29.7.2 / v5.5.0 |

## Image size

633,461,917 → 669,464,259 bytes: **+36.0 MB (+5.7 %)**.

Closes AGT-4039.