### PR TITLE
feat(health): report the daemon's heap so a stall can be measured, not inferred (AGT-4063)

### DIFF
--- a/src/support/healthEndpoint.test.ts
+++ b/src/support/healthEndpoint.test.ts
@@ -37,7 +37,10 @@ describe('buildHealthPayload', () => {
       uptimeS: 12.9,
       version: '1.2.3',
       instanceId: 'fixed-id',
+      memory: { heapUsedBytes: 1024 * 1024, heapLimitBytes: 2 * 1024 * 1024, rssBytes: 3 * 1024 * 1024 },
     });
+    // Exhaustive on purpose: this is the shape vega's shell parses, so an
+    // accidental addition should have to be acknowledged here.
     expect(payload).toEqual({
       status: 'ok',
       app: 'openswarm',
@@ -47,6 +50,9 @@ describe('buildHealthPayload', () => {
       backend_pid: 42,
       backend_parent_pid: 1,
       uptime_s: 12,
+      heap_used_mb: 1,
+      heap_limit_mb: 2,
+      rss_mb: 3,
     });
   });
 
@@ -203,4 +209,33 @@ describe('GET /api/health over the live server', () => {
       { path: '~/dev/kyte-portal', name: 'kyte-portal' },
     ]);
   });
+});
+
+// The daemon is single-threaded, so a heap near its ceiling means frequent
+// stop-the-world mark-compact pauses — nothing else on the loop runs. Measured
+// at 3.55 GB RSS against Node's default 4144 MB ceiling, with /api/health
+// latency bimodal at sub-second or tens of seconds; `used_heap_size` was
+// reported nowhere, so the cause could only be inferred from RSS. (AGT-4063)
+describe('buildHealthPayload memory reporting (AGT-4063)', () => {
+  it('reports heap used, heap ceiling, and RSS in MB', () => {
+    const payload = buildHealthPayload({
+      env: {},
+      memory: {
+        heapUsedBytes: 3_500 * 1024 * 1024,
+        heapLimitBytes: 4_144 * 1024 * 1024,
+        rssBytes: 3_711 * 1024 * 1024,
+      },
+    });
+    expect(payload).toMatchObject({ heap_used_mb: 3_500, heap_limit_mb: 4_144, rss_mb: 3_711 });
+  });
+
+  it('reads live process numbers when none are supplied', () => {
+    const payload = buildHealthPayload({ env: {} });
+    // A running V8 always has some heap and a ceiling above it; pinning exact
+    // values would test the runtime, not this code.
+    expect(payload.heap_used_mb).toBeGreaterThan(0);
+    expect(payload.rss_mb).toBeGreaterThan(0);
+    expect(payload.heap_limit_mb).toBeGreaterThan(payload.heap_used_mb);
+  });
+
 });

