### PR TITLE
feat(cli): add `openswarm attach` to upload files to a task's coordination inbox (AGT-4058)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -722,6 +722,19 @@ program
     process.exitCode = await runProviderCommand(name);
   });
 
+// openswarm attach
+
+program
+  .command('attach')
+  .description("Upload file(s) to a task's coordination inbox and notify its agent")
+  .argument('<issueId>', 'Linear issue id or identifier (e.g. AGT-123)')
+  .argument('<files...>', 'Local file path(s) to upload')
+  .option('-m, --message <text>', 'Message to send with the file(s)')
+  .action(async (issueId: string, files: string[], opts: { message?: string }) => {
+    const { runAttachCommand } = await import('./cli/attachHandler.js');
+    process.exitCode = await runAttachCommand(issueId, files, opts);
+  });
+
 // openswarm dash
 
 program

--- a/src/cli/attachHandler.test.ts
+++ b/src/cli/attachHandler.test.ts
@@ -1,0 +1,305 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CoordinationEvent } from '../coordination/coordinationStore.js';
+import {
+  latestAddressable,
+  openQuestionFor,
+  resolveIssue,
+  runAttachCommand,
+} from './attachHandler.js';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+const readFileSyncMock = vi.hoisted(() => vi.fn());
+vi.mock('node:fs', () => ({ readFileSync: readFileSyncMock }));
+
+function event(overrides: Partial<CoordinationEvent> = {}): CoordinationEvent {
+  return {
+    id: 'e1', seq: 1, timestamp: 1_000, repository: '/repo', taskId: 'uuid-1234-5678-9012',
+    actor: 'worker-a', actorName: 'Worker A', actorRole: 'worker',
+    kind: 'advice-request', status: 'open', correlationId: 'c1', summary: 'question?',
+    fingerprint: 'fp1',
+    ...overrides,
+  };
+}
+
+// ---- Ported pure functions: same scenarios as tests/web/conversationModel.test.ts,
+// to prove the TypeScript port behaves identically to the dashboard original it's
+// mirrored from. ---------------------------------------------------------------
+
+describe('latestAddressable (ported from conversationModel.mjs)', () => {
+  it('returns the newest agent speaker, skipping the operator', () => {
+    const target = latestAddressable([
+      event({ id: 'a', seq: 1 }),
+      event({ id: 'op', seq: 2, actor: 'operator-dashboard', actorName: 'Operator', actorRole: 'human' }),
+    ]);
+    expect(target?.id).toBe('a');
+  });
+
+  it('never addresses the daemon through its instruction snapshot', () => {
+    const target = latestAddressable([
+      event({ id: 'a', seq: 1 }),
+      event({ id: 'snap', seq: 2, actor: 'daemon', actorRole: 'daemon', kind: 'instruction-snapshot' }),
+    ]);
+    expect(target?.id).toBe('a');
+  });
+
+  it('returns null when nobody can be addressed', () => {
+    expect(latestAddressable([
+      event({ actor: 'operator-dashboard', actorRole: 'human' }),
+    ])).toBeNull();
+  });
+
+  // Caught by openswarm review, not self-caught: unlike the dashboard's own
+  // latestAddressable (only excludes 'human'), this CLI has no human in the
+  // loop to notice a bad pick, so a daemon-authored bookkeeping event must
+  // not look addressable just because its actorRole isn't 'human'.
+  it("skips a trailing adapter-route event — the daemon's provider-fallback bookkeeping, not an agent", () => {
+    const target = latestAddressable([
+      event({ id: 'worker-spoke', seq: 1, actor: 'sable', actorRole: 'worker' }),
+      event({
+        id: 'route', seq: 2, kind: 'adapter-route', actor: 'adapter-router', actorRole: 'daemon',
+        recipient: 'sable',
+      }),
+    ]);
+    expect(target?.id).toBe('worker-spoke');
+  });
+
+  it("skips a trailing mcp-audit event — the daemon's tool-policy bookkeeping, not an agent", () => {
+    const target = latestAddressable([
+      event({ id: 'worker-spoke', seq: 1, actor: 'sable', actorRole: 'worker' }),
+      event({
+        id: 'audit', seq: 2, kind: 'mcp-audit', actor: 'openswarm-daemon', actorRole: 'daemon',
+      }),
+    ]);
+    expect(target?.id).toBe('worker-spoke');
+  });
+
+  it('still addresses a trailing review-run event — a real review agent, not daemon bookkeeping', () => {
+    const target = latestAddressable([
+      event({ id: 'worker-spoke', seq: 1, actor: 'sable', actorRole: 'worker' }),
+      event({
+        id: 'review', seq: 2, kind: 'review-run', actor: 'reviewer-eb2a', actorRole: 'review-agent',
+      }),
+    ]);
+    expect(target?.id).toBe('review');
+  });
+});
+
+describe('openQuestionFor (ported from conversationModel.mjs, AGT-4030)', () => {
+  const question = (over: Partial<CoordinationEvent> = {}) => event({
+    kind: 'human-question', status: 'waiting', correlationId: 'hq-1',
+    actor: 'sable', actorRole: 'worker', recipient: 'human', seq: 5, ...over,
+  });
+
+  it('finds the question an agent is still parked on', () => {
+    expect(openQuestionFor([event({ seq: 1 }), question()], 'sable', { taskId: 'uuid-1234-5678-9012' })?.correlationId).toBe('hq-1');
+  });
+
+  it('ignores a question that has since been answered', () => {
+    const answered = event({
+      kind: 'human-answer', status: 'completed', correlationId: 'hq-1',
+      actor: 'operator-dashboard', actorRole: 'human', recipient: 'sable', seq: 6,
+    });
+    expect(openQuestionFor([question(), answered], 'sable', { taskId: 'uuid-1234-5678-9012' })).toBeNull();
+  });
+
+  it('is null for a different agent, and for none', () => {
+    const scope = { taskId: 'uuid-1234-5678-9012' };
+    expect(openQuestionFor([question()], 'worker-3f2a', scope)).toBeNull();
+    expect(openQuestionFor([question()], undefined, scope)).toBeNull();
+    expect(openQuestionFor([event({ seq: 1 })], 'sable', scope)).toBeNull();
+  });
+
+  it('will not cross tasks, and refuses when given no scope at all', () => {
+    const theirs = question({ taskId: 'another-task', correlationId: 'hq-other' });
+    expect(openQuestionFor([theirs], 'sable', { taskId: 'uuid-1234-5678-9012' })).toBeNull();
+    expect(openQuestionFor([theirs], 'sable', {})).toBeNull();
+  });
+});
+
+// ---- resolveIssue ------------------------------------------------------------
+
+describe('resolveIssue', () => {
+  it('resolves an identifier to its issue id via the injected getIssue', async () => {
+    const ensureTaskSource = vi.fn().mockResolvedValue(undefined);
+    const getIssue = vi.fn().mockResolvedValue({ id: 'uuid-abc', identifier: 'AGT-123' });
+    const result = await resolveIssue('AGT-123', { ensureTaskSource, getIssue });
+    expect(ensureTaskSource).toHaveBeenCalled();
+    expect(getIssue).toHaveBeenCalledWith('AGT-123');
+    expect(result).toEqual({ id: 'uuid-abc', identifier: 'AGT-123' });
+  });
+
+  it('returns null when the issue cannot be found', async () => {
+    const result = await resolveIssue('AGT-999', {
+      ensureTaskSource: vi.fn().mockResolvedValue(undefined),
+      getIssue: vi.fn().mockResolvedValue(null),
+    });
+    expect(result).toBeNull();
+  });
+});
+
+// ---- runAttachCommand (full HTTP flow) ---------------------------------------
+
+function statsOk() {
+  return { ok: true, json: async () => ({}) };
+}
+
+function historyOk(events: CoordinationEvent[]) {
+  return { ok: true, json: async () => ({ events }) };
+}
+
+function attachmentOk(filename: string, path: string, bytes = 42) {
+  return { ok: true, json: async () => ({ id: 'att-1', filename, path, bytes }) };
+}
+
+function messageOk() {
+  return { ok: true, json: async () => ({ delivered: true, mode: 'note', event: event() }) };
+}
+
+const deps = {
+  ensureTaskSource: vi.fn().mockResolvedValue(undefined),
+  getIssue: vi.fn().mockResolvedValue({ id: 'uuid-1234-5678-9012', identifier: 'AGT-123' }),
+};
+
+describe('runAttachCommand', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    readFileSyncMock.mockReset();
+    readFileSyncMock.mockReturnValue(Buffer.from('file contents'));
+    deps.ensureTaskSource.mockClear();
+    deps.getIssue.mockClear();
+  });
+
+  it('uploads a single file and notifies the addressable agent', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    fetchMock
+      .mockResolvedValueOnce(statsOk())
+      .mockResolvedValueOnce(historyOk([event({ actor: 'sable', actorRole: 'worker', actorName: 'Sable' })]))
+      .mockResolvedValueOnce(attachmentOk('report.pdf', '/state/attachments/uuid-1234-5678-9012/report.pdf'))
+      .mockResolvedValueOnce(messageOk());
+
+    const code = await runAttachCommand('AGT-123', ['/local/report.pdf'], { message: 'here is the data', deps });
+
+    expect(code).toBe(0);
+    const [, historyInit] = fetchMock.mock.calls[1];
+    const [attachUrl, attachInit] = fetchMock.mock.calls[2];
+    expect(attachUrl).toContain('/api/coordination/attachment?taskId=uuid-1234-5678-9012&filename=report.pdf');
+    expect(attachInit.method).toBe('POST');
+    const [messageUrl, messageInit] = fetchMock.mock.calls[3];
+    expect(messageUrl).toContain('/api/coordination/message');
+    const sentBody = JSON.parse(messageInit.body as string);
+    expect(sentBody.recipient).toBe('sable');
+    expect(sentBody.text).toContain('here is the data');
+    expect(sentBody.text).toContain('/state/attachments/uuid-1234-5678-9012/report.pdf');
+    // A daemon that answers the health probe can still stall on a later
+    // request — every operational call after it needs its own bound, or an
+    // interactive CLI has no way out of a stalled daemon (caught by
+    // openswarm review, not self-caught).
+    expect(historyInit.signal).toBeInstanceOf(AbortSignal);
+    expect(attachInit.signal).toBeInstanceOf(AbortSignal);
+    expect(messageInit.signal).toBeInstanceOf(AbortSignal);
+    consoleLog.mockRestore();
+  });
+
+  it('uploads multiple files and folds every path into one message', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    fetchMock
+      .mockResolvedValueOnce(statsOk())
+      .mockResolvedValueOnce(historyOk([event({ actor: 'sable', actorRole: 'worker' })]))
+      .mockResolvedValueOnce(attachmentOk('a.txt', '/state/a.txt'))
+      .mockResolvedValueOnce(attachmentOk('b.txt', '/state/b.txt'))
+      .mockResolvedValueOnce(messageOk());
+
+    const code = await runAttachCommand('AGT-123', ['/local/a.txt', '/local/b.txt'], { deps });
+
+    expect(code).toBe(0);
+    const [, messageInit] = fetchMock.mock.calls[4];
+    const sentBody = JSON.parse(messageInit.body as string);
+    expect(sentBody.text).toContain('/state/a.txt');
+    expect(sentBody.text).toContain('/state/b.txt');
+  });
+
+  it('prefers answering an open blocking question over the agent\'s later, unrelated remark', async () => {
+    // The agent asks a question (seq 5, correlationId hq-1) and, while still
+    // parked waiting for an answer, says something else on a different
+    // exchange (seq 6, correlationId c-later) — latestAddressable() picks
+    // that later remark as `target`, but the reply must still ride the
+    // still-open question's correlationId, not the later one (AGT-4030's
+    // exact bug: addressing the newest exchange instead leaves the agent
+    // parked forever).
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const question = event({
+      id: 'q', kind: 'human-question', status: 'waiting', correlationId: 'hq-1',
+      actor: 'sable', actorRole: 'worker', recipient: 'human', seq: 5,
+      taskId: 'uuid-1234-5678-9012', repository: '/work/cgf-portal',
+    });
+    const laterRemark = event({
+      id: 'later', kind: 'advice-request', status: 'open', correlationId: 'c-later',
+      actor: 'sable', actorRole: 'worker', seq: 6,
+      taskId: 'uuid-1234-5678-9012', repository: '/work/cgf-portal',
+    });
+    fetchMock
+      .mockResolvedValueOnce(statsOk())
+      .mockResolvedValueOnce(historyOk([question, laterRemark]))
+      .mockResolvedValueOnce(attachmentOk('a.txt', '/state/a.txt'))
+      .mockResolvedValueOnce(messageOk());
+
+    await runAttachCommand('AGT-123', ['/local/a.txt'], { deps });
+
+    const [, messageInit] = fetchMock.mock.calls[3];
+    const sentBody = JSON.parse(messageInit.body as string);
+    expect(sentBody.correlationId).toBe('hq-1');
+  });
+
+  it('fails cleanly when no agent is addressable yet, without uploading anything', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchMock
+      .mockResolvedValueOnce(statsOk())
+      .mockResolvedValueOnce(historyOk([]));
+
+    const code = await runAttachCommand('AGT-123', ['/local/a.txt'], { deps });
+
+    expect(code).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // stats + history only — no upload attempt
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('No agent is addressable yet'));
+    consoleError.mockRestore();
+  });
+
+  it('fails cleanly when the daemon is unreachable, without hanging', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    const code = await runAttachCommand('AGT-123', ['/local/a.txt'], { deps });
+
+    expect(code).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('not reachable'));
+    consoleError.mockRestore();
+  });
+
+  it('surfaces the server error verbatim when an upload is rejected (413)', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchMock
+      .mockResolvedValueOnce(statsOk())
+      .mockResolvedValueOnce(historyOk([event({ actor: 'sable', actorRole: 'worker' })]))
+      .mockResolvedValueOnce({ ok: false, status: 413, text: async () => JSON.stringify({ error: 'Attachment exceeds 67108864 bytes' }) });
+
+    const code = await runAttachCommand('AGT-123', ['/local/huge.bin'], { deps });
+
+    expect(code).toBe(1);
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('Attachment exceeds 67108864 bytes'));
+    consoleError.mockRestore();
+  });
+
+  it('returns 1 when the issue identifier cannot be resolved', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchMock.mockResolvedValueOnce(statsOk());
+    const code = await runAttachCommand('AGT-999', ['/local/a.txt'], {
+      deps: { ensureTaskSource: vi.fn().mockResolvedValue(undefined), getIssue: vi.fn().mockResolvedValue(null) },
+    });
+    expect(code).toBe(1);
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('Issue not found'));
+    consoleError.mockRestore();
+  });
+});

