### PR TITLE
feat(coordination): nudge worker/reviewer agents to check their inbox mid-task (AGT-4054)

### DIFF
--- a/src/adapters/agenticLoop.test.ts
+++ b/src/adapters/agenticLoop.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { compactPriorTurns, toolCallKey, allToolCallsSeen, shouldNudgeReadLoop, READ_LOOP_NUDGE_AT, runAgenticLoop, loopResultToCliResult, type ChatMessage, type AgenticLoopResult } from './agenticLoop.js';
+import { compactPriorTurns, toolCallKey, allToolCallsSeen, shouldNudgeReadLoop, READ_LOOP_NUDGE_AT, shouldNudgeCoordinationCheck, COORDINATION_CHECK_NUDGE_EVERY, runAgenticLoop, loopResultToCliResult, type ChatMessage, type AgenticLoopResult } from './agenticLoop.js';
 import type { ToolCall } from './tools.js';
 
 /** Scripted API response carrying a single tool call. */
@@ -163,6 +163,20 @@ describe('shouldNudgeReadLoop — early read-loop nudge (ported 8a1420f)', () =>
   });
   it('stops nudging once the budget is exhausted', () => {
     expect(shouldNudgeReadLoop(0, 3, 3, READ_LOOP_NUDGE_AT + 5)).toBe(false);
+  });
+});
+
+// AGT-4054
+describe('shouldNudgeCoordinationCheck', () => {
+  it('nudges once enough turns have passed without a check, with coordination enabled', () => {
+    expect(shouldNudgeCoordinationCheck(true, COORDINATION_CHECK_NUDGE_EVERY)).toBe(true);
+    expect(shouldNudgeCoordinationCheck(true, COORDINATION_CHECK_NUDGE_EVERY + 5)).toBe(true);
+  });
+  it('does NOT nudge before enough turns have passed', () => {
+    expect(shouldNudgeCoordinationCheck(true, COORDINATION_CHECK_NUDGE_EVERY - 1)).toBe(false);
+  });
+  it('does NOT nudge when there is no coordination context, regardless of turns elapsed', () => {
+    expect(shouldNudgeCoordinationCheck(false, COORDINATION_CHECK_NUDGE_EVERY + 100)).toBe(false);
   });
 });
 
