### PR TITLE
fix(security-audit): bound concurrent CodeQL runs so audits stop starving the daemon (AGT-4062)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -155,6 +155,14 @@ autonomous:
   securityAudit:
     enabled: true
     maxThreads: 2
+    # Memory target passed to each CodeQL run, in MB. Best-effort by CodeQL's
+    # own account — a large database can still exceed it.
+    maxRamMb: 4096
+    # How many CodeQL runs may execute at once is a PROCESS-wide bound, not a
+    # per-audit setting, so it lives in the environment rather than here:
+    # OPENSWARM_CODEQL_MAX_CONCURRENT (default 1, max 8). Raise it only on a
+    # host with cores to spare — the audit runs twice per task, and letting it
+    # scale with maxConcurrentTasks is what starved the daemon (AGT-4062).
 
   # Pipeline guards
   guards:

--- a/src/automation/prProcessor.test.ts
+++ b/src/automation/prProcessor.test.ts
@@ -192,7 +192,7 @@ describe('PRProcessor.fixOne (INT-3282)', () => {
     await newProcessor().fixOne(pr, '/tmp/proj');
 
     const args = createPipelineFromConfigImpl.mock.calls.at(-1);
-    expect(args?.[9]).toEqual({ enabled: true, maxThreads: 2 });
+    expect(args?.[9]).toEqual({ enabled: true, maxThreads: 2, maxRamMb: 4096 });
   });
 
   it('succeeds when there are no conflicts, the pipeline succeeds, and CI passes', async () => {

--- a/src/cli/prCommand.test.ts
+++ b/src/cli/prCommand.test.ts
@@ -203,7 +203,7 @@ describe('loadRolesBestEffort / buildProcessorConfig (INT-3282)', () => {
   });
 
   it('defaults PR remediation to the enabled CodeQL policy', () => {
-    expect(loadSecurityAuditBestEffort()).toEqual({ enabled: true, maxThreads: 2 });
+    expect(loadSecurityAuditBestEffort()).toEqual({ enabled: true, maxThreads: 2, maxRamMb: 4096 });
   });
 
   it('enables the conflict resolver by default', () => {

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -151,6 +151,7 @@ agents:
       expect(config.autonomous?.securityAudit).toEqual({
         enabled: true,
         maxThreads: 2,
+        maxRamMb: 4096,
       });
     });
 
@@ -182,6 +183,7 @@ agents:
       expect(loadConfig('/tmp/config.json').autonomous?.securityAudit).toEqual({
         enabled: false,
         maxThreads: 1,
+        maxRamMb: 4096,
       });
     });
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -268,7 +268,8 @@ const VerifyConfigSchema = z.object({
 const SecurityAuditConfigSchema = z.object({
   enabled: z.boolean().default(true),
   maxThreads: z.number().int().min(1).max(16).default(2),
-}).default({ enabled: true, maxThreads: 2 });
+  maxRamMb: z.number().int().min(512).max(65536).default(4096),
+}).default({ enabled: true, maxThreads: 2, maxRamMb: 4096 });
 
 const AutonomousConfigSchema = z.object({
   /** Auto-enable on service start */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -503,6 +503,10 @@ export type VerifyConfig = {
 export type SecurityAuditConfig = {
   enabled: boolean;
   maxThreads: number;
+  /** Memory target passed to each CodeQL run, in MB. Best-effort: CodeQL's own
+   *  help says a large database may still break the threshold, so the
+   *  concurrency gate — not this — is what actually bounds total usage. */
+  maxRamMb: number;
 };
 
 export type AutonomousStartupConfig = {

--- a/src/verify/securityAudit.test.ts
+++ b/src/verify/securityAudit.test.ts
@@ -22,6 +22,9 @@ vi.mock('node:fs/promises', async (importOriginal) => ({
 }));
 
 import {
+  codeqlGate,
+  ConcurrencyGate,
+  resolveCodeqlConcurrency,
   DEFAULT_SECURITY_AUDIT_CONFIG,
   detectCodeqlLanguages,
   listTrackedSecurityFiles,
@@ -34,6 +37,9 @@ import {
 beforeEach(() => {
   vi.stubEnv('PATH', '/tools');
   vi.clearAllMocks();
+  // Module state shared by every case here: without this, one test that leaves
+  // a slot held makes each later one wait out its full timeout.
+  codeqlGate.reset();
   fsMock.access.mockResolvedValue(undefined);
   fsMock.cp.mockResolvedValue(undefined);
   fsMock.lstat.mockResolvedValue({ isFile: () => true, isSymbolicLink: () => false });
@@ -259,5 +265,171 @@ describe('listTrackedSecurityFiles', () => {
       ['ls-files', '--cached', '--others', '--exclude-standard', '-z'],
       expect.objectContaining({ cwd: '/repo' }),
     );
+  });
+});
+
+// The audit runs per task, twice (baseline + post-work), so without a cap its
+// cost scaled with `maxConcurrentTasks`. Measured on the daemon at 6: two
+// overlapping runs held 6.5 GB beside the daemon's own 3.41 GB, the container
+// sat pinned at its 4-CPU cap with `memory.peak` at 13.76 of 16 GiB, and the
+// single JS thread stalled up to 40s. (AGT-4062)
+/** parseSarif requires version 2.1.0 — an omitted version ends the audit in `failed`. */
+const EMPTY_SARIF = JSON.stringify({ version: '2.1.0', runs: [{ results: [] }] });
+
+/** A wake-up that never comes should fail the test, not hang the suite. */
+function withinTick<T>(promise: Promise<T>, what: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`never resolved: ${what}`)), 100)),
+  ]);
+}
+
+describe('ConcurrencyGate', () => {
+  it('lets callers through up to the limit and makes the next one wait', async () => {
+    const gate = new ConcurrencyGate(2);
+    await gate.acquire();
+    await gate.acquire();
+    expect(gate.activeCount).toBe(2);
+
+    let third = false;
+    const pending = gate.acquire().then(() => { third = true; });
+    await Promise.resolve();
+    expect(third).toBe(false);
+    expect(gate.waitingCount).toBe(1);
+
+    gate.release();
+    await withinTick(pending, 'release did not wake the queued caller');
+    expect(third).toBe(true);
+  });
+
+  it('serves queued callers in arrival order', async () => {
+    const gate = new ConcurrencyGate(1);
+    await gate.acquire();
+    const order: string[] = [];
+    const first = gate.acquire().then(() => { order.push('queued-first'); });
+    const second = gate.acquire().then(() => { order.push('queued-second'); });
+
+    gate.release();
+    await withinTick(first, 'first queued caller');
+    expect(order).toEqual(['queued-first']);
+    expect(gate.activeCount).toBe(1);
+
+    gate.release();
+    await withinTick(second, 'second queued caller');
+    expect(order).toEqual(['queued-first', 'queued-second']);
+  });
+
+  it('never lets release drive the active count below zero', () => {
+    const gate = new ConcurrencyGate(1);
+    gate.release();
+    gate.release();
+    expect(gate.activeCount).toBe(0);
+  });
+
+  it('frees the slot on reset so one leaked hold cannot hang the rest of a file', async () => {
+    const gate = new ConcurrencyGate(1);
+    await gate.acquire();
+    gate.reset();
+    await withinTick(gate.acquire(), 'reset did not free the slot');
+    expect(gate.activeCount).toBe(1);
+  });
+});
+
+describe('resolveCodeqlConcurrency', () => {
+  // Read once at module load. A bad value must not fail the daemon's start, so
+  // anything unusable falls back to the cap the measurement supports.
+  it.each([
+    ['3', 3],
+    ['1', 1],
+    ['8', 8],
+    [undefined, 1],
+    ['', 1],
+    ['nonsense', 1],
+    ['0', 1],
+    ['-2', 1],
+    ['9', 1],
+    ['2.5', 1],
+  ])('resolves %s to %i', (raw, expected) => {
+    expect(resolveCodeqlConcurrency(raw as string | undefined)).toBe(expected);
+  });
+});
+
+describe('runSecurityAudit resource bounds (AGT-4062)', () => {
+  it('runs one audit at a time no matter how many callers arrive', { timeout: 3_000 }, async () => {
+    // Three concurrent callers, default config. Only the holder may reach
+    // CodeQL; the rest must be parked before spawning anything.
+    let releaseFirst: (() => void) | undefined;
+    const firstCallStarted = new Promise<void>((started) => {
+      execFileMock.mockImplementation(() => new Promise((resolve) => {
+        started();
+        releaseFirst = () => resolve({ stdout: '', stderr: '' });
+      }));
+    });
+
+    const audits = [
+      runSecurityAudit('/repo', ['src/a.ts']),
+      runSecurityAudit('/repo', ['src/b.ts']),
+      runSecurityAudit('/repo', ['src/c.ts']),
+    ];
+    await firstCallStarted;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // One `pack download`, from the single audit holding the gate.
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+
+    // Let everything drain so the shared gate is not left held for later tests.
+    execFileMock.mockImplementation(async () => ({ stdout: '', stderr: '' }));
+    releaseFirst?.();
+    fsMock.readFile.mockResolvedValue(EMPTY_SARIF);
+    await Promise.all(audits);
+  });
+
+  it('caps the memory each CodeQL invocation may take', async () => {
+    fsMock.readFile.mockResolvedValue(EMPTY_SARIF);
+    await runSecurityAudit('/repo', ['src/a.ts']);
+
+    const codeql = execFileMock.mock.calls
+      .map((call) => call[1] as string[])
+      .filter((args) => args[0] === 'database');
+    expect(codeql.length).toBeGreaterThanOrEqual(2); // create + analyze
+    for (const args of codeql) {
+      expect(args).toContain(`--ram=${DEFAULT_SECURITY_AUDIT_CONFIG.maxRamMb}`);
+    }
+  });
+
+  it('bounds concurrency per process, not per configured task parallelism', async () => {
+    // The bug was exactly this coupling: audit cost tracked maxConcurrentTasks
+    // while the container budget stayed fixed. Four callers, one process cap.
+    let inFlight = 0;
+    let peak = 0;
+    execFileMock.mockImplementation(async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      inFlight -= 1;
+      return { stdout: '', stderr: '' };
+    });
+    fsMock.readFile.mockResolvedValue(EMPTY_SARIF);
+
+    await Promise.all(['a', 'b', 'c', 'd'].map((n) => runSecurityAudit('/repo', [`src/${n}.ts`])));
+    expect(peak).toBe(1);
+  });
+});
+
+describe('the gate survives a failing snapshot cleanup (AGT-4062)', () => {
+  it('returns the slot even when cleanup throws', { timeout: 3_000 }, async () => {
+    // `rm` runs with force:true, which swallows ENOENT but not EACCES/EPERM/
+    // EBUSY. Before the gate a failed cleanup only leaked a temp directory;
+    // with a limit of 1 it would strand the slot and deadlock every later
+    // audit in this process.
+    fsMock.readFile.mockResolvedValue(EMPTY_SARIF);
+    fsMock.rm.mockRejectedValueOnce(Object.assign(new Error('EACCES'), { code: 'EACCES' }));
+
+    await expect(runSecurityAudit('/repo', ['src/a.ts'])).rejects.toThrow('EACCES');
+    expect(codeqlGate.activeCount).toBe(0);
+
+    // The next audit must still be able to start.
+    fsMock.rm.mockResolvedValue(undefined);
+    await expect(runSecurityAudit('/repo', ['src/b.ts'])).resolves.toMatchObject({ status: 'passed' });
   });
 });