--- a/src/cli/attachHandler.ts
+++ b/src/cli/attachHandler.ts
@@ -1,0 +1,281 @@
+// ============================================
+// OpenSwarm - `openswarm attach <issueId> <files...>`
+// ============================================
+//
+// Upload file(s) to a running task's coordination inbox and notify its
+// agent — the CLI's counterpart to the dashboard's /chat attach button
+// (AGT-4031, web/static/js/chatView.mjs). Neither
+// POST /api/coordination/attachment nor POST /api/coordination/message had
+// a CLI consumer before this (AGT-4058).
+
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+import type { CoordinationEvent } from '../coordination/coordinationStore.js';
+import { DAEMON_PORT } from './daemon.js';
+
+function baseUrl(port: number): string {
+  return `http://127.0.0.1:${port}`;
+}
+
+export interface ResolvedIssue {
+  id: string;
+  identifier: string;
+}
+
+export interface ResolveIssueDeps {
+  ensureTaskSource?: () => Promise<unknown>;
+  getIssue?: (id: string) => Promise<{ id: string; identifier: string } | null>;
+}
+
+/**
+ * `AGT-123` or a raw issue UUID -> `{ id (UUID), identifier }`. `taskId` on a
+ * coordination event is the Linear issue UUID, not the human-readable
+ * identifier (src/orchestration/decisionEngine.ts's `taskEventKey`), so this
+ * mirrors `openswarm work`'s own resolution (workCommand.ts) rather than
+ * inventing a second convention.
+ */
+export async function resolveIssue(identifier: string, deps: ResolveIssueDeps = {}): Promise<ResolvedIssue | null> {
+  const ensureTaskSource = deps.ensureTaskSource
+    ?? (async () => (await import('./reviewCommand.js')).ensureTaskSource());
+  const getIssue = deps.getIssue
+    ?? (async (id: string) => (await import('../linear/linear.js')).getIssue(id));
+  await ensureTaskSource();
+  const issue = await getIssue(identifier);
+  return issue ? { id: issue.id, identifier: issue.identifier } : null;
+}
+
+// ---- Ported from web/static/js/conversationModel.mjs -----------------------
+// Small, pure, dependency-free — ported natively rather than imported across
+// the src/ -> dist/ / web/static/ -> dist/web-static/ build boundary, which
+// resolves differently in dev (tsx, unbuilt) vs. prod (compiled dist/, where
+// web/static/js/ is not mirrored at dist/cli/'s relative path). Keep in sync
+// with conversationModel.mjs's `isUtterance`/`openQuestionFor`/
+// `latestAddressable` by hand if the dashboard's semantics change.
+
+const NON_CONVERSATION_KINDS = new Set<CoordinationEvent['kind']>(['instruction-snapshot']);
+
+function isUtterance(event: CoordinationEvent): boolean {
+  return !NON_CONVERSATION_KINDS.has(event.kind);
+}
+
+/**
+ * Last agent (non-human actor) to speak about this task, or null if none has
+ * yet. Also excludes `actorRole: 'daemon'`: unlike the dashboard's own
+ * `latestAddressable` (which only excludes `'human'`), this CLI picks a
+ * recipient with no human in the loop to notice a bad pick, so it must not
+ * be looser than the dashboard about it. `adapter-route`
+ * (`src/agents/worker.ts`'s `recordRoute`, actor `adapter-router`) and
+ * `mcp-audit` (`daemonActor` in `runCoordination.ts`/`orchestratorAgent.ts`,
+ * actor `openswarm-daemon`) are both stamped `actorRole: 'daemon'` — neither
+ * identity ever runs an agentic loop or calls `coordination_read`, so
+ * addressing either would silently strand the message forever. `review-run`
+ * events keep `actorRole: 'review-agent'` (a real agent's own call sign,
+ * `periodicReview.ts`) and are unaffected. Caught by `openswarm review`, not
+ * self-caught.
+ */
+export function latestAddressable(events: readonly CoordinationEvent[]): CoordinationEvent | null {
+  const spoken = [...events].filter(isUtterance).sort((a, b) => a.seq - b.seq);
+  for (let i = spoken.length - 1; i >= 0; i -= 1) {
+    if (spoken[i].actorRole !== 'human' && spoken[i].actorRole !== 'daemon') return spoken[i];
+  }
+  return null;
+}
+
+/**
+ * An unanswered blocking question `actorAddress` is parked on, scoped to the
+ * same task/repository — answering it beats filing a new note, or the agent
+ * stays blocked (AGT-4030). Returns null without a task/repository scope:
+ * an address is not unique (agents name themselves), so a scopeless lookup
+ * could offer to answer someone else's question on a different task.
+ */
+export function openQuestionFor(
+  events: readonly CoordinationEvent[],
+  actorAddress: string | undefined,
+  scope: { taskId?: string; repository?: string } = {},
+): CoordinationEvent | null {
+  if (!actorAddress) return null;
+  if (!scope.taskId && !scope.repository) return null;
+  const open = events
+    .filter((event) => event.kind === 'human-question'
+      && event.status === 'waiting'
+      && event.actor === actorAddress
+      && (!scope.repository || event.repository === scope.repository)
+      && (!scope.taskId || event.taskId === scope.taskId))
+    .filter((question) => !events.some((event) => event.correlationId === question.correlationId
+      && event.seq > question.seq
+      && ['completed', 'expired', 'failed'].includes(event.status)))
+    .sort((a, b) => a.seq - b.seq);
+  return open[open.length - 1] ?? null;
+}
+
+// ---- HTTP surface -----------------------------------------------------------
+
+/** Every daemon request after the initial health probe needs its own bound
+ * too — a daemon that answers /api/stats can still stall on a later request
+ * (lock contention, a slow write), and an interactive CLI has no other way
+ * out of that than a timeout. Caught by openswarm review, not self-caught. */
+const REQUEST_TIMEOUT_MS = 10_000;
+/** Uploads can be up to MAX_ATTACHMENT_BYTES (64MiB, attachmentStore.ts) —
+ * needs more room than a small JSON call. */
+const UPLOAD_TIMEOUT_MS = 60_000;
+
+async function fetchTaskHistory(taskId: string, port: number): Promise<CoordinationEvent[]> {
+  const res = await fetch(
+    `${baseUrl(port)}/api/coordination/history?taskId=${encodeURIComponent(taskId)}&limit=200`,
+    { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) },
+  );
+  if (!res.ok) throw new Error(`Could not read the coordination board (HTTP ${res.status})`);
+  const body = await res.json() as { events?: CoordinationEvent[] };
+  return body.events ?? [];
+}
+
+export interface UploadedAttachment {
+  filepath: string;
+  filename: string;
+  path: string;
+  bytes: number;
+}
+
+/** Throws with the server's own error text on 400/413/507, matching
+ * providerCommand.ts's res.ok -> else res.text() pattern. */
+async function uploadAttachment(taskId: string, filepath: string, port: number): Promise<UploadedAttachment> {
+  const filename = basename(filepath);
+  const bytes = readFileSync(filepath);
+  const query = `?taskId=${encodeURIComponent(taskId)}&filename=${encodeURIComponent(filename)}`;
+  const res = await fetch(`${baseUrl(port)}/api/coordination/attachment${query}`, {
+    method: 'POST',
+    body: bytes,
+    signal: AbortSignal.timeout(UPLOAD_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    let message = `upload failed (HTTP ${res.status})`;
+    try {
+      const parsed = JSON.parse(detail) as { error?: string };
+      if (parsed.error) message = parsed.error;
+    } catch {
+      if (detail) message = detail.slice(0, 200);
+    }
+    throw new Error(message);
+  }
+  const stored = await res.json() as { filename: string; path: string; bytes: number };
+  return { filepath, filename: stored.filename, path: stored.path, bytes: stored.bytes };
+}
+
+async function postMessage(
+  exchange: { correlationId: string; repository: string; taskId: string },
+  recipient: string,
+  text: string,
+  port: number,
+): Promise<void> {
+  const res = await fetch(`${baseUrl(port)}/api/coordination/message`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    body: JSON.stringify({
+      correlationId: exchange.correlationId,
+      recipient,
+      repository: exchange.repository,
+      taskId: exchange.taskId,
+      text,
+    }),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    let message = `message not delivered (HTTP ${res.status})`;
+    try {
+      const parsed = JSON.parse(detail) as { error?: string };
+      if (parsed.error) message = parsed.error;
+    } catch {
+      if (detail) message = detail.slice(0, 200);
+    }
+    throw new Error(message);
+  }
+}
+
+async function isDaemonReachable(port: number): Promise<boolean> {
+  try {
+    const res = await fetch(`${baseUrl(port)}/api/stats`, { signal: AbortSignal.timeout(1500) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export interface RunAttachOptions {
+  message?: string;
+  port?: number;
+  deps?: ResolveIssueDeps;
+}
+
+/** CLI entry point. Returns a process exit code, matching runProviderCommand's shape. */
+export async function runAttachCommand(
+  issueIdentifier: string,
+  filepaths: string[],
+  opts: RunAttachOptions = {},
+): Promise<number> {
+  const port = opts.port ?? DAEMON_PORT;
+
+  if (filepaths.length === 0) {
+    console.error('Pass at least one file to attach.');
+    return 1;
+  }
+
+  if (!(await isDaemonReachable(port))) {
+    console.error('OpenSwarm daemon is not reachable — start it first (`openswarm start`).');
+    return 1;
+  }
+
+  const issue = await resolveIssue(issueIdentifier, opts.deps);
+  if (!issue) {
+    console.error(`Issue not found: ${issueIdentifier}`);
+    return 1;
+  }
+
+  let events: CoordinationEvent[];
+  try {
+    events = await fetchTaskHistory(issue.id, port);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+
+  const target = latestAddressable(events);
+  if (!target) {
+    console.error(`No agent is addressable yet for ${issue.identifier} — it hasn't spoken on the coordination board.`);
+    return 1;
+  }
+  const question = openQuestionFor(events, target.actor, { repository: target.repository, taskId: target.taskId });
+  const exchange = question ?? target;
+
+  const uploaded: UploadedAttachment[] = [];
+  let hadFailure = false;
+  for (const filepath of filepaths) {
+    try {
+      const result = await uploadAttachment(issue.id, filepath, port);
+      uploaded.push(result);
+      console.log(`Uploaded ${filepath} -> ${result.path} (${result.bytes} bytes)`);
+    } catch (error) {
+      hadFailure = true;
+      console.error(`Failed to upload ${filepath}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  if (uploaded.length === 0) {
+    console.error('No files uploaded — nothing to notify the agent about.');
+    return 1;
+  }
+
+  const text = opts.message?.trim()
+    ? `${opts.message.trim()}\n\nAttached files (read them at these paths):\n${uploaded.map((u) => u.path).join('\n')}`
+    : `Attached files (read them at these paths):\n${uploaded.map((u) => u.path).join('\n')}`;
+
+  try {
+    await postMessage(exchange, target.actor, text, port);
+  } catch (error) {
+    console.error(`Files uploaded but the message was not delivered: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+
+  console.log(`Notified ${target.actorName ?? target.actor} on ${issue.identifier}.`);
+  return hadFailure ? 1 : 0;
+}

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -215,7 +215,7 @@ const ALLOWED_EVENTS = new Set(['invoke', 'complete', 'error', 'start', 'stop', 
  * failing test rather than a blind spot discovered months later.
  */
 const ALLOWED_COMMANDS = new Set([
-  'add', 'annotate', 'auth', 'chat', 'check', 'dash', 'design-pipeline', 'doctor',
+  'add', 'annotate', 'attach', 'auth', 'chat', 'check', 'dash', 'design-pipeline', 'doctor',
   'exec', 'fix', 'init', 'login', 'logout', 'mcp', 'memory', 'models', 'openswarm',
   'pr', 'projects', 'provider', 'remove', 'resume', 'review', 'run', 'schedule', 'start',
   'status', 'stop', 'upgrade', 'validate', 'version', 'work',


### PR DESCRIPTION
## Summary

Neither `POST /api/coordination/attachment` (AGT-4031) nor `POST /api/coordination/message` had a CLI consumer — only the dashboard's `/chat` page could hand a running agent a file. This adds `openswarm attach <issueId> <files...> [-m/--message]`, following the dashboard's own flow: upload the file(s), fold their returned paths into a coordination message, address it to whichever agent last spoke on the task (preferring an open blocking question over a plain note, matching AGT-4030's precedence).

- `taskId` on a coordination event is the Linear issue **UUID**, not the `AGT-123`-style identifier, so the command resolves that the same way `openswarm work` does (`ensureTaskSource` + `getIssue`).
- `latestAddressable`/`openQuestionFor` are ported natively from `web/static/js/conversationModel.mjs` (small, pure functions) rather than imported across the `src/`→`dist/` / `web/static/`→`dist/web-static/` build boundary, which resolves differently in dev vs. prod.

## Two defects caught by review, not self-caught

1. **`latestAddressable` could address a daemon.** It had to additionally exclude `actorRole: 'daemon'` beyond what the dashboard's own version excludes (just `'human'`) — `adapter-route` (`worker.ts`'s `recordRoute`, actor `adapter-router`) and `mcp-audit` (`daemonActor` in `runCoordination.ts`) are both daemon-authored bookkeeping; neither identity ever runs an agentic loop or calls `coordination_read`, so addressing one would silently strand the message forever. The CLI has no human in the loop to notice a bad recipient pick the way a dashboard operator would. Filed **AGT-4059** to bring the dashboard's own copy in line (lower priority there, since a human is watching).
2. **Every daemon request after the health probe was unbounded** and could hang the CLI indefinitely against a responsive-but-stalled daemon. Added `AbortSignal.timeout` to all of them (10s for JSON calls, 60s for uploads — a file can be up to `MAX_ATTACHMENT_BYTES`, 64 MiB).

Both fixed with regression tests.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/cli/attachHandler.test.ts src/cli/providerCommand.test.ts src/cli/workCommand.test.ts` — 82/82 passed
- [x] Each new test individually verified to fail when its corresponding fix is reverted (question-preference, no-addressable-agent guard, daemon-unreachable guard, daemon-actor exclusion, request timeouts)
- [x] Ported `latestAddressable`/`openQuestionFor` covered by the same scenarios as `tests/web/conversationModel.test.ts`, proving the TS port matches the dashboard original
- [x] `openswarm review` round 1: REVISE (daemon-actor recipient) → fixed
- [x] `openswarm review` round 2: REVISE (unbounded requests) → fixed
- [x] `openswarm review` round 3: **APPROVE**