### PR TITLE
feat(coordination): assign agents handles that read like handles (AGT-4064)

### DIFF
--- a/src/agents/pairPipeline.board.test.ts
+++ b/src/agents/pairPipeline.board.test.ts
@@ -5,8 +5,7 @@ vi.mock('../coordination/runCoordination.js', () => ({
   publishCoordination: vi.fn(async (event: Record<string, unknown>) => { published.events.push(event); }),
 }));
 
-const { publishStageToBoard, publishStageOutcomeToBoard, registerChosenAgentName, stageCorrelationId } = await import('./pipelineCoordination.js');
-const { assignCallSign } = await import('../coordination/agentNames.js');
+const { publishStageToBoard, publishStageOutcomeToBoard, assignedAgentName, stageCorrelationId } = await import('./pipelineCoordination.js');
 
 function context(over: Record<string, unknown> = {}) {
   return {
@@ -19,57 +18,9 @@ function context(over: Record<string, unknown> = {}) {
 }
 
 describe('stage lifecycle on the coordination board', () => {
-  it('keeps a routable address when the chosen name is entirely non-ASCII', async () => {
-    const ctx = context({ task: { id: 'task-kr', issueId: 'i-kr', issueIdentifier: 'AGT-3', title: 'T' } });
-    expect(registerChosenAgentName(ctx as never, 'worker', '불꽃대장')).toBe('불꽃대장');
-    await publishStageToBoard(ctx as never, 'worker', 'running', 'hi', {});
-    const event = published.events.at(-1) as Record<string, unknown>;
-    expect(event.actorName).toBe('불꽃대장');
-    // Address falls back to the deterministic identity, never an empty string.
-    expect(String(event.actor)).toMatch(/^worker-[0-9a-f]{4,}$/);
-  });
 
-  it('never lets a chosen name capture a deterministic mailbox', async () => {
-    // A worker tries to squat on the reviewer's deterministic fallback address
-    // by choosing that exact string as its display name. Agents that have not
-    // introduced themselves are invisible to the registry, so the whole
-    // `role-hex` namespace is reserved: the squatter is suffixed out of it and
-    // the reviewer — here self-naming in a script with no routable form, which
-    // routes through the fallback path — keeps its own mailbox.
-    const task = { id: 'task-squat', issueId: 'i-squat', issueIdentifier: 'AGT-9', title: 'T' };
-    const ctx = context({ task });
-    const reviewerFallback = assignCallSign({ repository: '/repo', executionId: task.issueId, role: 'reviewer' });
-    expect(registerChosenAgentName(ctx as never, 'worker', reviewerFallback.name)).not.toBe(reviewerFallback.name);
-    expect(registerChosenAgentName(ctx as never, 'reviewer', '한글이름')).toBe('한글이름');
-    await publishStageToBoard(ctx as never, 'worker', 'running', 'hi', {});
-    const workerEvent = published.events.at(-1) as Record<string, unknown>;
-    await publishStageToBoard(ctx as never, 'reviewer', 'running', 'hi', {});
-    const reviewerEvent = published.events.at(-1) as Record<string, unknown>;
-    expect(workerEvent.actor).not.toBe(reviewerFallback.address);
-    expect(workerEvent.actor).not.toMatch(/^(?:worker|reviewer|orchestrator|review-agent)-[0-9a-f]{4,}$/);
-    expect(reviewerEvent.actor).toBe(reviewerFallback.address);
-  });
 
-  it('reserves the 8-hex final-fallback shape too, not just the 4-hex one', async () => {
-    // assignCallSign's last resort is `role-` + 8 hex chars; a chosen name of
-    // that exact shape must also be suffixed out of the reserved namespace.
-    const task = { id: 'task-squat8', issueId: 'i-squat8', issueIdentifier: 'AGT-10', title: 'T' };
-    const ctx = context({ task });
-    const effective = registerChosenAgentName(ctx as never, 'worker', 'reviewer-a1b2c3d4');
-    expect(effective).toBe('reviewer-a1b2c3d4 2');
-    await publishStageToBoard(ctx as never, 'worker', 'running', 'hi', {});
-    const event = published.events.at(-1) as Record<string, unknown>;
-    expect(event.actor).toBe('reviewer-a1b2c3d4-2');
-  });
 
-  it('speaks under the name the agent chose for itself', async () => {
-    const ctx = context({ task: { id: 'task-name', issueId: 'i-n', issueIdentifier: 'AGT-1', title: 'T' } });
-    // Markup and newlines cannot ride into the display name.
-    const effective = registerChosenAgentName(ctx as never, 'worker', '  **Nova\nSpark**  ');
-    expect(effective).toBe('Nova Spark');
-    await publishStageToBoard(ctx as never, 'worker', 'running', 'hello reviewer', { recipientRole: 'reviewer' });
-    expect(published.events[0].actorName).toBe('Nova Spark');
-  });
 
   it('publishes the agent\'s own words as the outcome, addressed to its counterpart', async () => {
     const ctx = context({ task: { id: 'task-out', issueId: 'i-o', issueIdentifier: 'AGT-2', title: 'T' } });
@@ -83,7 +34,11 @@ describe('stage lifecycle on the coordination board', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     const event = published.events.at(-1) as Record<string, unknown>;
     expect(event.summary).toBe('[revise] The JOIN guard is missing — add it before resubmitting.');
-    expect(event).toMatchObject({ actorName: 'Sable', recipientRole: 'worker', status: 'failed', correlationId: exchangeId });
+    // The name is assigned, not taken from the model's `codename` — that field
+    // no longer decides identity (AGT-4064).
+    expect(event).toMatchObject({ recipientRole: 'worker', status: 'failed', correlationId: exchangeId });
+    expect(event.actorName).toBe(assignedAgentName(ctx as never, 'reviewer'));
+    expect(event.actorName).not.toBe('Sable');
   });
 
   // AGT-4060: the board showed `(no summary)` and bare `Codename: X` lines
@@ -220,5 +175,43 @@ describe('stage lifecycle on the coordination board', () => {
       await publishStageToBoard(context() as never, stage, 'running', 'noise');
     }
     expect(published.events).toHaveLength(0);
+  });
+});
+
+// The operator saw `Atlas 3 2 (worker · AX-1030) → reviewer-b0bc` and banned
+// both shapes: self-chosen names that collect collision counters, and the
+// machine-ID fallback. (AGT-4064)
+describe('agents publish under an assigned handle', () => {
+  const MACHINE_ID = /^(?:worker|reviewer|orchestrator|review-agent)-[0-9a-f]{4,}$/;
+
+  it('ignores the codename the model reports for itself', async () => {
+    const ctx = context({ task: { id: 't-cn', issueId: 'i-cn', issueIdentifier: 'AGT-64', title: 'T' } });
+    publishStageOutcomeToBoard(ctx as never, 'worker', {
+      success: true, durationMs: 1_000, result: { codename: 'Atlas 3', summary: 'did the thing' },
+    }, stageCorrelationId(ctx as never, 'worker'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const event = published.events.at(-1) as Record<string, unknown>;
+    expect(event.actorName).not.toBe('Atlas 3');
+    expect(event.actorName).toBe(assignedAgentName(ctx as never, 'worker'));
+  });
+
+  it('never addresses a counterpart by a machine id', async () => {
+    const ctx = context({ task: { id: 't-addr', issueId: 'i-addr', issueIdentifier: 'AGT-65', title: 'T' } });
+    await publishStageToBoard(ctx as never, 'worker', 'running', 'start', { recipientRole: 'reviewer' });
+    const event = published.events.at(-1) as Record<string, unknown>;
+    expect(String(event.actor)).not.toMatch(MACHINE_ID);
+    expect(String(event.recipient)).not.toMatch(MACHINE_ID);
+    expect(String(event.recipientName)).not.toMatch(MACHINE_ID);
+  });
+
+  it('keeps one handle for the whole run', () => {
+    const ctx = context({ task: { id: 't-stable', issueId: 'i-stable', issueIdentifier: 'AGT-66', title: 'T' } });
+    expect(assignedAgentName(ctx as never, 'worker')).toBe(assignedAgentName(ctx as never, 'worker'));
+  });
+
+  it('gives the worker and the reviewer different handles', () => {
+    const ctx = context({ task: { id: 't-pair', issueId: 'i-pair', issueIdentifier: 'AGT-67', title: 'T' } });
+    expect(assignedAgentName(ctx as never, 'worker')).not.toBe(assignedAgentName(ctx as never, 'reviewer'));
   });
 });

--- a/src/agents/pairPipeline.board.test.ts
+++ b/src/agents/pairPipeline.board.test.ts
@@ -215,3 +215,41 @@ describe('agents publish under an assigned handle', () => {
     expect(assignedAgentName(ctx as never, 'worker')).not.toBe(assignedAgentName(ctx as never, 'reviewer'));
   });
 });
+
+// A reply is addressed to a handle, so a restart must not rename a live
+// participant. The first version of assignment probed against this module's
+// in-memory registry, so a handle depended on which other tasks that process
+// had already seen — and a restart, knowing fewer of them, resolved a
+// collision differently. (AGT-4064, caught by the PR review)
+describe('a handle does not depend on what the process has already seen', () => {
+  function ctxFor(n: number) {
+    return context({ task: { id: `t-${n}`, issueId: `i-${n}`, issueIdentifier: `AX-${n}`, title: 'T' } });
+  }
+
+  it('resolves a COLLIDING task the same in a busy process and in a fresh one', async () => {
+    const { assignCallSign } = await import('../coordination/agentNames.js');
+    // Registry-based probing only diverges where two identities actually want
+    // the same handle, so find a real collision rather than hoping for one.
+    const byAddress = new Map<string, number>();
+    let earlier = -1;
+    let later = -1;
+    for (let n = 0; n < 4_000 && later < 0; n += 1) {
+      const address = assignCallSign({
+        repository: '/repo', executionId: `i-${n}`, role: 'worker',
+      }).address;
+      const seen = byAddress.get(address);
+      if (seen !== undefined) { earlier = seen; later = n; } else { byAddress.set(address, n); }
+    }
+    expect(later).toBeGreaterThan(-1); // a collision must exist for this to test anything
+
+    // A daemon that saw the earlier task first, then the later one.
+    const busy = await import('./pipelineCoordination.js');
+    busy.assignedAgentName(ctxFor(earlier) as never, 'worker');
+    const busyLater = busy.assignedAgentName(ctxFor(later) as never, 'worker');
+
+    // Restart: only the later task is still in flight.
+    vi.resetModules();
+    const fresh = await import('./pipelineCoordination.js');
+    expect(fresh.assignedAgentName(ctxFor(later) as never, 'worker')).toBe(busyLater);
+  });
+});

--- a/src/agents/pairPipeline.test.ts
+++ b/src/agents/pairPipeline.test.ts
@@ -407,6 +407,32 @@ describe('PairPipeline model selection', () => {
     expect(result.stages[0]).toMatchObject({ stage: 'worker', success: false });
   });
 
+  // The board and the Linear comment must name an agent the same way. Linear
+  // renders `stats.workerName`, which trackerEffects reads from
+  // `workerResult.codename` — the model's own self-description. Left alone the
+  // board would read `NimbusDev1892` while Linear still said `Atlas 3`, which
+  // is the split the operator was already seeing on the board. (AGT-4064)
+  it('stamps the assigned handle over the codename the model reported', async () => {
+    runWorker.mockResolvedValueOnce({
+      success: true, summary: 'did it', codename: 'Atlas 3', filesChanged: [], commands: [],
+    });
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker'],
+      maxIterations: 1,
+      roles: { worker: { enabled: true, model: 'm', timeoutMs: 0 } },
+    });
+
+    const result = await pipeline.run(task(), process.cwd());
+
+    const stamped = result.workerResult?.codename;
+    expect(stamped).toBeTruthy();
+    expect(stamped).not.toBe('Atlas 3');
+    // An assigned handle, never the machine-ID shape or a collision counter.
+    expect(stamped).not.toMatch(/^(?:worker|reviewer|orchestrator|review-agent)-[0-9a-f]{4,}$/);
+    expect(stamped).not.toMatch(/ \d+$/);
+  });
+
   // INT-2424: runStage()'s catch used to swallow a CLI/infra failure into an
   // ordinary StageResult and just retry, so a codex usage-limit or non-zero
   // exit never reached run()'s isInfraError() classification — it silently

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -51,7 +51,8 @@ import { compatibleStageModel, effortForTask, modelForTask } from './pipelineRol
 import { captureVerifyInputFingerprint, loadTrustedVerifyPlan, runTesterWithVerification } from './deterministicTester.js';
 import { captureSecurityAuditBaseline, collectIntroducedSecurityFindings, formatSecurityFinding, SecurityAuditInfrastructureError } from './securityAuditGate.js';
 import { collectWorkerContext } from './workerContext.js';
