### PR TITLE
fix(ledger): stop an adapter timeout from counting as the repository failing (AGT-4038)

### DIFF
--- a/src/agents/pairPipelineTypes.ts
+++ b/src/agents/pairPipelineTypes.ts
@@ -78,6 +78,16 @@ export interface PipelineResult {
   sessionId: string;
   stages: StageResult[];
   finalStatus: 'approved' | 'rejected' | 'failed' | 'cancelled' | 'decomposed' | 'superseded' | 'rate_limited' | 'infra_error' | 'waiting_on_operator';
+  /**
+   * Set only when `finalStatus === 'infra_error'` and the cause is the
+   * repository itself (disk full, `.git` lock, corrupt repo — a failed
+   * `git worktree add`), not an adapter timeout, tooling failure, or network
+   * blip. The repository failure circuit reads this to count only the former:
+   * an adapter retrying on a fixed clock is not the repository failing, and
+   * lumping the two together can close a healthy repository to every other
+   * task over transient LLM/network noise (AGT-4038).
+   */
+  repositoryInfra?: boolean;
   failureSignal?: 'gate-fail' | 'timeout' | 'stuck';
   stuckReason?: string;
   rateLimitResetsAt?: number;

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -361,6 +361,7 @@ export class DurableRunCoordinator {
       // This is coordination debt, not a repository implementation failure.
       // Keep it out of the failure circuit while NEEDS_RECONCILE blocks claims.
       finalStatus: publishedNeedsReconcile ? 'publication_reconcile' : result.finalStatus,
+      repositoryInfra: result.repositoryInfra,
       costUsd: result.totalCost?.costUsd,
       result: {
         sessionId: result.sessionId,

--- a/src/automation/runLedger.test.ts
+++ b/src/automation/runLedger.test.ts
@@ -532,6 +532,7 @@ describe('RunLedger claim and fencing races', () => {
     expect(ledger.recordAttemptResult(first, {
       success: false,
       finalStatus: 'infra_error',
+      repositoryInfra: true, // a failed git worktree add — the repository's own fault (AGT-4038)
       maxFailuresPerHour: 1,
       circuitCooldownMs: 60_000,
     }, 2_100)).toBe(true);
@@ -586,6 +587,7 @@ describe('RunLedger claim and fencing races', () => {
     expect(ledger.recordAttemptResult(first, {
       success: false,
       finalStatus: 'infra_error',
+      repositoryInfra: true, // a failed git worktree add — the repository's own fault (AGT-4038)
     }, 2_100)).toBe(true);
     expect(ledger.transition(first, 'RETRY_AT', { retryAt: 9_000 }, 2_101)).toBe(true);
 
@@ -646,6 +648,54 @@ describe('RunLedger claim and fencing races', () => {
     ledger.close();
   });
 
+  it('does not let an adapter timeout, tooling failure, or network blip close the repository (AGT-4038)', () => {
+    // infra_error is overloaded: a failed git worktree add (disk full, a stale
+    // .git lock, a corrupt repo) is the repository's own fault and should trip
+    // the circuit, but an adapter timeout or CodeQL/network failure is not —
+    // measured on vela, 5 adapter timeouts plus 1 real failure and 1
+    // executor_throw opened the circuit at 7/6 for a healthy repository.
+    const ledger = new RunLedger(createDbPath());
+    for (const id of ['ADAPTER-1', 'ADAPTER-2']) register(ledger, id, '/adapter-flaky-repo');
+    const held = claim(ledger, 'ADAPTER-1', 'daemon', 2_000, 2);
+    expect(ledger.recordAttemptResult(held, {
+      success: false,
+      finalStatus: 'infra_error', // codex-responses timeout after 360000ms — not repositoryInfra
+      maxFailuresPerHour: 1,
+      circuitCooldownMs: 60_000,
+    }, 2_100)).toBe(true);
+
+    expect(ledger.getMetrics(2_100).openCircuits).toBe(0);
+    expect(ledger.claimRun('ADAPTER-2', {
+      ownerInstanceId: 'daemon', leaseMs: 1_000, now: 2_200,
+      maxActiveForProject: 2, maxFailuresPerHour: 1,
+    })).not.toBeNull();
+    ledger.close();
+  });
+
+  it('opens the circuit for a git worktree add failure regardless of admission-check timing (AGT-4038)', () => {
+    // The two circuit checks — inline in claimRun's own budget check, and in
+    // recordAttemptResult right after the attempt that trips it — must agree
+    // on the same repositoryInfra distinction, or one path silently ignores
+    // what the other enforces.
+    const ledger = new RunLedger(createDbPath());
+    for (const id of ['WT-1', 'WT-2']) register(ledger, id, '/worktree-broken-repo');
+    const held = claim(ledger, 'WT-1', 'daemon', 2_000, 2);
+    expect(ledger.recordAttemptResult(held, {
+      success: false,
+      finalStatus: 'infra_error',
+      repositoryInfra: true, // disk full / .git lock / corrupt repo
+      maxFailuresPerHour: 1,
+      circuitCooldownMs: 60_000,
+    }, 2_100)).toBe(true);
+
+    expect(ledger.getMetrics(2_100).openCircuits).toBe(1);
+    expect(ledger.claimRun('WT-2', {
+      ownerInstanceId: 'daemon', leaseMs: 1_000, now: 2_200,
+      maxActiveForProject: 2, maxFailuresPerHour: 1,
+    })).toBeNull();
+    ledger.close();
+  });
+
   it('preserves remediated attempts while excluding them from the failure circuit', () => {
     const ledger = new RunLedger(createDbPath());
     register(ledger, 'FIXED-1', '/fixed-repo');
@@ -654,6 +704,7 @@ describe('RunLedger claim and fencing races', () => {
     expect(ledger.recordAttemptResult(first, {
       success: false,
       finalStatus: 'infra_error',
+      repositoryInfra: true, // a failed git worktree add — would open the circuit if not remediated
       maxFailuresPerHour: 1,
       circuitCooldownMs: 60_000,
     }, 2_100)).toBe(true);

--- a/src/automation/runLedger.ts
+++ b/src/automation/runLedger.ts
@@ -475,6 +475,7 @@ export class RunLedger {
           JOIN automation_runs r ON r.issue_id = a.issue_id
           WHERE r.project_path = ? AND a.started_at >= ? AND a.success = 0
             AND COALESCE(a.result_status, '') NOT IN (${placeholders(NON_FAILURE_RESULT_STATUSES)})
+            AND (a.result_status != 'infra_error' OR a.repository_infra = 1)
         `).get(row.project_path, hourAgo, ...NON_FAILURE_RESULT_STATUSES) as { count: number }).count;
         if (failures >= Math.max(1, options.maxFailuresPerHour)) {
           openCircuit(`failure circuit open: ${failures}/${options.maxFailuresPerHour} in 1h`);
@@ -611,7 +612,7 @@ export class RunLedger {
     const record = this.db.transaction(() => {
       const updated = this.db.prepare(`
         UPDATE automation_attempts
-        SET result_status = ?, success = ?, cost_usd = ?, result_json = ?
+        SET result_status = ?, success = ?, cost_usd = ?, result_json = ?, repository_infra = ?
         WHERE issue_id = ? AND attempt_no = ? AND lease_epoch = ?
           AND result_status IS NULL
           AND EXISTS (
@@ -625,6 +626,7 @@ export class RunLedger {
         input.success ? 1 : 0,
         input.costUsd ?? null,
         stringifyJson(input.result),
+        input.repositoryInfra ? 1 : 0,
         claim.issueId,
         claim.attemptNo,
         claim.leaseEpoch,
@@ -635,8 +637,8 @@ export class RunLedger {
       );
       if (updated.changes !== 1) return false;
 
-      const countsAsFailure = !input.success
-        && !NON_FAILURE_RESULT_STATUSES.includes(input.finalStatus);
+      const countsAsFailure = !input.success && !NON_FAILURE_RESULT_STATUSES.includes(input.finalStatus)
+        && (input.finalStatus !== 'infra_error' || input.repositoryInfra === true);
       if (countsAsFailure && input.maxFailuresPerHour != null) {
         const run = this.db.prepare('SELECT project_path FROM automation_runs WHERE issue_id = ?')
           .get(claim.issueId) as { project_path: string };
@@ -646,6 +648,7 @@ export class RunLedger {
           JOIN automation_runs r ON r.issue_id = a.issue_id
           WHERE r.project_path = ? AND a.started_at >= ? AND a.success = 0
             AND COALESCE(a.result_status, '') NOT IN (${placeholders(NON_FAILURE_RESULT_STATUSES)})
+            AND (a.result_status != 'infra_error' OR a.repository_infra = 1)
         `).get(run.project_path, now - 60 * 60_000, ...NON_FAILURE_RESULT_STATUSES) as { count: number }).count;
         if (failures >= Math.max(1, input.maxFailuresPerHour)) {
           const cooldownMs = Math.max(60_000, input.circuitCooldownMs ?? 60 * 60_000);

--- a/src/automation/runLedgerSchema.ts
+++ b/src/automation/runLedgerSchema.ts
@@ -124,6 +124,11 @@ export function migrateAutomationSchema(db: Database.Database): void {
       if (!attemptColumns.has('result_status')) db.exec('ALTER TABLE automation_attempts ADD COLUMN result_status TEXT');
       if (!attemptColumns.has('success')) db.exec('ALTER TABLE automation_attempts ADD COLUMN success INTEGER');
       if (!attemptColumns.has('cost_usd')) db.exec('ALTER TABLE automation_attempts ADD COLUMN cost_usd REAL');
+      // Distinguishes an infra_error caused by the repository itself (disk
+      // full, a stale .git lock, a corrupt repo) from one caused by an
+      // adapter timeout, tooling failure, or network blip — only the former
+      // should count toward the repository failure circuit (AGT-4038).
+      if (!attemptColumns.has('repository_infra')) db.exec('ALTER TABLE automation_attempts ADD COLUMN repository_infra INTEGER');
       db.exec(`CREATE INDEX IF NOT EXISTS idx_automation_attempts_budget
         ON automation_attempts(started_at, success, cost_usd)`);
 

--- a/src/automation/runLedgerTypes.ts
+++ b/src/automation/runLedgerTypes.ts
@@ -137,6 +137,12 @@ export interface TransitionPatch {
 export interface AttemptResultInput {
   success: boolean;
   finalStatus: string;
+  /**
+   * Only meaningful when `finalStatus === 'infra_error'`: whether the cause was
+   * the repository itself, not an adapter timeout, tooling failure, or network
+   * blip. The repository failure circuit counts only the former (AGT-4038).
+   */
+  repositoryInfra?: boolean;
   costUsd?: number;
   result?: unknown;
   maxFailuresPerHour?: number;

--- a/src/automation/runnerExecution.coverage.test.ts
+++ b/src/automation/runnerExecution.coverage.test.ts
@@ -772,17 +772,17 @@ describe('runnerExecution.ts coverage extension', () => {
       expect(preserveWorktree).not.toHaveBeenCalled();
     });
 
-    it('returns infra_error without ever constructing the pipeline when worktree creation fails', async () => {
+    it('returns a repository-scoped infra_error without ever constructing the pipeline when worktree creation fails (AGT-4038)', async () => {
       createWorktree.mockRejectedValue(new Error('git worktree add: disk full'));
 
       const result = await executePipeline(makeCtx({ worktreeMode: true }), task(), '/repo');
 
-      expect(result.finalStatus).toBe('infra_error');
-      expect(result.success).toBe(false);
+      expect(result).toMatchObject({ finalStatus: 'infra_error', success: false });
+      expect(result.repositoryInfra).toBe(true); // disk full is the repo's own fault
       expect(createPipelineFromConfig).not.toHaveBeenCalled();
     });
 
-    it('preserves an acquired worktree when durable attachment throws during setup', async () => {
+    it('preserves an acquired worktree when durable attachment throws during setup, without blaming the repository (AGT-4038)', async () => {
       createWorktree.mockResolvedValue(worktreeInfoFixture());
       const durability = {
         onWorktree: vi.fn(async () => { throw new Error('sqlite busy'); }),
@@ -794,6 +794,7 @@ describe('runnerExecution.ts coverage extension', () => {
       const result = await executePipeline(makeCtx({ worktreeMode: true, durability }), task(), '/repo');
 
       expect(result).toMatchObject({ success: false, finalStatus: 'infra_error' });
+      expect(result.repositoryInfra).toBeFalsy(); // ledger contention, not the repo's git state
       expect(createPipelineFromConfig).not.toHaveBeenCalled();
       expect(preserveWorktree).toHaveBeenCalledWith(
         expect.objectContaining({ issueId: 'issue-1' }),

--- a/src/automation/runnerExecution.coverage.test.ts
+++ b/src/automation/runnerExecution.coverage.test.ts
@@ -774,12 +774,17 @@ describe('runnerExecution.ts coverage extension', () => {
 
     it('returns a repository-scoped infra_error without ever constructing the pipeline when worktree creation fails (AGT-4038)', async () => {
       createWorktree.mockRejectedValue(new Error('git worktree add: disk full'));
-
       const result = await executePipeline(makeCtx({ worktreeMode: true }), task(), '/repo');
-
       expect(result).toMatchObject({ finalStatus: 'infra_error', success: false });
       expect(result.repositoryInfra).toBe(true); // disk full is the repo's own fault
       expect(createPipelineFromConfig).not.toHaveBeenCalled();
+    });
+
+    it('does not blame the repository when a preserved worktree just needs reconciliation (AGT-4038)', async () => {
+      createWorktree.mockRejectedValue(new Error('Preserved worktree requires reconciliation (valid=false, branch=main): /wt'));
+      const result = await executePipeline(makeCtx({ worktreeMode: true }), task(), '/repo');
+      expect(result).toMatchObject({ finalStatus: 'infra_error', success: false });
+      expect(result.repositoryInfra).toBeFalsy(); // stale bookkeeping, not disk/git health
     });
 
     it('preserves an acquired worktree when durable attachment throws during setup, without blaming the repository (AGT-4038)', async () => {
@@ -790,16 +795,11 @@ describe('runnerExecution.ts coverage extension', () => {
         beforePublish: vi.fn(async () => true),
         onPublication: vi.fn(async () => true),
       };
-
       const result = await executePipeline(makeCtx({ worktreeMode: true, durability }), task(), '/repo');
-
       expect(result).toMatchObject({ success: false, finalStatus: 'infra_error' });
       expect(result.repositoryInfra).toBeFalsy(); // ledger contention, not the repo's git state
       expect(createPipelineFromConfig).not.toHaveBeenCalled();
-      expect(preserveWorktree).toHaveBeenCalledWith(
-        expect.objectContaining({ issueId: 'issue-1' }),
-        'worktree setup or durable attachment failed',
-      );
+      expect(preserveWorktree).toHaveBeenCalledWith(expect.objectContaining({ issueId: 'issue-1' }), 'worktree setup or durable attachment failed');
       expect(removeWorktree).not.toHaveBeenCalled();
     });
 

--- a/src/automation/runnerExecution.coverage.test.ts
+++ b/src/automation/runnerExecution.coverage.test.ts
@@ -42,6 +42,9 @@ const plannerRunPlanner = vi.fn();
 const plannerFormatPlannerResult = vi.fn();
 const buildBranchName = vi.fn();
 const createWorktree = vi.fn();
+// Stand-in for the real class — the instanceof check under test resolves
+// through this same mock, so identity (not origin) is what matters (AGT-4038).
+const WorktreeCoordinationError = class extends Error {};
 const commitAndCreatePR = vi.fn();
 const findOpenPRFileOverlaps = vi.fn();
 const hasRecoverableWorktree = vi.fn();
@@ -103,6 +106,7 @@ vi.mock('../support/worktreeManager.js', () => ({
   hasRecoverableWorktree,
   preserveWorktree,
   removeWorktree,
+  WorktreeCoordinationError,
 }));
 
 vi.mock('../core/eventHub.js', () => ({ broadcastEvent }));
@@ -429,10 +433,7 @@ describe('runnerExecution.ts coverage extension', () => {
       const result = await executePipeline(makeCtx(), task(), '/repo');
 
       expect(result.finalStatus).toBe('approved');
-      expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Draft analysis failed'),
-        'Error: draft analyzer crashed',
-      );
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Draft analysis failed'), 'Error: draft analyzer crashed');
     });
 
     it('mirrors draft analysis onLog lines to stdout and the event hub', async () => {
@@ -780,11 +781,14 @@ describe('runnerExecution.ts coverage extension', () => {
       expect(createPipelineFromConfig).not.toHaveBeenCalled();
     });
 
-    it('does not blame the repository when a preserved worktree just needs reconciliation (AGT-4038)', async () => {
-      createWorktree.mockRejectedValue(new Error('Preserved worktree requires reconciliation (valid=false, branch=main): /wt'));
+    it.each([
+      ['a preserved worktree just needs reconciliation', 'Preserved worktree requires reconciliation (valid=false, branch=main): /wt'],
+      ['the worktree lifecycle lock is busy', 'Worktree lifecycle is busy for issue-1'],
+    ])('does not blame the repository when %s (AGT-4038)', async (_label, message) => {
+      createWorktree.mockRejectedValue(new WorktreeCoordinationError(message));
       const result = await executePipeline(makeCtx({ worktreeMode: true }), task(), '/repo');
       expect(result).toMatchObject({ finalStatus: 'infra_error', success: false });
-      expect(result.repositoryInfra).toBeFalsy(); // stale bookkeeping, not disk/git health
+      expect(result.repositoryInfra).toBeFalsy(); // coordination, not disk/git health
     });
 
     it('preserves an acquired worktree when durable attachment throws during setup, without blaming the repository (AGT-4038)', async () => {
@@ -872,10 +876,7 @@ describe('runnerExecution.ts coverage extension', () => {
       await expect(executePipeline(makeCtx({ worktreeMode: true }), task(), '/repo'))
         .rejects.toThrow('adapter process crashed');
 
-      expect(preserveWorktree).toHaveBeenCalledWith(
-        expect.objectContaining({ issueId: 'issue-1' }),
-        'session did not succeed',
-      );
+      expect(preserveWorktree).toHaveBeenCalledWith(expect.objectContaining({ issueId: 'issue-1' }), 'session did not succeed');
       expect(removeWorktree).not.toHaveBeenCalled();
     });
 
@@ -976,10 +977,7 @@ describe('runnerExecution.ts coverage extension', () => {
       expect(removeWorktree).not.toHaveBeenCalled();
       const runOptions = fp.run.mock.calls[0][2] as { signal: AbortSignal };
       expect(runOptions.signal.aborted).toBe(true);
-      expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Durable stage transition failed'),
-        expect.any(Error),
-      );
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Durable stage transition failed'), expect.any(Error));
     });
 
     it('posts a worker-start audit comment only for the worker stage on a task with an issueId', async () => {

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -33,6 +33,7 @@ import {
   hasRecoverableWorktree,
   preserveWorktree,
   removeWorktree,
+  WorktreeCoordinationError,
 } from '../support/worktreeManager.js';
 import type { WorktreeInfo } from '../support/worktreeManager.js';
 import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
@@ -872,23 +873,19 @@ export async function executePipeline(
         await preserveWorktree(worktreeInfo, 'worktree setup or durable attachment failed')
           .catch((cleanupError) => console.warn('[Worktree] Setup cleanup failed:', cleanupError));
       }
-      // `createWorktree` itself is internally multi-step, and only some of its
-      // throws are the repository's own fault. "requires reconciliation" means
-      // a preserved or crash-recovered worktree's local state is stale or on
-      // the wrong branch — a coordination/bookkeeping problem this daemon can
-      // resolve on its own reconciliation pass, not disk full, a stale `.git`
-      // lock, or a corrupt repo. `linkSharedPaths`/`ensureLfsSmudged` are
-      // self-contained best-effort (never throw), so what remains — the `git
-      // worktree add` call itself, and the active-marker file write — are
-      // genuine repo/filesystem failures (AGT-4038).
-      const needsReconciliation = err instanceof Error && /requires reconciliation/.test(err.message);
+      // Only some of createWorktree's throws are the repository's own fault.
+      // `WorktreeCoordinationError` covers a busy lifecycle lock and a stale
+      // preserved/crash-recovered tree — bookkeeping this daemon resolves on
+      // its own, not disk/git health. `instanceof`, not a message match, so
+      // it stays correct if worktreeManager.ts's wording changes (AGT-4038).
+      const isCoordinationFailure = err instanceof WorktreeCoordinationError;
       return {
         success: false,
         sessionId: `worktree-fail-${Date.now()}`,
         iterations: 0,
         totalDuration: 0,
         finalStatus: 'infra_error',
-        repositoryInfra: !worktreeInfo && !needsReconciliation,
+        repositoryInfra: !worktreeInfo && !isCoordinationFailure,
         stages: [],
       };
     }

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -872,18 +872,23 @@ export async function executePipeline(
         await preserveWorktree(worktreeInfo, 'worktree setup or durable attachment failed')
           .catch((cleanupError) => console.warn('[Worktree] Setup cleanup failed:', cleanupError));
       }
+      // `createWorktree` itself is internally multi-step, and only some of its
+      // throws are the repository's own fault. "requires reconciliation" means
+      // a preserved or crash-recovered worktree's local state is stale or on
+      // the wrong branch — a coordination/bookkeeping problem this daemon can
+      // resolve on its own reconciliation pass, not disk full, a stale `.git`
+      // lock, or a corrupt repo. `linkSharedPaths`/`ensureLfsSmudged` are
+      // self-contained best-effort (never throw), so what remains — the `git
+      // worktree add` call itself, and the active-marker file write — are
+      // genuine repo/filesystem failures (AGT-4038).
+      const needsReconciliation = err instanceof Error && /requires reconciliation/.test(err.message);
       return {
         success: false,
         sessionId: `worktree-fail-${Date.now()}`,
         iterations: 0,
         totalDuration: 0,
         finalStatus: 'infra_error',
-        // The repository circuit exists for exactly this: disk full, a stale
-        // `.git` lock, a corrupt repo. `!worktreeInfo` means `createWorktree`
-        // itself is what threw, not something after it (e.g. the durable
-        // attach fence, which can throw for reasons — ledger contention — that
-        // have nothing to do with this repository's own health) (AGT-4038).
-        repositoryInfra: !worktreeInfo,
+        repositoryInfra: !worktreeInfo && !needsReconciliation,
         stages: [],
       };
     }

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -878,6 +878,12 @@ export async function executePipeline(
         iterations: 0,
         totalDuration: 0,
         finalStatus: 'infra_error',
+        // The repository circuit exists for exactly this: disk full, a stale
+        // `.git` lock, a corrupt repo. `!worktreeInfo` means `createWorktree`
+        // itself is what threw, not something after it (e.g. the durable
+        // attach fence, which can throw for reasons — ledger contention — that
+        // have nothing to do with this repository's own health) (AGT-4038).
+        repositoryInfra: !worktreeInfo,
         stages: [],
       };
     }

--- a/src/support/repoMetadata.ts
+++ b/src/support/repoMetadata.ts
@@ -61,7 +61,15 @@ const RepoMetadataSchema = z.object({
     maxConcurrent: z.number().int().min(1).max(10).default(1),
     /** Rolling attempt budget. */
     maxAttemptsPerHour: z.number().int().min(1).max(100).default(12),
-    /** Rolling unsuccessful-attempt circuit breaker threshold. */
+    /**
+     * Rolling circuit breaker threshold: how many attempts in the last hour may
+     * end unsuccessfully before this repository is taken out of admission until
+     * `circuitCooldownMinutes` passes. "Unsuccessfully" excludes outcomes that
+     * are not the repository failing — `waiting_on_operator`, `cancelled`,
+     * `rate_limited`, and (as of AGT-4038) an `infra_error` caused by an
+     * adapter timeout, tooling failure, or network blip rather than the
+     * repository itself (disk full, a stale `.git` lock, a corrupt repo).
+     */
     maxFailuresPerHour: z.number().int().min(1).max(100).default(6),
     /** Optional daily model-cost ceiling. */
     maxCostUsdPerDay: z.number().positive().optional(),

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -280,6 +280,19 @@ async function activeMarkerPath(repoPath: string, issueId: string, ownerToken: s
   return join(await activeMarkerDirectory(repoPath), issueId, `${ownerToken}.json`);
 }
 
+/** A `createWorktree()` failure that is a coordination/staleness problem the
+ *  daemon resolves on its own reconciliation pass (a concurrent lease holding
+ *  the lifecycle lock, a preserved or crash-recovered tree needing
+ *  reconciliation) — never the target repository's own disk/git health.
+ *  Callers use `instanceof` rather than matching `.message` text, which stays
+ *  correct if the wording above ever changes (AGT-4038). */
+export class WorktreeCoordinationError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'WorktreeCoordinationError';
+  }
+}
+
 async function withWorktreeLifecycleLock<T>(
   repoPath: string,
   issueId: string,
@@ -300,7 +313,7 @@ async function withWorktreeLifecycleLock<T>(
   } catch (error) {
     lockDb.close();
     if ((error as { code?: string }).code?.startsWith('SQLITE_BUSY')) {
-      throw new Error(`Worktree lifecycle is busy for ${issueId}`, { cause: error });
+      throw new WorktreeCoordinationError(`Worktree lifecycle is busy for ${issueId}`, { cause: error });
     }
     throw error;
   }
@@ -589,7 +602,7 @@ export async function createWorktree(
       console.log(`[Worktree] Resuming preserved worktree: ${worktreePath} (branch: ${branchName})`);
       return resumed;
     }
-    throw new Error(`Preserved worktree requires reconciliation (valid=${valid}, branch=${branch}): ${worktreePath}`);
+    throw new WorktreeCoordinationError(`Preserved worktree requires reconciliation (valid=${valid}, branch=${branch}): ${worktreePath}`);
   }
 
   // Crash recovery: never delete an existing tree before the durable reconciler
@@ -599,7 +612,7 @@ export async function createWorktree(
     const valid = await git(worktreePath, 'status', '--porcelain').then(() => true).catch(() => false);
     const branch = await git(worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD').then((b) => b.trim()).catch(() => '');
     if (!valid || branch !== branchName) {
-      throw new Error(`Existing worktree requires reconciliation (valid=${valid}, branch=${branch}): ${worktreePath}`);
+      throw new WorktreeCoordinationError(`Existing worktree requires reconciliation (valid=${valid}, branch=${branch}): ${worktreePath}`);
     }
     const resumed: WorktreeInfo = {
       worktreePath, branchName, originalPath: repoPath, issueId,


### PR DESCRIPTION
## Summary
- The repository failure circuit counted every `infra_error` attempt as a repository failure, but `infra_error` is overloaded: a failed `git worktree add` (disk full, a stale `.git` lock, a corrupt repo) is the repository's own fault, while an adapter timeout, CodeQL/tooling failure, or network blip is not.
- Measured on vela: 5 adapter timeouts plus 1 real failure and 1 `executor_throw` opened the circuit at 7/6 for a healthy repository, with 23 runs sitting in READY for the next hour.
- Added `PipelineResult.repositoryInfra`, set only where `createWorktree()` itself throws — disambiguated from the durable-attach fence throwing for its own, unrelated reasons (ledger contention) via the existing `worktreeInfo`-null check already in that catch block. Carried through `AttemptResultInput` to a new `repository_infra` column, read by both places the circuit counts failures.
- Documented the new "unsuccessfully" semantics on `maxFailuresPerHour` in `repoMetadata.ts` where it's configured.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx oxlint` clean on all touched files
- [x] Targeted vitest: `runLedger.test.ts` (2 updated + 2 new tests proving both directions), `runnerExecution.coverage.test.ts` (2 updated tests), `durableRunCoordinator.test.ts`, `autonomousRunner.durable.test.ts`, `autonomousRunner.operatorQuestionPark.test.ts`, `autonomousRunner.operatorPark.test.ts`, `runnerExecution.followups/integration.coverage/overlap.test.ts`, `pairPipeline.test.ts`, `repoMetadata.test.ts` — all pass
- [ ] Verified live against vela once deployed (deferred — daemon has stayed busy all session; will confirm circuit no longer opens on adapter-only failures once redeployed)

AGT-4038