@@ -364,6 +378,111 @@ describe('runAgenticLoop blocking human decision', () => {
     // turn in which it could answer its own question.
     expect(calls).toEqual(['turn-1', 'turn-2']);
     expect(result.text).toContain('Blocked');
+  });
+});
+
+// AGT-4054: an operator/agent can message a running worker/reviewer without
+// it asking first (unlike ask_human), so nothing else surfaces that — this
+// nudge is the only active prompt telling the agent to go check.
+describe('runAgenticLoop coordination-inbox nudge (AGT-4054)', () => {
+  const coordinationContext = {
+    repository: process.cwd(),
+    taskId: 't-coord-nudge',
+    actor: 'worker-coord-nudge-test',
+    actorName: 'Coord Nudge Test',
+  };
+
+  it('nudges to check the coordination inbox after enough turns of silence', async () => {
+    const logs: string[] = [];
+    let call = 0;
+    const callApi = async () => {
+      call++;
+      if (call <= COORDINATION_CHECK_NUDGE_EVERY + 1) {
+        return toolCallResp(`c${call}`, 'read_file', { path: `nope${call}.ts` });
+      }
+      return finalResp('done');
+    };
+
+    await runAgenticLoop({
+      prompt: 'x', cwd: process.cwd(), model: 'test', callApi,
+      coordinationContext, maxTurns: COORDINATION_CHECK_NUDGE_EVERY + 5, webTools: false,
+      onLog: (l) => logs.push(l),
+    });
+
+    expect(logs.some((l) => l.includes('Coordination-inbox nudge'))).toBe(true);
+  });
+
+  it('does NOT nudge when the run has no coordination context', async () => {
+    const logs: string[] = [];
+    let call = 0;
+    const callApi = async () => {
+      call++;
+      if (call <= COORDINATION_CHECK_NUDGE_EVERY + 3) {
+        return toolCallResp(`c${call}`, 'read_file', { path: `nope${call}.ts` });
+      }
+      return finalResp('done');
+    };
+
+    await runAgenticLoop({
+      prompt: 'x', cwd: process.cwd(), model: 'test', callApi,
+      maxTurns: COORDINATION_CHECK_NUDGE_EVERY + 5, webTools: false,
+      onLog: (l) => logs.push(l),
+    });
+
+    expect(logs.some((l) => l.includes('Coordination-inbox nudge'))).toBe(false);
+  });
+
+  it('resets the clock when the agent checks its inbox on its own', async () => {
+    const logs: string[] = [];
+    let call = 0;
+    // 3 turns of silence (turns 0-2), a self-initiated check at turn 3, then
+    // 4 more turns of silence (turns 4-7) — 7 turns elapsed since turn 0
+    // overall, which WOULD cross COORDINATION_CHECK_NUDGE_EVERY (6) measured
+    // from the start. It must NOT cross measured from the turn-3 check
+    // (turn 7 - turn 3 = 4 < 6). A broken/missing reset would nudge around
+    // turn 6; a working one keeps this silent through turn 7.
+    const CHECK_AT_CALL = 4;
+    const callApi = async () => {
+      call++;
+      if (call === CHECK_AT_CALL) return toolCallResp(`c${call}`, 'coordination_read', {});
+      if (call <= CHECK_AT_CALL + 4) {
+        return toolCallResp(`c${call}`, 'read_file', { path: `nope${call}.ts` });
+      }
+      return finalResp('done');
+    };
+
+    await runAgenticLoop({
+      prompt: 'x', cwd: process.cwd(), model: 'test', callApi,
+      coordinationContext, maxTurns: 10, webTools: false,
+      onLog: (l) => logs.push(l),
+    });
+
+    expect(logs.some((l) => l.includes('Coordination-inbox nudge'))).toBe(false);
+  });
+
+  it('does NOT reset the clock on coordination_history alone — it consumes nothing from the live inbox', async () => {
+    const logs: string[] = [];
+    let call = 0;
+    // Call coordination_history every turn instead of coordination_read. If it
+    // wrongly counted as a check, this would look identical to the previous
+    // test and never nudge — but it must, because the live inbox was never
+    // actually consumed. Vary the args per call so the no-progress stall
+    // guard (identical tool calls 3 turns running) doesn't cut the run short.
+    const callApi = async () => {
+      call++;
+      if (call <= COORDINATION_CHECK_NUDGE_EVERY + 1) {
+        return toolCallResp(`c${call}`, 'coordination_history', { limit: call });
+      }
+      return finalResp('done');
+    };
+
+    await runAgenticLoop({
+      prompt: 'x', cwd: process.cwd(), model: 'test', callApi,
+      coordinationContext, maxTurns: COORDINATION_CHECK_NUDGE_EVERY + 5, webTools: false,
+      onLog: (l) => logs.push(l),
+    });
+
+    expect(logs.some((l) => l.includes('Coordination-inbox nudge'))).toBe(true);
   });
 });
 

--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -291,6 +291,15 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
   // could exhaust it and then slip past the guard, ending analysis-only. (INT-1925)
   let noEditNudgesUsed = 0;
   let readLoopNudgesUsed = 0;
+  // AGT-4054: an operator or another agent can reach out mid-task without this
+  // agent asking first — nothing else in the loop surfaces that unprompted, so
+  // track how long it has been since coordination_read last actually consumed
+  // the live inbox (turn 0 = "as if checked at the start") and nudge
+  // periodically. coordination_history does NOT count — it searches the
+  // permanent trace and consumes nothing (its own tool description says so),
+  // so an agent could call it repeatedly and never see a newly addressed
+  // message; only a real coordination_read proves the inbox was checked.
+  let lastCoordinationCheckTurn = 0;
   // search-replace stall guard: consecutive finish-turns where S/R blocks were
   // present but ALL failed to apply. A model can re-emit the same non-matching
   // block forever, burning turns at full API cost — bail after a couple. (INT-1676)
@@ -516,6 +525,17 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
       (tc.function.name === 'edit_file' || tc.function.name === 'write_file' || tc.function.name === 'apply_patch') && !results[i]?.is_error,
     ).length;
 
+    // AGT-4054: only a successful coordination_read resets the nudge clock —
+    // coordination_history consumes nothing (it searches the permanent trace,
+    // not the live inbox), so it must NOT count as "checked" or an agent could
+    // satisfy the nudge forever without ever consuming a newly addressed
+    // message. A reset here is otherwise indistinguishable from one caused by
+    // the nudge firing itself (set below) — a check the model does on its own
+    // looks the same either way.
+    if (toolCalls.some((tc, i) => tc.function.name === 'coordination_read' && !results[i]?.is_error)) {
+      lastCoordinationCheckTurn = turn;
+    }
+
     // Capture the shell commands the worker actually ran (ground truth for the
     // validation-evidence gate — the model's self-reported `commands` is often
     // empty). Only successful bash calls; deduped, capped. (INT-2485)
