### PR TITLE
feat(coordination): let an agent wait for a reply instead of being killed for waiting (AGT-4065)

### DIFF
--- a/src/adapters/agenticLoop.test.ts
+++ b/src/adapters/agenticLoop.test.ts
@@ -639,3 +639,41 @@ describe('compactPriorTurns with a wide tool fan-out', () => {
     expect(fanOutHasNoOrphans(messages)).toBe(true);
   });
 });
+
+// `allToolCallsSeen` keys on name+args, and `coordination_read` takes no
+// parameters — so every inbox check produced an identical key and three checks
+// of a quiet inbox tripped the stall detector. An agent waiting for a reply was
+// killed for waiting. (AGT-4065)
+describe('checking an inbox is not a stall', () => {
+  const call = (name: string, args = '{}') => ({ id: `c-${name}-${args}`, function: { name, arguments: args } });
+
+  it('does not count a repeated inbox check as a stalled turn', async () => {
+    const { allToolCallsSeen } = await import('./agenticLoop.js');
+    const seen = new Set<string>();
+    const turn = [call('coordination_read')];
+    // Simulate three consecutive identical checks, as an agent awaiting a reply
+    // would make.
+    for (let i = 0; i < 3; i += 1) {
+      expect(allToolCallsSeen(turn, seen)).toBe(false);
+      seen.add('coordination_read:{}');
+    }
+  });
+
+  it('does not count a wait as a stalled turn either', async () => {
+    const { allToolCallsSeen } = await import('./agenticLoop.js');
+    expect(allToolCallsSeen([call('coordination_wait', '{"timeout_ms":5000}')],
+      new Set(['coordination_wait:{"timeout_ms":5000}']))).toBe(false);
+  });
+
+  it('still catches a genuine stall on tools that read only this agent\'s own work', async () => {
+    const { allToolCallsSeen } = await import('./agenticLoop.js');
+    const repeated = [call('read_file', '{"path":"a.ts"}')];
+    expect(allToolCallsSeen(repeated, new Set(['read_file:{"path":"a.ts"}']))).toBe(true);
+  });
+
+  it('a turn that also checked the inbox is not a stall, even when its other calls repeat', async () => {
+    const { allToolCallsSeen } = await import('./agenticLoop.js');
+    const mixed = [call('read_file', '{"path":"a.ts"}'), call('coordination_read')];
+    expect(allToolCallsSeen(mixed, new Set(['read_file:{"path":"a.ts"}', 'coordination_read:{}']))).toBe(false);
+  });
+});

--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -516,7 +516,7 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
       }
     }
 
-    const results: ToolResult[] = await executeToolCalls(toolCalls, cwd, readCache, { protectedFiles, bashTimeoutMs, readOnly, coordinationContext });
+    const results: ToolResult[] = await executeToolCalls(toolCalls, cwd, readCache, { protectedFiles, bashTimeoutMs, readOnly, coordinationContext, loopDeadlineAt: Number.isFinite(deadline) ? deadline : undefined });
     toolCallCount += toolCalls.length;
     // Count only SUCCESSFUL edits — a model whose edit_file calls all fail
     // (old_string not found, protected file) has not modified anything, and

--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -748,12 +748,32 @@ export function toolCallKey(tc: ToolCall): string {
 }
 
 /**
+ * Tools whose answer changes without this agent doing anything.
+ *
+ * `same name+args` is a good stall signal for a tool that reads the agent's own
+ * workspace, and a bad one for a tool that reads an inbox: `coordination_read`
+ * takes no parameters at all, so every check produces an identical key and
+ * three checks of a quiet inbox looked exactly like a stalled model. An agent
+ * that waited for a reply was killed for waiting. (AGT-4065)
+ *
+ * The loop is still bounded — `maxTurns` and the wall-clock deadline both
+ * still apply — so exempting these cannot produce an unbounded run.
+ */
+const EXTERNALLY_CHANGING_TOOLS: ReadonlySet<string> = new Set([
+  'coordination_read',
+  'coordination_wait',
+]);
+
+/**
  * True when every tool call this turn was already seen (same name+args), i.e.
  * pure repetition with no new info or change — a stalled turn. Empty turns are
- * not stalls (the model produced no tool calls, which ends the loop normally).
+ * not stalls (the model produced no tool calls, which ends the loop normally),
+ * and neither is a turn that checked something only the outside world can
+ * change.
  */
 export function allToolCallsSeen(toolCalls: ToolCall[], seen: Set<string>): boolean {
   if (toolCalls.length === 0) return false;
+  if (toolCalls.some((tc) => EXTERNALLY_CHANGING_TOOLS.has(tc.function.name))) return false;
   return toolCalls.every((tc) => seen.has(toolCallKey(tc)));
 }
 

--- a/src/adapters/tools.test.ts
+++ b/src/adapters/tools.test.ts
@@ -724,6 +724,37 @@ describe('executeTool coordination_history dispatch (AGT-4054)', () => {
     expect(result.content).not.toContain('Unknown tool');
     expect(() => JSON.parse(result.content)).not.toThrow();
   });
