### PR TITLE
fix(linear): converge addComment's idempotent recovery on id+issue alone (AGT-4051)

### DIFF
--- a/src/linear/linear.test.ts
+++ b/src/linear/linear.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createSubIssue, drainLinearConnection, effectCommentId, fetchIssuesForStates, initLinear, parseBlockerIdentifiers } from './linear.js';
+import { addComment, createSubIssue, drainLinearConnection, effectCommentId, fetchIssuesForStates, initLinear, parseBlockerIdentifiers } from './linear.js';
 import { LinearClient } from '@linear/sdk';
 
 // createSubIssue reads the module-level client singleton (getClient()), set only
@@ -203,5 +203,39 @@ describe('createSubIssue idempotent recovery (AGT-4048)', () => {
     });
 
     expect(result).toHaveProperty('error');
+  });
+});
+
+// AGT-4051: same shape as AGT-4048, one call deeper — a stable commentId is
+// the identity guarantee; the body (which callers bake a timestamp into) can
+// legitimately differ on every retry and must not block convergence.
+describe('addComment idempotent recovery (AGT-4051)', () => {
+  it('converges on an existing comment by id+issue alone, even when the body differs (a timestamp changed)', async () => {
+    const fakeClient = {
+      createComment: vi.fn(async () => {
+        throw new Error('Conflict on insert of Comment - Entity Comment with id comment-1 already exists.');
+      }),
+      comment: vi.fn(async ({ id }: { id: string }) =>
+        id === 'comment-1'
+          ? { body: 'stale body with an old timestamp', issue: Promise.resolve({ id: 'issue-1' }) }
+          : (() => { throw new Error(`unexpected comment() call: ${id}`); })()),
+    };
+    vi.mocked(LinearClient).mockImplementation(function (this: unknown) { return fakeClient as never; } as never);
+    initLinear('fake-key', 'team-1');
+
+    await expect(addComment('issue-1', 'fresh body with a new timestamp', 'comment-1')).resolves.toBeUndefined();
+  });
+
+  it('rejects convergence when the existing comment belongs to a different issue', async () => {
+    const fakeClient = {
+      createComment: vi.fn(async () => {
+        throw new Error('Conflict on insert of Comment - Entity Comment with id comment-1 already exists.');
+      }),
+      comment: vi.fn(async () => ({ body: 'body', issue: Promise.resolve({ id: 'some-other-issue' }) })),
+    };
+    vi.mocked(LinearClient).mockImplementation(function (this: unknown) { return fakeClient as never; } as never);
+    initLinear('fake-key', 'team-1');
+
+    await expect(addComment('issue-1', 'body', 'comment-1')).rejects.toThrow('already exists');
   });
 });

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -975,7 +975,16 @@ export async function addComment(
       try {
         const existing = await linear.comment({ id: commentId });
         const existingIssue = await existing.issue;
-        if (existingIssue?.id === issueId && existing.body === body) return;
+        // The stable id is the identity guarantee, not a byte-for-byte body
+        // match — callers like buildTaskStateSyncComment bake in a timestamp,
+        // which by construction can never match a prior call's body (AGT-4051,
+        // same shape as createSubIssue's AGT-4048 fix).
+        if (existingIssue?.id === issueId) {
+          if (existing.body !== body) {
+            console.warn(`[Linear] Idempotent comment ${commentId} body differs from this retry's content — converging on the existing artifact anyway`);
+          }
+          return;
+        }
       } catch {
         // Preserve the original create error if artifact reconciliation fails.
       }


### PR DESCRIPTION
## Summary
- Same defect shape as AGT-4048, one call deeper: `addComment`'s idempotent-collision recovery required an exact body match to converge on an already-posted comment. `buildTaskStateSyncComment` and the worker start/complete audit comments all bake a timestamp (and often a session id) into the body — that can never match a prior call's, by construction, so this failed on *every* retry that hit an already-posted stable-id comment, not just occasionally.
- Observed live: `AX-870` (the same task AGT-4048 used as its own example) hit `Conflict on insert of Comment - Entity Comment with id ... already exists.` posting its decomposition child-state-sync comment, failing the whole task.
- Fix: the stable `commentId` + owning issue is the actual identity guarantee. A body mismatch is now a diagnostic `console.warn`, not a reason to fail — mirrors AGT-4048's `createSubIssue` fix exactly.

## Test plan
- [x] `npx tsc --noEmit -p .` clean
- [x] New test: recovery succeeds when the existing comment's body differs (a timestamp changed)
- [x] New test: recovery still correctly rejects when the existing comment belongs to a *different* issue
- [x] Verified the fix matters: reverted the one changed condition, confirmed the new test fails exactly as predicted, restored it
- [x] `npx vitest run src/linear/linear.test.ts` — 19/19 pass
- [x] `openswarm review` (tier-1 gate): APPROVE

Fixes AGT-4051.