--- a/src/verify/securityAudit.ts
+++ b/src/verify/securityAudit.ts
@@ -31,9 +31,89 @@ const QUERY_PACK_BY_LANGUAGE: Record<string, string> = {
 const RUNTIME_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const OPENSWARM_SECURITY_SUITE = join(RUNTIME_ROOT, '.codeql', 'security', 'openswarm-security-extended.qls');
 
+/**
+ * Process-wide cap on how many CodeQL runs execute at once.
+ *
+ * The audit runs per task — once to capture a baseline, once after the work —
+ * so without a gate its cost scales with `maxConcurrentTasks` while the
+ * container's budget does not. Measured on the daemon at `maxConcurrentTasks:
+ * 6`: two overlapping runs held 3.32 GB + 3.21 GB of RSS beside the daemon's
+ * own 3.41 GB, the container sat pinned at its 4-CPU cap, and `memory.peak`
+ * reached 13.76 GiB of a 16 GiB limit. The daemon's single JS thread was
+ * starved for up to 40s at a stretch — long enough that `/api/health`, which
+ * builds a pure in-memory payload, timed out and the container read
+ * `unhealthy` while working normally. (AGT-4062)
+ *
+ * The gate belongs here rather than at the scheduler: bounding the expensive
+ * stage keeps task parallelism intact, whereas lowering `maxConcurrentTasks`
+ * would cut all of it to contain one stage.
+ *
+ * The limit is fixed for the life of the process. It was briefly a per-audit
+ * config field, and every review round of this change found a different defect
+ * in that shape — a later caller silently raising the cap out from under a
+ * running audit, a lowered cap that could never take hold, a raise that was
+ * discarded rather than deferred. All three were symptoms of one mistake:
+ * a process-wide resource bound is not a per-call argument.
+ */
+export class ConcurrencyGate {
+  private active = 0;
+  private readonly waiting: Array<() => void> = [];
+
+  constructor(private readonly limit: number) {}
+
+  get activeCount(): number { return this.active; }
+  get waitingCount(): number { return this.waiting.length; }
+
+  /**
+   * Drop all state. Exists for test isolation: the CodeQL gate below is module
+   * state shared by every case in a file, so one test that leaves a slot held
+   * makes every later one wait out its full timeout instead of failing where
+   * the fault is.
+   */
+  reset(): void {
+    this.active = 0;
+    this.waiting.length = 0;
+  }
+
+  async acquire(): Promise<void> {
+    if (this.active < this.limit) { this.active += 1; return; }
+    return new Promise<void>((resolve) => { this.waiting.push(resolve); });
+  }
+
+  /**
+   * Hand the slot to the longest-waiting caller, or free it when none is
+   * queued. No cap re-check is needed: `limit` is fixed for the life of the
+   * gate, and a caller only ever queues once `active` has reached it, so after
+   * a release there is always room for exactly the one being admitted.
+   */
+  release(): void {
+    const next = this.waiting.shift();
+    if (next) { next(); return; }
+    this.active = Math.max(0, this.active - 1);
+  }
+}
+
+/**
+ * Read the cap once, at module load. One is right for the container this was
+ * measured in (4 CPUs, `--threads=2` per run leaves two for the daemon); a
+ * larger host can raise it. An unset, unparseable, or out-of-range value falls
+ * back to the safe default rather than failing the daemon's start.
+ */
+export function resolveCodeqlConcurrency(raw: string | undefined): number {
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 8) return 1;
+  return parsed;
+}
+
+/** Shared by every pipeline: they all run inside the one daemon process. */
+export const codeqlGate = new ConcurrencyGate(
+  resolveCodeqlConcurrency(process.env.OPENSWARM_CODEQL_MAX_CONCURRENT),
+);
+
 export const DEFAULT_SECURITY_AUDIT_CONFIG: SecurityAuditConfig = {
   enabled: true,
   maxThreads: 2,
+  maxRamMb: 4096,
 };
 
 export type SecurityFindingLevel = 'error' | 'warning' | 'note';