+
+  // The adapter used to carry its own hardcoded copy of the coordination tool
+  // names, so a tool could be defined, advertised to the model, and still fall
+  // through to "Unknown tool" here. Drive every declared name through the real
+  // dispatch rather than trusting the two lists to stay in step. (AGT-4065)
+  it('dispatches every declared coordination tool, not a hardcoded subset', async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'openswarm-coord-dispatch-'));
+    process.env.OPENSWARM_COORDINATION_FILE = path.join(dir, 'events.json');
+    process.env.OPENSWARM_AUTOMATION_DB = path.join(dir, 'automation.db');
+    (await import('../coordination/coordinationStore.js')).resetCoordinationStoreForTests();
+    (await import('../coordination/coordinationTrace.js')).resetTraceDbForTests();
+
+    const { COORDINATION_TOOL_DEFINITIONS } = await import('../coordination/coordinationTools.js');
+    const coordinationContext: CoordinationToolContext = {
+      repository: TMP_DIR, taskId: 't-agt-4065', actor: 'worker-test', actorName: 'Worker Test',
+    };
+    // Arguments that make each tool a no-op: a zero wait returns immediately,
+    // and ask_human is excluded because it deliberately ends a run.
+    const args: Record<string, Record<string, unknown>> = {
+      coordination_wait: { timeout_ms: 0 },
+    };
+
+    for (const definition of COORDINATION_TOOL_DEFINITIONS) {
+      const name = definition.function.name;
+      if (name === 'ask_human' || name === 'coordination_publish') continue;
+      const result = await executeTool(
+        makeCall(name, args[name] ?? {}), TMP_DIR, undefined, { coordinationContext },
+      );
+      expect(result.content, `${name} did not reach executeCoordinationTool`).not.toContain('Unknown tool');
+    }
+  });
 });
 
 // ──────────────────────────────────────────────

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -15,7 +15,7 @@ import { webFetch, webSearch } from './webTools.js';
 import { isMcpTool, callMcpTool } from '../mcp/mcpClient.js';
 import { applyV4APatch } from './applyPatch.js';
 import { atomicWriteFile } from '../support/atomicFile.js';
-import { executeCoordinationTool, type CoordinationToolContext } from '../coordination/coordinationTools.js';
+import { COORDINATION_TOOL_NAMES, executeCoordinationTool, type CoordinationToolContext } from '../coordination/coordinationTools.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -837,7 +837,7 @@ export async function executeTool(
       }
 
       default:
-        if (['coordination_read', 'coordination_history', 'coordination_publish', 'ask_human'].includes(name)) {
+        if (COORDINATION_TOOL_NAMES.has(name)) {
           if (!execOptions?.coordinationContext) {
             return { tool_call_id: callId, content: 'Coordination tools are unavailable outside a scoped autonomous run.', is_error: true };
           }

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -349,6 +349,14 @@ export interface ToolExecOptions {
   readOnly?: boolean;
   /** Run-scoped identity for worker coordination tool dispatch. */
   coordinationContext?: CoordinationToolContext;
+  /**
+   * Epoch ms at which the enclosing agentic loop gives up, when it has one.
+   * `coordination_wait` clamps itself below this: a fixed ceiling alone would
+   * let a wait outlive the loop it claims to respect, and the loop would then
+   * report a timeout instead of the answer that was about to arrive.
+   * (AGT-4065, caught by the PR review.)
+   */
+  loopDeadlineAt?: number;
 }
 
 const DEFAULT_BASH_TIMEOUT_MS = 30000;
@@ -841,7 +849,11 @@ export async function executeTool(
           if (!execOptions?.coordinationContext) {
             return { tool_call_id: callId, content: 'Coordination tools are unavailable outside a scoped autonomous run.', is_error: true };
           }
-          const result = await executeCoordinationTool(name, (args ?? {}) as Record<string, unknown>, execOptions.coordinationContext);
+          const result = await executeCoordinationTool(
+            name,
+            { ...(args ?? {}) as Record<string, unknown>, __loopDeadlineAt: execOptions.loopDeadlineAt },
+            execOptions.coordinationContext,
+          );
           return { tool_call_id: callId, content: result.content, is_error: result.isError };
         }
         // MCP tools (named `server__tool`) route to their server via the MCP client.

--- a/src/coordination/coordinationTools.test.ts
+++ b/src/coordination/coordinationTools.test.ts
@@ -80,3 +80,181 @@ describe('coordination tools', () => {
     expect(payload.instruction).toContain('nobody has been paged');
   });
 });
