### PR TITLE
fix(automation): reopen branchless orphaned NEEDS_RECONCILE rows instead of leaving them stuck forever (AGT-4056)

### DIFF
--- a/src/automation/durableRunCoordinator.test.ts
+++ b/src/automation/durableRunCoordinator.test.ts
@@ -200,9 +200,14 @@ describe('DurableRunCoordinator', () => {
     ownershipProbe.mockRestore();
     exitAck.mockRestore();
     warning.mockRestore();
-    expect(coordinator.reconcile(Date.now() + 4_000)).toHaveLength(1);
+    // 2, not 1: the expired-lease reconciliation itself, plus the same call's
+    // NEEDS_RECONCILE pass auto-reopening the row straight to READY once its
+    // owner/lease just cleared and nothing was ever published (AGT-4054
+    // follow-up — previously this sat in NEEDS_RECONCILE forever, unclaimable
+    // yet still counted against the project's admission cap).
+    expect(coordinator.reconcile(Date.now() + 4_000)).toHaveLength(2);
     expect(ledger.getRun('LEDGER-READ-FAIL')).toMatchObject({
-      state: 'NEEDS_RECONCILE',
+      state: 'READY',
       ownerInstanceId: undefined,
       leaseToken: undefined,
     });
@@ -243,9 +248,12 @@ describe('DurableRunCoordinator', () => {
     });
 
     vi.setSystemTime(5_000);
-    expect(coordinator.reconcile(5_000)).toHaveLength(1);
+    // 2, not 1 — see the identical note in the ledger-read-failure test above
+    // (AGT-4054 follow-up): auto-reopen fires in the same call that clears
+    // the loser's owner/lease, since nothing was ever published.
+    expect(coordinator.reconcile(5_000)).toHaveLength(2);
     expect(ledger.getRun('LOSE-LEASE')).toMatchObject({
-      state: 'NEEDS_RECONCILE',
+      state: 'READY',
       ownerInstanceId: undefined,
       leaseToken: undefined,
     });
@@ -839,6 +847,124 @@ describe('DurableRunCoordinator', () => {
       leaseToken: undefined,
     });
     expect(ledger.markReady('PID-REUSE', 4_001 + 5_001)).toBe(true);
+
+    coordinator.close();
+    ledger.close();
+  });
+
+  // AGT-4054 follow-up: AGT-4052 only cleared a NEEDS_RECONCILE row's stale
+  // owner/lease — it never advanced the row's STATE, so a row a prior sweep
+  // (or claimRun()'s own reconcileExpiredRows()) already orphaned is stuck
+  // forever: not claimable (CLAIMABLE_STATES excludes NEEDS_RECONCILE) yet
+  // still counted against claimRun()'s per-project admission cap. Confirmed
+  // live on vela: AX-1018/885/1044 sat 2+ hours post-restart with owner/lease
+  // already null, silently starving 5 other CGF-Portal claims every
+  // heartbeat with "Durable claim unavailable ... concurrent owner".
+  it('auto-reopens an orphaned NEEDS_RECONCILE row once nothing was published', () => {
+    const path = dbPath();
+    const ledger = new RunLedger(path);
+    ledger.registerRun({ issueId: 'ORPHAN-NO-PR', source: 'linear', projectPath: '/repo' }, 1_000);
+    const claim = ledger.claimRun('ORPHAN-NO-PR', {
+      ownerInstanceId: 'dead-generation', leaseMs: 3_000, now: 1_000,
+    })!;
+    expect(ledger.transition(claim, 'EXECUTING', {}, 1_100)).toBe(true);
+
+    const coordinator = new DurableRunCoordinator({
+      mode: 'primary', ledger, instanceId: 'live-generation',
+      processIsAlive: () => true, // pid reuse — probe alone can never disprove
+      reconcileAbandonMs: 5_000,
+    });
+
+    // Same 3-call cadence as the PID-REUSE test above: lease expires -> brand
+    // new NEEDS_RECONCILE (age 0, stays fenced) -> still under threshold
+    // (stays fenced) -> age threshold crossed (owner/lease cleared here).
+    coordinator.reconcile(4_001);
+    coordinator.reconcile(4_001 + 4_999);
+    coordinator.reconcile(4_001 + 5_000);
+    expect(ledger.getRun('ORPHAN-NO-PR')).toMatchObject({
+      state: 'NEEDS_RECONCILE', ownerInstanceId: undefined, leaseToken: undefined, prUrl: undefined,
+    });
+
+    // The very next reconcile() — no manual markReady() call — must reopen it.
+    const reopened = coordinator.reconcile(4_001 + 5_001);
+    expect(ledger.getRun('ORPHAN-NO-PR')).toMatchObject({ state: 'READY' });
+    expect(reopened.map((r) => r.issueId)).toContain('ORPHAN-NO-PR');
+
+    coordinator.close();
+    ledger.close();
+  });
+
+  it('leaves an orphaned NEEDS_RECONCILE row alone when a PR was actually published', () => {
+    const path = dbPath();
+    const ledger = new RunLedger(path);
+    ledger.registerRun({ issueId: 'ORPHAN-WITH-PR', source: 'linear', projectPath: '/repo' }, 1_000);
+    const claim = ledger.claimRun('ORPHAN-WITH-PR', {
+      ownerInstanceId: 'dead-generation', leaseMs: 3_000, now: 1_000,
+    })!;
+    expect(ledger.transition(claim, 'EXECUTING', {}, 1_100)).toBe(true);
+    expect(ledger.transition(claim, 'PUBLISHING', { prUrl: 'https://github.com/x/y/pull/1' }, 1_200)).toBe(true);
+
+    const coordinator = new DurableRunCoordinator({
+      mode: 'primary', ledger, instanceId: 'live-generation',
+      processIsAlive: () => true,
+      reconcileAbandonMs: 5_000,
+    });
+
+    coordinator.reconcile(4_001);
+    coordinator.reconcile(4_001 + 4_999);
+    coordinator.reconcile(4_001 + 5_000);
+    expect(ledger.getRun('ORPHAN-WITH-PR')).toMatchObject({
+      state: 'NEEDS_RECONCILE', ownerInstanceId: undefined, leaseToken: undefined,
+      prUrl: 'https://github.com/x/y/pull/1',
+    });
+
+    // A discovered PR means artifact state a human/reconciler still needs to
+    // look at (recoverPublishedRun/markNeedsHuman own that path) — must NOT
+    // be silently reopened as if nothing happened.
+    coordinator.reconcile(4_001 + 5_001);
+    expect(ledger.getRun('ORPHAN-WITH-PR')).toMatchObject({ state: 'NEEDS_RECONCILE' });
+
+    coordinator.close();
+    ledger.close();
+  });
+
+  // Caught by fresh PR review, not self-caught: prUrl == null only proves the
+  // LEDGER never recorded a PR — it does not prove nothing was pushed. A row
+  // can reach here having run `gh pr create` successfully but died before the
+  // ledger write that would have set prUrl. reconcileDurableArtifacts() (in
+  // autonomousRunner.ts) owns exactly this case: it checks GitHub for a real
+  // PR by branchName before ever falling back to worktree-evidence
+  // inspection. reconcile() has no filesystem/GitHub access, so it must defer
+  // to that path — not race ahead of it — for any row with a branchName.
+  // Confirmed live on vela: AX-1018/AX-885/AX-1044 all carry a branchName.
+  it('leaves a branchName-carrying orphaned NEEDS_RECONCILE row for reconcileDurableArtifacts, not a direct reopen', () => {
+    const path = dbPath();
+    const ledger = new RunLedger(path);
+    ledger.registerRun({ issueId: 'ORPHAN-WITH-BRANCH', source: 'linear', projectPath: '/repo' }, 1_000);
+    const claim = ledger.claimRun('ORPHAN-WITH-BRANCH', {
+      ownerInstanceId: 'dead-generation', leaseMs: 3_000, now: 1_000,
+    })!;
+    expect(ledger.transition(claim, 'EXECUTING', { branchName: 'swarm/ORPHAN-WITH-BRANCH' }, 1_100)).toBe(true);
+
+    const coordinator = new DurableRunCoordinator({
+      mode: 'primary', ledger, instanceId: 'live-generation',
+      processIsAlive: () => true,
+      reconcileAbandonMs: 5_000,
+    });
+
+    coordinator.reconcile(4_001);
+    coordinator.reconcile(4_001 + 4_999);
+    coordinator.reconcile(4_001 + 5_000);
+    expect(ledger.getRun('ORPHAN-WITH-BRANCH')).toMatchObject({
+      state: 'NEEDS_RECONCILE', ownerInstanceId: undefined, leaseToken: undefined,
+      branchName: 'swarm/ORPHAN-WITH-BRANCH', prUrl: undefined,
+    });
+
+    // Must stay parked here even though prUrl is null — only
+    // reconcileDurableArtifacts()'s GitHub lookup can prove nothing was
+    // published for this branch.
+    coordinator.reconcile(4_001 + 5_001);
+    expect(ledger.getRun('ORPHAN-WITH-BRANCH')).toMatchObject({ state: 'NEEDS_RECONCILE' });
 
     coordinator.close();
     ledger.close();

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -491,7 +491,29 @@ export class DurableRunCoordinator {
       }
     }
     for (const run of this.ledger.listRuns(['NEEDS_RECONCILE'])) {
-      if (!run.ownerInstanceId || !run.leaseToken) continue;
+      if (!run.ownerInstanceId || !run.leaseToken) {
+        // Owner/lease already cleared — by a prior sweep of this same loop, or
+        // by claimRun()'s own reconcileExpiredRows() path — but the row's
+        // STATE never advanced past NEEDS_RECONCILE, so it is stuck forever:
+        // not claimable (CLAIMABLE_STATES excludes NEEDS_RECONCILE) yet still
+        // counted against claimRun()'s per-project admission cap, silently
+        // squatting a slot no other issue in the repo can ever use (AGT-4056).
+        //
+        // Only safe to reopen here when NOTHING was ever pushed
+        // (branchName == null): reconcile() has no filesystem/GitHub access,
+        // so `prUrl == null` alone cannot prove nothing was published — the
+        // ledger write and the actual `gh pr create` are two separate steps,
+        // and a row can reach here having done the second without ever
+        // completing the first. A row with a branchName MUST go through
+        // autonomousRunner's reconcileDurableArtifacts() instead, which
+        // checks GitHub for a real PR by branch name before ever falling back
+        // to worktree-evidence inspection — reopening here would race ahead
+        // of that check and can duplicate published work.
+        if (run.branchName == null && run.prUrl == null && this.ledger.markReady(run.issueId, now)) {
+          reconciled.push(this.ledger.getRun(run.issueId)!);
+        }
+        continue;
+      }
       const pid = ownerProcessId(run.ownerInstanceId);
       // A container assigns the daemon the same pid every start, so a row
       // orphaned by a restart reads as "alive" forever — the new daemon's


### PR DESCRIPTION
## Summary

- AGT-4052/4053 cleared a NEEDS_RECONCILE row's stale owner/lease once a container-restart pid-reuse trap could no longer disprove it by age, but nothing ever advanced the row's **state** afterward. `NEEDS_RECONCILE` is not in `CLAIMABLE_STATES` (can never be reclaimed) yet `claimRun()`'s admission check counts it toward the per-project active-run cap — so a row that reaches this state permanently squats one admission slot, forever.
- Live evidence, found during 24h autonomous-loop monitoring: 3 CGF-Portal rows (AX-1018, AX-885, AX-1044) sat 2+ hours with owner/lease already null and `pr_url` null; cgf-portal's `maxConcurrentTasks=2` meant these 3 zombie rows alone permanently blocked every other claim in the project, catching 5 issues (AX-863, AX-872, AX-1027, AX-1028, AX-1030) in an infinite `claim_deferred` retry loop, `attempt_no` climbing into double digits.
- `reconcile()`'s NEEDS_RECONCILE loop now reopens an orphaned row straight to READY when it has **no `branchName` at all** (nothing was ever pushed, so there's nothing to look up).
- A row **with** a `branchName` is left alone: `prUrl == null` only proves the ledger never recorded a PR, not that one was never published — `reconcileDurableArtifacts()` already owns that case via a GitHub-by-branch lookup before falling back to worktree-evidence inspection, and reopening here would race ahead of it and risk duplicating published work. **This scope narrowing was caught by round-1 `openswarm review`, not self-caught** — my first draft used `prUrl == null` alone.

## Important: does not resolve AX-1018/885/1044 directly

All 3 production rows carry a `branchName`, so this fix's condition does not apply to them. Investigating further: they're each on `worktreeManager.ts`'s own, already-shipped (AGT-4053) `activeMarkerAbandonMs` 24h timer — a deliberate safety margin (the worktree marker has no per-heartbeat renewal to lean on, unlike a ledger lease), not a bug. Their markers were 4h47m-21h50m old at check time; they'll self-heal on that timeline. See AGT-4056 for the full correction and the related throughput-vs-safety tradeoff this surfaced (not changed here — flagged as an open question).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/automation/durableRunCoordinator.test.ts src/automation/runLedger.test.ts src/automation/autonomousRunner.durable.test.ts` — 98/98 passed
- [x] Each new/modified test individually verified to fail when its corresponding fix piece is reverted
- [x] `openswarm review` round 1: REVISE (`prUrl == null` alone isn't proof nothing was published for a branch-bearing row) → fixed + regression test added
- [x] `openswarm review` round 2: **APPROVE**