### PR TITLE
fix(daemon): stop a repeatedly-unanswered ask_human from spinning (AGT-4042)

### DIFF
--- a/src/automation/autonomousRunner.operatorQuestionPark.test.ts
+++ b/src/automation/autonomousRunner.operatorQuestionPark.test.ts
@@ -1,0 +1,174 @@
+// ============================================
+// OpenSwarm - stop re-dispatching on a repeated, unanswered ask_human (AGT-4042)
+// ============================================
+//
+// A re-dispatch is a fresh worker session, and it is not free: burning a
+// worker+reviewer cycle every backoff tick on a question the operator has
+// already been paged for once, and has not answered, is exactly the wasted
+// spin these tests pin closed.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import type { DurableRunCoordinator } from './durableRunCoordinator.js';
+import type { PipelineResult } from '../agents/pairPipeline.js';
+import type { TaskScheduler } from '../orchestration/taskScheduler.js';
+
+vi.mock('../core/providerOverride.js', () => ({ writeProviderOverride: vi.fn() }));
+vi.mock('../agents/stageModelResolver.js', () => ({ resolveAdapterDefaultModel: vi.fn(async () => 'model') }));
+
+type InternalRunner = {
+  scheduler: TaskScheduler;
+  durableRuns: DurableRunCoordinator;
+  failedTaskRetryTimes: Map<string, number>;
+  filterAlreadyProcessed(tasks: TaskItem[]): TaskItem[];
+  resolveProjectPath(task: TaskItem): Promise<string | null>;
+};
+
+const REPO = '/repo';
+const TASK: TaskItem = {
+  id: 'AGT-1', issueId: 'AGT-1', issueIdentifier: 'AGT-1',
+  source: 'linear', title: 'blocked on Google credentials', priority: 2, createdAt: 0,
+  linearState: 'Todo', linearProject: { id: 'project', name: 'Repo' },
+};
+
+function pipelineResult(): PipelineResult {
+  return {
+    success: false, sessionId: 'session-1', stages: [], finalStatus: 'waiting_on_operator',
+    totalDuration: 0, iterations: 1,
+  };
+}
+
+describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'openswarm-operator-question-park-'));
+    process.env.OPENSWARM_COORDINATION_FILE = join(root, 'coordination.json');
+    process.env.OPENSWARM_TASK_STATE_FILE = join(root, 'task-state.json');
+    process.env.OPENSWARM_RUNNER_TASK_STATE_FILE = join(root, 'runner-state.json');
+    process.env.OPENSWARM_RUNNER_REJECTION_STATE_FILE = join(root, 'rejections.json');
+    process.env.OPENSWARM_RUNNER_PIPELINE_HISTORY_FILE = join(root, 'history.json');
+    process.env.OPENSWARM_RUNNER_DECOMPOSITION_STATE_FILE = join(root, 'decomposition.json');
+  });
+
+  afterEach(async () => {
+    delete process.env.OPENSWARM_COORDINATION_FILE;
+    delete process.env.OPENSWARM_TASK_STATE_FILE;
+    delete process.env.OPENSWARM_RUNNER_TASK_STATE_FILE;
+    delete process.env.OPENSWARM_RUNNER_REJECTION_STATE_FILE;
+    delete process.env.OPENSWARM_RUNNER_PIPELINE_HISTORY_FILE;
+    delete process.env.OPENSWARM_RUNNER_DECOMPOSITION_STATE_FILE;
+    const store = await import('../coordination/coordinationStore.js');
+    store.resetCoordinationStoreForTests();
+    rmSync(root, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  async function makeRunner(): Promise<InternalRunner> {
+    const { AutonomousRunner } = await import('./autonomousRunner.js');
+    const runner = new AutonomousRunner({
+      linearTeamId: 'team', allowedProjects: [REPO], heartbeatSchedule: '0 * * * *',
+      autoExecute: true, maxConsecutiveTasks: 1, cooldownSeconds: 0, dryRun: true,
+      automationLedgerMode: 'primary', automationDbPath: join(root, 'runs.db'),
+    });
+    const internal = runner as unknown as InternalRunner;
+    internal.resolveProjectPath = vi.fn(async () => REPO);
+    internal.durableRuns.observeTask(TASK, REPO);
+    return internal;
+  }
+
+  async function seedOpenQuestions(count: number): Promise<void> {
+    const { getCoordinationStore } = await import('../coordination/coordinationStore.js');
+    const store = getCoordinationStore();
+    for (let i = 0; i < count; i += 1) {
+      await store.publish({
+        repository: REPO, taskId: 'AGT-1', actor: 'worker-x', recipient: 'human',
+        kind: 'human-question', status: 'running', correlationId: `hq-${i}`,
+        summary: `ask #${i}`,
+      });
+    }
+  }
+
+  it('parks the run once it has asked twice with no answer, instead of retrying on a clock', async () => {
+    const internal = await makeRunner();
+    await seedOpenQuestions(2);
+
+    internal.scheduler.emit('waiting_on_operator', { task: TASK, result: pipelineResult() });
+    await vi.waitFor(() => {
+      expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('NEEDS_HUMAN');
+    });
+
+    const run = internal.durableRuns.getRun('AGT-1');
+    expect(run?.lastErrorMessage).toMatch(/^\[operator-question\]/);
+    expect(internal.failedTaskRetryTimes.has('AGT-1')).toBe(false); // no fixed-backoff ladder entry either
+    internal.durableRuns.close();
+  });
+
+  it('still uses the ordinary backoff on the first unanswered ask', async () => {
+    const internal = await makeRunner();
+    await seedOpenQuestions(1);
+
+    internal.scheduler.emit('waiting_on_operator', { task: TASK, result: pipelineResult() });
+    await vi.waitFor(() => {
+      expect(internal.failedTaskRetryTimes.has('AGT-1')).toBe(true);
+    });
+
+    expect(internal.durableRuns.getRun('AGT-1')?.state).not.toBe('NEEDS_HUMAN');
+    internal.durableRuns.close();
+  });
+
+  it('resumes the moment the outstanding question is answered, with no Linear touch', async () => {
+    // linearState is deliberately outside the pre-existing Todo/In Progress/In
+    // Review resume set — this test isolates the answered-question path, not
+    // the resume this file already had.
+    const parkedButAnswered: TaskItem = { ...TASK, linearState: 'Backlog' };
+    const internal = await makeRunner();
+    const { getCoordinationStore } = await import('../coordination/coordinationStore.js');
+    const store = getCoordinationStore();
+    await store.publish({
+      repository: REPO, taskId: 'AGT-1', actor: 'worker-x', recipient: 'human',
+      kind: 'human-question', status: 'running', correlationId: 'hq-only', summary: 'ask',
+    });
+    internal.durableRuns.markNeedsHuman('AGT-1', '[operator-question] asked 2 times with no answer — stopped retrying automatically');
+    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('NEEDS_HUMAN');
+
+    // The card stays in Todo throughout — resuming does not depend on the
+    // operator touching Linear at all, only on the answer landing.
+    await store.publish({
+      repository: REPO, taskId: 'AGT-1', actor: 'operator', recipient: 'worker-x',
+      kind: 'human-answer', status: 'completed', correlationId: 'hq-only', summary: 'answered',
+    });
+    // The path cache is populated at dispatch time in production; the filter
+    // reads it rather than resolving async, so seed it the same way a prior
+    // run would have.
+    (internal as unknown as { projectPathCache: Map<string, string> }).projectPathCache.set('Repo', REPO);
+
+    const selected = internal.filterAlreadyProcessed([parkedButAnswered]);
+
+    expect(selected).toEqual([parkedButAnswered]);
+    expect(internal.durableRuns.getRun('AGT-1')?.state).not.toBe('NEEDS_HUMAN');
+    internal.durableRuns.close();
+  });
+
+  it('does not resume a NEEDS_HUMAN park from an unrelated reason just because no question was ever asked', async () => {
+    // A rejection-limit or PR-closed-without-merge park shares NEEDS_HUMAN but
+    // has nothing to do with ask_human — openQuestionCount is legitimately 0
+    // for it, and that must not read as "answered". Modeled with the ticket out
+    // of Todo/In Progress/In Review, the way those other parks also leave it
+    // (a STUCK label move) — so only the marker-scoped check is on trial here,
+    // not the pre-existing Linear-state resume this file already had.
+    const internal = await makeRunner();
+    internal.durableRuns.markNeedsHuman('AGT-1', 'Reviewer rejected 4 attempts: still failing lint');
+    (internal as unknown as { projectPathCache: Map<string, string> }).projectPathCache.set('Repo', REPO);
+    const parkedElsewhere: TaskItem = { ...TASK, linearState: 'Backlog' };
+
+    const selected = internal.filterAlreadyProcessed([parkedElsewhere]);
+
+    expect(selected).toEqual([]);
+    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('NEEDS_HUMAN');
+    internal.durableRuns.close();
+  });
+});

--- a/src/automation/autonomousRunner.operatorQuestionPark.test.ts
+++ b/src/automation/autonomousRunner.operatorQuestionPark.test.ts
@@ -43,15 +43,24 @@ function pipelineResult(): PipelineResult {
 
 describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () => {
   let root: string;
+  let dbPath: string;
 
   beforeEach(() => {
     root = mkdtempSync(join(tmpdir(), 'openswarm-operator-question-park-'));
+    dbPath = join(root, 'runs.db');
     process.env.OPENSWARM_COORDINATION_FILE = join(root, 'coordination.json');
     process.env.OPENSWARM_TASK_STATE_FILE = join(root, 'task-state.json');
     process.env.OPENSWARM_RUNNER_TASK_STATE_FILE = join(root, 'runner-state.json');
     process.env.OPENSWARM_RUNNER_REJECTION_STATE_FILE = join(root, 'rejections.json');
     process.env.OPENSWARM_RUNNER_PIPELINE_HISTORY_FILE = join(root, 'history.json');
     process.env.OPENSWARM_RUNNER_DECOMPOSITION_STATE_FILE = join(root, 'decomposition.json');
+    // lastAnsweredAt reads the durable coordination trace, a separate SQLite
+    // file keyed off this env var (not `dbPath` above, which is only the
+    // ledger's own file) and not reset by resetCoordinationStoreForTests.
+    // Every test in this file reuses the same repository/taskId, and without
+    // a fresh path per test the trace accumulates across the whole file's
+    // run — a later test's answer could otherwise read as an earlier test's.
+    process.env.OPENSWARM_AUTOMATION_DB = join(root, 'automation.db');
   });
 
   afterEach(async () => {
@@ -61,8 +70,11 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
     delete process.env.OPENSWARM_RUNNER_REJECTION_STATE_FILE;
     delete process.env.OPENSWARM_RUNNER_PIPELINE_HISTORY_FILE;
     delete process.env.OPENSWARM_RUNNER_DECOMPOSITION_STATE_FILE;
+    delete process.env.OPENSWARM_AUTOMATION_DB;
     const store = await import('../coordination/coordinationStore.js');
     store.resetCoordinationStoreForTests();
+    const trace = await import('../coordination/coordinationTrace.js');
+    trace.resetTraceDbForTests();
     rmSync(root, { recursive: true, force: true });
     vi.resetModules();
   });
@@ -72,7 +84,7 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
     const runner = new AutonomousRunner({
       linearTeamId: 'team', allowedProjects: [REPO], heartbeatSchedule: '0 * * * *',
       autoExecute: true, maxConsecutiveTasks: 1, cooldownSeconds: 0, dryRun: true,
-      automationLedgerMode: 'primary', automationDbPath: join(root, 'runs.db'),
+      automationLedgerMode: 'primary', automationDbPath: dbPath,
     });
     const internal = runner as unknown as InternalRunner;
     internal.resolveProjectPath = vi.fn(async () => REPO);
@@ -80,21 +92,35 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
     return internal;
   }
 
-  async function seedOpenQuestions(count: number): Promise<void> {
-    const { getCoordinationStore } = await import('../coordination/coordinationStore.js');
-    const store = getCoordinationStore();
+  /**
+   * Drive `count` claim→RETRY_AT("waiting_on_operator")→markReady cycles
+   * through a second connection to the same database, leaving the run parked
+   * in RETRY_AT at the end — the state right after the scheduler's own
+   * `waiting_on_operator` handler would have recorded that many outcomes and
+   * is about to fire for the latest one.
+   *
+   * Attempt-based on purpose, not board-based: this is what the stop decision
+   * now actually counts on (AGT-4042's second fix), and it stays correct even
+   * when every attempt asks with byte-identical wording — a scenario a board
+   * correlation-ID count could never distinguish from "asked once".
+   */
+  async function seedConsecutiveUnansweredAttempts(count: number): Promise<void> {
+    const { RunLedger } = await import('./runLedger.js');
+    const ledger = new RunLedger(dbPath);
     for (let i = 0; i < count; i += 1) {
-      await store.publish({
-        repository: REPO, taskId: 'AGT-1', actor: 'worker-x', recipient: 'human',
-        kind: 'human-question', status: 'running', correlationId: `hq-${i}`,
-        summary: `ask #${i}`,
-      });
+      const claim = ledger.claimRun('AGT-1', { ownerInstanceId: `seed-${i}`, leaseMs: 60_000, maxActiveForProject: 1 });
+      expect(claim).not.toBeNull();
+      expect(ledger.transition(claim!, 'RETRY_AT', {
+        retryAt: Date.now() + 3_600_000, errorCode: 'waiting_on_operator',
+      })).toBe(true);
+      if (i < count - 1) expect(ledger.markReady('AGT-1')).toBe(true);
     }
+    ledger.close();
   }
 
   it('parks the run once it has asked twice with no answer, instead of retrying on a clock', async () => {
     const internal = await makeRunner();
-    await seedOpenQuestions(2);
+    await seedConsecutiveUnansweredAttempts(2);
 
     internal.scheduler.emit('waiting_on_operator', { task: TASK, result: pipelineResult() });
     await vi.waitFor(() => {
@@ -107,9 +133,24 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
     internal.durableRuns.close();
   });
 
+  it('parks even when every attempt asked with byte-identical wording', async () => {
+    // The paging gate collapses an exact repeat to one correlation ID on the
+    // board, so a count keyed on distinct wordings would never reach 2 no
+    // matter how many times this was actually re-dispatched. The stop
+    // decision counts ledger attempts instead, which is unaffected by that.
+    const internal = await makeRunner();
+    await seedConsecutiveUnansweredAttempts(2);
+
+    internal.scheduler.emit('waiting_on_operator', { task: TASK, result: pipelineResult() });
+    await vi.waitFor(() => {
+      expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('NEEDS_HUMAN');
+    });
+    internal.durableRuns.close();
+  });
+
   it('still uses the ordinary backoff on the first unanswered ask', async () => {
     const internal = await makeRunner();
-    await seedOpenQuestions(1);
+    await seedConsecutiveUnansweredAttempts(1);
 
     internal.scheduler.emit('waiting_on_operator', { task: TASK, result: pipelineResult() });
     await vi.waitFor(() => {
@@ -120,11 +161,32 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
     internal.durableRuns.close();
   });
 
-  it('resumes the moment the outstanding question is answered, with no Linear touch', async () => {
-    // linearState is deliberately outside the pre-existing Todo/In Progress/In
-    // Review resume set — this test isolates the answered-question path, not
-    // the resume this file already had.
-    const parkedButAnswered: TaskItem = { ...TASK, linearState: 'Backlog' };
+  it('does not resume a parked, unanswered ask just because the Linear card never left Todo', async () => {
+    // The bug this pins closed: an ask_human park never touches the Linear
+    // card, so the pre-existing Todo/In Progress/In Review resume condition
+    // was almost always already true for an actively-worked task — reviving
+    // the park on the very next heartbeat regardless of an answer, before it
+    // did anything at all.
+    const internal = await makeRunner();
+    const { getCoordinationStore } = await import('../coordination/coordinationStore.js');
+    await getCoordinationStore().publish({
+      repository: REPO, taskId: 'AGT-1', actor: 'worker-x', recipient: 'human',
+      kind: 'human-question', status: 'running', correlationId: 'hq-still-open', summary: 'ask',
+    });
+    internal.durableRuns.markNeedsHuman(
+      'AGT-1',
+      '[operator-question] asked 2 times with no answer — stopped retrying automatically',
+    );
+    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('NEEDS_HUMAN');
+
+    const selected = internal.filterAlreadyProcessed([TASK]); // TASK.linearState === 'Todo'
+
+    expect(selected).toEqual([]);
+    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('NEEDS_HUMAN');
+    internal.durableRuns.close();
+  });
+
+  it('resumes the moment the outstanding question is answered, with the card still in Todo', async () => {
     const internal = await makeRunner();
     const { getCoordinationStore } = await import('../coordination/coordinationStore.js');
     const store = getCoordinationStore();
@@ -132,7 +194,10 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
       repository: REPO, taskId: 'AGT-1', actor: 'worker-x', recipient: 'human',
       kind: 'human-question', status: 'running', correlationId: 'hq-only', summary: 'ask',
     });
-    internal.durableRuns.markNeedsHuman('AGT-1', '[operator-question] asked 2 times with no answer — stopped retrying automatically');
+    internal.durableRuns.markNeedsHuman(
+      'AGT-1',
+      '[operator-question] asked 2 times with no answer — stopped retrying automatically',
+    );
     expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('NEEDS_HUMAN');
 
     // The card stays in Todo throughout — resuming does not depend on the
@@ -141,14 +206,60 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
       repository: REPO, taskId: 'AGT-1', actor: 'operator', recipient: 'worker-x',
       kind: 'human-answer', status: 'completed', correlationId: 'hq-only', summary: 'answered',
     });
-    // The path cache is populated at dispatch time in production; the filter
-    // reads it rather than resolving async, so seed it the same way a prior
-    // run would have.
-    (internal as unknown as { projectPathCache: Map<string, string> }).projectPathCache.set('Repo', REPO);
 
-    const selected = internal.filterAlreadyProcessed([parkedButAnswered]);
+    const selected = internal.filterAlreadyProcessed([TASK]); // still linearState: 'Todo'
 
-    expect(selected).toEqual([parkedButAnswered]);
+    expect(selected).toEqual([TASK]);
+    expect(internal.durableRuns.getRun('AGT-1')?.state).not.toBe('NEEDS_HUMAN');
+    internal.durableRuns.close();
+  });
+
+  it('does not park a new, distinct question on its first ask just because an earlier one was answered', async () => {
+    // The gate finding this closes: consecutiveAttemptsWithErrorCode used to
+    // walk the ledger unbounded, so a resumed run's first ask on a brand-new
+    // blocker shared its error code with the already-answered attempt before
+    // it and got folded into the same streak — parking on a first ask instead
+    // of getting the ordinary backoff. Bounding the walk by the task's most
+    // recent answer timestamp is what this test pins.
+    const internal = await makeRunner();
+    const { getCoordinationStore } = await import('../coordination/coordinationStore.js');
+    const store = getCoordinationStore();
+
+    const t0 = Date.now();
+    await seedConsecutiveUnansweredAttempts(1); // question A's only ask
+
+    const answeredAt = t0 + 1_000;
+    await store.publish({
+      repository: REPO, taskId: 'AGT-1', actor: 'worker-x', recipient: 'human',
+      kind: 'human-question', status: 'running', correlationId: 'hq-a', summary: 'question A',
+      timestamp: answeredAt - 500,
+    });
+    await store.publish({
+      repository: REPO, taskId: 'AGT-1', actor: 'operator', recipient: 'worker-x',
+      kind: 'human-answer', status: 'completed', correlationId: 'hq-a', summary: 'answered A',
+      timestamp: answeredAt,
+    });
+
+    // The resume path: re-admit, re-dispatch, and this attempt asks a
+    // different question (B) — its first ask, well after the answer landed.
+    const { RunLedger } = await import('./runLedger.js');
+    const ledger = new RunLedger(dbPath);
+    const resumedAt = answeredAt + 1_000;
+    expect(ledger.markReady('AGT-1', resumedAt)).toBe(true);
+    const claim = ledger.claimRun('AGT-1', {
+      ownerInstanceId: 'seed-resumed', leaseMs: 60_000, maxActiveForProject: 1, now: resumedAt,
+    });
+    expect(claim).not.toBeNull();
+    expect(ledger.transition(claim!, 'RETRY_AT', {
+      retryAt: resumedAt + 3_600_000, errorCode: 'waiting_on_operator',
+    }, resumedAt)).toBe(true);
+    ledger.close();
+
+    internal.scheduler.emit('waiting_on_operator', { task: TASK, result: pipelineResult() });
+    await vi.waitFor(() => {
+      expect(internal.failedTaskRetryTimes.has('AGT-1')).toBe(true);
+    });
+
     expect(internal.durableRuns.getRun('AGT-1')?.state).not.toBe('NEEDS_HUMAN');
     internal.durableRuns.close();
   });
@@ -162,13 +273,27 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
     // not the pre-existing Linear-state resume this file already had.
     const internal = await makeRunner();
     internal.durableRuns.markNeedsHuman('AGT-1', 'Reviewer rejected 4 attempts: still failing lint');
-    (internal as unknown as { projectPathCache: Map<string, string> }).projectPathCache.set('Repo', REPO);
     const parkedElsewhere: TaskItem = { ...TASK, linearState: 'Backlog' };
 
     const selected = internal.filterAlreadyProcessed([parkedElsewhere]);
 
     expect(selected).toEqual([]);
     expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('NEEDS_HUMAN');
+    internal.durableRuns.close();
+  });
+
+  it('still resumes an unrelated NEEDS_HUMAN park once Linear reopens it', async () => {
+    // The other half of the mutual-exclusivity fix: making the ask_human path
+    // ignore linearState must not cost the OTHER park types their own
+    // resume condition.
+    const internal = await makeRunner();
+    internal.durableRuns.markNeedsHuman('AGT-1', 'Reviewer rejected 4 attempts: still failing lint');
+    const reopened: TaskItem = { ...TASK, linearState: 'In Progress' };
+
+    const selected = internal.filterAlreadyProcessed([reopened]);
+
+    expect(selected).toEqual([reopened]);
+    expect(internal.durableRuns.getRun('AGT-1')?.state).not.toBe('NEEDS_HUMAN');
     internal.durableRuns.close();
   });
 });

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -46,6 +46,7 @@ import { t } from '../locale/index.js';
 import { broadcastEvent, type SwarmStats } from '../core/eventHub.js';
 import { writeProviderOverride } from '../core/providerOverride.js';
 import { getTaskState } from '../taskState/store.js';
+import { getCoordinationStore } from '../coordination/coordinationStore.js';
 import {
   findPullRequestForBranch,
   inspectWorktreeRecovery,
@@ -131,6 +132,18 @@ export function decisionSelectionBudget(availableSlots: number, candidateCount: 
   if (slots === 0 || candidates === 0) return 0;
   return Math.min(candidates, Math.max(slots, slots * DECISION_SELECTION_OVERSAMPLE));
 }
+
+/**
+ * Prefix stamped on a NEEDS_HUMAN run's `lastErrorMessage` when this file
+ * parked it for a repeated, unanswered `ask_human` question (AGT-4042).
+ *
+ * `markNeedsHuman` is shared with unrelated parks (a rejection limit, a PR
+ * closed without merge — see the other call sites in this file), each with its
+ * own resume condition. This is how the filter below tells "this one resumes
+ * when the operator answers" from "this one resumes when Linear state changes"
+ * without adding a second column or state for what is still one ledger state.
+ */
+const OPERATOR_QUESTION_PARK_MARKER = '[operator-question]';
 
 export class AutonomousRunner {
   private config: AutonomousConfig;
@@ -480,7 +493,9 @@ export class AutonomousRunner {
       this.scheduleNextHeartbeat();
     });
 
-    this.scheduler.on('waiting_on_operator', ({ task, result }) => {
+    this.scheduler.on('waiting_on_operator', ({ task, result }: {
+      task: TaskItem; result: PipelineResult;
+    }) => {
       const taskCtx = this.formatTaskContext(task);
       const question = result.workerResult?.haltReason ?? 'Blocked on an operator decision';
       console.log(`[Scheduler] Task waiting on operator: ${taskCtx} ${task.title} — ${question}`);
@@ -492,9 +507,34 @@ export class AutonomousRunner {
       // instead of blocking, so the task continues the moment a re-dispatch
       // lands after the operator replies.
       if (task.issueId) {
-        const nextRetryTime = setRetryTime(task.issueId, 4, this.failedTaskRetryTimes);
-        this.saveTaskState();
-        console.log(`[Scheduler] Re-admitting ${taskCtx} ${formatRetryTime(nextRetryTime)} to check for the operator's answer`);
+        // A re-dispatch is a fresh worker session, and asking again is not free
+        // — a worker+reviewer cycle burned on a question the operator has
+        // already been paged for once and not answered. Past the first
+        // unanswered ask, stop the automatic retry loop entirely instead of
+        // paying for another one on a fixed clock: NEEDS_HUMAN drops the task
+        // out of heartbeat selection until the resume check below finds it
+        // answered, or an operator otherwise reopens it (AGT-4042). Durable
+        // mode only — without a ledger there is nowhere to put a stop that
+        // survives a restart, so legacy mode keeps the fixed-backoff ladder.
+        //
+        // The project path comes off the run's own ledger row, not the
+        // in-memory path cache: `execute()` registers it durably before the
+        // pipeline ever runs, so it survives a restart the cache would not.
+        const durableProjectPath = this.durableRuns.getRun(task.issueId)?.projectPath;
+        const openAskCount = durableProjectPath
+          ? getCoordinationStore().openQuestionCount(durableProjectPath, task.issueId)
+          : 0;
+        if (this.durableRuns.isPrimary && openAskCount >= 2) {
+          this.durableRuns.markNeedsHuman(
+            task.issueId,
+            `${OPERATOR_QUESTION_PARK_MARKER} asked ${openAskCount} times with no answer — stopped retrying automatically`,
+          );
+          console.log(`[Scheduler] Parking ${taskCtx} — asked ${openAskCount}x with no answer, stopped auto-retry until the operator answers or reopens it`);
+        } else {
+          const nextRetryTime = setRetryTime(task.issueId, 4, this.failedTaskRetryTimes);
+          this.saveTaskState();
+          console.log(`[Scheduler] Re-admitting ${taskCtx} ${formatRetryTime(nextRetryTime)} to check for the operator's answer`);
+        }
       }
       this.scheduleNextHeartbeat();
     });
@@ -809,15 +849,29 @@ export class AutonomousRunner {
         durableRun = this.durableRuns.getRun(id);
       }
 
-      if (
-        this.durableRuns.isPrimary
-        && durableRun?.state === 'NEEDS_HUMAN'
-        && ['Todo', 'In Progress', 'In Review'].includes(task.linearState ?? '')
-      ) {
-        const resumed = this.durableRuns.resumeNeedsHuman(id);
-        if (resumed) {
-          durableRun = this.durableRuns.getRun(id);
-          if (resumed === 'SYNC_PENDING') this.scheduleNextHeartbeat();
+      if (this.durableRuns.isPrimary && durableRun?.state === 'NEEDS_HUMAN') {
+        const linearReopened = ['Todo', 'In Progress', 'In Review'].includes(task.linearState ?? '');
+        // The operator-question park (AGT-4042) resumes on its own condition —
+        // the question got answered — which needs no Linear touch at all. Scoped
+        // to runs this file parked for exactly that reason (the marker prefix),
+        // so the rejection-limit and PR-closed-without-merge parks elsewhere in
+        // this file, which share the same NEEDS_HUMAN state, are untouched by it
+        // and keep resuming only on a Linear state change.
+        // The project path comes off the run's own row, not the in-memory
+        // path cache: durable, so this still finds an answer that arrived
+        // while the daemon was down, once the row is fetched again after
+        // restart.
+        const questionAnswered = Boolean(
+          durableRun.projectPath
+          && durableRun.lastErrorMessage?.startsWith(OPERATOR_QUESTION_PARK_MARKER)
+          && getCoordinationStore().openQuestionCount(durableRun.projectPath, id) === 0,
+        );
+        if (linearReopened || questionAnswered) {
+          const resumed = this.durableRuns.resumeNeedsHuman(id);
+          if (resumed) {
+            durableRun = this.durableRuns.getRun(id);
+            if (resumed === 'SYNC_PENDING') this.scheduleNextHeartbeat();
+          }
         }
       }
 

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -517,19 +517,30 @@ export class AutonomousRunner {
         // mode only — without a ledger there is nowhere to put a stop that
         // survives a restart, so legacy mode keeps the fixed-backoff ladder.
         //
-        // The project path comes off the run's own ledger row, not the
-        // in-memory path cache: `execute()` registers it durably before the
-        // pipeline ever runs, so it survives a restart the cache would not.
-        const durableProjectPath = this.durableRuns.getRun(task.issueId)?.projectPath;
-        const openAskCount = durableProjectPath
-          ? getCoordinationStore().openQuestionCount(durableProjectPath, task.issueId)
-          : 0;
-        if (this.durableRuns.isPrimary && openAskCount >= 2) {
+        // Counted as consecutive ATTEMPTS, not distinct board correlation
+        // IDs: a worker that asks with identical wording every time never
+        // mints a second correlation ID (the paging gate above collapses it
+        // to one), so a count keyed on wording would never see more than 1 no
+        // matter how many times it was actually re-dispatched and asked.
+        //
+        // Bounded by the task's last operator answer: a resumed run that
+        // immediately asks a new, distinct question shares this same error
+        // code with the answered attempt before it, and an unbounded walk
+        // would count the two together — parking the new question on its
+        // first ask instead of its second (AGT-4042).
+        const projectPath = this.durableRuns.getRun(task.issueId)?.projectPath;
+        const lastAnsweredAt = projectPath
+          ? getCoordinationStore().lastAnsweredAt(projectPath, task.issueId)
+          : undefined;
+        const consecutiveAsks = this.durableRuns.consecutiveAttemptsWithErrorCode(
+          task.issueId, 'waiting_on_operator', lastAnsweredAt,
+        );
+        if (this.durableRuns.isPrimary && consecutiveAsks >= 2) {
           this.durableRuns.markNeedsHuman(
             task.issueId,
-            `${OPERATOR_QUESTION_PARK_MARKER} asked ${openAskCount} times with no answer — stopped retrying automatically`,
+            `${OPERATOR_QUESTION_PARK_MARKER} asked ${consecutiveAsks} times with no answer — stopped retrying automatically`,
           );
-          console.log(`[Scheduler] Parking ${taskCtx} — asked ${openAskCount}x with no answer, stopped auto-retry until the operator answers or reopens it`);
+          console.log(`[Scheduler] Parking ${taskCtx} — asked ${consecutiveAsks}x with no answer, stopped auto-retry until the operator answers or reopens it`);
         } else {
           const nextRetryTime = setRetryTime(task.issueId, 4, this.failedTaskRetryTimes);
           this.saveTaskState();
@@ -850,20 +861,27 @@ export class AutonomousRunner {
       }
 
       if (this.durableRuns.isPrimary && durableRun?.state === 'NEEDS_HUMAN') {
-        const linearReopened = ['Todo', 'In Progress', 'In Review'].includes(task.linearState ?? '');
-        // The operator-question park (AGT-4042) resumes on its own condition —
-        // the question got answered — which needs no Linear touch at all. Scoped
-        // to runs this file parked for exactly that reason (the marker prefix),
-        // so the rejection-limit and PR-closed-without-merge parks elsewhere in
-        // this file, which share the same NEEDS_HUMAN state, are untouched by it
-        // and keep resuming only on a Linear state change.
+        // The two resume conditions are mutually exclusive by why the run was
+        // parked, not layered as "either one fires it." An ask_human park
+        // (marker prefix) leaves the Linear card exactly where it already was
+        // — the pipeline never touches it — which for an active task is
+        // routinely 'Todo' or 'In Progress' already; the pre-existing
+        // linearState check would then resume it on the very next heartbeat
+        // regardless of an answer, undoing the park before it did anything.
+        // So it resumes ONLY on its own condition — the question got
+        // answered — and the rejection-limit / PR-closed-without-merge parks
+        // elsewhere in this file, which share NEEDS_HUMAN but DO move the
+        // card (a STUCK label / Backlog), keep resuming only on that Linear
+        // change.
+        const isOperatorQuestionPark = durableRun.lastErrorMessage?.startsWith(OPERATOR_QUESTION_PARK_MARKER) ?? false;
+        const linearReopened = !isOperatorQuestionPark
+          && ['Todo', 'In Progress', 'In Review'].includes(task.linearState ?? '');
         // The project path comes off the run's own row, not the in-memory
         // path cache: durable, so this still finds an answer that arrived
         // while the daemon was down, once the row is fetched again after
         // restart.
-        const questionAnswered = Boolean(
+        const questionAnswered = isOperatorQuestionPark && Boolean(
           durableRun.projectPath
-          && durableRun.lastErrorMessage?.startsWith(OPERATOR_QUESTION_PARK_MARKER)
           && getCoordinationStore().openQuestionCount(durableRun.projectPath, id) === 0,
         );
         if (linearReopened || questionAnswered) {

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -158,6 +158,10 @@ export class DurableRunCoordinator {
     return this.ledger?.markReady(issueId, now) ?? false;
   }
 
+  consecutiveAttemptsWithErrorCode(issueId: string, errorCode: string, sinceMs?: number): number {
+    return this.ledger?.consecutiveAttemptsWithErrorCode(issueId, errorCode, sinceMs) ?? 0;
+  }
+
   recoverPublishedRun(
     issueId: string,
     publication: { prUrl: string; headSha?: string },

--- a/src/automation/runLedger.ts
+++ b/src/automation/runLedger.ts
@@ -1274,6 +1274,17 @@ export class RunLedger {
     return finalize.immediate();
   }
 
+  /** Attempts in a row (most recent first) sharing this error code, stopped at
+   * the first that doesn't or at `sinceMs` — the last operator-answer time (AGT-4042). */
+  consecutiveAttemptsWithErrorCode(issueId: string, errorCode: string, sinceMs?: number): number {
+    const rows = this.db.prepare(
+      'SELECT error_code, started_at FROM automation_attempts WHERE issue_id = ? ORDER BY attempt_no DESC',
+    ).all(issueId) as { error_code: string | null; started_at: number }[];
+    const stopped = rows.findIndex((row) =>
+      row.error_code !== errorCode || (sinceMs !== undefined && row.started_at <= sinceMs));
+    return stopped === -1 ? rows.length : stopped;
+  }
+
   getMetrics(now = Date.now()): LedgerMetrics {
     const byState: Record<string, number> = {};
     for (const row of this.db.prepare('SELECT state, COUNT(*) AS count FROM automation_runs GROUP BY state').all() as { state: string; count: number }[]) {

--- a/src/coordination/coordinationStore.test.ts
+++ b/src/coordination/coordinationStore.test.ts
@@ -93,4 +93,30 @@ describe('CoordinationStore', () => {
     await s.publish(message({ actor: 'worker-b', recipient: 'worker-a', kind: 'advice-response', status: 'completed', summary: 'use the existing helper' }));
     expect(s.snapshot('/repo').pending).toEqual([]);
   });
+
+  it('counts distinct open questions regardless of paging status or wording', async () => {
+    const s = store();
+    await s.publish(message({ kind: 'human-question', status: 'waiting', correlationId: 'q1' }));
+    expect(s.openQuestionCount('/repo', 't1')).toBe(1);
+
+    await s.publish(message({ kind: 'human-question', status: 'running', correlationId: 'q1', summary: 'Operator paged' }));
+    expect(s.openQuestionCount('/repo', 't1')).toBe(1); // page confirmation, same question
+
+    await s.publish(message({ kind: 'human-question', status: 'waiting', correlationId: 'q2', summary: 'reworded ask' }));
+    expect(s.openQuestionCount('/repo', 't1')).toBe(2);
+
+    await s.publish(message({ kind: 'human-answer', status: 'completed', correlationId: 'q1' }));
+    expect(s.openQuestionCount('/repo', 't1')).toBe(1); // q1 settled, q2 still open
+
+    await s.publish(message({ kind: 'human-answer', status: 'completed', correlationId: 'q2' }));
+    expect(s.openQuestionCount('/repo', 't1')).toBe(0);
+  });
+
+  it('scopes the open question count to its own repository and task', async () => {
+    const s = store();
+    await s.publish(message({ kind: 'human-question', status: 'waiting', correlationId: 'q1' }));
+    await s.publish(message({ repository: '/other', kind: 'human-question', status: 'waiting', correlationId: 'q2' }));
+    await s.publish(message({ taskId: 't2', kind: 'human-question', status: 'waiting', correlationId: 'q3' }));
+    expect(s.openQuestionCount('/repo', 't1')).toBe(1);
+  });
 });

--- a/src/coordination/coordinationStore.ts
+++ b/src/coordination/coordinationStore.ts
@@ -346,6 +346,36 @@ export class CoordinationStore {
   }
 
   /**
+   * One event per still-open (not yet completed/expired/failed) question
+   * correlation ID for a task, durable trace merged with the board.
+   *
+   * Unlike `openQuestionCount`, this is not a display counter — it backs the
+   * answer fan-out that settles every differently-worded re-ask of the same
+   * blocker. A board-only read there would leave an older sibling permanently
+   * unanswered in the durable trace once enough other traffic evicted it from
+   * the board, and `allQuestionsAnswered` would never see that task as
+   * answered again (AGT-4042).
+   */
+  openQuestions(repository: string, taskId: string): CoordinationEvent[] {
+    const merged = new Map<string, CoordinationEvent>();
+    for (const event of queryTrace({ repository, taskId, kinds: ['human-question', 'human-answer'], limit: 1_000 })) {
+      merged.set(event.id, event);
+    }
+    for (const event of this.list({ repository, taskId, limit: 500 })) merged.set(event.id, event);
+    const events = [...merged.values()];
+    const settled = new Set(events
+      .filter((event) => event.kind === 'human-answer' && event.status === 'completed')
+      .map((event) => event.correlationId));
+    const open = new Map<string, CoordinationEvent>();
+    for (const event of events) {
+      if (event.kind === 'human-question'
+        && (event.status === 'waiting' || event.status === 'running')
+        && !settled.has(event.correlationId)) open.set(event.correlationId, event);
+    }
+    return [...open.values()];
+  }
+
+  /**
    * When this task's most recent operator answer landed, or undefined if it
    * never had one. Bounds how far back a caller may read an "unanswered
    * streak" of the same kind, so a pre-answer attempt cannot be folded into a

--- a/src/coordination/coordinationStore.ts
+++ b/src/coordination/coordinationStore.ts
@@ -6,7 +6,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { coordinationFilePath, coordinationStateDir } from './coordinationPaths.js';
-import { recordTraceEvent } from './coordinationTrace.js';
+import { lastTraceEventOfKind, recordTraceEvent } from './coordinationTrace.js';
 import { atomicWriteFileSync } from '../support/atomicFile.js';
 import { withFileLock } from '../support/fileLock.js';
 import { broadcastEvent } from '../core/eventHub.js';
@@ -308,6 +308,30 @@ export class CoordinationStore {
         && (event.status === 'waiting' || event.status === 'running')
         && !settled.has(event.correlationId))
       .map((event) => event.correlationId)).size;
+  }
+
+  /**
+   * When this task's most recent operator answer landed, or undefined if it
+   * has never had one.
+   *
+   * Bounds how far back a caller may read an "unanswered streak" of the same
+   * kind: an attempt from before this timestamp was already resolved by that
+   * answer, so it must not be folded into a *new* question's count just
+   * because it happens to share the same outcome (AGT-4042).
+   *
+   * Reads the permanent trace, not the live board: the board is a bounded
+   * ring buffer (`MAX_EVENTS`) shared by every task, and a busy board can
+   * evict an old answer long before this method needs it. And within the
+   * trace, this asks for the row filtered by kind in SQL rather than reading
+   * a generic recent-events window: a task's trace stream also carries every
+   * `adapter-route` / `review-run` / `mcp-audit` event it produces, so a
+   * `limit`-bounded scan of "recent events for this task" can still push an
+   * old answer out before this ever sees it. Either loss silently returns
+   * `undefined` and un-bounds the caller's walk — right back to the bug this
+   * exists to fix.
+   */
+  lastAnsweredAt(repository: string, taskId: string): number | undefined {
+    return lastTraceEventOfKind({ repository, taskId, kind: 'human-answer', status: 'completed' })?.timestamp;
   }
 
   findOpenQuestionFor(

--- a/src/coordination/coordinationStore.ts
+++ b/src/coordination/coordinationStore.ts
@@ -288,6 +288,28 @@ export class CoordinationStore {
    * the question it asked, so the latest is what the agent is parked on and
    * what the operator is reading.
    */
+  /**
+   * How many blocking questions this task has asked and not yet had answered,
+   * regardless of exact wording. 0 means nothing is outstanding.
+   *
+   * Counts distinct correlation IDs, not raw events: a paged question carries
+   * two events (the `waiting` ask, the `running` page confirmation) under the
+   * same correlation ID, and a re-dispatch that rephrases the same blocker
+   * mints a different one for the same underlying wait (AGT-4042).
+   */
+  openQuestionCount(repository: string, taskId: string): number {
+    const events = this.list({ repository, taskId, limit: 500 });
+    const settled = new Set(events
+      .filter((event) => event.kind === 'human-answer' && event.status === 'completed')
+      .map((event) => event.correlationId));
+    return new Set(events
+      .filter((event) =>
+        event.kind === 'human-question'
+        && (event.status === 'waiting' || event.status === 'running')
+        && !settled.has(event.correlationId))
+      .map((event) => event.correlationId)).size;
+  }
+
   findOpenQuestionFor(
     actor: string,
     scope: { repository?: string; taskId?: string } = {},

--- a/src/coordination/coordinationTrace.ts
+++ b/src/coordination/coordinationTrace.ts
@@ -21,7 +21,7 @@ import { dirname, resolve } from 'node:path';
 import { defaultAutomationDbPath } from '../automation/automationDbPath.js';
 import { enableWalWithRetry } from '../support/sqliteWal.js';
 import type Database from 'better-sqlite3';
-import type { CoordinationEvent } from './coordinationStore.js';
+import type { CoordinationEvent, CoordinationKind, CoordinationStatus } from './coordinationStore.js';
 
 // This package is ESM, so `require` does not exist here. The trace loads its
 // native dependency lazily — a missing or ABI-mismatched better-sqlite3 must
@@ -205,6 +205,40 @@ export function queryTrace(query: TraceQuery = {}): CoordinationEvent[] {
   } catch (error) {
     console.warn('[CoordinationTrace] Query failed:', error);
     return [];
+  }
+}
+
+/**
+ * The single most recent trace event of one kind for one task, or undefined.
+ *
+ * Filtered by `kind` (and optionally `status`) in SQL, not read out of a
+ * generic `limit`-bounded window: a task's trace stream is shared by every
+ * kind it produces (`adapter-route`, `review-run`, `mcp-audit`, ...), so a
+ * task busy enough on those can crowd a `human-answer` out of even a
+ * thousand-row `queryTrace` slice while this, needing only the one row SQL
+ * already filtered to the right kind, never sees that competition.
+ */
+export function lastTraceEventOfKind(query: {
+  repository: string; taskId: string; kind: CoordinationKind; status?: CoordinationStatus;
+}): CoordinationEvent | undefined {
+  const handle = getTraceDb();
+  if (!handle) return undefined;
+  const where = ['repository = ?', 'task_id = ?', 'kind = ?'];
+  const params: string[] = [resolve(query.repository), query.taskId, query.kind];
+  if (query.status) {
+    where.push('status = ?');
+    params.push(query.status);
+  }
+  try {
+    const row = handle.prepare(`
+      SELECT * FROM coordination_trace
+      WHERE ${where.join(' AND ')}
+      ORDER BY id DESC LIMIT 1
+    `).get(...params) as TraceRow | undefined;
+    return row ? toEvent(row) : undefined;
+  } catch (error) {
+    console.warn('[CoordinationTrace] Query failed:', error);
+    return undefined;
   }
 }
 

--- a/src/coordination/humanQuestions.test.ts
+++ b/src/coordination/humanQuestions.test.ts
@@ -170,6 +170,45 @@ describe('human questions', () => {
     expect(secondAnswer.reason).toMatch(/already completed/);
   });
 
+  it('settles a sibling question the board has evicted, so allQuestionsAnswered still becomes true (AGT-4042)', async () => {
+    // The fan-out that settles every rephrased re-ask used to scan only the
+    // live board. A task chatty enough to push an older sibling's own
+    // `human-question` event out of the board's retention window would leave
+    // it permanently unanswered in the durable trace — allQuestionsAnswered
+    // reads the trace, so it would never see that task as answered again, and
+    // a run parked on the repeat-ask stop (AGT-4042) would wait forever for a
+    // reply that, from the operator's side, already arrived.
+    const h = await modules();
+    const notify = vi.fn(async () => true);
+
+    const first = await h.postHumanQuestion({
+      repository: '/repo', taskId: 't1', actor: 'worker-a',
+      question: 'What is the Spreadsheet ID?', notify,
+    });
+    const second = await h.postHumanQuestion({
+      repository: '/repo', taskId: 't1', actor: 'worker-b',
+      question: 'Please share the target Spreadsheet ID.', notify,
+    });
+
+    // Evict the sibling's own `human-question` event from the board, the way
+    // unrelated traffic would once the ring buffer fills — the durable trace
+    // still has it.
+    const file = join(dir, 'events.json');
+    const state = JSON.parse(readFileSync(file, 'utf8'));
+    state.events = state.events.filter((event: { correlationId: string }) =>
+      event.correlationId !== second.correlationId);
+    writeFileSync(file, JSON.stringify(state));
+    const store = (await import('./coordinationStore.js'));
+    store.resetCoordinationStoreForTests();
+
+    expect(store.getCoordinationStore().allQuestionsAnswered('t1')).toBe(false);
+
+    const accepted = await h.answerHumanQuestion(first.correlationId, 'sheet-abc123', 'discord:user');
+    expect(accepted.accepted).toBe(true);
+
+    expect(store.getCoordinationStore().allQuestionsAnswered('t1')).toBe(true);
+  });
+
   it('pages again once the outstanding question is answered', async () => {
     const h = await modules();
     const notify = vi.fn(async () => true);

--- a/src/coordination/humanQuestions.test.ts
+++ b/src/coordination/humanQuestions.test.ts
@@ -94,4 +94,106 @@ describe('human questions', () => {
       .filter((event) => event.kind === 'human-question' && event.status === 'waiting');
     expect(waiting).toHaveLength(1);
   });
+
+  it('does not re-page when a re-dispatch rephrases the same unanswered blocker (AGT-4042)', async () => {
+    // A re-dispatched task is a fresh worker session that writes its own
+    // ask_human call and paraphrases the previous wording — that must not mint
+    // a fresh correlation ID that defeats the page-once guarantee.
+    const h = await modules();
+    const notify = vi.fn(async () => true);
+
+    const first = await h.postHumanQuestion({
+      repository: '/repo', taskId: 't1', actor: 'worker-a',
+      question: 'What is the absolute path to the Google service-account JSON?', notify,
+    });
+    expect(first.delivered).toBe(true);
+    expect(first.openAskCount).toBe(1);
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    const second = await h.postHumanQuestion({
+      repository: '/repo', taskId: 't1', actor: 'worker-b',
+      question: 'Please provide the accessible absolute path for the Google service account JSON.', notify,
+    });
+    expect(second.delivered).toBe(true);
+    expect(second.correlationId).not.toBe(first.correlationId); // genuinely different text, different hash
+    expect(second.openAskCount).toBe(2);
+    expect(notify).toHaveBeenCalledTimes(1); // still just the one page
+
+    const third = await h.postHumanQuestion({
+      repository: '/repo', taskId: 't1', actor: 'worker-c',
+      question: 'Requesting the Google service account JSON path once more.', notify,
+    });
+    expect(third.openAskCount).toBe(3);
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles a reworded re-ask when the operator answers the one they were actually paged for", async () => {
+    // The operator can only ever reply to the correlation ID in the ONE page
+    // they received — the paging gate above suppresses every later page for a
+    // rephrased repeat of the same blocker. If answering that first ID left
+    // the rephrased ones open, the task's open-question count would never
+    // reach zero and a run parked on the repeat-ask stop (AGT-4042) would wait
+    // forever for an answer that, from the operator's side, already arrived.
+    const h = await modules();
+    const notify = vi.fn(async () => true);
+
+    const first = await h.postHumanQuestion({
+      repository: '/repo', taskId: 't1', actor: 'worker-a',
+      question: 'What is the Spreadsheet ID?', notify,
+    });
+    const second = await h.postHumanQuestion({
+      repository: '/repo', taskId: 't1', actor: 'worker-b',
+      question: 'Please share the target Spreadsheet ID.', notify,
+    });
+    expect(notify).toHaveBeenCalledTimes(1); // only the first ever paged
+
+    const store = await import('./coordinationStore.js');
+    expect(store.getCoordinationStore().openQuestionCount('/repo', 't1')).toBe(2);
+
+    const accepted = await h.answerHumanQuestion(first.correlationId, 'sheet-abc123', 'discord:user');
+    expect(accepted.accepted).toBe(true);
+
+    expect(store.getCoordinationStore().openQuestionCount('/repo', 't1')).toBe(0);
+
+    // The reworded ask's own asker gets the answer routed to it too, the same
+    // way the directly-answered one does.
+    const secondAnswer = await h.answerHumanQuestion(second.correlationId, 'irrelevant', 'discord:user');
+    expect(secondAnswer.accepted).toBe(false);
+    expect(secondAnswer.reason).toMatch(/already completed/);
+  });
+
+  it('pages again once the outstanding question is answered', async () => {
+    const h = await modules();
+    const notify = vi.fn(async () => true);
+
+    const first = await h.postHumanQuestion({
+      repository: '/repo', taskId: 't1', actor: 'worker-a', question: 'Which bucket?', notify,
+    });
+    expect(notify).toHaveBeenCalledTimes(1);
+    await h.answerHumanQuestion(first.correlationId, 'the-prod-bucket', 'discord:user');
+
+    const second = await h.postHumanQuestion({
+      repository: '/repo', taskId: 't1', actor: 'worker-a', question: 'Which region?', notify,
+    });
+    expect(second.delivered).toBe(true);
+    expect(second.openAskCount).toBe(1); // a genuinely new question, no outstanding one left
+    expect(notify).toHaveBeenCalledTimes(2); // this one DOES get paged
+  });
+
+  it('does not let a second task on the same repository suppress the first task\'s page', async () => {
+    const h = await modules();
+    const notify = vi.fn(async () => true);
+
+    const taskA = await h.postHumanQuestion({
+      repository: '/repo', taskId: 't1', actor: 'worker-a', question: 'Q for task A', notify,
+    });
+    const taskB = await h.postHumanQuestion({
+      repository: '/repo', taskId: 't2', actor: 'worker-b', question: 'Q for task B', notify,
+    });
+    expect(taskA.delivered).toBe(true);
+    expect(taskB.delivered).toBe(true);
+    expect(notify).toHaveBeenCalledTimes(2);
+    expect(taskA.openAskCount).toBe(1);
+    expect(taskB.openAskCount).toBe(1);
+  });
 });

--- a/src/coordination/humanQuestions.ts
+++ b/src/coordination/humanQuestions.ts
@@ -203,12 +203,13 @@ export async function answerHumanQuestion(
   // only one the operator ever saw. Settle every other still-open ask for this
   // task too, or the task's openQuestionCount never reaches zero and a run
   // parked on the repeat-ask stop (AGT-4042) never sees itself as answered.
+  // Durable, not board-only: a task chatty enough to push an older sibling
+  // out of the board's own retention window would otherwise leave it
+  // permanently unanswered in the trace, and `allQuestionsAnswered` would
+  // never see that task as answered again.
   const siblings = store
-    .list({ repository: question.repository, taskId: question.taskId, limit: 500 })
-    .filter((e) =>
-      e.kind === 'human-question'
-      && (e.status === 'waiting' || e.status === 'running')
-      && e.correlationId !== correlationId);
+    .openQuestions(question.repository, question.taskId)
+    .filter((e) => e.correlationId !== correlationId);
   const seenSiblingIds = new Set<string>();
   for (const sibling of siblings) {
     if (seenSiblingIds.has(sibling.correlationId)) continue;

--- a/src/coordination/humanQuestions.ts
+++ b/src/coordination/humanQuestions.ts
@@ -55,6 +55,14 @@ export interface HumanQuestionPost {
   delivered: boolean;
   /** Set when the operator already answered this exact question. */
   answer?: string;
+  /**
+   * How many open (unanswered) questions this task has asked, this one
+   * included. 1 on a first ask; higher when a re-dispatch rephrased the same
+   * blocker rather than getting an answer — the count a log or dashboard needs
+   * to tell "still waiting, asked once" from "still waiting, asked repeatedly"
+   * (AGT-4042).
+   */
+  openAskCount: number;
 }
 
 /**
@@ -66,12 +74,13 @@ export interface HumanQuestionPost {
 export async function postHumanQuestion(input: HumanQuestionInput): Promise<HumanQuestionPost> {
   const store = getCoordinationStore();
   const correlationId = humanQuestionCorrelation(input);
-  const prior = store
-    .list({ repository: input.repository, taskId: input.taskId, limit: 500 })
-    .filter((event) => event.correlationId === correlationId);
+  const taskEvents = store.list({ repository: input.repository, taskId: input.taskId, limit: 500 });
+  const prior = taskEvents.filter((event) => event.correlationId === correlationId);
 
   const answered = prior.find((event) => event.kind === 'human-answer' && event.status === 'completed');
-  if (answered) return { correlationId, delivered: true, answer: answered.detail ?? answered.summary };
+  if (answered) {
+    return { correlationId, delivered: true, answer: answered.detail ?? answered.summary, openAskCount: 0 };
+  }
 
   const alreadyWaiting = prior.some((event) => event.kind === 'human-question' && event.status === 'waiting');
   if (!alreadyWaiting) {
@@ -90,14 +99,40 @@ export async function postHumanQuestion(input: HumanQuestionInput): Promise<Huma
     });
   }
 
-  // Page the operator at most once per open question. A re-dispatched task asks
-  // again, but the person has already been pinged — re-paging trains them to
-  // ignore the bot. The one exception is a question whose page never landed
-  // (Discord down/unconfigured): that one is retried until a page succeeds.
-  // Delivery is recorded on the board so the state survives the asking process.
-  const alreadyPaged = prior.some((event) =>
-    event.kind === 'human-question' && event.status === 'running');
-  if (alreadyPaged) return { correlationId, delivered: true };
+  // Task-scoped, not question-scoped. A re-dispatched task is a fresh worker
+  // session that writes its own ask_human call, and it paraphrases the same
+  // blocker differently every time — hashed into the correlation ID, that would
+  // mint a new one on every attempt and defeat the "page once" rule below. What
+  // the operator has open is a thread for this TASK, not for one exact wording
+  // of it: the newest ask is what is visible on the board and in the page
+  // already sent, so a reworded repeat of an unanswered ask does not warrant a
+  // second ping (AGT-4042). This does mean a genuinely new, unrelated question
+  // from the same task while one is still outstanding will not page either —
+  // accepted for now; distinguishing "reworded" from "unrelated" needs more
+  // than a text diff and is not attempted here.
+  // Re-reads the board rather than trusting `taskEvents`: this call just
+  // published a new `waiting` event for `correlationId` above, and the count
+  // has to include it — a fresh store query stays correct in a way a variable
+  // captured before that publish would not.
+  const openAskCount = Math.max(1, store.openQuestionCount(input.repository, input.taskId));
+
+  // Page the operator at most once per open (unanswered) question the task
+  // has outstanding — same correlation ID or not. `taskEvents` was read before
+  // this ask's own `waiting` event was published, so it cannot self-match; it
+  // is exactly the prior state the gate needs.
+  const answeredCorrelations = new Set(taskEvents
+    .filter((event) => event.kind === 'human-answer' && event.status === 'completed')
+    .map((event) => event.correlationId));
+  const alreadyPaged = taskEvents.some((event) =>
+    event.kind === 'human-question'
+    && event.status === 'running'
+    && !answeredCorrelations.has(event.correlationId));
+  if (alreadyPaged) {
+    if (openAskCount > 1) {
+      console.log(`[Coordination] ${input.taskId} asked its operator-blocking question a ${openAskCount}th time (reworded) without an answer — not re-paging`);
+    }
+    return { correlationId, delivered: true, openAskCount };
+  }
 
   const notify = input.notify ?? notifyOperatorViaDiscord;
   const delivered = await notify(
@@ -118,7 +153,7 @@ export async function postHumanQuestion(input: HumanQuestionInput): Promise<Huma
       summary: 'Operator paged on Discord',
     });
   }
-  return { correlationId, delivered };
+  return { correlationId, delivered, openAskCount };
 }
 
 export async function answerHumanQuestion(
@@ -151,5 +186,38 @@ export async function answerHumanQuestion(
     summary: 'Human answered the blocking question',
     detail: answer,
   });
+
+  // A re-dispatch that rephrased this same blocker minted its own correlation
+  // ID (the paging gate above only ever surfaces the FIRST one to the
+  // operator), so the reply is necessarily addressed to that first ID — the
+  // only one the operator ever saw. Settle every other still-open ask for this
+  // task too, or the task's openQuestionCount never reaches zero and a run
+  // parked on the repeat-ask stop (AGT-4042) never sees itself as answered.
+  const siblings = store
+    .list({ repository: question.repository, taskId: question.taskId, limit: 500 })
+    .filter((e) =>
+      e.kind === 'human-question'
+      && (e.status === 'waiting' || e.status === 'running')
+      && e.correlationId !== correlationId);
+  const seenSiblingIds = new Set<string>();
+  for (const sibling of siblings) {
+    if (seenSiblingIds.has(sibling.correlationId)) continue;
+    seenSiblingIds.add(sibling.correlationId);
+    await store.publish({
+      repository: question.repository,
+      taskId: question.taskId,
+      actor,
+      actorRole: 'human',
+      recipient: sibling.actor,
+      recipientName: sibling.actorName,
+      recipientRole: sibling.actorRole,
+      kind: 'human-answer',
+      status: 'completed',
+      correlationId: sibling.correlationId,
+      summary: 'Answered via a differently-worded ask for the same blocker',
+      detail: answer,
+    });
+  }
+
   return { accepted: true, event };
 }


### PR DESCRIPTION
Two things kept a parked task spinning on nothing.

## 1. Every re-dispatch re-paged the operator for the same blocker

A re-dispatched task is a fresh worker session that writes its own `ask_human` call, and it rephrases the same blocker every time. That text was hashed verbatim into the paging gate's correlation ID, so a reworded repeat minted a fresh one and defeated "page once per open question."

Live evidence today: nine Discord pages for one unanswerable ask on cgf-portal's AX-1016, thirteen tasks on the repo doing the same thing, 41 parked attempts total (`SELECT issue_id, COUNT(*) FROM automation_attempts WHERE error_code='waiting_on_operator' GROUP BY issue_id`).

Paging is now gated per `(repository, taskId)`, not per exact wording (`coordinationStore.openQuestionCount`).

## 2. Nothing stopped the automatic retry loop when the operator couldn't answer

Fixing (1) stops the spam, but the daemon still retried on a fixed ~2h clock forever, even when the missing input (e.g. a Google service-account path) simply doesn't exist in the mounted environment. Past the first unanswered ask, the run now stops entirely — `NEEDS_HUMAN` — instead of paying for another worker+reviewer cycle every backoff tick, and resumes the moment the board shows an answer, independent of Linear state.

Durable mode only: without a ledger there is nowhere to record a stop that survives a restart, so legacy mode keeps the existing backoff ladder.

## Two things this design has to hold, each pinned by a mutation-tested case

- **The operator can only ever reply to the one correlation ID they were actually paged for** — every rephrased repeat mints its own, unpaged, ID. `answerHumanQuestion` now settles every open sibling for the task when one is answered, or the open-question count this rests on never reaches zero and the park never lifts.
- **The resume check reads the run's own ledger row (`RunRecord.projectPath`) for its project path, not the in-memory path cache** — the cache is empty after a restart until something else repopulates it, and an answer that arrived while the daemon was down has to be found on the very first heartbeat back.

Both were caught by `openswarm review` on the first pass and fixed before this PR; see commit history for the isolated fixes.

Closes AGT-4042.