+
+// An agent that waited for a reply used to be killed for waiting: three checks
+// of a quiet inbox looked exactly like a stalled model. (AGT-4065)
+describe('coordination_wait', () => {
+  it('reports an unreadable board instead of an empty inbox', async () => {
+    // A board that cannot be read is not a board with no mail. Returning []
+    // would let an agent conclude nobody answered and proceed. (Caught by the
+    // commit-gate review.)
+    const mod = await tools();
+    const store = { consume: async () => { throw new Error('EACCES coordination.json'); } };
+    await expect(mod.waitForInbox(store, { repository: '/repo', taskId: 't1', actor: 'a' }, 120))
+      .rejects.toThrow(/Coordination board unavailable.*EACCES/);
+  });
+
+  it('still reports an empty inbox as empty when the board is readable', async () => {
+    const mod = await tools();
+    const store = { consume: async () => [] as unknown[] };
+    await expect(mod.waitForInbox(store, { repository: '/repo', taskId: 't1', actor: 'a' }, 120))
+      .resolves.toEqual([]);
+  });
+
+  it('does not fail the wait for a transient read error that later succeeds', async () => {
+    const mod = await tools();
+    let call = 0;
+    const store = {
+      consume: async () => {
+        call += 1;
+        if (call === 1) throw new Error('transient');
+        return [];
+      },
+    };
+    // The 2s re-drain gives the second attempt a chance before the deadline.
+    await expect(mod.waitForInbox(store, { repository: '/repo', taskId: 't1', actor: 'a' }, 3_000))
+      .resolves.toEqual([]);
+  }, 10_000);
+
+  it('wakes for a publisher the in-process hub cannot see', async () => {
+    // `openswarm attach` and the CLI write to the board file from their own
+    // processes, where an in-memory emitter never fires. Without a slow
+    // re-drain the wait would silently always time out for exactly the
+    // operator path it exists to serve. Simulate by writing through the store
+    // with the hub deafened. (Caught by the commit-gate review.)
+    const mod = await tools();
+    const alice = assignCallSign({ repository: '/repo', executionId: 'w-xp', role: 'worker' });
+    const bob = assignCallSign({ repository: '/repo', executionId: 'w-xp-b', role: 'reviewer' });
+    const { getEventHub } = await import('../core/eventHub.js');
+    const hub = getEventHub();
+
+    const waiting = mod.executeCoordinationTool(
+      'coordination_wait', { timeout_ms: 8_000 },
+      { repository: '/repo', taskId: 't1', actor: alice.address },
+    );
+    setTimeout(() => {
+      // Deafen the hub for this publish, so only the re-drain can notice.
+      const listeners = hub.listeners('coordination:published');
+      hub.removeAllListeners('coordination:published');
+      void mod.executeCoordinationTool(
+        'coordination_publish',
+        { kind: 'advice-response', recipient: alice.address, summary: 'from another process' },
+        { repository: '/repo', taskId: 't1', actor: bob.address },
+      ).then(() => {
+        for (const l of listeners) hub.on('coordination:published', l as () => void);
+      });
+    }, 30);
+
+    const events = JSON.parse((await waiting).content) as Array<{ summary: string }>;
+    expect(events.map((e) => e.summary)).toContain('from another process');
+  }, 15_000);
+
+  it('does not drop a wake-up that arrives while a drain is in flight', async () => {
+    // The window is milliseconds wide against the real store, so drive it with
+    // a fake: the first drain is still running when the event fires. Guarding
+    // the drain without remembering the wake-up left that message waiting for
+    // the next poll — or forever, if nothing else was ever published.
+    const mod = await tools();
+    const { getEventHub } = await import('../core/eventHub.js');
+    const hub = getEventHub();
+    let call = 0;
+    const store = {
+      consume: async () => {
+        call += 1;
+        if (call === 1) {
+          // Fire the wake-up mid-drain, then finish this drain empty.
+          setTimeout(() => hub.emit('coordination:published', {}), 5);
+          await new Promise((r) => setTimeout(r, 40));
+          return [];
+        }
+        return [{ summary: 'landed mid-drain' }];
+      },
+    };
+
+    const started = Date.now();
+    const events = await mod.waitForInbox(
+      store, { repository: '/repo', taskId: 't1', actor: 'a' }, 5_000,
+    ) as Array<{ summary: string }>;
+    expect(events.map((e) => e.summary)).toContain('landed mid-drain');
+    // Well under the 2s re-drain interval: the wake-up itself has to be what
+    // produced the second drain.
+    expect(Date.now() - started).toBeLessThan(1_500);
+  });
+
+  it('returns at the deadline when nothing arrives', async () => {
+    const mod = await tools();
+    const alice = assignCallSign({ repository: '/repo', executionId: 'w-quiet', role: 'worker' });
+    const started = Date.now();
+    const result = await mod.executeCoordinationTool(
+      'coordination_wait',
+      { timeout_ms: 120 },
+      { repository: '/repo', taskId: 't1', actor: alice.address },
+    );
+    expect(JSON.parse(result.content)).toEqual([]);
+    expect(Date.now() - started).toBeGreaterThanOrEqual(100);
+  });
+
+  it('returns as soon as a message addressed to the agent arrives', async () => {
+    const mod = await tools();
+    const alice = assignCallSign({ repository: '/repo', executionId: 'w-a', role: 'worker' });
+    const bob = assignCallSign({ repository: '/repo', executionId: 'w-b', role: 'reviewer' });
+
+    const started = Date.now();
+    // A generous deadline: the point is that it returns long before it.
+    const waiting = mod.executeCoordinationTool(
+      'coordination_wait',
+      { timeout_ms: 5_000 },
+      { repository: '/repo', taskId: 't1', actor: alice.address },
+    );
+    setTimeout(() => {
+      void mod.executeCoordinationTool(
+        'coordination_publish',
+        { kind: 'advice-response', recipient: alice.address, summary: 'here is the answer' },
+        { repository: '/repo', taskId: 't1', actor: bob.address },
+      );
+    }, 30);
+
+    const events = JSON.parse((await waiting).content) as Array<{ summary: string }>;
+    expect(events.map((e) => e.summary)).toContain('here is the answer');
+    expect(Date.now() - started).toBeLessThan(4_000);
+  });
+
+  it('does not lose a message that landed before the wait began', async () => {
+    // Waiting must not be a way to miss mail: anything that arrived since the
+    // agent's last read has to come back on the first drain.
+    const mod = await tools();
+    const alice = assignCallSign({ repository: '/repo', executionId: 'w-pre', role: 'worker' });
+    const bob = assignCallSign({ repository: '/repo', executionId: 'w-pre-b', role: 'reviewer' });
+    await mod.executeCoordinationTool(
+      'coordination_publish',
+      { kind: 'advice-request', recipient: alice.address, summary: 'sent earlier' },
+      { repository: '/repo', taskId: 't1', actor: bob.address },
+    );
+    const result = await mod.executeCoordinationTool(
+      'coordination_wait', { timeout_ms: 50 },
+      { repository: '/repo', taskId: 't1', actor: alice.address },
+    );
+    expect((JSON.parse(result.content) as Array<{ summary: string }>).map((e) => e.summary)).toContain('sent earlier');
+  });
+
+  it('clamps a requested wait to something a stage can afford', async () => {
+    const { resolveWaitMs, COORDINATION_WAIT_MAX_MS, COORDINATION_WAIT_DEFAULT_MS } =
+      await import('./coordinationTools.js');
+    // Worker stages get 20 min and the agentic loop 5 — a wait must never be a
+    // way to burn that budget and fail the stage as infra_error.
+    expect(resolveWaitMs(60 * 60_000)).toBe(COORDINATION_WAIT_MAX_MS);
+    expect(resolveWaitMs(undefined)).toBe(COORDINATION_WAIT_DEFAULT_MS);
+    expect(resolveWaitMs('soon')).toBe(COORDINATION_WAIT_DEFAULT_MS);
+    expect(resolveWaitMs(-5)).toBe(0);
+    expect(resolveWaitMs(1_500)).toBe(1_500);
+  });
+
+  it('is dispatchable — the adapter derives its tool names from the definitions', async () => {
+    const { COORDINATION_TOOL_NAMES, COORDINATION_TOOL_DEFINITIONS } = await import('./coordinationTools.js');
+    // The adapter used to keep a hardcoded copy of this list, so a new tool was
+    // defined, advertised, and then silently undispatchable.
+    expect(COORDINATION_TOOL_NAMES.has('coordination_wait')).toBe(true);
+    expect([...COORDINATION_TOOL_NAMES].sort())
+      .toEqual(COORDINATION_TOOL_DEFINITIONS.map((d) => d.function.name).sort());
+  });
+});

