### PR TITLE
fix(deps): bump nanoid past its high-severity infinite-loop advisory (AGT-4049)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6433,9 +6433,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- `npm audit fix` for `nanoid <3.3.18` (GHSA-2v37-7h3g-55p8, custom generators can loop indefinitely when size is zero), transitive via `postcss` (dev/build tooling, Tailwind pipeline).
- Confirmed unrelated to AGT-4047's `adm-zip`/`sharp` bump — zero line overlap in that PR's lockfile diff.
- Resolved by the lockfile bump alone: `postcss` already declares `nanoid@^3.3.16`, and `3.3.18` satisfies that range — no `package.json` `overrides` entry needed.

## Test plan
- [x] `npm audit` shows 0 open findings for `nanoid`
- [x] `npx tsc --noEmit -p .` clean
- [x] `npm run build` clean
- [x] `npx oxlint` — 0 errors (4 pre-existing unrelated warnings in untouched files)
- [x] `openswarm review` (tier-1 gate): APPROVE

Fixes AGT-4049.