### PR TITLE
fix(automation): free NEEDS_RECONCILE rows a container-restart orphans forever (AGT-4052)

### DIFF
--- a/src/automation/durableRunCoordinator.test.ts
+++ b/src/automation/durableRunCoordinator.test.ts
@@ -784,4 +784,63 @@ describe('DurableRunCoordinator', () => {
     deadReplacement.close();
     deadLedger.close();
   });
+
+  it('rejects a negative reconcileAbandonMs instead of silently collapsing the safety margin', () => {
+    expect(() => new DurableRunCoordinator({
+      mode: 'primary', dbPath: dbPath(), reconcileAbandonMs: -1,
+    })).toThrow(/reconcileAbandonMs/);
+  });
+
+  // AGT-4052: a container assigns the daemon the same pid every restart, so
+  // a NEEDS_RECONCILE row orphaned by a restart has processIsAlive report
+  // true forever (the new daemon's own pid probe hits itself). Age must be
+  // able to free it even while the pid probe insists the owner is alive.
+  it('abandons a NEEDS_RECONCILE owner by age once a pid probe alone can never disprove it', () => {
+    const path = dbPath();
+    const ledger = new RunLedger(path);
+    ledger.registerRun({ issueId: 'PID-REUSE', source: 'linear', projectPath: '/repo' }, 1_000);
+    const claim = ledger.claimRun('PID-REUSE', {
+      ownerInstanceId: '7-orphaned-generation', leaseMs: 3_000, now: 1_000,
+    })!;
+    expect(ledger.transition(claim, 'EXECUTING', {}, 1_100)).toBe(true);
+
+    const coordinator = new DurableRunCoordinator({
+      mode: 'primary', ledger, instanceId: '7-current-generation',
+      // Simulates pid reuse: a live daemon now occupies the orphaned row's
+      // pid, so a bare pid probe can never prove the original owner is dead.
+      processIsAlive: () => true,
+      reconcileAbandonMs: 5_000,
+    });
+
+    // First reconcile() call: reconcileExpiredLeases() moves EXECUTING ->
+    // NEEDS_RECONCILE at t=4_001 (lease expired at 4_000), setting
+    // updatedAt=4_001. The NEEDS_RECONCILE loop runs in the same call but
+    // the row is brand new (age 0), so it must stay fenced despite the
+    // stubbed-alive pid — proving the age check doesn't free prematurely.
+    expect(coordinator.reconcile(4_001)).toHaveLength(1);
+    expect(ledger.getRun('PID-REUSE')).toMatchObject({
+      state: 'NEEDS_RECONCILE',
+      ownerInstanceId: '7-orphaned-generation',
+      leaseToken: claim.leaseToken,
+    });
+
+    // Just under the abandon threshold: still fenced.
+    coordinator.reconcile(4_001 + 4_999);
+    expect(ledger.getRun('PID-REUSE')).toMatchObject({
+      ownerInstanceId: '7-orphaned-generation',
+    });
+
+    // At/past the abandon threshold: freed by age alone, even though
+    // processIsAlive still (falsely) reports the owner as alive.
+    coordinator.reconcile(4_001 + 5_000);
+    expect(ledger.getRun('PID-REUSE')).toMatchObject({
+      state: 'NEEDS_RECONCILE',
+      ownerInstanceId: undefined,
+      leaseToken: undefined,
+    });
+    expect(ledger.markReady('PID-REUSE', 4_001 + 5_001)).toBe(true);
+
+    coordinator.close();
+    ledger.close();
+  });
 });

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -25,6 +25,13 @@ export interface DurableRunCoordinatorConfig {
   maxActiveForProject?: number;
   /** Test seam for crash recovery; production probes the owner PID. */
   processIsAlive?: (pid: number) => boolean;
+  /**
+   * How long a NEEDS_RECONCILE row's stale owner is trusted once a pid probe
+   * alone can't disprove it (container pid reuse — see reconcile()). Default
+   * matches leaseMs: by the time a row reaches NEEDS_RECONCILE its lease has
+   * already fully expired once, so this is a second, independent wait.
+   */
+  reconcileAbandonMs?: number;
 }
 
 export interface ExecutionDurabilityHooks {
@@ -128,6 +135,7 @@ export class DurableRunCoordinator {
   private readonly leaseMs: number;
   private readonly maxActiveForProject: number;
   private readonly processIsAlive: (pid: number) => boolean;
+  private readonly reconcileAbandonMs: number;
   private readonly exitedClaims = new Map<string, RunClaim>();
   private closed = false;
 
@@ -137,7 +145,14 @@ export class DurableRunCoordinator {
     this.leaseMs = config.leaseMs ?? 10 * 60_000;
     this.maxActiveForProject = Math.max(1, Math.floor(config.maxActiveForProject ?? 1));
     this.processIsAlive = config.processIsAlive ?? processIsAlive;
+    this.reconcileAbandonMs = config.reconcileAbandonMs ?? this.leaseMs;
     if (this.leaseMs < 3_000) throw new Error('Durable run lease must be at least 3000ms');
+    // A negative value would make `now - run.updatedAt >= reconcileAbandonMs`
+    // trivially true for every row the instant it enters NEEDS_RECONCILE,
+    // silently collapsing the whole safety margin this is meant to enforce.
+    if (!Number.isFinite(this.reconcileAbandonMs) || this.reconcileAbandonMs < 0) {
+      throw new Error('reconcileAbandonMs must be a non-negative, finite number of milliseconds');
+    }
     this.ledger = config.mode === 'off' ? undefined : (config.ledger ?? new RunLedger(config.dbPath));
     this.ownsLedger = config.mode !== 'off' && !config.ledger;
   }
@@ -478,7 +493,22 @@ export class DurableRunCoordinator {
     for (const run of this.ledger.listRuns(['NEEDS_RECONCILE'])) {
       if (!run.ownerInstanceId || !run.leaseToken) continue;
       const pid = ownerProcessId(run.ownerInstanceId);
-      if (pid == null || this.processIsAlive(pid)) continue;
+      // A container assigns the daemon the same pid every start, so a row
+      // orphaned by a restart reads as "alive" forever — the new daemon's
+      // own pid probe hits itself. Age is the only signal that survives that
+      // (see reference_container_pid_reuse_lock.md; same trap already fixed
+      // once in taskState/store.ts's LOCK_ABANDON_MS).
+      //
+      // Why age alone is safe here: reaching NEEDS_RECONCILE at all already
+      // required a full leaseMs of silence — execute()'s renewTimer renews
+      // every leaseMs/3, so a genuinely alive, functioning owner renews
+      // several times over before its lease can expire. updatedAt marks that
+      // expiry moment, so reconcileAbandonMs (default leaseMs) stacks a
+      // second full lease window of silence on top — ~2*leaseMs of missed
+      // renewal (multiple consecutive misses, not one) before this frees the
+      // row, purely as a fallback for when the pid probe can't be trusted.
+      const abandonedByAge = now - run.updatedAt >= this.reconcileAbandonMs;
+      if (!abandonedByAge && (pid == null || this.processIsAlive(pid))) continue;
       this.confirmExitedClaim({
         issueId: run.issueId,
         ownerInstanceId: run.ownerInstanceId,


### PR DESCRIPTION
## Summary
- `DurableRunCoordinator.reconcile()` only cleared a `NEEDS_RECONCILE` row's stale owner once `processIsAlive(ownerProcessId(...))` reported it dead. This container assigns the daemon the same pid every restart, so an orphaned row reads as "alive" forever — the new daemon's own pid probe hits itself.
- Same trap already fixed once in `taskState/store.ts` (`LOCK_ABANDON_MS`); this is a second, independent occurrence in `durableRunCoordinator.ts`, confirmed live on vela (3 CGF-Portal issues stuck 80+ min post-redeploy).
- Adds a time-based abandonment fallback to the `NEEDS_RECONCILE` loop only — the `CLAIMED/EXECUTING/VERIFYING/PUBLISHING` loop is untouched, since a stuck claim there is still swept by natural lease expiry.

## Test plan
- [x] New regression test proves the fix: reverted the changed line, confirmed the test failed as predicted; restored, confirmed it passes.
- [x] `npx tsc --noEmit` passes.
- [x] `npx vitest run src/automation/durableRunCoordinator.test.ts` — 31/31 passing.
- [x] Commit-gate review (tier-1, 4 rounds, each round fixed a real finding: leaseMs-derived default, explicit safety-margin justification, input validation on `reconcileAbandonMs`) — final: APPROVE.