@@ -238,6 +318,10 @@ export async function runSecurityAudit(
     }] };
   }
 
+  // Held across the snapshot copy and every CodeQL invocation — the whole
+  // stretch that competes with the daemon for CPU and RAM (AGT-4062).
+  await codeqlGate.acquire();
+
   let snapshot: { root: string; cleanup(): Promise<void> } | undefined;
   try {
     snapshot = await createSnapshot(projectPath, sourceFiles);
@@ -270,6 +354,7 @@ export async function runSecurityAudit(
       }
     }
 
+    const ram = `--ram=${config.maxRamMb ?? DEFAULT_SECURITY_AUDIT_CONFIG.maxRamMb}`;
     const findings: SecurityFinding[] = [];
     const skippedCodeqlLanguages: string[] = [];
     let infrastructureFailure = false;
@@ -280,7 +365,7 @@ export async function runSecurityAudit(
       const sarif = join(snapshot.root, `.codeql-${language}.sarif`);
       const create = await run(executable, [
         'database', 'create', database, `--language=${language}`, '--build-mode=none',
-        `--source-root=${snapshot.root}`, `--threads=${config.maxThreads}`,
+        `--source-root=${snapshot.root}`, `--threads=${config.maxThreads}`, ram,
       ], snapshot.root);
       if (create.exitCode !== 0) {
         if (rejectsNoBuildMode(create.stderr || create.stdout, language)) {
@@ -296,7 +381,7 @@ export async function runSecurityAudit(
         : `${pack}:codeql-suites/${language}-security-extended.qls`;
       const analyze = await run(executable, [
         'database', 'analyze', database, querySuite,
-        '--format=sarifv2.1.0', `--output=${sarif}`, `--threads=${config.maxThreads}`,
+        '--format=sarifv2.1.0', `--output=${sarif}`, `--threads=${config.maxThreads}`, ram,
       ], snapshot.root);
       if (analyze.exitCode !== 0) {
         infrastructureFailure = true;
@@ -335,6 +420,15 @@ export async function runSecurityAudit(
       ruleId: 'openswarm/security-codeql-runtime', level: 'error', message: `CodeQL security audit failed: ${cause}`,
     }], detail: cause };
   } finally {
-    await snapshot?.cleanup();
+    // Nested so the slot is returned even when cleanup throws. `rm` runs with
+    // `force: true`, which swallows ENOENT but not EACCES/EPERM/EBUSY — and
+    // before the gate existed a failed cleanup only leaked a temp directory,
+    // whereas now it would strand the slot and deadlock every later audit in
+    // this process. (Caught by the commit-gate review.)
+    try {
+      await snapshot?.cleanup();
+    } finally {
+      codeqlGate.release();
+    }
   }
 }


### PR DESCRIPTION
Closes AGT-4062.

## The problem

The security-audit gate runs CodeQL **per task** — once for a baseline, once after the work — with nothing capping how many run at a time. Its cost therefore scaled with `maxConcurrentTasks` (6 on the deployed daemon) while the container's budget stayed fixed at 4 CPUs / 16 GiB.

Measured on the live daemon, 2026-08-29:

`/api/health` builds a **pure in-memory payload** (`healthEndpoint.ts` — zero I/O, version read once at module load), so its latency reads event-loop delay directly:

```
23.59  32.84  0.06  0.00  32.51  0.15  33.72  0.08  40.43  0.03  0.20  34.90  0.06  0.13   (s)
n=14   p50=0.20   over 10s: 6/14   over 25s: 5/14   max=40.43
```

Bimodal — sub-second or tens of seconds, nothing between. The signature of a thread that simply is not being scheduled.

| cgroup v2 | value |
|---|---|
| `cpu.max` | `400000 100000` → 4.0 CPUs |
| observed | **399.90%** — pinned at the cap |
| `memory.max` | 16 GiB |
| **`memory.peak`** | **13.76 GiB (86%)** |

RSS inside the container: CodeQL java **3.32 GB** + **3.21 GB**, daemon `node` **3.41 GB (1 thread)**.

Two consequences, one visible and one sharp:

- The healthcheck (`curl /api/health`, 10s timeout) hit `FailingStreak: 5` and the container read `Up 2 hours (unhealthy)` with `RestartCount: 0`. It was working fine. That is worse than noise — it stops `unhealthy` from meaning *broken*, which is the one thing a healthcheck is for.
- At 86% of the memory limit with only two audits overlapping, one more plausibly crosses 16 GiB and the kernel OOM-kills the container, **orphaning every in-flight task at once**.

## The fix

A process-wide gate held across the snapshot copy and every CodeQL invocation, plus an explicit `--ram` target per run.

At a cap of 1: ~3.3 GB CodeQL + 3.4 GB daemon ≈ 7 GB of 16, and 2 of 4 CPUs (`--threads=2`), leaving room for the daemon's loop and the agent CLIs.

Deliberately **not** lowering `maxConcurrentTasks`: that cuts all task parallelism to contain one expensive stage. Bounding the stage keeps the rest.

`--ram=<MB>` verified against the **deployed CodeQL 2.26.4** on both subcommands (`-M, --ram=<MB>`). Its own help calls analyze's version best-effort — *"may be broken by file-backed…"* — so the gate, not the flag, is what actually bounds usage. The wording in the config and type comments says so rather than claiming a ceiling.

## Why the cap is not configurable per audit

It was, briefly. Three review rounds each found a **different** defect in that shape:

| round | finding |
|---|---|
| 2 | a later caller silently raises the cap out from under a running audit |
| 3 | a cap lowered mid-flight can never take hold — each release refills the seat it vacated |
| 4 | a raise is *discarded* rather than deferred, so under sustained load the configured value never applies |

All three are one mistake: **a process-wide resource bound is not a per-call argument.** So the field is gone rather than patched. The cap is read once at module load from `OPENSWARM_CODEQL_MAX_CONCURRENT` (default 1, max 8) — the idiom this repo already uses for its other 30+ process-wide knobs — and is immutable thereafter. A missing or unparseable value falls back to the safe default rather than failing the daemon's start.

Removing mutability also removed the cap re-check in `release()`, which became provably unreachable once the limit was fixed; leaving it would have been dead code.

`maxRamMb` stays in config: it is a genuine per-run argument with no shared state.

## Cleanup cannot strand a slot

`release()` is nested in its own `finally`. `rm` runs with `force: true`, which swallows ENOENT but **not** EACCES/EPERM/EBUSY. Before the gate, a failed cleanup only leaked a temp directory; with a cap of 1 it would strand the slot and deadlock every later audit in the process. Found by the commit-gate review.

## Verification

33 tests in `securityAudit.test.ts`, **each verified to fail when the behaviour it covers is reverted**:

| mutation | test(s) killed |
|---|---|
| gate removed entirely | serialized audits; per-process bound |
| LIFO instead of FIFO | arrival order |
| env parser accepts out-of-range | 5 parser cases |
| `--ram` dropped | per-invocation RAM argument |
| cleanup throw skips release | slot returned on cleanup failure |
| `reset()` leaves the slot held | reset frees the slot |
| release underflows past zero | active count floor |

Test isolation: the gate is module state shared by every case in the file, so `reset()` runs in `beforeEach`. Without it a single leaked hold made every later case wait out its full timeout — an injected fault took **90s** and produced 5 cascading failures; with isolation and explicit 3s timeouts it fails in **6.4s** at the actual fault.

One earlier round of my own tests did **not** discriminate and was rewritten: a mocked SARIF missing `version: '2.1.0'` made audits end in `failed`, which several assertions never looked at, so they passed regardless.

`npm run typecheck` clean, `oxlint` clean, **170 tests green** across all 5 files touching `securityAudit`. Commit gate: `openswarm review` ×5 — REVISE ×3 (each a new, correct finding), then APPROVE.

## Deliberately out of scope

The healthcheck timeout. Raising it before knowing the post-fix latency distribution would be guessing at the number. It is a compose-level override, so re-tuning after measurement costs no image rebuild. Tracked in the issue's DoD.

## After merge

Re-measure on the daemon and report `/api/health` p90 and `memory.peak` as a before/after against the numbers above.