### PR TITLE
fix(tools): let agents read local material linked in from the main checkout (AGT-4061)

### DIFF
--- a/src/adapters/tools.test.ts
+++ b/src/adapters/tools.test.ts
@@ -16,6 +16,16 @@ vi.mock('../memory/repoKnowledge.js', () => ({
       : 'A non-empty query is required.',
 }));
 
+// `worktree.useRelativePaths` landed in git 2.48; older git always writes the
+// worktree back-link as an absolute path, so the relative-mode test has nothing
+// to discriminate and is skipped rather than passing vacuously.
+let hasRelativeWorktrees = false;
+try {
+  const raw = execFileSync('git', ['--version'], { stdio: 'pipe' }).toString();
+  const [, major, minor] = /(\d+)\.(\d+)/.exec(raw) ?? [];
+  hasRelativeWorktrees = Number(major) > 2 || (Number(major) === 2 && Number(minor) >= 48);
+} catch { /* git not installed */ }
+
 // Check if rg binary is available (not just a shell function wrapper)
 let hasRg = false;
 try {
@@ -713,5 +723,200 @@ describe('executeTool coordination_history dispatch (AGT-4054)', () => {
     expect(result.is_error).toBe(false);
     expect(result.content).not.toContain('Unknown tool');
     expect(() => JSON.parse(result.content)).not.toThrow();
+  });
+});
+
+// ──────────────────────────────────────────────
+// 12. Local-only material linked from the main checkout (AGT-4061)
+// ──────────────────────────────────────────────
+
+// A repo may symlink material git cannot carry (client data, .env) from its
+// main checkout into every worktree — cgf-portal's `link-local-assets.sh`
+// post-checkout hook does exactly that. canonicalizePath resolves the symlink
+// to its target outside the worktree, so every read was refused and the agent
+// reported the data as missing while `ls` through the same link worked.
+//
+// The fixture lives under /var/tmp, NOT /tmp: validatePath allows /tmp
+// outright, so a fixture there would pass with the fix reverted.
+describe('reads that resolve into the worktree\'s main checkout', () => {
+  let root = '';
+  let mainRoot = '';
+  let worktree = '';
+  let linked = '';
+  let git = true;
+
+  beforeAll(async () => {
+    root = await fs.mkdtemp('/var/tmp/openswarm-agt4061-');
+    mainRoot = path.join(root, 'main');
+    worktree = path.join(root, 'wt');
+    await fs.mkdir(mainRoot, { recursive: true });
+    const run = (args: string[]) =>
+      execFileSync('git', ['-c', 'user.email=t@t', '-c', 'user.name=t', ...args], { cwd: mainRoot, stdio: 'pipe' });
+    try {
+      run(['init', '-q', '-b', 'main']);
+      await fs.writeFile(path.join(mainRoot, 'README.md'), 'main\n', 'utf-8');
+      run(['add', '-A']);
+      run(['commit', '-qm', 'init']);
+      run(['worktree', 'add', '-q', '-b', 'wt', worktree]);
+    } catch {
+      git = false;
+      return;
+    }
+    // Local-only material: present in the main checkout, linked into the worktree.
+    await fs.mkdir(path.join(mainRoot, 'local-data'), { recursive: true });
+    await fs.writeFile(path.join(mainRoot, 'local-data', 'asset.txt'), 'CGF ROWS\n', 'utf-8');
+    linked = path.join(worktree, 'local-data');
+    await fs.symlink(path.join(mainRoot, 'local-data'), linked);
+  });
+
+  afterAll(async () => {
+    if (root) await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('reads a file through a symlink into the main checkout', async () => {
+    if (!git) return;
+    const r = await executeTool(makeCall('read_file', { path: 'local-data/asset.txt' }), worktree);
+    expect(r.is_error).toBe(false);
+    expect(r.content).toContain('CGF ROWS');
+  });
+
+  it('refuses to write through that same symlinked path', async () => {
+    if (!git) return;
+    // Writing into the main checkout would break worktree isolation — the exact
+    // failure link-local-assets.sh documents for `.venv`.
+    const r = await executeTool(
+      makeCall('write_file', { path: 'local-data/asset.txt', content: 'clobbered' }),
+      worktree,
+    );
+    expect(r.is_error).toBe(true);
+    expect(r.content).toContain('outside the project root');
+    expect(await fs.readFile(path.join(mainRoot, 'local-data', 'asset.txt'), 'utf-8')).toBe('CGF ROWS\n');
+  });
+
+  it('refuses the same read for a read-only run', async () => {
+    if (!git) return;
+    // A read-only reviewer has `bash` denied, so this sandbox is its real
+    // outbound boundary (INT-3189) and must not widen. An ordinary worker can
+    // already reach the main checkout through the unvalidated `bash` tool.
+    const r = await executeTool(
+      makeCall('read_file', { path: 'local-data/asset.txt' }), worktree, undefined, { readOnly: true },
+    );
+    expect(r.is_error).toBe(true);
+    expect(r.content).toContain('outside the project root');
+  });
+
+  it('still refuses a path outside both the worktree and its main checkout', async () => {
+    if (!git) return;
+    const sibling = path.join(root, 'elsewhere.txt');
+    await fs.writeFile(sibling, 'nope', 'utf-8');
+    const r = await executeTool(makeCall('read_file', { path: sibling }), worktree);
+    expect(r.is_error).toBe(true);
+    expect(r.content).toContain('outside the project root');
+  });
+
+  it('grants nothing extra to a plain checkout that is not a worktree', async () => {
+    if (!git) return;
+    // `.git` is a directory here, so there is no main checkout to fall back to
+    // and the exception must not resolve to some ancestor.
+    const outside = path.join(root, 'elsewhere.txt');
+    expect(() => validatePath(outside, mainRoot, { allowMainCheckoutRead: true }))
+      .toThrow('outside the project root');
+  });
+});
+
+// A worktree's own `.git` is INSIDE the sandbox, so `write_file` can rewrite it
+// and claim any directory as this worktree's "main checkout". git also records
+// a back-link at `<gitDir>/gitdir` inside the main checkout, where no write
+// path reaches — so the link is only trustworthy checked in both directions.
+describe('a forged worktree link cannot widen the sandbox (AGT-4061)', () => {
+  let root = '';
+  const at = (...p: string[]) => path.join(root, ...p);
+
+  beforeAll(async () => {
+    root = await fs.mkdtemp('/var/tmp/openswarm-agt4061-forge-');
+    await fs.writeFile(await mk('decoy', 'secret.txt'), 'private', 'utf-8');
+    // Three worktree metadata dirs in the decoy's `.git`, and three checkouts
+    // pointing at them. Only the last pair links back to each other.
+    for (const [name, backLink] of [
+      ['no-backlink', null],
+      ['other', at('someone-else', '.git')],
+      ['mine', at('genuine', '.git')],
+    ] as Array<[string, string | null]>) {
+      await fs.mkdir(at('decoy', '.git', 'worktrees', name), { recursive: true });
+      if (backLink) await fs.writeFile(at('decoy', '.git', 'worktrees', name, 'gitdir'), `${backLink}\n`, 'utf-8');
+    }
+    for (const [checkout, meta] of [
+      ['wt-nolink', 'no-backlink'], ['wt-other', 'other'], ['genuine', 'mine'],
+    ]) {
+      await fs.mkdir(at(checkout), { recursive: true });
+      await fs.writeFile(at(checkout, '.git'), `gitdir: ${at('decoy', '.git', 'worktrees', meta)}\n`, 'utf-8');
+    }
+  });
+
+  async function mk(...parts: string[]): Promise<string> {
+    await fs.mkdir(path.join(root, ...parts.slice(0, -1)), { recursive: true });
+    return path.join(root, ...parts);
+  }
+
+  afterAll(async () => {
+    if (root) await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const read = (checkout: string) =>
+    validatePath(at('decoy', 'secret.txt'), at(checkout), { allowMainCheckoutRead: true });
+
+  it('refuses a claimed main checkout that recorded no back-link at all', () => {
+    expect(() => read('wt-nolink')).toThrow('outside the project root');
+  });
+
+  it('refuses a back-link that points at a different worktree', () => {
+    // The dangerous shape: on a host running many worktrees, every other repo
+    // already has a real `<main>/.git/worktrees/<id>/gitdir`. Pointing at one
+    // would hand this agent reads across another repository's main checkout.
+    expect(() => read('wt-other')).toThrow('outside the project root');
+  });
+
+  it('accepts the one link git actually wrote, in both directions', async () => {
+    expect(read('genuine')).toBe(path.join(await fs.realpath(at('decoy')), 'secret.txt'));
+  });
+});
+
+describe.skipIf(!hasRelativeWorktrees)('worktrees that record their links as relative paths (AGT-4061)', () => {
+  let root = '';
+  let worktree = '';
+  let backLinkRaw = '';
+
+  beforeAll(async () => {
+    root = await fs.mkdtemp('/var/tmp/openswarm-agt4061-rel-');
+    const mainRoot = path.join(root, 'main');
+    worktree = path.join(root, 'wt');
+    await fs.mkdir(mainRoot, { recursive: true });
+    const run = (args: string[]) =>
+      execFileSync('git', ['-c', 'user.email=t@t', '-c', 'user.name=t', ...args], { cwd: mainRoot, stdio: 'pipe' });
+    run(['init', '-q', '-b', 'main']);
+    run(['commit', '-q', '--allow-empty', '-m', 'init']);
+    run(['config', 'worktree.useRelativePaths', 'true']);
+    run(['worktree', 'add', '-q', '-b', 'wt', worktree]);
+    await fs.mkdir(path.join(mainRoot, 'local-data'), { recursive: true });
+    await fs.writeFile(path.join(mainRoot, 'local-data', 'asset.txt'), 'CGF ROWS\n', 'utf-8');
+    await fs.symlink(path.join(mainRoot, 'local-data'), path.join(worktree, 'local-data'));
+    const gitDir = path.resolve(worktree, (await fs.readFile(path.join(worktree, '.git'), 'utf-8')).replace(/^gitdir:\s*/, '').trim());
+    backLinkRaw = (await fs.readFile(path.join(gitDir, 'gitdir'), 'utf-8')).trim();
+  });
+
+  afterAll(async () => {
+    if (root) await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('git really did record the back-link relatively', () => {
+    // Guards the test below from passing vacuously if git ever stops honouring
+    // the config — then the absolute-mode fixture would be all that runs.
+    expect(path.isAbsolute(backLinkRaw)).toBe(false);
+  });
+
+  it('still reads through the symlink into the main checkout', async () => {
+    const r = await executeTool(makeCall('read_file', { path: 'local-data/asset.txt' }), worktree);
+    expect(r.is_error).toBe(false);
+    expect(r.content).toContain('CGF ROWS');
   });
 });

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -6,7 +6,7 @@
 // ============================================
 
 import fs from 'node:fs/promises';
-import { existsSync, realpathSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { homedir } from 'node:os';
@@ -366,6 +366,66 @@ function canonicalizePath(candidate: string): string {
   return path.join(realpathSync(ancestor), ...suffix);
 }
 
+/**
+ * The main checkout a linked git worktree belongs to, or null when `root` is
+ * not a linked worktree.
+ *
+ * Derived from git's own metadata rather than guessed: a linked worktree's
+ * `.git` is a FILE holding `gitdir: <main>/.git/worktrees/<name>`, so stripping
+ * the trailing `/.git/worktrees/<name>` yields the main checkout. Read directly
+ * instead of shelling out to `git worktree list --porcelain` (which is what
+ * cgf-portal's own `link-local-assets.sh` uses) because validatePath runs on
+ * every file-tool call and must not spawn a process per read.
+ *
+ * Deliberately uncached. Measured at ~36µs per resolve — noise beside the file
+ * read it guards — and a cache keyed by path would go stale the moment the
+ * worktree metadata it reads changes, in a daemon that outlives many worktrees.
+ */
+function mainCheckoutOf(root: string): string | null {
+  const dotGit = path.join(root, '.git');
+  let raw: string;
+  try {
+    if (!statSync(dotGit).isFile()) return null; // plain checkout: `.git` is a directory
+    raw = readFileSync(dotGit, 'utf-8');
+  } catch {
+    return null;
+  }
+  const match = /^gitdir:\s*(.+?)\s*$/m.exec(raw);
+  if (!match) return null;
+  // `gitdir` may be relative (git >= 2.48 with --relative-paths), so resolve it
+  // against the worktree before walking up.
+  const gitDir = path.resolve(root, match[1]);
+  if (path.basename(path.dirname(gitDir)) !== 'worktrees') return null;
+  const commonDir = path.dirname(path.dirname(gitDir));
+  if (path.basename(commonDir) !== '.git') return null;
+  // Require git's own back-link. The worktree's `.git` is INSIDE the sandbox,
+  // so an agent could rewrite it to `gitdir: /etc/.git/worktrees/x` and open
+  // all of /etc to reads. git also writes `<gitDir>/gitdir` pointing back at
+  // this worktree's `.git`, and that file lives in the main checkout where no
+  // write path can reach it — checking both directions turns a forgeable
+  // one-way pointer into a link only git could have created.
+  let backLink: string;
+  try {
+    backLink = readFileSync(path.join(gitDir, 'gitdir'), 'utf-8').trim();
+  } catch {
+    return null;
+  }
+  // Resolved against `gitDir`, not the process cwd: with
+  // `worktree.useRelativePaths=true` (git >= 2.48) the back-link is written
+  // relative to the metadata dir — e.g. `../../../../wt/.git` — and resolving
+  // that against the daemon's cwd yields a garbage path, silently rejecting
+  // every relative-path worktree. (Caught by the commit-gate review.)
+  if (!backLink || canonicalizePath(path.dirname(path.resolve(gitDir, backLink))) !== root) return null;
+  const mainRoot = path.dirname(commonDir);
+  // A main checkout at the filesystem root would make the exception meaningless.
+  if (path.dirname(mainRoot) === mainRoot) return null;
+  try {
+    return statSync(mainRoot).isDirectory() ? mainRoot : null;
+  } catch {
+    return null;
+  }
+}
+
 export function isProtectedPath(resolved: string, protectedFiles?: string[]): boolean {
   if (!protectedFiles?.length) return false;
   return protectedFiles.some((p) => {
@@ -375,8 +435,36 @@ export function isProtectedPath(resolved: string, protectedFiles?: string[]): bo
   });
 }
 
+export interface ValidatePathOptions {
+  /**
+   * Also accept a path whose canonical form lands inside the main checkout this
+   * worktree belongs to. READ-ONLY tools only.
+   *
+   * A repo may symlink local-only material (data the agent needs but git cannot
+   * carry) from its main checkout into every worktree — cgf-portal's
+   * `link-local-assets.sh` post-checkout hook does exactly this for
+   * `docs/CGF_data` and the `.env` family. `canonicalizePath` resolves the
+   * symlink to its target in the main checkout, which is outside the worktree,
+   * so the read was refused and the agent reported the data as missing
+   * (AGT-4061: worker-86be asked the operator twice for files that were in
+   * fact linked into its worktree and readable).
+   *
+   * Reads only, never writes: writing into the main checkout would break
+   * worktree isolation — the exact failure `link-local-assets.sh` documents for
+   * `.venv`, where a guard test kept passing because the import resolved
+   * through the main tree instead of the worktree under test.
+   *
+   * Callers must additionally withhold this for `readOnly` runs. An ordinary
+   * worker can already reach the main checkout through the unvalidated `bash`
+   * tool, so there this is a usability fix, not a widening. A read-only
+   * reviewer has `bash` denied (READ_ONLY_DENIED_TOOLS), which makes this
+   * sandbox its real outbound boundary — INT-3189 — and it stays untouched.
+   */
+  allowMainCheckoutRead?: boolean;
+}
+
 /** 프로젝트 경로 내로 접근을 제한하는 경로 검증 */
-export function validatePath(filePath: string, cwd: string): string {
+export function validatePath(filePath: string, cwd: string, options: ValidatePathOptions = {}): string {
   const requestedRoot = path.resolve(cwd);
   const projectRoot = existsSync(requestedRoot) ? realpathSync(requestedRoot) : requestedRoot;
   const resolved = path.resolve(projectRoot, filePath);
@@ -387,9 +475,10 @@ export function validatePath(filePath: string, cwd: string): string {
     const rel = path.relative(canonicalRoot, canonical);
     return rel === '' || (!rel.startsWith(`..${path.sep}`) && rel !== '..' && !path.isAbsolute(rel));
   };
+  const mainCheckout = options.allowMainCheckoutRead ? mainCheckoutOf(projectRoot) : null;
   // cwd 하위이거나, /tmp 하위만 허용. 문자열 prefix 비교는 상대 cwd를
   // 전부 거부하고 `/repo-evil` 같은 sibling을 `/repo` 내부로 오인한다.
-  if (!inside(projectRoot) && !inside('/tmp')) {
+  if (!inside(projectRoot) && !inside('/tmp') && !(mainCheckout && inside(mainCheckout))) {
     // 모델이 자가수정하도록 안내 — 그냥 거부만 하면 같은 실수를 반복한다.
     throw new Error(
       `Path "${filePath}" is outside the project root (${projectRoot}). ` +
@@ -486,7 +575,11 @@ export async function executeTool(
 
     switch (name) {
       case 'read_file': {
-        const filePath = validatePath(args.path, cwd);
+        // Reads may follow a symlink into this worktree's main checkout, so an
+        // agent can reach local-only material the repo links in (AGT-4061).
+        // Withheld in readOnly: there `bash` is denied, so this sandbox is the
+        // run's real outbound boundary (INT-3189).
+        const filePath = validatePath(args.path, cwd, { allowMainCheckoutRead: !execOptions?.readOnly });
         const offset = args.offset ?? 0;
         const limit = args.limit ?? 500;
         const cacheKey = `${filePath}#${offset}:${limit}`;
@@ -631,7 +724,7 @@ export async function executeTool(
       }
 
       case 'search_files': {
-        const searchPath = validatePath(args.path, cwd);
+        const searchPath = validatePath(args.path, cwd, { allowMainCheckoutRead: !execOptions?.readOnly });
         const rgArgs = ['--no-heading', '--line-number', '--max-count', '50'];
         if (args.glob) {
           rgArgs.push('--glob', args.glob);


### PR DESCRIPTION
Closes AGT-4061.

## The bug

A repo can hand its worktrees material git cannot carry — client data, `.env` files — by symlinking it in from the main checkout on `post-checkout`. cgf-portal does exactly that for `docs/CGF_data` and the `.env` family.

`validatePath` canonicalizes through the symlink (`realpathSync`) and then requires the **target** to be inside the worktree. The target is in the main checkout, so every read was refused.

Live impact: `worker-86be` on AX-1039 asked the operator twice (06:40 and 11:36 KST) for files that were linked into its worktree and readable the whole time, then parked as `NEEDS_HUMAN`. **The agent's report was accurate, not a hallucination.** It went unnoticed because the earlier verification used a *shell* — `bash` is not path-validated, `read_file` is.

## The fix

Accept a canonical path landing inside the main checkout this worktree belongs to — for `read_file` and `search_files` only.

| | before | after |
|---|---|---|
| `read_file` / `search_files`, normal run | refused | **allowed** |
| `write_file` / `edit_file` / `apply_patch` | refused | refused |
| any tool, `readOnly` run | refused | refused |
| unrelated path outside both | refused | refused |
| `/tmp` | allowed | allowed |

**Writes keep the old containment.** Writing into the main checkout breaks worktree isolation — the exact failure `link-local-assets.sh` documents for `.venv`, where a guard test kept passing because the import resolved through the main tree.

**Read-only runs get nothing.** An ordinary worker can already reach the main checkout through the unvalidated `bash` tool, so there this is a usability fix, not a widening. A read-only reviewer has `bash` denied (`READ_ONLY_DENIED_TOOLS`), which makes this sandbox its real outbound boundary — INT-3189 — and it stays untouched.

## Why the link is checked in both directions

The main checkout is read from git's metadata, not guessed: a linked worktree's `.git` is a file holding `gitdir: <main>/.git/worktrees/<name>`.

But **that file is inside the sandbox** — `write_file` can reach it. An agent could rewrite it to `gitdir: /etc/.git/worktrees/x`, or point it at another repository's real worktree metadata on the same host, and open that checkout to reads. git also writes a back-link at `<gitDir>/gitdir` pointing back at this worktree, and *that* file lives in the main checkout where no write path reaches. Requiring both directions turns a forgeable one-way pointer into a link only git could have created.

Both links resolve against their own directory, so `worktree.useRelativePaths=true` repos (git ≥ 2.48) work — the back-link there is `../../../../wt/.git`, and resolving it against the process cwd yielded a garbage path that silently rejected every such worktree. Caught by the commit-gate review, reproduced, fixed, and covered.

Uncached deliberately: measured ~36 µs per resolve (noise beside the file read it guards), and a path-keyed cache would go stale in a daemon that outlives many worktrees.

## Verification

10 new tests in `tools.test.ts`, **each verified to fail when the behaviour it covers is reverted** (8 mutations):

| mutation | test(s) killed |
|---|---|
| exception removed entirely | symlink read; genuine back-link accepted |
| exception leaked into `write_file` | write refused |
| `readOnly` gate dropped | read-only read refused |
| widened to the main checkout's *parent* | unrelated outside path refused |
| plain checkout falls back to an ancestor | plain checkout gets nothing |
| back-link requirement removed | no-back-link refused; wrong-target refused |
| back-link existence checked but not direction | wrong-target refused |
| back-link resolved against process cwd | relative-path worktree read |

Fixtures live under `/var/tmp`, **not** `/tmp` — `validatePath` allows `/tmp` outright, so a fixture there would pass with the fix reverted.

`npm run typecheck` clean, `oxlint` clean, 185 tests green across all 9 test files that import `tools.js`.

Commit gate: `openswarm review` ×3 — APPROVE → REVISE (the relative-path back-link, above) → APPROVE.

## Still to do after merge

Verify on vela that an agent's **file tool** can read under `docs/CGF_data`. A shell check is explicitly not sufficient evidence here — that is the exact trap that hid this bug.