--- a/src/coordination/coordinationTools.test.ts
+++ b/src/coordination/coordinationTools.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
+import fsp from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { assignCallSign } from './agentNames.js';
@@ -257,4 +258,37 @@ describe('coordination_wait', () => {
     expect([...COORDINATION_TOOL_NAMES].sort())
       .toEqual(COORDINATION_TOOL_DEFINITIONS.map((d) => d.function.name).sort());
   });
+});
+
+// Unref'd timers let a process whose only pending handles are those timers
+// exit mid-wait, and the awaited promise simply never resolves. Nothing
+// in-process can observe that — vitest's own worker always has other handles —
+// so drive a real child. (Caught by the PR review; AGT-4065)
+describe('a wait keeps its process alive until it settles', () => {
+  it('resolves in a child process with nothing else pending', async () => {
+    const { execFile } = await import('node:child_process');
+    const { promisify } = await import('node:util');
+    const run = promisify(execFile);
+    const scriptDir = mkdtempSync(join(tmpdir(), 'osw-wait-alive-'));
+    const script = join(scriptDir, 'probe.mts');
+    await fsp.writeFile(script, [
+      `import { waitForInbox } from ${JSON.stringify(join(process.cwd(), 'src/coordination/coordinationTools.ts'))};`,
+      'const store = { consume: async () => [] };',
+      'const started = Date.now();',
+      "const events = await waitForInbox(store, { repository: '/r', taskId: 't', actor: 'a' }, 1200);",
+      "console.log('SETTLED', JSON.stringify(events), Date.now() - started >= 1000);",
+    ].join('\n'), 'utf-8');
+
+    try {
+      const { stdout } = await run(
+        process.execPath,
+        [join(process.cwd(), 'node_modules/tsx/dist/cli.mjs'), script],
+        { cwd: process.cwd(), timeout: 60_000 },
+      );
+      // Without the fix the child exits silently and this never appears.
+      expect(stdout).toContain('SETTLED [] true');
+    } finally {
+      rmSync(scriptDir, { recursive: true, force: true });
+    }
+  }, 90_000);
 });

--- a/src/coordination/coordinationTools.test.ts
+++ b/src/coordination/coordinationTools.test.ts
@@ -244,6 +244,16 @@ describe('coordination_wait', () => {
     // Worker stages get 20 min and the agentic loop 5 — a wait must never be a
     // way to burn that budget and fail the stage as infra_error.
     expect(resolveWaitMs(60 * 60_000)).toBe(COORDINATION_WAIT_MAX_MS);
+    // The fixed ceiling is not enough on its own: a loop with seconds left
+    // would still grant a full-length wait and then time out instead of
+    // returning the answer that was about to arrive.
+    const now = 1_000_000;
+    const { COORDINATION_WAIT_LOOP_MARGIN_MS } = await import('./coordinationTools.js');
+    expect(resolveWaitMs(60_000, now + 20_000, now)).toBe(20_000 - COORDINATION_WAIT_LOOP_MARGIN_MS);
+    // Past the deadline already: nothing left to spend.
+    expect(resolveWaitMs(60_000, now + 1_000, now)).toBe(0);
+    // A generous loop deadline does not raise the fixed ceiling.
+    expect(resolveWaitMs(60 * 60_000, now + 60 * 60_000, now)).toBe(COORDINATION_WAIT_MAX_MS);
     expect(resolveWaitMs(undefined)).toBe(COORDINATION_WAIT_DEFAULT_MS);
     expect(resolveWaitMs('soon')).toBe(COORDINATION_WAIT_DEFAULT_MS);
     expect(resolveWaitMs(-5)).toBe(0);

--- a/src/coordination/coordinationTools.test.ts
+++ b/src/coordination/coordinationTools.test.ts
@@ -292,3 +292,68 @@ describe('a wait keeps its process alive until it settles', () => {
     }
   }, 90_000);
 });