@@ -594,6 +614,28 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
           'You have spent several turns reading/searching with ZERO edits. You have enough ' +
           'context now — STOP reading and apply the fix with edit_file immediately, then verify. ' +
           'Do not read more files unless an edit actually fails.',
+      });
+    }
+
+    // AGT-4054: an operator or another agent can message this agent mid-task
+    // without it asking first (unlike ask_human, which the agent itself
+    // initiates) — nothing else here surfaces that, so nudge periodically.
+    // Not readOnly-gated here: coordination tools are already withheld from
+    // `tools` when readOnly or !coordinationContext, so a nudge in that case
+    // would just get ignored — but skip it anyway to avoid a pointless turn.
+    const turnsSinceCoordinationCheck = turn - lastCoordinationCheckTurn;
+    if (!readOnly && shouldNudgeCoordinationCheck(Boolean(coordinationContext), turnsSinceCoordinationCheck)) {
+      onLog?.(`↩ Coordination-inbox nudge: turn ${turn}, ${turnsSinceCoordinationCheck} turns since last check`);
+      // Treat the nudge itself as a check for spacing purposes — the model
+      // gets a fresh window either way, whether it heeds this one or not.
+      lastCoordinationCheckTurn = turn;
+      messages.push({
+        role: 'user',
+        content:
+          'It has been a while since you checked your coordination inbox. Call coordination_read ' +
+          'now to see if the operator or another agent has sent you anything. If you find a ' +
+          'message that is not a reply to something you initiated, acknowledge it with ' +
+          'coordination_publish before continuing your work.',
       });
     }
   }
@@ -730,6 +772,24 @@ export function shouldNudgeReadLoop(
   turn: number,
 ): boolean {
   return editToolCount === 0 && nudgesUsed < nudgeMax && turn >= READ_LOOP_NUDGE_AT;
+}
+
+/**
+ * How often a coordination-enabled agent gets nudged to check its inbox when
+ * it hasn't checked on its own. Matches READ_LOOP_NUDGE_AT's cadence — the
+ * same turn budget this loop is already tuned around. Unlike the read-loop
+ * nudge, this repeats (not capped by a nudge-count budget): a long task
+ * should get checked in on more than once, and an agent already checking on
+ * its own never triggers it, since its own calls reset the clock. (AGT-4054)
+ */
+export const COORDINATION_CHECK_NUDGE_EVERY = 6;
+
+/** True when a coordination-enabled agent has gone too long without checking its inbox. */
+export function shouldNudgeCoordinationCheck(
+  hasCoordinationContext: boolean,
+  turnsSinceLastCheck: number,
+): boolean {
+  return hasCoordinationContext && turnsSinceLastCheck >= COORDINATION_CHECK_NUDGE_EVERY;
 }
 
 // ============ 히스토리 압축 (VEGA compaction.py 패턴 이식) ============

--- a/src/adapters/tools.test.ts
+++ b/src/adapters/tools.test.ts
@@ -5,6 +5,7 @@ import { execFileSync } from 'node:child_process';
 import * as os from 'node:os';
 import { TOOL_DEFINITIONS, executeTool, createReadCache, ToolCall, buildBashToolEnv, validatePath } from './tools.js';
 import { homedir } from 'node:os';
+import type { CoordinationToolContext } from '../coordination/coordinationTools.js';
 
 // search_memory loads the memory core lazily; stub the shared helper so the tool
 // test stays fast and deterministic (no LanceDB / embedding model).