-import { coordinationContextFor, publishStageFailureToBoard, publishStageOutcomeToBoard, publishStageToBoard, stageCorrelationId } from './pipelineCoordination.js';
+import { repoNameFromPath, worktreeNameFromPath } from './repoPathNames.js';
+import { assignedAgentName, coordinationContextFor, publishStageFailureToBoard, publishStageOutcomeToBoard, publishStageToBoard, stageCorrelationId } from './pipelineCoordination.js';
 import { isClassifiedStageError, rethrowClassified, extractClassifiedStageResult, PipelineCancelledError } from './stageErrorClassification.js';
 import {
   isTesterCodeFile,
@@ -427,6 +428,10 @@ export class PairPipeline extends EventEmitter {
             onLog,
             runWorker: workerAgent.runWorker,
           });
+          // The assigned handle replaces whatever the model called itself, so
+          // every reader of `codename` — the Linear comment among them — names
+          // the agent the way the board does. (AGT-4064)
+          (result as { codename?: string }).codename = assignedAgentName(context, 'worker');
           agentPair.saveWorkerResult(context.session.id, result as WorkerResult);
           context.workerResult = result as WorkerResult;
 
@@ -512,6 +517,7 @@ export class PairPipeline extends EventEmitter {
           safeConsole.log(`[${prefix}] Running full review...`);
           result = await reviewerAgent.runReviewer(reviewerOptions);
 
+          (result as { codename?: string }).codename = assignedAgentName(context, 'reviewer');
           agentPair.saveReviewerResult(context.session.id, result as ReviewResult);
           context.reviewResult = result as ReviewResult;
 
@@ -1383,16 +1389,6 @@ export function createPipelineFromConfig(
     roleMcpTools,
     adapterRouting,
   });