--- a/src/support/healthEndpoint.ts
+++ b/src/support/healthEndpoint.ts
@@ -11,6 +11,7 @@ import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { randomUUID } from 'node:crypto';
+import { getHeapStatistics } from 'node:v8';
 
 export interface HealthPayload {
   status: 'ok';
@@ -23,7 +24,26 @@ export interface HealthPayload {
   backend_pid: number;
   backend_parent_pid: number | null;
   uptime_s: number;
+  /**
+   * V8 old-space in use, its ceiling, and process RSS — all MB.
+   *
+   * The daemon is single-threaded, so a heap near its ceiling means frequent
+   * full mark-compact collections, and those stop the world: nothing else on
+   * the loop runs for the duration. Measured on the container at 3.55 GB RSS
+   * against Node's default 4144 MB ceiling, with `/api/health` latency bimodal
+   * at sub-second or tens of seconds — but `used_heap_size` was not reported
+   * anywhere, so the cause could only be inferred from RSS. (AGT-4063)
+   *
+   * Cheap enough to sit in a payload the healthcheck polls every 30s: both
+   * calls are in-process reads of counters V8 already maintains, no syscall
+   * and no I/O.
+   */
+  heap_used_mb: number;
+  heap_limit_mb: number;
+  rss_mb: number;
 }
+
+const MB = 1024 * 1024;
 
 // One id per process lifetime, minted at module load (daemon boot).
 const INSTANCE_ID = randomUUID();
@@ -68,6 +88,7 @@ export function buildHealthPayload(
     uptimeS?: number;
     version?: string;
     instanceId?: string;
+    memory?: { heapUsedBytes: number; heapLimitBytes: number; rssBytes: number };
   } = {},
 ): HealthPayload {
   return {
@@ -79,5 +100,19 @@ export function buildHealthPayload(
     backend_pid: deps.pid ?? process.pid,
     backend_parent_pid: deps.ppid ?? process.ppid ?? null,
     uptime_s: Math.floor(deps.uptimeS ?? process.uptime()),
+    ...memoryFields(deps.memory),
+  };
+}
+
+function memoryFields(
+  override?: { heapUsedBytes: number; heapLimitBytes: number; rssBytes: number },
+): Pick<HealthPayload, 'heap_used_mb' | 'heap_limit_mb' | 'rss_mb'> {
+  const heapUsedBytes = override?.heapUsedBytes ?? process.memoryUsage().heapUsed;
+  const heapLimitBytes = override?.heapLimitBytes ?? getHeapStatistics().heap_size_limit;
+  const rssBytes = override?.rssBytes ?? process.memoryUsage.rss();
+  return {
+    heap_used_mb: Math.round(heapUsedBytes / MB),
+    heap_limit_mb: Math.round(heapLimitBytes / MB),
+    rss_mb: Math.round(rssBytes / MB),
   };
 }


### PR DESCRIPTION
Part of AGT-4063 (the reporting half; the decision it enables comes after measurement).

## Why

Diagnosing the 23–40 s event-loop stalls in AGT-4062, the daemon showed:

```
VmRSS  3.55 GB      VmHWM 3.71 GB       # plateaued, not still climbing
heap_size_limit     4144 MB             # Node's default; NODE_OPTIONS empty
```

with `/api/health` latency **bimodal** — sub-second or tens of seconds, nothing between. That is the shape of stop-the-world mark-compact pauses on a heap near its ceiling, and it is a *different* cause from the CPU contention AGT-4062 addresses.

It could not be confirmed, because nothing reported the heap:

```
grep -rn "memoryUsage\|heapUsed\|getHeapStatistics" src --include='*.ts' | grep -v test
→ (no matches)
```

RSS is not heap usage. Reading `used_heap_size` through the inspector would mean signalling a production daemon — not worth it for a diagnostic.

## What

`heap_used_mb`, `heap_limit_mb`, `rss_mb` on the existing payload.

Both sources are in-process reads of counters V8 already maintains — no syscall, no I/O. That matters here specifically: the endpoint's diagnostic value is that **its latency reads event-loop delay rather than work it does itself**, and a syscall would silently destroy that.

The exhaustive `toEqual` on the vega BackendHealth contract stays exhaustive, with the three fields added, so a future addition has to be acknowledged rather than slipping into the shape that shell parses.

## Verification

Both mutations kill the right tests:

| mutation | tests killed |
|---|---|
| memory fields dropped from the payload | contract shape; MB reporting; live-read fallback |
| bytes reported instead of MB | same three |

`npm run typecheck` clean, `oxlint` clean, 10/10 in `healthEndpoint.test.ts`. Commit gate: `openswarm review` — APPROVE, first round.

**One test I wrote was removed rather than kept**: an assertion that the payload does no file I/O, via a spy on `fs.readFileSync`. It cannot fail — the module captures `readFileSync` in a local binding at load time, so a namespace spy never intercepts it, and `VERSION` is read once at load anyway. A test that cannot fail is worse than no test; the property is documented in the code comment instead.

## Sequencing

This is observability only. It ships alongside the AGT-4062 gate deliberately: reporting a number does not change behaviour, so it cannot confound the measurement of whether that gate fixes the stalls.