@@ -667,5 +668,50 @@ describe('search_files without ripgrep', () => {
     } finally {
       process.env.PATH = savedPath;
     }
+  });
+});
+
+// AGT-4054: coordination_history was defined, advertised, and had a working
+// handler in coordinationTools.ts, but the executeTool dispatcher's
+// special-case list never included its name — so any call fell through to
+// "Unknown tool". These exercise the dispatcher itself (not
+// executeCoordinationTool directly), since that's the layer that broke.
+describe('executeTool coordination_history dispatch (AGT-4054)', () => {
+  const ORIGINAL_COORDINATION_FILE = process.env.OPENSWARM_COORDINATION_FILE;
+  const ORIGINAL_AUTOMATION_DB = process.env.OPENSWARM_AUTOMATION_DB;
+  let dir = '';
+
+  afterAll(async () => {
+    (await import('../coordination/coordinationStore.js')).resetCoordinationStoreForTests();
+    (await import('../coordination/coordinationTrace.js')).resetTraceDbForTests();
+    process.env.OPENSWARM_COORDINATION_FILE = ORIGINAL_COORDINATION_FILE;
+    process.env.OPENSWARM_AUTOMATION_DB = ORIGINAL_AUTOMATION_DB;
+    if (dir) await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('routes to executeCoordinationTool instead of failing as an unknown tool', async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'openswarm-coord-history-'));
+    process.env.OPENSWARM_COORDINATION_FILE = path.join(dir, 'events.json');
+    process.env.OPENSWARM_AUTOMATION_DB = path.join(dir, 'automation.db');
+    (await import('../coordination/coordinationStore.js')).resetCoordinationStoreForTests();
+    (await import('../coordination/coordinationTrace.js')).resetTraceDbForTests();
+
+    const coordinationContext: CoordinationToolContext = {
+      repository: TMP_DIR,
+      taskId: 't-agt-4054',
+      actor: 'worker-test',
+      actorName: 'Worker Test',
+    };
+
+    const result = await executeTool(
+      makeCall('coordination_history', {}),
+      TMP_DIR,
+      undefined,
+      { coordinationContext },
+    );
+
+    expect(result.is_error).toBe(false);
+    expect(result.content).not.toContain('Unknown tool');
+    expect(() => JSON.parse(result.content)).not.toThrow();
   });
 });

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -744,7 +744,7 @@ export async function executeTool(
       }
 
       default:
