### PR TITLE
fix(worktree): stop a container-restart-orphaned active marker blocking recovery/prune forever (AGT-4053)

### DIFF
--- a/src/support/worktreeManager.coverage.test.ts
+++ b/src/support/worktreeManager.coverage.test.ts
@@ -244,6 +244,48 @@ describe('createWorktree retry/resume error paths', () => {
     expect(readFileSync(join(worktreePath, 'stray.txt'), 'utf8')).toBe('leftover');
   });
 
+  // AGT-4053: this container assigns the daemon the same pid every restart,
+  // so a marker from a dead prior generation makes processAppearsAlive hit
+  // the *current* process's own pid and read "alive" forever. Age must be
+  // able to reclassify it as orphaned even while the pid probe insists the
+  // marker's owner is alive.
+  it('reclassifies a very old active marker as orphaned even when its pid still appears alive (AGT-4053)', async () => {
+    const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-pid-reuse');
+    const markerPath = join(
+      repo, '.git', 'openswarm', 'active-worktrees', 'INT-1', `${info.activeMarkerToken}.json`,
+    );
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
+    // ownerPid stays process.pid (genuinely alive right now) — simulating a
+    // container that reused this same pid for a new, unrelated daemon.
+    marker.createdAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    writeFileSync(markerPath, JSON.stringify(marker));
+
+    await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
+      state: 'orphaned',
+    });
+  });
+
+  it('honors OPENSWARM_ACTIVE_MARKER_ABANDON_MS for deployments with unusually long stage timeouts (AGT-4053)', async () => {
+    const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-abandon-override');
+    const markerPath = join(
+      repo, '.git', 'openswarm', 'active-worktrees', 'INT-1', `${info.activeMarkerToken}.json`,
+    );
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
+    marker.createdAt = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(); // 2h old — well under the 24h default
+    writeFileSync(markerPath, JSON.stringify(marker));
+
+    const prev = process.env.OPENSWARM_ACTIVE_MARKER_ABANDON_MS;
+    process.env.OPENSWARM_ACTIVE_MARKER_ABANDON_MS = String(60 * 60 * 1000); // 1h override
+    try {
+      await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
+        state: 'orphaned',
+      });
+    } finally {
+      if (prev === undefined) delete process.env.OPENSWARM_ACTIVE_MARKER_ABANDON_MS;
+      else process.env.OPENSWARM_ACTIVE_MARKER_ABANDON_MS = prev;
+    }
+  });
+
   it('distinguishes a live owner, a dead owner, and a safely preserved worktree', async () => {
     const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-recovery');
     await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
@@ -509,6 +551,24 @@ describe('pruneWorktrees (INT-1810 R4 / INT-2503 / INT-2506)', () => {
     // The expired tree's partial work was committed to its branch before removal (INT-2506).
     const show = execFileSync('git', ['-C', repo, 'show', 'swarm/INT-4-expired:app.py'], { encoding: 'utf8' });
     expect(show).toBe('base\nexpired-wip\n');
+  });
+
+  // AGT-4053: a container-reused pid makes processAppearsAlive report true
+  // forever for a marker from a dead prior generation. A proven orphan must
+  // still sweep once its marker is old enough, even though its pid probe
+  // alone can never disprove the (unrelated, container-reused) live pid.
+  it('sweeps a proven orphan whose stale marker still has a live-looking pid, once old enough (AGT-4053)', async () => {
+    const orphan = await createWorktree(repo, 'INT-6', 'swarm/INT-6-pid-reuse');
+    const markerPath = join(
+      repo, '.git', 'openswarm', 'active-worktrees', 'INT-6', `${orphan.activeMarkerToken}.json`,
+    );
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
+    marker.createdAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    writeFileSync(markerPath, JSON.stringify(marker));
+
+    await pruneWorktrees(repo, new Set(), new Set([orphan.worktreePath]));
+
+    expect(existsSync(orphan.worktreePath)).toBe(false);
   });
 
   it('does not throw when the repo path is not a git repository at all (both internal sweeps fail cleanly)', async () => {

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -423,6 +423,39 @@ function processAppearsAlive(pid: number): boolean {
   }
 }
 
+/** This container assigns the daemon process the same pid every restart, so
+ * a marker from a dead prior generation makes `processAppearsAlive` hit the
+ * *current* daemon and read "alive" forever (reference_container_pid_reuse_lock.md,
+ * occurrence #3). Unlike a ledger lease, this marker is written once at
+ * createWorktree() and never touched again by a single in-flight execution,
+ * so there's no per-heartbeat renewal to fall back on — the threshold must
+ * instead outlast the longest a genuinely still-alive same-generation owner
+ * could hold it.
+ *
+ * `stageTimeoutMs()` only FLOORS an unset/zero stage timeout up to a default
+ * ceiling (worker 20min, reviewer/tester/documenter/auditor 6min each —
+ * "Never allow 0", INT-2521) — it does not cap a deliberately configured
+ * longer value. With defaults and `maxIterations` (default 3), a continuous
+ * single-attempt execution is on the order of a couple hours, giving the
+ * 24h default here roughly a 10x margin — every *retried* attempt on the
+ * same worktree also calls createWorktree()'s resume path, which rewrites
+ * this marker (resetting its age) before that attempt starts. A deployment
+ * that deliberately configures per-stage timeouts far beyond the defaults
+ * can override the default via OPENSWARM_ACTIVE_MARKER_ABANDON_MS. */
+const DEFAULT_ACTIVE_MARKER_ABANDON_MS = 24 * 60 * 60 * 1000;
+
+function activeMarkerAbandonMs(): number {
+  const parsed = Number(process.env.OPENSWARM_ACTIVE_MARKER_ABANDON_MS);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_ACTIVE_MARKER_ABANDON_MS;
+}
+
+/** Null on an unreadable/unparseable timestamp — callers must treat that as
+ * "not provably abandoned" (mirrors preserveMarkerAgeMs's fail-safe null). */
+function activeMarkerAgeMs(marker: ActiveWorktreeMarker): number | null {
+  const at = Date.parse(marker.createdAt);
+  return Number.isFinite(at) ? Date.now() - at : null;
+}
+
 /** Fail-closed recovery evidence for an expired run. A live marker owner may
  * still be writing after losing its lease, so only a preserved tree or a dead
  * owner is safe to resume automatically. */
@@ -436,7 +469,9 @@ export async function inspectWorktreeRecovery(
     : resolveWorktreePath(repoPath, issueId);
   if (!existsSync(worktreePath)) return { state: 'missing', worktreePath };
   const active = await readActiveWorktreeMarkers(repoPath, worktreePath);
-  const liveMarker = active.markers.find((marker) => processAppearsAlive(marker.ownerPid));
+  const liveMarker = active.markers.find(
+    (marker) => processAppearsAlive(marker.ownerPid) && (activeMarkerAgeMs(marker) ?? 0) < activeMarkerAbandonMs(),
+  );
   if (liveMarker) return { state: 'active_owner', worktreePath, marker: liveMarker };
   if (existsSync(join(worktreePath, PRESERVE_MARKER))) {
     return preserveMarkerAgeMs(worktreePath) === null
@@ -1249,7 +1284,10 @@ export async function pruneWorktrees(
           // owner either writes its marker first (and is retained), or waits
           // until this proven-orphan cleanup has finished.
           const active = await readActiveWorktreeMarkers(repoPath, p);
-          const liveMarker = active.markers.find((candidate) => processAppearsAlive(candidate.ownerPid));
+          const liveMarker = active.markers.find(
+            (candidate) => processAppearsAlive(candidate.ownerPid)
+              && (activeMarkerAgeMs(candidate) ?? 0) < activeMarkerAbandonMs(),
+          );
           if (liveMarker) {
             console.log(`[Worktree] Retaining live owner ${liveMarker.ownerPid}: ${p}`);
             return;


### PR DESCRIPTION
## Summary
- `inspectWorktreeRecovery` and `pruneWorktrees` both call `processAppearsAlive(marker.ownerPid)` with no age fallback. This container assigns the daemon the same pid every restart, so a marker from a dead prior generation reads "alive" forever — third occurrence of the trap already fixed in `taskState/store.ts` and in `DurableRunCoordinator.reconcile()` (AGT-4052, #443).
- Confirmed live on vela: AX-1018/AX-885/AX-1044's active-worktree markers all carry `ownerPid: 7` (the daemon's fixed container pid) — without this fix, these 3 issues would stay blocked even after AGT-4052 ships.
- Adds a time-based abandonment fallback (default 24h, overridable via `OPENSWARM_ACTIVE_MARKER_ABANDON_MS`) to both call sites.

## Test plan
- [x] New regression tests prove the fix: reverted, confirmed failures as predicted; restored, confirmed passing.
- [x] `npx tsc --noEmit` passes.
- [x] `npx vitest run src/support/worktreeManager.coverage.test.ts src/support/worktreeManager.test.ts src/support/worktreeManager.auditPR.test.ts` — 78/78 passing.
- [x] Commit-gate review (tier-1, 3 rounds — each fixed a real finding: initially scoped `pruneWorktrees` too, verified via `stageTimeoutMs`/`maxIterations` math it's actually safe there too; then caught my comment overclaiming a "hard ceiling" that configured stage timeouts aren't actually capped by, fixed by making the threshold overridable via env var) — final: APPROVE.