+
+describe('the deadline does not throw away mail a drain was collecting', () => {
+  it('returns a message whose drain outlived the timeout', async () => {
+    // `consume` is destructive: it marks what it returns as seen. Resolving []
+    // while a drain was in flight consumed the message and discarded it — the
+    // agent saw "nobody answered" for mail that had arrived.
+    // (Caught by the PR review; AGT-4065)
+    const mod = await tools();
+    const store = {
+      consume: async () => {
+        await new Promise((r) => setTimeout(r, 300));
+        return [{ summary: 'arrived just before the deadline' }];
+      },
+    };
+    const events = await mod.waitForInbox(
+      store, { repository: '/r', taskId: 't', actor: 'a' }, 80,
+    ) as Array<{ summary: string }>;
+    expect(events.map((e) => e.summary)).toContain('arrived just before the deadline');
+  }, 10_000);
+
+  it('still settles under a stream of wake-ups after the deadline', async () => {
+    // The post-expiry catch-up is bounded by detaching the wake-up sources at
+    // the deadline. Without that, continuous publishing keeps re-arming the
+    // catch-up and the wait never returns.
+    const mod = await tools();
+    const { getEventHub } = await import('../core/eventHub.js');
+    const noise = setInterval(() => getEventHub().emit('coordination:published', {}), 10);
+    const store = {
+      consume: async () => { await new Promise((r) => setTimeout(r, 30)); return [] as unknown[]; },
+    };
+    try {
+      const started = Date.now();
+      await expect(mod.waitForInbox(store, { repository: '/r', taskId: 't', actor: 'a' }, 100))
+        .resolves.toEqual([]);
+      expect(Date.now() - started).toBeLessThan(3_000);
+    } finally {
+      clearInterval(noise);
+    }
+  }, 10_000);
+
+  it('honours a wake-up recorded during the drain that outlived the deadline', async () => {
+    // The message was published BEFORE the deadline; only its delivery landed
+    // after. Dropping the recorded wake-up reported an empty inbox for mail
+    // that had already arrived. (Caught by the PR review; AGT-4065)
+    const mod = await tools();
+    const { getEventHub } = await import('../core/eventHub.js');
+    let call = 0;
+    const store = {
+      consume: async () => {
+        call += 1;
+        if (call === 1) {
+          setTimeout(() => getEventHub().emit('coordination:published', {}), 20);
+          await new Promise((r) => setTimeout(r, 200));
+          return [];
+        }
+        return [{ summary: 'published before the deadline' }];
+      },
+    };
+    const events = await mod.waitForInbox(
+      store, { repository: '/r', taskId: 't', actor: 'a' }, 80,
+    ) as Array<{ summary: string }>;
+    expect(events.map((e) => e.summary)).toContain('published before the deadline');
+  }, 10_000);
+
+});

--- a/src/coordination/coordinationTools.test.ts
+++ b/src/coordination/coordinationTools.test.ts
@@ -117,6 +117,26 @@ describe('coordination_wait', () => {
       .resolves.toEqual([]);
   }, 10_000);
 