-        if (['coordination_read', 'coordination_publish', 'ask_human'].includes(name)) {
+        if (['coordination_read', 'coordination_history', 'coordination_publish', 'ask_human'].includes(name)) {
           if (!execOptions?.coordinationContext) {
             return { tool_call_id: callId, content: 'Coordination tools are unavailable outside a scoped autonomous run.', is_error: true };
           }

--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -14,7 +14,7 @@ import { isInfraError } from '../adapters/errorClassification.js';
 import type { VerifyEvidence } from '../verify/runner.js';
 import { renderVerifyEvidence } from './verificationEvidence.js';
 import type { InstructionCapsule } from './instructionCapsule.js';
-import type { CoordinationToolContext } from '../coordination/coordinationTools.js';
+import { COORDINATION_GUIDANCE_PROMPT, type CoordinationToolContext } from '../coordination/coordinationTools.js';
 
 // Types
 
@@ -93,6 +93,19 @@ export interface ReviewerOptions {
 function reviewerIdentityHeader(callSign: string | undefined): string {
   if (!callSign) return '';
   return `\n\n## Your identity\nYou are **${callSign}**. Sign your review with that call sign so the worker and the operator know who reviewed the change.\n`;
+}
+
+/**
+ * Coordination tools are withheld while readOnly is set (INT-3189) even
+ * though coordinationContext is still carried for identity/labeling — so
+ * this must check both, not just coordinationContext, or the reviewer would
+ * be told to use a tool it doesn't actually have. (AGT-4054)
+ */
+function reviewerCoordinationGuidance(
+  coordinationContext: CoordinationToolContext | undefined,
+  readOnly: boolean | undefined,
+): string {
+  return coordinationContext && !readOnly ? COORDINATION_GUIDANCE_PROMPT : '';
 }
 
 export interface PreCheckResult {
@@ -317,6 +330,7 @@ export async function runReviewer(options: ReviewerOptions): Promise<ReviewResul
       processContext: options.processContext,
       systemPrompt: getPrompts().systemPrompt
         + reviewerIdentityHeader(options.coordinationContext?.actorName)
+        + reviewerCoordinationGuidance(options.coordinationContext, options.readOnly)
         + (options.instructionCapsule?.text ?? ''),
       reasoningEffort: options.reasoningEffort,
       mcpTools: options.mcpTools,

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -19,7 +19,7 @@ import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { safeConsole as console } from '../support/safeLog.js';
 import type { InstructionCapsule } from './instructionCapsule.js';
-import type { CoordinationToolContext } from '../coordination/coordinationTools.js';
+import { COORDINATION_GUIDANCE_PROMPT, type CoordinationToolContext } from '../coordination/coordinationTools.js';
 import {
   isRouteReasonAllowed,
   planAdapterAttempts,
@@ -366,7 +366,11 @@ export async function runWorker(options: WorkerOptions): Promise<WorkerResult> {
     const callSignHeader = options.coordinationContext?.actorName
       ? `\n\n## Your identity\nYou are **${options.coordinationContext.actorName}**. Other agents address you by that call sign, and you address them by theirs.\n`
       : '';
-    let systemPrompt = getPrompts().systemPrompt + callSignHeader
+    // Gated on coordinationContext itself (not actorName): that's the same
+    // condition agenticLoop.ts uses to decide whether coordination tools are
+    // even exposed to this run (AGT-4054).
+    const coordinationGuidance = options.coordinationContext ? COORDINATION_GUIDANCE_PROMPT : '';
+    let systemPrompt = getPrompts().systemPrompt + callSignHeader + coordinationGuidance
       + (options.instructionCapsule?.text ?? loadWorkerRepoRules(cwd));
     if (editFormat === 'search-replace') systemPrompt += SEARCH_REPLACE_PROMPT;
     else if (editFormat === 'whole-file') systemPrompt += WHOLE_FILE_PROMPT;

--- a/src/coordination/coordinationTools.ts
+++ b/src/coordination/coordinationTools.ts
@@ -80,6 +80,26 @@ export const COORDINATION_TOOL_DEFINITIONS: ToolDefinition[] = [
   },
 ];
 
+/**
+ * Appended to a worker/reviewer's system prompt whenever it has a
+ * coordinationContext, alongside the periodic in-loop nudge
+ * (src/adapters/agenticLoop.ts's shouldNudgeCoordinationCheck). The nudge
+ * says *when* to check; this says *why it matters and what a good response
+ * looks like*, so it stays short — the nudge message itself carries the
+ * "do it now" instruction. (AGT-4054)
+ */
+export const COORDINATION_GUIDANCE_PROMPT = `
+
+## Coordination inbox
+
+An operator or another agent may message you mid-task through the
+coordination board, without you asking first. If you check your inbox
+(\`coordination_read\`) and find a message that is not a reply to something
+you initiated, acknowledge it with \`coordination_publish\` before you finish
+your work — do not just silently fold it into your next edit with no
+response.
+`;
+
 export async function executeCoordinationTool(
   name: string,
   args: Record<string, unknown>,


### PR DESCRIPTION
## Summary

- An operator's unsolicited message to a running worker (AX-858, CGF-Portal) landed correctly on the coordination board, but the worker never called `coordination_read` to see it — nothing actively prompts a running agent to check its pull-based inbox.
- Add a periodic in-loop nudge in `agenticLoop.ts`: every 6 turns without a real inbox check, inject a `coordination_read` reminder. Only a successful `coordination_read` resets the clock — `coordination_history` searches the permanent trace and consumes nothing live, so it must not count (caught by round-1 `openswarm review`, fixed + regression-tested).
- Pair the nudge with short static system-prompt guidance on worker/reviewer (`COORDINATION_GUIDANCE_PROMPT`) explaining what to do once a message is found: acknowledge via `coordination_publish` before finishing the stage, not silently fold it into the next edit.
- Fix `coordination_history`'s dispatcher, which fell through to `"Unknown tool"` for every call — independently discovered while researching this feature, worth shipping in the same change since a robust "catch up on messages" flow wants this tool working.

**Scope note (adapter type)**: this only benefits the 6 adapters that run through OpenSwarm's own turn loop (`codex-responses` — this deployment's default — `cc-router`, `gpt`, `openrouter`, `atlascloud`, `local`). The other 4 (`claude`, `codex`, `cursor`, +1) shell out to an external CLI's own opaque tool loop with zero turn-level visibility, and already drop coordination tools entirely (`base.ts:88-101`) — unrelated to and not fixed by this change.

**Scope note (execution path)**: this benefits any run that already has a `coordinationContext` wired in — confirmed for the autonomous daemon pipeline (`pairPipeline.ts`'s `coordinationContextFor`, called for both worker and reviewer). The interactive Discord `/pair` flow (`discordPair.ts`) calls `worker.runWorker`/`reviewer.runReviewer` directly and never constructs a `coordinationContext` at all, so this PR's nudge/guidance/tools are inert there today — verified via the fresh PR review, confirmed by reading `discordPair.ts` directly. Wiring that up isn't a small addition: `coordinationContextFor` needs a `TaskItem`-shaped `{id, issueId}` (`taskEventKey`), while a `PairSession` only carries a flat `taskId` string, and a Discord-only pair session doesn't always originate from a Linear issue — a real design question, not touched here. Tracked as a follow-up.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/adapters/agenticLoop.test.ts src/adapters/tools.test.ts src/agents/worker.test.ts src/agents/reviewer.test.ts` — 167/167 passed
- [x] Each new test individually verified to fail when its corresponding fix is reverted (nudge injection, reset detection, `coordination_history` exclusion, dispatcher fix)
- [x] `openswarm review` round 1: REVISE (`coordination_history` wrongly reset the check clock) → fixed + regression test added
- [x] `openswarm review` round 2: **APPROVE**
- [x] `openswarm pr review --fresh`: REVISE (Discord pair path has no coordination context) → verified true, out of this PR's scope, documented above, follow-up filed