### PR TITLE
fix(coordination): stop publishing "(no summary)" and bare codenames as an agent's report (AGT-4060)

### DIFF
--- a/src/agents/pairPipeline.board.test.ts
+++ b/src/agents/pairPipeline.board.test.ts
@@ -86,6 +86,46 @@ describe('stage lifecycle on the coordination board', () => {
     expect(event).toMatchObject({ actorName: 'Sable', recipientRole: 'worker', status: 'failed', correlationId: exchangeId });
   });
 
+  // AGT-4060: the board showed `(no summary)` and bare `Codename: X` lines
+  // where the agent's report should be. Both reached it as truthy strings, so
+  // the `said || timing-fallback` never fired. Reported by the user watching
+  // the live board, not caught by a test.
+  describe('a summary that carries no report falls through to the timing fallback (AGT-4060)', () => {
+    async function outcomeSummary(summary: string | undefined, success = true): Promise<unknown> {
+      const ctx = context({ task: { id: `t-${summary ?? 'none'}`, issueId: `i-${summary ?? 'none'}`, issueIdentifier: 'AGT-60', title: 'T' } });
+      publishStageOutcomeToBoard(ctx as never, 'worker', {
+        success, durationMs: 3_300, result: { summary },
+      }, stageCorrelationId(ctx as never, 'worker'));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      return (published.events.at(-1) as Record<string, unknown>).summary;
+    }
+
+    it("does not publish the adapter's literal `(no summary)` placeholder", async () => {
+      expect(await outcomeSummary('(no summary)')).toBe('Finished in 3.3s');
+    });
+
+    it('does not publish a summary that is only the agent\'s Codename introduction', async () => {
+      // worker.ts strips this line but restores the original when stripping
+      // empties it, so a codename-only summary arrives here intact and would
+      // otherwise read as the agent reporting its own name as its work.
+      expect(await outcomeSummary('Codename: Atlas')).toBe('Finished in 3.3s');
+    });
+
+    it('uses the failure wording when a reportless stage failed', async () => {
+      expect(await outcomeSummary('(no summary)', false)).toBe('Did not pass in 3.3s');
+    });
+
+    it('still publishes a real summary untouched', async () => {
+      expect(await outcomeSummary('Added the JOIN guard and a regression test.'))
+        .toBe('Added the JOIN guard and a regression test.');
+    });
+
+    it('keeps the report when a codename line merely precedes it', async () => {
+      expect(await outcomeSummary('Codename: Atlas\nAdded the JOIN guard.')).toBe('Added the JOIN guard.');
+    });
+  });
+
   beforeEach(() => { published.events = []; });
 
   it('records a worker start as a delegation addressed from a named agent', async () => {

--- a/src/agents/pairPipeline.board.test.ts
+++ b/src/agents/pairPipeline.board.test.ts
@@ -124,6 +124,23 @@ describe('stage lifecycle on the coordination board', () => {
     it('keeps the report when a codename line merely precedes it', async () => {
       expect(await outcomeSummary('Codename: Atlas\nAdded the JOIN guard.')).toBe('Added the JOIN guard.');
     });
+
+    // Caught by the fresh PR review, not self-caught: the adapters emit the
+    // ACTIVE locale's placeholder (`t('common.fallback.noSummary')`), so an
+    // English-only comparison still published `(요약 없음)` verbatim on a
+    // Korean deployment — which is this repo's own default locale.
+    it("recognizes the placeholder in whatever locale the adapters emitted it", async () => {
+      const { initLocale, t } = await import('../locale/index.js');
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+      initLocale('ko');
+      try {
+        expect(t('common.fallback.noSummary')).toBe('(요약 없음)');
+        expect(await outcomeSummary('(요약 없음)')).toBe('Finished in 3.3s');
+      } finally {
+        initLocale('en');
+        log.mockRestore();
+      }
+    });
   });
 
   beforeEach(() => { published.events = []; });

--- a/src/agents/pipelineCoordination.ts
+++ b/src/agents/pipelineCoordination.ts
@@ -8,6 +8,7 @@
 import type { PipelineContext } from './pairPipelineTypes.js';
 import { assignCallSign, callSignAddress, sanitizeAgentDisplayName, type AgentRole } from '../coordination/agentNames.js';
 import { taskEventKey } from '../orchestration/decisionEngine.js';
+import { t } from '../locale/index.js';
 
 /**
  * Roles that appear on the coordination board as deployed agents.
@@ -152,11 +153,16 @@ const exchangeQueues = new Map<string, Promise<void>>();
  * A summary that carries no actual report, normalized to undefined so the
  * caller's timing fallback fires. Two things reach here that are not words:
  *
- * - The literal `(no summary)` an adapter substitutes for a missing summary
- *   (`src/adapters/claude.ts`, `agents/documenter.ts`, `agents/auditor.ts`,
- *   `agents/skillDocumenter.ts`). It is truthy, so `said || fallback` took it
- *   and the board showed the placeholder where a duration would at least have
- *   been true.
+ * - The placeholder an adapter substitutes for a missing summary
+ *   (`src/adapters/resultParsing.ts`, `codex.ts`, `claude.ts`,
+ *   `agents/documenter.ts`, `agents/auditor.ts`, `agents/skillDocumenter.ts`).
+ *   It is truthy, so `said || fallback` took it and the board showed the
+ *   placeholder where a duration would at least have been true. Compared
+ *   through `t()` rather than a hardcoded string: the adapters emit the ACTIVE
+ *   locale's value, so an English-only check would still publish `(요약 없음)`
+ *   on a Korean deployment — this repo's own default. `worker.ts` already
+ *   compares against `t('common.fallback.noSummary')` for the same reason.
+ *   (Caught by the fresh PR review, not self-caught.)
  * - A summary that is only the agent's `Codename:` self-introduction
  *   (AGT-4019). `worker.ts` strips that line, but restores the original when
  *   stripping empties the string, so a codename-only summary arrived intact
@@ -166,7 +172,7 @@ const exchangeQueues = new Map<string, Promise<void>>();
  */
 function boardWords(summary: string | undefined): string | undefined {
   const stripped = summary?.replace(/^\s*Codename:.*$/gim, '').trim();
-  if (!stripped || stripped === '(no summary)') return undefined;
+  if (!stripped || stripped === t('common.fallback.noSummary')) return undefined;
   return stripped;
 }
 

--- a/src/agents/pipelineCoordination.ts
+++ b/src/agents/pipelineCoordination.ts
@@ -149,6 +149,28 @@ const exchangeQueues = new Map<string, Promise<void>>();
  * record must never fail the stage it describes.
  */
 /**
+ * A summary that carries no actual report, normalized to undefined so the
+ * caller's timing fallback fires. Two things reach here that are not words:
+ *
+ * - The literal `(no summary)` an adapter substitutes for a missing summary
+ *   (`src/adapters/claude.ts`, `agents/documenter.ts`, `agents/auditor.ts`,
+ *   `agents/skillDocumenter.ts`). It is truthy, so `said || fallback` took it
+ *   and the board showed the placeholder where a duration would at least have
+ *   been true.
+ * - A summary that is only the agent's `Codename:` self-introduction
+ *   (AGT-4019). `worker.ts` strips that line, but restores the original when
+ *   stripping empties the string, so a codename-only summary arrived intact
+ *   and read as if the agent had reported its own name as its work.
+ *   `src/linear/format.ts` already strips it without restoring for the Linear
+ *   comment path; this is the same rule for the board. (AGT-4060)
+ */
+function boardWords(summary: string | undefined): string | undefined {
+  const stripped = summary?.replace(/^\s*Codename:.*$/gim, '').trim();
+  if (!stripped || stripped === '(no summary)') return undefined;
+  return stripped;
+}
+
+/**
  * Publish a finished stage as the agent's own words, addressed to its
  * counterpart. Registers the codename the agent introduced itself with
  * (first introduction wins), then speaks its summary/feedback instead of a
@@ -169,7 +191,7 @@ export function publishStageOutcomeToBoard(
   }
   const said = stage === 'reviewer'
     ? [spoken?.decision ? `[${spoken.decision}]` : undefined, spoken?.feedback?.trim()].filter(Boolean).join(' ')
-    : spoken?.summary?.trim();
+    : boardWords(spoken?.summary);
   const seconds = (outcome.durationMs / 1000).toFixed(1);
   void publishStageToBoard(
     context,


### PR DESCRIPTION
## Summary

The user reported the coordination board showing lines like `Nimbus (worker · AX-859) → reviewer-eb2a: (no summary)`. Confirmed live on vela's `coordination_trace`: every degraded line is a `delegation-result` whose summary is either the literal `(no summary)` or a bare `Codename: Atlas` / `Codename: 린터`. Two independent causes, both defeating the same existing fallback.

`publishStageOutcomeToBoard` already falls back to a timing line when an agent said nothing (`said || (success ? 'Finished in Ns' : 'Did not pass in Ns')`) — but two non-reports reach it as **truthy strings**, so `||` takes them:

1. **`(no summary)`** — adapters substitute this literal for a missing summary (`claude.ts:213`, and the same pattern in `documenter.ts`, `auditor.ts`, `skillDocumenter.ts`). The board showed a placeholder where a duration would at least have been true.
2. **`Codename: X`** — `worker.ts:481` strips the agent's self-introduction (AGT-4019) but with a `|| parsedResult.summary` restore, so a summary that was *only* that line comes back intact and reads as the agent reporting its own name as its work.

Fixed with a `boardWords()` helper that normalizes both to `undefined` at the board boundary, so the existing fallback fires. Fixing it here rather than in the adapters leaves other consumers of `(no summary)` untouched; `src/linear/format.ts:95-101` already strips the codename line without restoring for the Linear-comment path, so this applies the same rule to the board.

## Live evidence (vela, before the fix)

| kind | from → to | summary |
|---|---|---|
| delegation-result | Delta → reviewer-a4f2 | `(no summary)` |
| delegation-result | Atlas → reviewer-8eb5 | `Codename: Atlas` |
| delegation-result | 린터 → reviewer-167f | `Codename: 린터` |
| advice-response | worker-6c1f → reviewer-c1ef | (healthy — real sentence) |
| delegation-request | worker-6c1f → reviewer-c1ef | (healthy — `Taking on: ...`) |

Only `delegation-result` degraded; the other kinds were unaffected.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/agents/pairPipeline.board.test.ts src/agents/worker.test.ts` — 52/52 passed
- [x] 5 new cases: `(no summary)` → timing fallback; codename-only → timing fallback; failure wording on a failed reportless stage; a **real summary passes through untouched**; a codename line *preceding* a real report keeps the report
- [x] Each new test verified to fail when `boardWords` is reverted (4 of 5 fail; the real-summary case correctly passes either way)
- [x] `openswarm review`: **APPROVE**

Not yet done (post-merge): confirm on vela after redeploy that new `delegation-result` events carry real text.