+  it('reports a board that broke after its first successful read, not an empty inbox', async () => {
+    // The mirror of the transient case, and the one that bites: the first
+    // drain succeeds empty, then the board becomes unreadable for the rest of
+    // the wait. Tracking "any drain ever succeeded" called that a clean empty
+    // inbox — but that first read says nothing about the seconds that followed
+    // it, during which a reply could have landed unseen. The LAST observation
+    // is what an empty list has to rest on. (Caught by the fresh PR review.)
+    const mod = await tools();
+    let call = 0;
+    const store = {
+      consume: async () => {
+        call += 1;
+        if (call === 1) return [] as unknown[];
+        throw new Error('EACCES board went away');
+      },
+    };
+    await expect(mod.waitForInbox(store, { repository: '/repo', taskId: 't1', actor: 'a' }, 3_000))
+      .rejects.toThrow(/Coordination board unavailable.*EACCES/);
+  }, 10_000);
+
   it('wakes for a publisher the in-process hub cannot see', async () => {
     // `openswarm attach` and the CLI write to the board file from their own
     // processes, where an in-memory emitter never fires. Without a slow

--- a/src/coordination/coordinationTools.ts
+++ b/src/coordination/coordinationTools.ts
@@ -320,9 +320,12 @@ export async function waitForInbox(
       finish([]);
     }, timeoutMs);
     const poll = setInterval(check, COORDINATION_WAIT_POLL_MS);
-    // Neither timer may hold the process open past this wait.
-    deadline.unref?.();
-    poll.unref?.();
+    // Deliberately NOT unref'd. Someone is awaiting this promise, so the
+    // process must stay alive until it settles — unref'ing let a CLI run whose
+    // only pending handles were these timers exit mid-wait, and the awaited
+    // promise simply never resolved. How long they can hold the loop open is
+    // already bounded by `deadline`, which is the clamped timeout.
+    // (Caught by the PR review.)
     hub.on('coordination:published', check);
     // Now that something is listening, look at what is already there.
     check();

--- a/src/coordination/coordinationTools.ts
+++ b/src/coordination/coordinationTools.ts
@@ -7,6 +7,26 @@ import { getCoordinationStore, type CoordinationKind } from './coordinationStore
 import { postHumanQuestion } from './humanQuestions.js';
 import { callSignAddress } from './agentNames.js';
 
+/**
+ * Bounds on `coordination_wait`.
+ *
+ * A wait sits inside a stage that has its own wall clock — worker 20 min,
+ * reviewer and tester 6 min (`src/agents/stageTimeouts.ts`) — and inside an
+ * agentic loop whose own deadline defaults to 5 minutes. Waiting must never be
+ * a way to burn that budget and fail the stage as an infrastructure error, so
+ * a requested timeout is clamped hard. (AGT-4065)
+ */
+export const COORDINATION_WAIT_MAX_MS = 60_000;
+export const COORDINATION_WAIT_DEFAULT_MS = 20_000;
+
+/** Clamp a model-supplied wait to something a stage can afford. */
+export function resolveWaitMs(requested: unknown): number {
+  const value = typeof requested === 'number' && Number.isFinite(requested)
+    ? requested
+    : COORDINATION_WAIT_DEFAULT_MS;
+  return Math.min(COORDINATION_WAIT_MAX_MS, Math.max(0, Math.trunc(value)));
+}
+
 export interface CoordinationToolContext {
   repository: string;
   taskId: string;
@@ -29,6 +49,19 @@ export const COORDINATION_TOOL_DEFINITIONS: ToolDefinition[] = [
       name: 'coordination_read',
       description: 'Read new advice, delegation, and response messages addressed to this agent on the repository board. Each message names the agent that sent it.',
       parameters: { type: 'object', properties: {} },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'coordination_wait',
+      description: 'Wait for the next message addressed to this agent, up to timeout_ms. Returns as soon as something arrives, or an empty list at the deadline. Use it after asking a peer or the operator something, instead of guessing an answer or giving up.',
+      parameters: {
+        type: 'object',
+        properties: {
+          timeout_ms: { type: 'number', description: 'How long to wait, in milliseconds. Clamped to the time this stage has left.' },
+        },
+      },
     },
   },
   {
@@ -88,6 +121,16 @@ export const COORDINATION_TOOL_DEFINITIONS: ToolDefinition[] = [
  * looks like*, so it stays short — the nudge message itself carries the
  * "do it now" instruction. (AGT-4054)
  */
+/**
+ * The tool names this module dispatches, derived from the definitions above.
+ *
+ * The adapter used to carry its own hardcoded copy of this list, so adding a
+ * tool here left it undispatchable until someone noticed. (AGT-4065)
+ */
+export const COORDINATION_TOOL_NAMES: ReadonlySet<string> = new Set(
+  COORDINATION_TOOL_DEFINITIONS.map((definition) => definition.function.name),
+);
+
 export const COORDINATION_GUIDANCE_PROMPT = `
 
 ## Coordination inbox
@@ -109,6 +152,15 @@ export async function executeCoordinationTool(
   if (name === 'coordination_read') {
     const events = await store.consume(context.actor, { repository: context.repository, taskId: context.taskId });
     return { content: JSON.stringify(events), isError: false };
+  }
+  if (name === 'coordination_wait') {
+    try {
+      const events = await waitForInbox(store, context, resolveWaitMs(args.timeout_ms));
+      return { content: JSON.stringify(events), isError: false };
+    } catch (error) {
+      // An unreadable board must not look like a quiet one.
+      return { content: error instanceof Error ? error.message : String(error), isError: true };
+    }
   }
   if (name === 'coordination_history') {
     const { queryTrace } = await import('./coordinationTrace.js');
@@ -184,4 +236,95 @@ export async function executeCoordinationTool(
     };
   }
   return { content: `Unknown coordination tool: ${name}`, isError: true };
+}
+
+/**
+ * Block until something addressed to this agent lands, or the deadline passes.
+ *
+ * Two wake-up paths, because neither alone is sufficient:
+ *
+ *  - **The event hub** (`coordination:published`, emitted by
+ *    `CoordinationStore.publish`) is the fast path and covers everything that
+ *    happens inside the daemon — a peer agent, and an operator message arriving
+ *    through the dashboard's HTTP endpoint. Latency is effectively zero.
+ *  - **A slow re-drain** covers publishers in *another* process. The board is a
+ *    file, and `openswarm attach` and the CLI write to it from their own
+ *    processes, where an in-memory emitter cannot reach. Without this the wait
+ *    would silently degrade to "always times out" for exactly the operator path
+ *    it exists to serve. (Both caught by the commit-gate review.)
+ *
+ * The subscription is installed BEFORE the first drain. Draining first left a
+ * window where a message published in between reached neither — the drain had
+ * already run, and nothing was listening yet — so the agent waited out its full
+ * deadline on mail that had actually arrived.
+ */
+const COORDINATION_WAIT_POLL_MS = 2_000;
+
+export async function waitForInbox(
+  store: { consume: (actor: string, options: { repository: string; taskId: string }) => Promise<unknown[]> },
+  context: CoordinationToolContext,
+  timeoutMs: number,
+): Promise<unknown[]> {
+  const drain = () => store.consume(context.actor, { repository: context.repository, taskId: context.taskId });
+  if (timeoutMs <= 0) return drain();
+
+  const { getEventHub } = await import('../core/eventHub.js');
+  const hub = getEventHub();
+
+  return new Promise<unknown[]>((resolve, reject) => {
+    let settled = false;
+    let draining = false;
+    let again = false;
+    // A board that cannot be read is not the same as a board with no mail. If
+    // every drain failed, the deadline must report that rather than hand back
+    // an empty list an agent would read as "nobody answered". (Caught by the
+    // commit-gate review.)
+    let anySuccess = false;
+    let lastError: unknown;
+
+    const stop = () => {
+      settled = true;
+      clearTimeout(deadline);
+      clearInterval(poll);
+      hub.off('coordination:published', check);
+    };
+    const finish = (events: unknown[]) => { if (!settled) { stop(); resolve(events); } };
+    const fail = (error: unknown) => { if (!settled) { stop(); reject(error); } };
+
+    // Serialised: two overlapping drains would each mark events consumed, and
+    // the loser would return an empty list for mail the winner already took.
+    // A wake-up that arrives mid-drain is remembered rather than dropped —
+    // otherwise the message that woke us would wait for the next poll, or
+    // forever if nothing else is ever published.
+    function check(): void {
+      if (settled) return;
+      if (draining) { again = true; return; }
+      draining = true;
+      drain()
+        .then((events) => {
+          anySuccess = true;
+          if (events.length > 0) finish(events);
+        })
+        .catch((error) => { lastError = error; })
+        .finally(() => {
+          draining = false;
+          if (again && !settled) { again = false; check(); }
+        });
+    }
+
+    const deadline = setTimeout(() => {
+      if (!anySuccess && lastError !== undefined) {
+        fail(new Error(`Coordination board unavailable: ${lastError instanceof Error ? lastError.message : String(lastError)}`));
+        return;
+      }
+      finish([]);
+    }, timeoutMs);
+    const poll = setInterval(check, COORDINATION_WAIT_POLL_MS);
+    // Neither timer may hold the process open past this wait.
+    deadline.unref?.();
+    poll.unref?.();
+    hub.on('coordination:published', check);
+    // Now that something is listening, look at what is already there.
+    check();
+  });
 }

--- a/src/coordination/coordinationTools.ts
+++ b/src/coordination/coordinationTools.ts
@@ -281,6 +281,7 @@ export async function waitForInbox(
     // commit-gate review.)
     let anySuccess = false;
     let lastError: unknown;
+    let expired = false;
 
     const stop = () => {
       settled = true;
@@ -308,16 +309,40 @@ export async function waitForInbox(
         .catch((error) => { lastError = error; })
         .finally(() => {
           draining = false;
-          if (again && !settled) { again = false; check(); }
+          if (settled) return;
+          // A wake-up recorded during this drain is honoured even after the
+          // deadline: the message it announced was published before the
+          // deadline, and dropping it would report an empty inbox for mail
+          // that had already arrived. Bounded, because expiry detaches the
+          // wake-up sources — nothing can set `again` again.
+          if (again) { again = false; check(); return; }
+          if (expired) settleExpired();
         });
     }
 
-    const deadline = setTimeout(() => {
+    function settleExpired(): void {
       if (!anySuccess && lastError !== undefined) {
         fail(new Error(`Coordination board unavailable: ${lastError instanceof Error ? lastError.message : String(lastError)}`));
         return;
       }
       finish([]);
+    }
+
+    // The deadline does not cut off a drain that is already running. `consume`
+    // is destructive — it marks what it returns as seen — so resolving `[]`
+    // while a drain was in flight threw away the message that drain was in the
+    // middle of collecting. The wait can therefore overrun its timeout by one
+    // store read, which is the right trade against losing mail.
+    // (Caught by the PR review.)
+    const deadline = setTimeout(() => {
+      expired = true;
+      // Detach first: no new wake-ups may be recorded past the deadline, which
+      // is what bounds the catch-up above to a single extra drain.
+      hub.off('coordination:published', check);
+      clearInterval(poll);
+      if (draining) return;
+      if (again) { again = false; check(); return; }
+      settleExpired();
     }, timeoutMs);
     const poll = setInterval(check, COORDINATION_WAIT_POLL_MS);
     // Deliberately NOT unref'd. Someone is awaiting this promise, so the

--- a/src/coordination/coordinationTools.ts
+++ b/src/coordination/coordinationTools.ts
@@ -19,12 +19,30 @@ import { callSignAddress } from './agentNames.js';
 export const COORDINATION_WAIT_MAX_MS = 60_000;
 export const COORDINATION_WAIT_DEFAULT_MS = 20_000;
 
-/** Clamp a model-supplied wait to something a stage can afford. */
-export function resolveWaitMs(requested: unknown): number {
+/**
+ * Headroom left for the loop to wrap up after a wait returns — emit a final
+ * message, write its result. A wait that ran right up to the deadline would
+ * take the answer and then have the loop time out anyway.
+ */
+export const COORDINATION_WAIT_LOOP_MARGIN_MS = 5_000;
+
+/**
+ * Clamp a model-supplied wait to something the enclosing run can afford.
+ *
+ * The fixed ceiling is not enough on its own: a loop with 8 seconds left would
+ * still grant a 60-second wait and then report a timeout instead of the answer
+ * that was about to arrive. When the caller knows its deadline, that wins.
+ * (AGT-4065, caught by the PR review.)
+ */
+export function resolveWaitMs(requested: unknown, loopDeadlineAt?: number, now: number = Date.now()): number {
   const value = typeof requested === 'number' && Number.isFinite(requested)
     ? requested
     : COORDINATION_WAIT_DEFAULT_MS;
-  return Math.min(COORDINATION_WAIT_MAX_MS, Math.max(0, Math.trunc(value)));
+  let capped = Math.min(COORDINATION_WAIT_MAX_MS, Math.max(0, Math.trunc(value)));
+  if (typeof loopDeadlineAt === 'number' && Number.isFinite(loopDeadlineAt)) {
+    capped = Math.min(capped, Math.max(0, loopDeadlineAt - now - COORDINATION_WAIT_LOOP_MARGIN_MS));
+  }
+  return capped;
 }
 
 export interface CoordinationToolContext {
@@ -155,7 +173,7 @@ export async function executeCoordinationTool(
   }
   if (name === 'coordination_wait') {
     try {
-      const events = await waitForInbox(store, context, resolveWaitMs(args.timeout_ms));
+      const events = await waitForInbox(store, context, resolveWaitMs(args.timeout_ms, args.__loopDeadlineAt as number | undefined));
       return { content: JSON.stringify(events), isError: false };
     } catch (error) {
       // An unreadable board must not look like a quiet one.

--- a/src/coordination/coordinationTools.ts
+++ b/src/coordination/coordinationTools.ts
@@ -293,12 +293,18 @@ export async function waitForInbox(
     let settled = false;
     let draining = false;
     let again = false;
-    // A board that cannot be read is not the same as a board with no mail. If
-    // every drain failed, the deadline must report that rather than hand back
-    // an empty list an agent would read as "nobody answered". (Caught by the
-    // commit-gate review.)
-    let anySuccess = false;
-    let lastError: unknown;
+    // A board that cannot be read is not the same as a board with no mail: an
+    // empty list is a claim about the board's contents, and only a drain that
+    // actually completed can support it. (Caught by the commit-gate review.)
+    //
+    // What matters is the LAST attempt, not whether any ever worked. `consume`
+    // returns everything unseen rather than a delta, so one good read at the
+    // end also observes whatever arrived during an earlier failure — but a
+    // first read that succeeded empty says nothing about the twenty seconds of
+    // failures that followed it, during which a reply could have landed
+    // unseen. Tracking "any success" reported those as a clean empty inbox.
+    // (Caught by the fresh PR review.)
+    let pendingError: unknown;
     let expired = false;
 
     const stop = () => {
@@ -321,10 +327,10 @@ export async function waitForInbox(
       draining = true;
       drain()
         .then((events) => {
-          anySuccess = true;
+          pendingError = undefined; // this read saw the board; earlier failures are covered
           if (events.length > 0) finish(events);
         })
-        .catch((error) => { lastError = error; })
+        .catch((error) => { pendingError = error; })
         .finally(() => {
           draining = false;
           if (settled) return;
@@ -339,8 +345,8 @@ export async function waitForInbox(
     }
 
     function settleExpired(): void {
-      if (!anySuccess && lastError !== undefined) {
-        fail(new Error(`Coordination board unavailable: ${lastError instanceof Error ? lastError.message : String(lastError)}`));
+      if (pendingError !== undefined) {
+        fail(new Error(`Coordination board unavailable: ${pendingError instanceof Error ? pendingError.message : String(pendingError)}`));
         return;
       }
       finish([]);


### PR DESCRIPTION
Closes AGT-4065. First step toward the operator's goal: **conversation and replies that flow in real time**.

## The finding

There is **no wait primitive anywhere in the system**. Every path writes to the board, returns immediately, and hopes the addressee polls before its run ends. `CoordinationStore.consume` is pure mark-and-return (`coordinationStore.ts:420-432`) — an empty inbox comes back instantly.

And an agent that tried to wait by polling **was killed for it**:

```ts
// agenticLoop.ts:555-560
if (allToolCallsSeen(toolCalls, seenToolCalls)) {
  noProgressTurns++;
  if (noProgressTurns >= NO_PROGRESS_LIMIT) { /* = 3 */ break; }
```

`allToolCallsSeen` keys on `name + args`, and `coordination_read` takes **no parameters** — so every check produced an identical key. Three checks of a quiet inbox looked exactly like a stalled model.

## What changed

**1. Checking an inbox is not a stall.** Tools whose answer changes without this agent doing anything are exempt from the repetition judgement. The loop stays bounded by `maxTurns` and its wall clock, so this cannot produce an unbounded run.

**2. `coordination_wait(timeout_ms)`** — returns as soon as something addressed to this agent lands, or an empty list at the deadline. Clamped hard (default 20s, max 60s): a wait sits inside a stage with its own budget (worker 20 min, reviewer 6 — `stageTimeouts.ts`) and must never become a way to burn it and fail as `infra_error`.

## Three defects the commit gate found in my own implementation

| round | finding | fix |
|---|---|---|
| 1 | **subscription race** — draining before subscribing left a window where a message reached neither path, and the agent waited out its whole deadline on mail that had arrived | subscribe first, then drain |
| 1 | **in-process only** — the hub cannot see `openswarm attach` or the CLI, which write to the board file from their own processes. The wait would silently always time out for exactly the operator path it exists to serve | a 2s re-drain alongside the hub |
| 3 | **an unreadable board looked like a quiet one** — a swallowed store failure returned `[]`, which an agent reads as "nobody answered" and proceeds on | report it as an error; a transient failure that later succeeds still resolves normally |

And one I introduced while fixing the first: guarding against overlapping drains made a wake-up arriving **mid-drain** get dropped, so the message that woke us would wait for the next re-drain — or forever. It is now remembered and re-checked.

## Incidental

The adapter kept its **own hardcoded copy** of the coordination tool names (`tools.ts:840`), so a newly declared tool could be defined, advertised to the model, and still fall through to "Unknown tool". It now derives them from the definitions, and a test drives every declared name through the real dispatch.

## Verification

Seven mutations, each killing exactly the intended tests:

| mutation | tests killed |
|---|---|
| stall exemption removed | 3 inbox-check tests |
| no initial drain | pre-arrived mail |
| never subscribes to the hub | early return on arrival |
| clamp removed | timeout clamping |
| adapter reverts to a hardcoded list | every-declared-tool dispatch |
| no cross-process re-drain | wake for an unseen publisher |
| mid-drain wake-up dropped | mid-drain wake-up |
| store failure swallowed | unreadable board reported |

The mid-drain race is milliseconds wide against the real store, so that test drives `waitForInbox` with a fake whose first drain is still running when the event fires — a timing-based test could not hit it reliably. `waitForInbox` is exported for that reason, and the comment says so.

`npm run typecheck` clean, `oxlint` clean, **130 tests green** across the six affected files. Commit gate: `openswarm review` ×4 — REVISE ×3 (above), then APPROVE.

## Deliberately not in this change

- Splitting `ask_human` from "stop this run" — welded in three places; it deserves its own change now that waiting exists.
- Relaxing `consume`'s `taskId` filter, which makes cross-task peer messaging write-only.
- Worker/reviewer overlap. Judge it after these land.