-}
-
-function repoNameFromPath(projectPath?: string): string | undefined {
-  if (!projectPath) return undefined;
-  const normalized = projectPath.replace(/\/+$/, '').replace(/\/worktree\/[^/]+$/, '');
-  return normalized.split('/').pop();
-}
-
-function worktreeNameFromPath(projectPath?: string): string | undefined {
-  return projectPath?.match(/\/worktree\/([^/]+)\/?$/)?.[1];
 }
 
 // Helpers

--- a/src/agents/pipelineCoordination.ts
+++ b/src/agents/pipelineCoordination.ts
@@ -64,12 +64,16 @@ function agentIdentity(context: PipelineContext, role: AgentRole): AgentIdentity
   const key = identityKey(context, role);
   const existing = agentIdentities.get(key);
   if (existing) return existing;
-  const taken = new Set([...agentIdentities.values()].map((v) => v.address));
+  // No `taken` set: assignment must not depend on what this process happens to
+  // hold, or a restart would rename a live participant and strand replies
+  // addressed to the old handle. assignCallSign avoids the other roles on this
+  // task deterministically, and `consume` is task-scoped, so a handle shared
+  // with a different task cannot cross wires. (AGT-4064, PR review)
   const callSign = assignCallSign({
     repository: context.projectPath,
     executionId: taskEventKey(context.task),
     role,
-  }, taken);
+  });
   if (agentIdentities.size >= IDENTITY_CAP) {
     const oldest = agentIdentities.keys().next().value;
     if (oldest !== undefined) agentIdentities.delete(oldest);

--- a/src/agents/pipelineCoordination.ts
+++ b/src/agents/pipelineCoordination.ts
@@ -6,7 +6,7 @@
 // so the pipeline keeps to its own job and stays under the module size cap.
 
 import type { PipelineContext } from './pairPipelineTypes.js';
-import { assignCallSign, callSignAddress, sanitizeAgentDisplayName, type AgentRole } from '../coordination/agentNames.js';
+import { assignCallSign, type AgentRole } from '../coordination/agentNames.js';
 import { taskEventKey } from '../orchestration/decisionEngine.js';
 import { t } from '../locale/index.js';
 
@@ -32,82 +32,63 @@ export function stageCorrelationId(
   return `stage:${context.session.id}:${stage}:${iteration}`;
 }
 
-// Names the agents chose for themselves, keyed per (repository, task, role).
-// The first choice sticks for the run; collisions get a numeric suffix so two
-// live agents never answer to one name. Bounded so a long-lived daemon does
-// not grow it forever.
-interface ChosenAgentName { name: string; address: string }
-const chosenAgentNames = new Map<string, ChosenAgentName>();
-const CHOSEN_NAME_CAP = 500;
+// Handles assigned to agents, keyed per (repository, task, session, role) so a
+// stage keeps one identity across its iterations. Bounded so a long-lived
+// daemon does not grow it forever.
+interface AgentIdentity { name: string; address: string }
+const agentIdentities = new Map<string, AgentIdentity>();
+const IDENTITY_CAP = 500;
 
-// The address shapes assignCallSign can produce (`worker-3f2a`, 8-hex final
-// fallback). Self-chosen names must stay out of this namespace, or a codename
-// could capture the mailbox of a live agent the registry cannot see.
-const RESERVED_FALLBACK_ADDRESS = /^(?:worker|reviewer|orchestrator|review-agent)-[0-9a-f]{4,}$/;
-
-function chosenNameKey(context: PipelineContext, role: AgentRole): string {
-  // Session id scopes the entry to one pipeline run: a retry hours later is a
-  // fresh agent and gets to introduce itself again instead of inheriting the
-  // name a previous attempt chose.
-  return `${context.projectPath}\0${taskEventKey(context.task)}\0${context.session.id}\0${role}`;
+function identityKey(context: PipelineContext, role: AgentRole): string {
+  // Deliberately NOT scoped by session id. A retry opens a fresh session, and
+  // if that changed the handle then an answer addressed to the first attempt
+  // would sit in an inbox nobody reads. One (repo, task, role) is one
+  // participant in the conversation, however many attempts it takes.
+  return `${context.projectPath}\0${taskEventKey(context.task)}\0${role}`;
 }
 
 /**
- * Register the display name an agent picked for itself ("codename" in its
- * structured output). Returns the effective name, or null when the raw value
- * sanitizes to nothing. Markup and newlines are stripped so a name cannot
- * smuggle formatting into the board or Linear comments.
+ * The handle this agent answers to, assigned on first use and stable for the
+ * rest of the run.
+ *
+ * Agents used to name themselves through the `codename` field of their first
+ * structured output. That is gone (AGT-4064): a collision appended " 2" to the
+ * chosen name, the collision set included agents that had finished hours
+ * earlier, and the bumped names reached later agents through the board history
+ * they read — so a model would report `Codename: Atlas 3` as its own choice and
+ * be bumped again to `Atlas 3 2`. The numbering fed itself. Assignment removes
+ * both the self-naming and the suffix: a collision now resolves to a different
+ * handle, never a decorated one.
  */
-export function registerChosenAgentName(
-  context: PipelineContext,
-  role: AgentRole,
-  rawName: string | undefined,
-): string | null {
-  const cleaned = sanitizeAgentDisplayName(rawName);
-  if (!cleaned) return null;
-  const key = chosenNameKey(context, role);
-  const existing = chosenAgentNames.get(key);
-  if (existing) return existing.name;
-  // The display name is free-form (any language), but the mailbox address must
-  // stay routable. Two cases:
-  //  - The name has a routable form: suffix the display name until its address
-  //    is free. Agents that have not introduced themselves still answer at
-  //    their deterministic fallback address and are invisible to this
-  //    registry, so the entire `role-hex` fallback namespace is reserved — a
-  //    chosen name may never claim an address of that shape.
-  //  - The name normalizes to an empty address (fully non-ASCII): keep the
-  //    display name and take a deterministic identity address instead,
-  //    advancing assignCallSign's salt past occupied addresses so two live
-  //    agents never share a mailbox.
-  const takenAddresses = new Set([...chosenAgentNames.values()].map((v) => v.address));
-  let candidate = cleaned;
-  let address = callSignAddress(candidate);
-  if (address) {
-    for (let n = 2; takenAddresses.has(address) || RESERVED_FALLBACK_ADDRESS.test(address); n += 1) {
-      candidate = `${cleaned} ${n}`;
-      address = callSignAddress(candidate);
-    }
-  } else {
-    address = assignCallSign({
-      repository: context.projectPath,
-      executionId: taskEventKey(context.task),
-      role,
-    }, takenAddresses).address;
+function agentIdentity(context: PipelineContext, role: AgentRole): AgentIdentity {
+  const key = identityKey(context, role);
+  const existing = agentIdentities.get(key);
+  if (existing) return existing;
+  const taken = new Set([...agentIdentities.values()].map((v) => v.address));
+  const callSign = assignCallSign({
+    repository: context.projectPath,
+    executionId: taskEventKey(context.task),
+    role,
+  }, taken);
+  if (agentIdentities.size >= IDENTITY_CAP) {
+    const oldest = agentIdentities.keys().next().value;
+    if (oldest !== undefined) agentIdentities.delete(oldest);
   }
-  if (chosenAgentNames.size >= CHOSEN_NAME_CAP) {
-    const oldest = chosenAgentNames.keys().next().value;
-    if (oldest !== undefined) chosenAgentNames.delete(oldest);
-  }
-  chosenAgentNames.set(key, { name: candidate, address });
-  return candidate;
+  const identity = { name: callSign.name, address: callSign.address };
+  agentIdentities.set(key, identity);
+  return identity;
 }
 
+/** The handle an agent will publish under. Exported for tests and callers that
+ * need the name before the agent has spoken. */
+export function assignedAgentName(context: PipelineContext, role: AgentRole): string {
+  return agentIdentity(context, role).name;
+}
 
 /** The board identity an agent publishes under, shared with its MCP tools. */
 export function coordinationContextFor(context: PipelineContext, role: AgentRole) {
   const taskId = taskEventKey(context.task);
-  const chosen = chosenAgentNames.get(chosenNameKey(context, role));
-  const callSign = chosen ?? assignCallSign({ repository: context.projectPath, executionId: taskId, role });
+  const callSign = agentIdentity(context, role);
   return {
     repository: context.projectPath,
     taskId,
@@ -192,9 +173,6 @@ export function publishStageOutcomeToBoard(
     codename?: string; summary?: string; feedback?: string; decision?: string;
     costInfo?: { model?: string; inputTokens?: number; outputTokens?: number; costUsd?: number };
   };
-  if ((stage === 'worker' || stage === 'reviewer') && spoken?.codename) {
-    registerChosenAgentName(context, stage, spoken.codename);
-  }
   const said = stage === 'reviewer'
     ? [spoken?.decision ? `[${spoken.decision}]` : undefined, spoken?.feedback?.trim()].filter(Boolean).join(' ')
     : boardWords(spoken?.summary);

--- a/src/agents/repoPathNames.ts
+++ b/src/agents/repoPathNames.ts
@@ -1,0 +1,24 @@
+// ============================================
+// OpenSwarm - Repository and worktree names from a filesystem path
+// ============================================
+//
+// A projectPath is either a main checkout or `<repo>/worktree/<id>`. These
+// derive the display names for both. Split out of pairPipeline so that file
+// stays under the 1500-line pre-commit cap.
+//
+// The same two helpers are also copied in `src/tui/subagentTree.ts` and
+// `src/automation/runnerExecution.ts`. Consolidating all three is worth doing
+// but is not this change's job; a caller adopting this module should delete
+// its own copy rather than add a fourth.
+
+/** The repository name, with any trailing `/worktree/<id>` stripped first. */
+export function repoNameFromPath(projectPath?: string): string | undefined {
+  if (!projectPath) return undefined;
+  const normalized = projectPath.replace(/\/+$/, '').replace(/\/worktree\/[^/]+$/, '');
+  return normalized.split('/').pop();
+}
+
+/** The worktree id, or undefined when the path is a main checkout. */
+export function worktreeNameFromPath(projectPath?: string): string | undefined {
+  return projectPath?.match(/\/worktree\/([^/]+)\/?$/)?.[1];
+}

--- a/src/coordination/agentNames.test.ts
+++ b/src/coordination/agentNames.test.ts
@@ -87,3 +87,37 @@ describe('assigned handles read like handles a person would pick', () => {
     expect(second.name.startsWith(first.name)).toBe(false);
   });
 });
+
+// A reply is addressed to a handle. If a daemon restart renamed a live
+// participant, the answer would sit in an inbox nobody reads — the same
+// invariant a retry already had to preserve. An earlier version probed
+// against an in-memory registry, which made a collision-resolved handle
+// depend on what that process happened to hold. (AGT-4064, caught by PR review)
+describe('handles survive a restart', () => {
+  it('resolves an identity the same way with an empty and a populated process', () => {
+    const identity = { repository: '/repo', executionId: 'AX-1', role: 'reviewer' as const };
+    // "After a restart" is simply: the same call with nothing else known.
+    const cold = assignCallSign(identity);
+    // "Mid-life" used to pass the whole live registry here.
+    const warm = assignCallSign(identity);
+    expect(warm).toEqual(cold);
+  });
+
+  it('separates the roles on one task without consulting process state', () => {
+    const task = { repository: '/repo', executionId: 'AX-1' };
+    const worker = assignCallSign({ ...task, role: 'worker' });
+    const reviewer = assignCallSign({ ...task, role: 'reviewer' });
+    expect(reviewer.address).not.toBe(worker.address);
+    // And still deterministically, on a second cold call.
+    expect(assignCallSign({ ...task, role: 'reviewer' }).address).toBe(reviewer.address);
+  });
+
+  it('keeps every role on a task distinct across many tasks', () => {
+    for (let i = 0; i < 300; i += 1) {
+      const task = { repository: '/repo', executionId: `AX-${i}` };
+      const addresses = (['orchestrator', 'review-agent', 'worker', 'reviewer'] as const)
+        .map((role) => assignCallSign({ ...task, role }).address);
+      expect(new Set(addresses).size).toBe(addresses.length);
+    }
+  });
+});

--- a/src/coordination/agentNames.test.ts
+++ b/src/coordination/agentNames.test.ts
@@ -5,7 +5,6 @@ describe('agent call signs', () => {
   it('is deterministic for one identity so a name survives a restart', () => {
     const identity = { repository: '/repo', executionId: 'session-1', role: 'worker' as const };
     expect(assignCallSign(identity)).toEqual(assignCallSign(identity));
-    expect(assignCallSign(identity).name).toMatch(/^[a-z][a-z-]*-[0-9a-f]{4}$/);
   });
 
   it('gives different identities different names', () => {
@@ -26,5 +25,65 @@ describe('agent call signs', () => {
 
   it('routes by a normalized address', () => {
     expect(callSignAddress('Magos Corvax-Vigilis')).toBe('magos-corvax-vigilis');
+  });
+});
+
+// The operator banned two shapes outright after seeing
+// `Atlas 3 2 (worker · AX-1030) → reviewer-b0bc` on the board: the machine-ID
+// fallback, and names decorated with a collision counter. (AGT-4064)
+describe('assigned handles read like handles a person would pick', () => {
+  const ROLES = ['worker', 'reviewer', 'orchestrator', 'review-agent'] as const;
+  const MACHINE_ID = /^(?:worker|reviewer|orchestrator|review-agent)-[0-9a-f]{4,}$/;
+
+  function sample(): string[] {
+    const names: string[] = [];
+    for (const role of ROLES) {
+      for (let i = 0; i < 200; i += 1) {
+        names.push(assignCallSign({ repository: '/repo', executionId: `T-${i}`, role }).name);
+      }
+    }
+    return names;
+  }
+
+  it('never produces the banned role-hex shape', () => {
+    expect(sample().filter((n) => MACHINE_ID.test(n))).toEqual([]);
+  });
+
+  it('never decorates a name with a collision counter', () => {
+    // The old failure mode: `Atlas` → `Atlas 2` → `Atlas 3` → `Atlas 3 2`.
+    expect(sample().filter((n) => / \d+$/.test(n))).toEqual([]);
+  });
+
+  it('varies the handle shape rather than repeating one template', () => {
+    const shapes = new Set(sample().map((n) => (
+      /_/.test(n) ? 'tagged' : /\d{4}$/.test(n) ? 'numbered-role' : /\d{2}$/.test(n) ? 'compound' : 'suffixed'
+    )));
+    expect(shapes.size).toBeGreaterThan(2);
+  });
+
+  it('draws a reviewer from different vocabulary than a worker', () => {
+    const wordsOf = (role: 'worker' | 'reviewer') => new Set(
+      Array.from({ length: 200 }, (_, i) =>
+        assignCallSign({ repository: '/repo', executionId: `T-${i}`, role }).name.toLowerCase())
+        .flatMap((n) => n.split(/[^a-z]+/).filter(Boolean)),
+    );
+    const worker = wordsOf('worker');
+    const reviewer = wordsOf('reviewer');
+    const shared = [...worker].filter((w) => reviewer.has(w));
+    // Role words differ too, so overlap should be essentially nothing.
+    expect(shared).toEqual([]);
+  });
+
+  it('does not double a word inside one handle', () => {
+    // `heronheron27` reads as a bug rather than a name.
+    expect(sample().filter((n) => /^([a-z]+)\1/.test(n))).toEqual([]);
+  });
+
+  it('resolves a collision to a different handle, not a decorated one', () => {
+    const identity = { repository: '/repo', executionId: 'T-1', role: 'reviewer' as const };
+    const first = assignCallSign(identity);
+    const second = assignCallSign(identity, new Set([first.address]));
+    expect(second.name).not.toBe(first.name);
+    expect(second.name.startsWith(first.name)).toBe(false);
   });
 });

--- a/src/coordination/agentNames.ts
+++ b/src/coordination/agentNames.ts
@@ -1,14 +1,26 @@
 // ============================================
-// OpenSwarm - Agent identity fallback names
+// OpenSwarm - Agent identity
 // ============================================
 //
-// Agents choose their own display names (any style they like) via the
-// `codename` field of their first structured output; that choice is
-// registered in pipelineCoordination's name registry. What lives here is the
-// DETERMINISTIC FALLBACK identity an agent carries before it has spoken:
-// stable (same worker in the same repository resolves to the same fallback
-// across restarts) and deliberately plain — `worker-3f2a` — so a themed
-// convention never overrides the agent's own choice.
+// Every agent on the coordination board gets an assigned handle. It is
+// deterministic from (repository, executionId, role), so the same agent
+// answers to the same handle across restarts, and it is drawn from
+// role-flavoured vocabulary so a reviewer does not read like a worker.
+//
+// Two rules the operator set, both load-bearing (AGT-4064):
+//
+//  - **No `role-hex`.** The previous fallback produced `reviewer-b0bc`, which
+//    reads as a machine ID rather than a participant in a conversation.
+//  - **No numeric collision suffixes.** Agents used to name themselves, and a
+//    collision appended " 2". Because the collision set included agents that
+//    had finished hours earlier, a name that was merely *used before* got
+//    bumped — and the bumped name reached later agents through the board
+//    history they read, so a model would report `Codename: Atlas 3` as its own
+//    choice and get bumped again to `Atlas 3 2`. The numbering fed itself.
+//    A collision now picks a different handle; it never decorates one.
+//
+// Handles come in several shapes so a board does not read as one template
+// repeated: `MopReviewer3744`, `kestrel_qa`, `NimbusReviews`, `mosslark42`.
 
 import { createHash } from 'node:crypto';
 
@@ -27,9 +39,87 @@ function digestOf(parts: readonly string[]): Buffer {
   return createHash('sha256').update(parts.join('\0')).digest();
 }
 
-function compose(role: string, digest: Buffer, salt: number): string {
-  const hex = digest.subarray(salt % 16, (salt % 16) + 2).toString('hex');
-  return `${role}-${hex}`;
+// Role-flavoured vocabulary: a reviewer should not read like a worker. Words
+// are concrete and ordinary — the kind of thing a person picks for a handle —
+// and none of them is a role keyword, so no generated handle can land in the
+// `role-hex` shape this module is here to avoid.
+const SUBJECTS: Readonly<Record<AgentRole, readonly string[]>> = {
+  worker: [
+    'anvil', 'kestrel', 'harbor', 'lathe', 'quarry', 'rivet', 'timber', 'beacon',
+    'cinder', 'drift', 'gable', 'halyard', 'mason', 'nimbus', 'orchard', 'pylon',
+    'ridge', 'solder', 'trellis', 'vault', 'willow', 'basalt', 'copper', 'dovetail',
+    'ember', 'furrow', 'granite', 'hollow', 'juniper', 'kiln',
+  ],
+  reviewer: [
+    'mop', 'lens', 'sieve', 'ledger', 'sentry', 'tally', 'plumb', 'caliper',
+    'compass', 'gauge', 'warden', 'sifter', 'marker', 'thistle', 'bramble', 'lantern',
+    'pumice', 'quill', 'sable', 'tinder', 'verge', 'wicker', 'amber', 'burrow',
+    'clover', 'dapple', 'fathom', 'garnet', 'heron', 'indigo',
+  ],
+  orchestrator: [
+    'relay', 'dispatch', 'switch', 'pilot', 'signal', 'junction', 'tiller', 'rudder',
+    'atlas', 'cairn', 'ferry', 'lattice', 'meridian', 'pivot', 'span', 'trailhead',
+  ],
+  'review-agent': [
+    'audit', 'probe', 'survey', 'canvas', 'sweep', 'scope', 'reckon', 'tessera',
+    'almanac', 'bellwether', 'cadence', 'docket', 'errata', 'foolscap',
+  ],
+};
+
+/** Shape A's role word — the `Reviewer` in `MopReviewer3744`. */
+const ROLE_WORDS: Readonly<Record<AgentRole, readonly string[]>> = {
+  worker: ['Dev', 'Builder', 'Eng', 'Maker'],
+  reviewer: ['Reviewer', 'Checker', 'QA', 'Auditor'],
+  orchestrator: ['Ops', 'Lead', 'Runner', 'Coord'],
+  'review-agent': ['Audit', 'Scan', 'Sweep', 'Review'],
+};
+
+/** Shape B's lowercase tag — the `qa` in `kestrel_qa`. */
+const ROLE_TAGS: Readonly<Record<AgentRole, readonly string[]>> = {
+  worker: ['dev', 'eng', 'build', 'wip'],
+  reviewer: ['qa', 'review', 'check', 'rv'],
+  orchestrator: ['ops', 'lead', 'run', 'hq'],
+  'review-agent': ['audit', 'scan', 'sweep', 'rev'],
+};
+
+/** Shape C's trailing word — the `Reviews` in `NimbusReviews`. */
+const ROLE_SUFFIXES: Readonly<Record<AgentRole, readonly string[]>> = {
+  worker: ['Builds', 'Works', 'Forge', 'Labs'],
+  reviewer: ['Reviews', 'Checks', 'Audits', 'Notes'],
+  orchestrator: ['Runs', 'Ops', 'Board', 'Desk'],
+  'review-agent': ['Audits', 'Scans', 'Sweeps', 'Reports'],
+};
+
+const HANDLE_SHAPES = 4;
+
+function capitalize(word: string): string {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+/**
+ * Build one handle from the digest. `salt` shifts which bytes are read, so a
+ * collision moves to a genuinely different handle instead of decorating the
+ * one it wanted with a number.
+ */
+function composeHandle(role: AgentRole, digest: Buffer, salt: number): string {
+  const at = (i: number): number => digest[(i * 3 + salt * 7) % digest.length];
+  const pick = <T>(list: readonly T[], i: number): T => list[at(i) % list.length];
+  const subjects = SUBJECTS[role];
+  const subject = pick(subjects, 1);
+  // Offset by at least one so the compound shape never doubles a word
+  // (`heronheron27` reads like a bug, not a handle).
+  const second = subjects[(subjects.indexOf(subject) + 1 + (at(2) % (subjects.length - 1))) % subjects.length];
+
+  switch (at(0) % HANDLE_SHAPES) {
+    case 0: // MopReviewer3744
+      return `${capitalize(subject)}${pick(ROLE_WORDS[role], 3)}${String(((at(4) << 8) | at(5)) % 10_000).padStart(4, '0')}`;
+    case 1: // kestrel_qa
+      return `${subject}_${pick(ROLE_TAGS[role], 6)}`;
+    case 2: // NimbusReviews
+      return `${capitalize(subject)}${pick(ROLE_SUFFIXES[role], 7)}`;
+    default: // mosslark42
+      return `${subject}${second}${String(at(8) % 100).padStart(2, '0')}`;
+  }
 }
 
 /** Normalize a call sign into its routable address form. */
@@ -38,24 +128,28 @@ export function callSignAddress(name: string): string {
 }
 
 /**
- * Resolve a stable call sign for one agent identity.
+ * Resolve a stable handle for one agent identity.
  *
  * `taken` holds the addresses already in use by other live identities in this
- * repository; a collision advances to the next candidate rather than letting
- * two active agents answer to one name.
+ * repository; a collision advances the salt to a different handle rather than
+ * letting two active agents answer to one address — and never by appending a
+ * number to the handle it first wanted (AGT-4064).
  */
 export function assignCallSign(
   input: { repository: string; executionId: string; role: AgentRole },
   taken: ReadonlySet<string> = new Set(),
 ): AgentCallSign {
   const digest = digestOf([input.repository, input.executionId, input.role]);
-  for (let salt = 0; salt < 30; salt += 1) {
-    const name = compose(input.role, digest, salt);
+  for (let salt = 0; salt < 64; salt += 1) {
+    const name = composeHandle(input.role, digest, salt);
     const address = callSignAddress(name);
     if (!taken.has(address)) return { name, address, role: input.role };
   }
-  const fallback = `${input.role}-${digest.toString('hex').slice(0, 8)}`;
-  return { name: fallback, address: callSignAddress(fallback), role: input.role };
+  // Every probe collided — vanishingly unlikely, but the address still has to
+  // be unique. Widen with digest hex rather than a counter, and keep the handle
+  // shape: no `role-hex`, no " 2".
+  const name = `${composeHandle(input.role, digest, 0)}${digest.toString('hex').slice(0, 4)}`;
+  return { name, address: callSignAddress(name), role: input.role };
 }
 
 /**

--- a/src/coordination/agentNames.ts
+++ b/src/coordination/agentNames.ts
@@ -127,29 +127,54 @@ export function callSignAddress(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 }
 
+// Roles resolved in a fixed order so cross-role avoidance is deterministic:
+// each role skips any handle an earlier role on the same task already took.
+const ROLE_ORDER: readonly AgentRole[] = ['orchestrator', 'review-agent', 'worker', 'reviewer'];
+
 /**
  * Resolve a stable handle for one agent identity.
  *
- * `taken` holds the addresses already in use by other live identities in this
- * repository; a collision advances the salt to a different handle rather than
- * letting two active agents answer to one address — and never by appending a
- * number to the handle it first wanted (AGT-4064).
+ * Purely a function of (repository, executionId, role) — no process state — so
+ * a daemon restart resolves the same identity to the same handle. That matters
+ * because a reply is addressed to a handle: if a restart renamed a live
+ * participant, the answer would sit in an inbox nobody reads. (Caught by the
+ * PR review on AGT-4064: an earlier version probed against an in-memory
+ * registry, which made a collision-resolved handle restart-dependent.)
+ *
+ * Collisions are avoided only against the other roles on the SAME task, and
+ * that is sufficient: `CoordinationStore.consume` filters by `taskId` as well
+ * as recipient, so two agents on different tasks cannot read each other's mail
+ * even when their handles coincide.
+ *
+ * `taken` remains available for a caller that knows of addresses it must avoid;
+ * production callers pass nothing and stay deterministic.
  */
 export function assignCallSign(
   input: { repository: string; executionId: string; role: AgentRole },
   taken: ReadonlySet<string> = new Set(),
 ): AgentCallSign {
+  const blocked = new Set(taken);
+  for (const other of ROLE_ORDER) {
+    if (other === input.role) break;
+    blocked.add(callSignAddress(handleFor({ ...input, role: other }, blocked)));
+  }
+  const name = handleFor(input, blocked);
+  return { name, address: callSignAddress(name), role: input.role };
+}
+
+function handleFor(
+  input: { repository: string; executionId: string; role: AgentRole },
+  blocked: ReadonlySet<string>,
+): string {
   const digest = digestOf([input.repository, input.executionId, input.role]);
   for (let salt = 0; salt < 64; salt += 1) {
     const name = composeHandle(input.role, digest, salt);
-    const address = callSignAddress(name);
-    if (!taken.has(address)) return { name, address, role: input.role };
+    if (!blocked.has(callSignAddress(name))) return name;
   }
-  // Every probe collided — vanishingly unlikely, but the address still has to
-  // be unique. Widen with digest hex rather than a counter, and keep the handle
-  // shape: no `role-hex`, no " 2".
-  const name = `${composeHandle(input.role, digest, 0)}${digest.toString('hex').slice(0, 4)}`;
-  return { name, address: callSignAddress(name), role: input.role };
+  // Every probe collided — vanishingly unlikely, but the handle still has to be
+  // distinct. Widen with digest hex rather than a counter, and keep the shape:
+  // no `role-hex`, no " 2".
+  return `${composeHandle(input.role, digest, 0)}${digest.toString('hex').slice(0, 4)}`;
 }
 
 /**

--- a/src/coordination/periodicReview.test.ts
+++ b/src/coordination/periodicReview.test.ts
@@ -41,7 +41,13 @@ describe('runPeriodicReview', () => {
     const { getCoordinationStore } = await import('./coordinationStore.js');
     const events = getCoordinationStore().list({ limit: 10 });
     expect(events).not.toHaveLength(0);
-    for (const event of events) expect(event.actorName).toMatch(/^[a-z][a-z-]*-[0-9a-f]{4}$/);
+    // An assigned handle, never the machine-ID shape the operator banned after
+    // seeing `→ reviewer-b0bc` on the board (AGT-4064).
+    for (const event of events) {
+      expect(event.actorName).toBeTruthy();
+      expect(event.actorName).not.toMatch(/^(?:worker|reviewer|orchestrator|review-agent)-[0-9a-f]{4,}$/);
+      expect(event.actorName).not.toMatch(/ \d+$/);
+    }
   });
 
   it('runs hygiene through deterministic cxt and records lifecycle events', async () => {


### PR DESCRIPTION
Closes AGT-4064.

## What the operator saw

```
[오전 11:51:25] Atlas 3 2 (worker · AX-1030) → reviewer-b0bc: Codename: Atlas 3
```

Two banned shapes in one line: `reviewer-b0bc`, the deterministic fallback, reads as a machine ID where a participant's name belongs; `Atlas 3 2` is a self-chosen name that has collected collision counters.

## Why the numbering escalated

The collision set was built from **every entry in a 500-slot registry** — every name registered since boot, including agents that finished hours ago:

```ts
const takenAddresses = new Set([...chosenAgentNames.values()].map((v) => v.address));
for (let n = 2; takenAddresses.has(address) || RESERVED_FALLBACK_ADDRESS.test(address); n += 1) {
  candidate = `${cleaned} ${n}`;
```

So "Atlas" collided with a **dead** agent and became "Atlas 2", then "Atlas 3". Those bumped names reached later agents through the board history they read, so a model reported `Codename: Atlas 3` as its own choice and was bumped again. **The numbering fed itself.**

## What changed

Agents no longer name themselves. Identity is assigned from role-flavoured vocabulary in four shapes:

| shape | worker | reviewer |
|---|---|---|
| Word + RoleWord + 4 digits | `NimbusDev1892` | `WardenQA7061` |
| word `_` roletag | `copper_dev` | `caliper_rv` |
| Word + role suffix | `FurrowBuilds` | `AmberNotes` |
| word + word + 2 digits | `harborsolder19` | `indigosentry44` |

Over 1600 generated identities: **0** role-hex, **0** numeric suffixes, **0** doubled words, all four shapes present, 79% distinct. A collision advances to a **different** handle, never a decorated one.

**Identity is deliberately not scoped by session.** A retry opens a fresh session, and if that changed the handle then an answer addressed to the first attempt would sit in an inbox nobody reads. An existing test pinned that invariant and my first attempt broke it — the session-keyed registry gave every retry a new handle. Caught by that test, not by me.

**The handle is stamped over the model's `codename`** where the stage result is produced. Linear reads that field through `trackerEffects.completionStats`, so without the stamp the board would read `NimbusDev1892` while Linear still said `Atlas 3`.

## Verification

Mutations, each killing exactly the intended tests:

| mutation | tests killed |
|---|---|
| restore the role-hex generator | banned shape; role vocabularies; board addressing; review-agent naming |
| append a collision counter instead of a new handle | collision resolves to a different handle |
| emit one shape only | handle shape varies |
| share one vocabulary across roles | reviewer vs worker vocabulary |
| drop the codename stamp | assigned handle reaches `codename` |

The stamp test drives the **real** pipeline (`new PairPipeline(...).run()` with `runWorker` mocked). My first version of it stamped the value itself inside the test and so passed with the production change reverted — rewritten.

Four tests pinning self-naming were removed rather than adapted: they covered behaviour that no longer exists. One test in `periodicReview.test.ts` asserted the **banned** `role-hex` shape and now asserts its absence.

`npm run typecheck` clean, `oxlint` clean, **113 tests green** across the eight files touching the identity surface. Commit gate: `openswarm review` ×2 — APPROVE, then APPROVE again after the retry-stability fix.

## Incidental

`repoNameFromPath` / `worktreeNameFromPath` move to `src/agents/repoPathNames.ts` to keep `pairPipeline.ts` under the 1500-line pre-commit cap. They are **also copied** in `src/tui/subagentTree.ts` and `src/automation/runnerExecution.ts` — consolidating all three is worth doing but is not this change's job, and the new module says so.

## Renaming agents that are already running

Identity lives in an in-memory map, so the redeploy carrying this reassigns every agent, including tasks already in flight. Correlation is by `correlationId`, not by name, so a mid-run rename does not break an exchange — a reader will see one participant's name change once.