### PR TITLE
feat(orchestration): read the graph as conversations about tasks (AGT-4066)

### DIFF
--- a/tests/web/orchestrationModel.test.ts
+++ b/tests/web/orchestrationModel.test.ts
@@ -7,7 +7,14 @@
 
 import { describe, expect, it } from 'vitest';
 // @ts-expect-error — browser ESM asset without type declarations
-import { buildOrchestrationModel, dominantKind, KIND_COLORS } from '../../web/static/js/orchestrationModel.mjs';
+import {
+  buildOrchestrationModel, dominantKind, filterGraphNodes, KIND_COLORS, taskLanesOf,
+} from '../../web/static/js/orchestrationModel.mjs';
+
+type Node = {
+  id: string; name: string; role: string; taskId?: string; taskLabel?: string;
+  active: boolean; firstSeen: number; lastSeen: number;
+};
 
 let seq = 0;
 function event(over: Record<string, unknown> = {}) {
@@ -76,7 +83,7 @@ describe('buildOrchestrationModel', () => {
     expect(roles['adapter-router']).toBe('daemon');
   });
 
-  it('tracks the task a node last ACTED in, ignoring tasks it merely received from', () => {
+  it('prefers the task a node ACTED in over any task it was merely addressed within', () => {
     const model = buildOrchestrationModel([
       event({ taskId: 'task-1' }),
       // Cross-task advice TO this node must not drag it into task-9.
@@ -93,5 +100,104 @@ describe('buildOrchestrationModel', () => {
     );
     expect(model.nodes[0].active).toBe(false);
     expect(model.stats.activeAgents).toBe(0);
+  });
+
+  // A node that has never acted has no task of its own to defend, so seating
+  // it with the people addressing it beats stranding it in a lane of one —
+  // without weakening the rule above, which the next test pins.
+  it('seats a pure recipient in the task it was addressed within', () => {
+    const model = buildOrchestrationModel([
+      event({ taskId: 'task-1', recipient: 'adept', recipientName: 'Adept', recipientRole: 'reviewer' }),
+    ]);
+    const adept = model.nodes.find((node: Node) => node.id === 'adept');
+    expect(adept).toMatchObject({ taskId: 'task-1', role: 'reviewer' });
+  });
+
+  // `firstSeen` is the layout's seating order; if it drifted with activity the
+  // stability guarantee it underwrites would drift with it.
+  it('pins firstSeen at the earliest sighting while lastSeen follows activity', () => {
+    const model = buildOrchestrationModel([
+      event({ timestamp: 5_000 }),
+      event({ timestamp: 9_000 }),
+    ], { now: 9_000 });
+    expect(model.nodes[0]).toMatchObject({ firstSeen: 5_000, lastSeen: 9_000 });
+  });
+
+  it('counts the agents parked on the operator, not the questions they asked', () => {
+    const model = buildOrchestrationModel([
+      event({ kind: 'human-question', status: 'waiting', recipient: 'human', correlationId: 'q1' }),
+      // Same agent asking twice is still one agent to unblock.
+      event({ kind: 'human-question', status: 'waiting', recipient: 'human', correlationId: 'q2' }),
+      event({
+        actor: 'adept', actorRole: 'reviewer', kind: 'human-question', status: 'waiting',
+        recipient: 'human', correlationId: 'q3',
+      }),
+    ]);
+    expect(model.stats.pendingQuestions).toBe(3);
+    expect(model.stats.agentsAwaitingOperator).toBe(2);
+  });
+});
+
+// Cause #1 in the issue: the client keeps every event the server ring ever
+// handed it, so an agent that spoke once at 09:00 was still a dot at 17:00.
+describe('filterGraphNodes', () => {
+  const nodes = [
+    { id: 'human', name: 'Operator', role: 'human', active: false },
+    { id: 'openswarm-daemon', name: 'daemon', role: 'daemon', active: false },
+    { id: 'w1', name: 'Enginseer', role: 'worker', taskId: 't1', taskLabel: 'AGT-1', active: true },
+    { id: 'w2', name: 'Vindicator', role: 'worker', taskId: 't2', active: true },
+    { id: 'old', name: 'Retired', role: 'reviewer', taskId: 't1', active: false },
+  ];
+  const idsOf = (list: Array<{ id: string }>) => list.map((node) => node.id);
+
+  it('drops idle participants by default but never the rails', () => {
+    expect(idsOf(filterGraphNodes(nodes))).toEqual(['human', 'openswarm-daemon', 'w1', 'w2']);
+  });
+
+  it('brings the idle back when the operator expands them', () => {
+    expect(idsOf(filterGraphNodes(nodes, { showIdle: true }))).toContain('old');
+  });
+
+  it('narrows to one task while keeping the rails the lanes hang from', () => {
+    const shown = idsOf(filterGraphNodes(nodes, { taskId: 't1' }));
+    expect(shown).toContain('w1');
+    expect(shown).toContain('human');
+    expect(shown).not.toContain('w2');
+  });
+
+  it('searches names, addresses and task labels, case-insensitively', () => {
+    expect(idsOf(filterGraphNodes(nodes, { query: 'vindic' }))).toContain('w2');
+    expect(idsOf(filterGraphNodes(nodes, { query: 'agt-1' }))).toContain('w1');
+    expect(idsOf(filterGraphNodes(nodes, { query: 'agt-1' }))).not.toContain('w2');
+  });
+
+  it('filters by role', () => {
+    expect(idsOf(filterGraphNodes(nodes, { role: 'worker' }))).toEqual(['w1', 'w2']);
+  });
+});
+
+describe('taskLanesOf', () => {
+  it('orders lanes by first sighting so a new task appends instead of re-stacking', () => {
+    const lanes = taskLanesOf([
+      { id: 'b', role: 'worker', taskId: 't-late', firstSeen: 50, lastSeen: 99 },
+      { id: 'a', role: 'worker', taskId: 't-early', firstSeen: 10, lastSeen: 12 },
+      { id: 'c', role: 'reviewer', taskId: 't-early', firstSeen: 20, lastSeen: 30, taskLabel: 'AGT-9' },
+      // Rails belong to every task, so they are not a lane of their own.
+      { id: 'human', role: 'human', taskId: 't-early', firstSeen: 1, lastSeen: 1 },
+    ]);
+    expect(lanes.map((lane: { taskId: string }) => lane.taskId)).toEqual(['t-early', 't-late']);
+    expect(lanes[0]).toMatchObject({ label: 'AGT-9', count: 2, firstSeen: 10, lastSeen: 30 });
+  });
+
+  // A node from before `firstSeen` existed would otherwise put NaN into the
+  // comparator, and a NaN comparator makes the lane order arbitrary rather
+  // than merely wrong — the failure would be invisible and irreproducible.
+  it('falls back for legacy nodes rather than comparing NaN', () => {
+    const lanes = taskLanesOf([
+      { id: 'a', role: 'worker', taskId: 't-b', lastSeen: 20 },
+      { id: 'b', role: 'worker', taskId: 't-a', lastSeen: 10 },
+    ]);
+    expect(lanes.every((lane: { firstSeen: number }) => Number.isFinite(lane.firstSeen))).toBe(true);
+    expect(lanes.map((lane: { taskId: string }) => lane.taskId)).toEqual(['t-a', 't-b']);
   });
 });

--- a/tests/web/orchestrationView.test.ts
+++ b/tests/web/orchestrationView.test.ts
@@ -4,11 +4,39 @@
 // page: a fetch shape mismatch, an unhooked selection, or an SSE event that
 // never reaches the model. Drive it with a faked fetch and assert real DOM.
 
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 // @ts-expect-error — browser ESM asset without type declarations
-import { startOrchestrationView, nodeRadius, ROLE_COLORS } from '../../web/static/js/orchestrationView.mjs';
+import {
+  startOrchestrationView, edgeKey, nodeRadius, ROLE_COLORS, wireControls,
+} from '../../web/static/js/orchestrationView.mjs';
 
 function shell(): Document {
+  document.body.innerHTML = `
+    <div id="stats"></div>
+    <div id="waiting"></div>
+    <div id="controls">
+      <input id="filter-search" type="search" />
+      <select id="filter-task" data-options=""><option value="">all tasks</option></select>
+      <select id="filter-role">
+        <option value="">all roles</option>
+        <option value="worker">worker</option>
+        <option value="reviewer">reviewer</option>
+      </select>
+      <input id="filter-idle" type="checkbox" />
+      <span id="idle-count"></span>
+    </div>
+    <svg id="graph"></svg>
+    <div id="legend"></div>
+    <div id="detail"></div>
+    <div id="feed"></div>
+    <div id="thread"></div>`;
+  return document;
+}
+
+/** The controls are optional furniture; some hosts render the graph alone. */
+function bareShell(): Document {
   document.body.innerHTML = `
     <div id="stats"></div>
     <svg id="graph"></svg>
@@ -18,6 +46,9 @@ function shell(): Document {
     <div id="thread"></div>`;
   return document;
 }
+
+/** Built, never typed: a literal NUL in this file would defeat its own guard. */
+const NUL = String.fromCharCode(0);
 
 function boardEvent(over: Record<string, unknown> = {}) {
   return {
@@ -61,10 +92,11 @@ describe('startOrchestrationView', () => {
     expect(nodes).toContain('adept-helion-cognitor');
     expect(nodes).toContain('human');
 
-    // The hierarchy is stated by the drawing: all four tier bands labeled, and
-    // the operator seated above the worker.
+    // The hierarchy is stated by the drawing: the three shared rails labeled,
+    // then a lane per task, and the operator seated above the worker.
     const labels = [...doc.querySelectorAll('.tier-label')].map((el) => el.textContent);
-    expect(labels).toEqual(['OPERATOR', 'CONTROL PLANE', 'COORDINATION', 'EXECUTION']);
+    expect(labels.slice(0, 3)).toEqual(['OPERATOR', 'CONTROL PLANE', 'COORDINATION']);
+    expect(labels).toContain('t1');
     const yOf = (id: string) => Number(/translate\(\S+ (\S+)\)/.exec(
       doc.querySelector(`[data-node="${id}"]`)!.getAttribute('transform')!)![1]);
     expect(yOf('human')).toBeLessThan(yOf('enginseer-rhodanis-novum'));
@@ -137,6 +169,336 @@ describe('startOrchestrationView', () => {
   it('scales node radius with activity but caps it readable', () => {
     expect(nodeRadius({ eventCount: 0 })).toBe(10);
     expect(nodeRadius({ eventCount: 10_000 })).toBe(26);
+  });
+});
+
+describe('the picture stays bounded and legible (AGT-4066)', () => {
+  // The server ring drops coordination events at 2000; this map kept every one
+  // it ever saw, so a dashboard left open for a shift outgrew the daemon's own
+  // history and every agent that once spoke stayed a node forever.
+  it('evicts the oldest events instead of growing without bound', async () => {
+    const doc = shell();
+    const flood = Array.from({ length: 2400 }, (_, index) => boardEvent({
+      id: `e${index}`,
+      seq: index + 1,
+      correlationId: `c${index}`,
+      actor: `agent-${index}`,
+      actorName: `Agent ${index}`,
+      status: 'completed',
+      summary: `line ${index}`,
+    }));
+    const view = startOrchestrationView(doc, { fetchImpl: fetchWith(flood), eventSourceImpl: null, pollMs: 1e9 });
+    await vi.waitFor(() => expect(doc.querySelectorAll('.node').length).toBeGreaterThan(0));
+
+    // The cap is a ceiling on what is retained, not an average it drifts above:
+    // 2400 events arrived, at most the server ring's own 2000 are still held.
+    const eventStat = [...doc.querySelectorAll('#stats .stat')]
+      .find((cell) => cell.textContent!.endsWith('events'))!;
+    const retained = Number(eventStat.querySelector('b')!.textContent);
+    expect(retained).toBeLessThanOrEqual(2000);
+    // ...and it prunes a batch, not the whole map.
+    expect(retained).toBeGreaterThan(1500);
+
+    // The very first speakers were pruned; the newest are still on the board.
+    expect(doc.querySelector('[data-node="agent-0"]')).toBeNull();
+    expect(doc.querySelector('[data-node="agent-2399"]')).not.toBeNull();
+    view.stop();
+  });
+
+  // Liveness is wall-clock, but only an event, a poll change, a resize or a
+  // control action redraws. On a quiet board nothing ever crossed the window,
+  // so an agent that stopped talking stayed on screen forever — the very
+  // unbounded population the eviction above is meant to prevent.
+  it('sheds an agent that ages out even when the board stays silent', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const doc = shell();
+      const view = startOrchestrationView(doc, {
+        fetchImpl: fetchWith([boardEvent({ id: 'e1', seq: 1, status: 'completed' })]),
+        eventSourceImpl: null,
+        pollMs: 1e9,
+      });
+      await vi.waitFor(() => expect(doc.querySelector('[data-node="enginseer-rhodanis-novum"]')).not.toBeNull());
+
+      // No new events, no resize, no clicks — only time passing.
+      await vi.advanceTimersByTimeAsync(31 * 60_000);
+
+      expect(doc.querySelector('[data-node="enginseer-rhodanis-novum"]')).toBeNull();
+      view.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops sweeping once the view is stopped', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const doc = shell();
+      const view = startOrchestrationView(doc, {
+        // Addressed to the operator, so the board carries a RAIL node. Rails
+        // are exempt from the liveness filter, so a sweep that outlived stop()
+        // would repaint one — without it the assertion could not tell a leaked
+        // timer from a correctly aged-out board.
+        fetchImpl: fetchWith([boardEvent({
+          id: 'e1', seq: 1, status: 'completed', kind: 'human-answer',
+          recipient: 'human', recipientName: undefined, recipientRole: 'human',
+        })]),
+        eventSourceImpl: null,
+        pollMs: 1e9,
+      });
+      await vi.waitFor(() => expect(doc.querySelector('[data-node="human"]')).not.toBeNull());
+      view.stop();
+
+      const svg = doc.getElementById('graph')!;
+      svg.innerHTML = '';
+      await vi.advanceTimersByTimeAsync(31 * 60_000);
+      expect(svg.querySelectorAll('.node')).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps node elements across redraws instead of tearing the graph down', async () => {
+    const doc = shell();
+    const listeners: { onmessage?: (msg: { data: string }) => void } = {};
+    class FakeSource {
+      set onmessage(fn: (msg: { data: string }) => void) { listeners.onmessage = fn; }
+      close(): void { /* noop */ }
+    }
+    const view = startOrchestrationView(doc, {
+      fetchImpl: fetchWith([boardEvent({ id: 'e1', seq: 1 })]),
+      eventSourceImpl: FakeSource,
+    });
+    await vi.waitFor(() => expect(doc.querySelector('[data-node="enginseer-rhodanis-novum"]')).not.toBeNull());
+    const before = doc.querySelector('[data-node="enginseer-rhodanis-novum"]')!;
+
+    listeners.onmessage!({
+      data: JSON.stringify({
+        type: 'coordination:event',
+        data: boardEvent({ id: 'e-live', seq: 9, actor: 'vindicator-ferrus-theta', actorName: 'Vindicator Ferrus-Theta', correlationId: 'c9' }),
+      }),
+    });
+
+    // Same element object, not a replacement: that identity is what lets CSS
+    // transition a move rather than cutting to it.
+    expect(doc.querySelector('[data-node="enginseer-rhodanis-novum"]')).toBe(before);
+    view.stop();
+  });
+
+  // A NUL joined the two addresses at first. Node parsed it happily, but the
+  // served asset became a binary file to `file`, to static-asset middleware and
+  // to every text tool that touches it.
+  it('keeps the served asset text, and keeps edge keys unambiguous', async () => {
+    // Read from disk, not through the import: the module graph would happily
+    // hand back a parsed module and hide the byte that is the actual problem.
+    const source = await readFile(
+      resolve(process.cwd(), 'web/static/js/orchestrationView.mjs'), 'utf8');
+    expect(source).not.toHaveLength(0);
+    expect(source.includes(NUL)).toBe(false);
+
+    // Injective: no pair of addresses can produce another pair's key.
+    expect(edgeKey('a', 'b->c')).not.toBe(edgeKey('a->b', 'c'));
+    expect(edgeKey('a', 'b')).toBe(edgeKey('a', 'b'));
+    expect(edgeKey('a>b', 'c')).not.toContain(NUL);
+  });
+
+  it('names both ends of an edge by handle, not by routing address', async () => {
+    const doc = shell();
+    const view = startOrchestrationView(doc, {
+      fetchImpl: fetchWith([boardEvent({ id: 'e1', seq: 1 })]),
+      eventSourceImpl: null,
+      pollMs: 1e9,
+    });
+    await vi.waitFor(() => expect(doc.querySelector('[data-edge] title')).not.toBeNull());
+
+    const tooltip = doc.querySelector('[data-edge] title')!.textContent!;
+    expect(tooltip).toContain('Enginseer Rhodanis-Novum → Adept Helion-Cognitor');
+    expect(tooltip).not.toContain('enginseer-rhodanis-novum');
+    view.stop();
+  });
+
+  it('says how many agents are waiting on the operator without any interaction', async () => {
+    const doc = shell();
+    const view = startOrchestrationView(doc, {
+      fetchImpl: fetchWith([
+        boardEvent({ id: 'q1', seq: 1, kind: 'human-question', status: 'waiting', recipient: 'human', recipientRole: 'human', correlationId: 'hq-1' }),
+        boardEvent({
+          id: 'q2', seq: 2, kind: 'human-question', status: 'waiting', recipient: 'human',
+          recipientRole: 'human', correlationId: 'hq-2',
+          actor: 'vindicator-ferrus-theta', actorName: 'Vindicator Ferrus-Theta',
+        }),
+      ]),
+      eventSourceImpl: null,
+      pollMs: 1e9,
+    });
+    await vi.waitFor(() => expect(doc.getElementById('waiting')!.textContent).toContain('waiting on you'));
+
+    expect(doc.getElementById('waiting')!.textContent).toBe('2 agents are waiting on you');
+    expect(doc.getElementById('waiting')!.className).toContain('is-blocking');
+    view.stop();
+  });
+
+  it('tells the operator nothing needs them when nothing does', async () => {
+    const doc = shell();
+    const view = startOrchestrationView(doc, {
+      fetchImpl: fetchWith([boardEvent({ id: 'e1', seq: 1, status: 'completed' })]),
+      eventSourceImpl: null,
+      pollMs: 1e9,
+    });
+    await vi.waitFor(() => expect(doc.getElementById('waiting')!.textContent).toBeTruthy());
+    expect(doc.getElementById('waiting')!.textContent).toBe('nothing is waiting on you');
+    expect(doc.getElementById('waiting')!.className).not.toContain('is-blocking');
+    view.stop();
+  });
+});
+
+describe('filter and collapse controls (AGT-4066)', () => {
+  const twoTasks = () => [
+    boardEvent({ id: 'e1', seq: 1, taskId: 't1', taskLabel: 'AGT-1' }),
+    boardEvent({
+      id: 'e2', seq: 2, taskId: 't2', taskLabel: 'AGT-2', correlationId: 'c2',
+      actor: 'vindicator-ferrus-theta', actorName: 'Vindicator Ferrus-Theta', actorRole: 'worker',
+      recipient: 'castellan-mordax-invictus', recipientName: 'Castellan Mordax-Invictus',
+      recipientRole: 'orchestrator',
+    }),
+  ];
+
+  it('offers the live tasks as filter options and narrows the graph to one', async () => {
+    const doc = shell();
+    const view = startOrchestrationView(doc, { fetchImpl: fetchWith(twoTasks()), eventSourceImpl: null, pollMs: 1e9 });
+    await vi.waitFor(() => expect(doc.querySelectorAll('.node').length).toBeGreaterThan(2));
+
+    const select = doc.getElementById('filter-task') as HTMLSelectElement;
+    expect([...select.options].map((option) => option.textContent)).toEqual(['all tasks', 'AGT-1', 'AGT-2']);
+
+    select.value = 't1';
+    select.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+    expect(doc.querySelector('[data-node="enginseer-rhodanis-novum"]')).not.toBeNull();
+    expect(doc.querySelector('[data-node="vindicator-ferrus-theta"]')).toBeNull();
+    // The orchestrator is a shared rail, so it survives a task filter.
+    expect(doc.querySelector('[data-node="castellan-mordax-invictus"]')).not.toBeNull();
+    view.stop();
+  });
+
+  it('searches by handle', async () => {
+    const doc = shell();
+    const view = startOrchestrationView(doc, { fetchImpl: fetchWith(twoTasks()), eventSourceImpl: null, pollMs: 1e9 });
+    await vi.waitFor(() => expect(doc.querySelectorAll('.node').length).toBeGreaterThan(2));
+
+    const search = doc.getElementById('filter-search') as HTMLInputElement;
+    search.value = 'vindic';
+    search.dispatchEvent(new window.Event('input', { bubbles: true }));
+
+    expect(doc.querySelector('[data-node="vindicator-ferrus-theta"]')).not.toBeNull();
+    expect(doc.querySelector('[data-node="enginseer-rhodanis-novum"]')).toBeNull();
+    view.stop();
+  });
+
+  it('collapses agents outside the activity window and expands them on request', async () => {
+    const doc = shell();
+    const old = Date.now() - 45 * 60_000;
+    const view = startOrchestrationView(doc, {
+      fetchImpl: fetchWith([
+        boardEvent({ id: 'fresh', seq: 2 }),
+        boardEvent({
+          id: 'stale', seq: 1, timestamp: old, correlationId: 'c-old', status: 'completed',
+          actor: 'retired-agent', actorName: 'Retired Agent', recipient: undefined,
+          recipientName: undefined, recipientRole: undefined,
+        }),
+      ]),
+      eventSourceImpl: null,
+      pollMs: 1e9,
+    });
+    await vi.waitFor(() => expect(doc.querySelectorAll('.node').length).toBeGreaterThan(0));
+
+    expect(doc.querySelector('[data-node="retired-agent"]')).toBeNull();
+    expect(doc.getElementById('idle-count')!.textContent).toBe('(1)');
+
+    const toggle = doc.getElementById('filter-idle') as HTMLInputElement;
+    toggle.checked = true;
+    toggle.dispatchEvent(new window.Event('change', { bubbles: true }));
+    expect(doc.querySelector('[data-node="retired-agent"]')).not.toBeNull();
+    view.stop();
+  });
+
+  // Redraws run on every SSE event, so a control that gained a listener per
+  // wiring pass would eventually fire dozens of times per click.
+  // Expanding the idle set must not re-stack the conversations — that would be
+  // the vertical twin of the sliding row this issue exists to remove.
+  it('keeps the lane order fixed when idle agents are expanded', async () => {
+    const doc = shell();
+    const old = Date.now() - 45 * 60_000;
+    const view = startOrchestrationView(doc, {
+      fetchImpl: fetchWith([
+        // The oldest sighting on task B is idle, so collapsing it would make
+        // task B look younger than task A and swap the two lanes.
+        boardEvent({
+          id: 'b-old', seq: 1, timestamp: old, taskId: 'tB', taskLabel: 'B', correlationId: 'cb',
+          status: 'completed', actor: 'veteran', actorName: 'Veteran',
+          recipient: undefined, recipientName: undefined, recipientRole: undefined,
+        }),
+        boardEvent({ id: 'a1', seq: 2, taskId: 'tA', taskLabel: 'A', correlationId: 'ca' }),
+        boardEvent({
+          id: 'b-new', seq: 3, taskId: 'tB', taskLabel: 'B', correlationId: 'cb2',
+          actor: 'vindicator-ferrus-theta', actorName: 'Vindicator Ferrus-Theta',
+          recipient: undefined, recipientName: undefined, recipientRole: undefined,
+        }),
+      ]),
+      eventSourceImpl: null,
+      pollMs: 1e9,
+    });
+    await vi.waitFor(() => expect(doc.querySelectorAll('.lane-label').length).toBeGreaterThan(0));
+    const lanesNow = () => [...doc.querySelectorAll('.lane-label')].map((el) => el.textContent);
+    const collapsed = lanesNow();
+    expect(collapsed).toEqual(['B', 'A']);
+
+    const toggle = doc.getElementById('filter-idle') as HTMLInputElement;
+    toggle.checked = true;
+    toggle.dispatchEvent(new window.Event('change', { bubbles: true }));
+    expect(lanesNow()).toEqual(collapsed);
+    view.stop();
+  });
+
+  it('binds each control once even if wiring runs again', () => {
+    const doc = shell();
+    const filters = { showIdle: false, taskId: null, role: null, query: '' };
+    let changes = 0;
+    wireControls(doc, filters, () => { changes += 1; });
+    wireControls(doc, filters, () => { changes += 1; });
+
+    const toggle = doc.getElementById('filter-idle') as HTMLInputElement;
+    toggle.checked = true;
+    toggle.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+    expect(changes).toBe(1);
+    expect(filters.showIdle).toBe(true);
+  });
+
+  // A stopped view that still answers resize keeps repainting the graph and
+  // keeps its whole event map alive for as long as the page lives.
+  it('lets go of the resize listener when it is stopped', async () => {
+    const doc = shell();
+    const view = startOrchestrationView(doc, {
+      fetchImpl: fetchWith([boardEvent({ id: 'e1', seq: 1 })]),
+      eventSourceImpl: null,
+      pollMs: 1e9,
+    });
+    await vi.waitFor(() => expect(doc.querySelectorAll('.node').length).toBeGreaterThan(0));
+    view.stop();
+
+    const svg = doc.getElementById('graph')!;
+    svg.innerHTML = '';
+    doc.defaultView!.dispatchEvent(new window.Event('resize'));
+    expect(svg.querySelectorAll('.node')).toHaveLength(0);
+  });
+
+  it('still renders when the host page ships no controls at all', async () => {
+    const doc = bareShell();
+    const view = startOrchestrationView(doc, { fetchImpl: fetchWith(twoTasks()), eventSourceImpl: null, pollMs: 1e9 });
+    await vi.waitFor(() => expect(doc.querySelectorAll('.node').length).toBeGreaterThan(2));
+    expect(doc.getElementById('feed')!.textContent).toContain('Reuse the auth helper?');
+    view.stop();
   });
 });
 

--- a/tests/web/orchestrationView.test.ts
+++ b/tests/web/orchestrationView.test.ts
@@ -230,32 +230,48 @@ describe('the picture stays bounded and legible (AGT-4066)', () => {
     }
   });
 
-  it('stops sweeping once the view is stopped', async () => {
+  // `redraw` no-ops after stop, so a leaked sweep repaints nothing — which is
+  // exactly why this asserts the timer itself. An armed sweep holds a
+  // half-hour wake and the whole view closure alive regardless.
+  it('disarms every timer it armed when it is stopped', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     try {
       const doc = shell();
       const view = startOrchestrationView(doc, {
-        // Addressed to the operator, so the board carries a RAIL node. Rails
-        // are exempt from the liveness filter, so a sweep that outlived stop()
-        // would repaint one — without it the assertion could not tell a leaked
-        // timer from a correctly aged-out board.
-        fetchImpl: fetchWith([boardEvent({
-          id: 'e1', seq: 1, status: 'completed', kind: 'human-answer',
-          recipient: 'human', recipientName: undefined, recipientRole: 'human',
-        })]),
+        fetchImpl: fetchWith([boardEvent({ id: 'e1', seq: 1, status: 'completed' })]),
         eventSourceImpl: null,
         pollMs: 1e9,
       });
-      await vi.waitFor(() => expect(doc.querySelector('[data-node="human"]')).not.toBeNull());
-      view.stop();
+      await vi.waitFor(() => expect(doc.querySelectorAll('.node').length).toBeGreaterThan(0));
+      // The poll interval and the liveness sweep are both armed by now.
+      expect(vi.getTimerCount()).toBeGreaterThan(1);
 
-      const svg = doc.getElementById('graph')!;
-      svg.innerHTML = '';
-      await vi.advanceTimersByTimeAsync(31 * 60_000);
-      expect(svg.querySelectorAll('.node')).toHaveLength(0);
+      view.stop();
+      expect(vi.getTimerCount()).toBe(0);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  // stop() clears the timers it can see, but a fetch already awaiting its
+  // response is not one of them: its continuation would rebuild the graph and
+  // arm a fresh liveness timer that nothing is left to clear.
+  it('does not redraw after stop when a fetch was already in flight', async () => {
+    let release: (value: unknown) => void = () => {};
+    const gate = new Promise((resolve) => { release = resolve; });
+    const doc = shell();
+    const fetchImpl = vi.fn(() => gate.then(() => ({
+      ok: true,
+      json: async () => ({ events: [boardEvent({ id: 'e1', seq: 1 })], pending: [], lastSeq: 1 }),
+    })));
+
+    const view = startOrchestrationView(doc, { fetchImpl, eventSourceImpl: null, pollMs: 1e9 });
+    view.stop();          // the snapshot has not landed yet
+    release(null);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(doc.querySelectorAll('.node')).toHaveLength(0);
+    expect(doc.getElementById('graph')!.querySelector('[data-layer]')).toBeNull();
   });
 
   it('keeps node elements across redraws instead of tearing the graph down', async () => {
@@ -475,9 +491,10 @@ describe('filter and collapse controls (AGT-4066)', () => {
     expect(filters.showIdle).toBe(true);
   });
 
-  // A stopped view that still answers resize keeps repainting the graph and
-  // keeps its whole event map alive for as long as the page lives.
-  it('lets go of the resize listener when it is stopped', async () => {
+  // Same reasoning as the timers: `redraw` no-ops after stop, so a listener
+  // left attached is invisible from the DOM — but it still pins the view's
+  // whole closure, and its event map, to the window for the page's lifetime.
+  it('releases the resize listener when it is stopped', async () => {
     const doc = shell();
     const view = startOrchestrationView(doc, {
       fetchImpl: fetchWith([boardEvent({ id: 'e1', seq: 1 })]),
@@ -485,12 +502,14 @@ describe('filter and collapse controls (AGT-4066)', () => {
       pollMs: 1e9,
     });
     await vi.waitFor(() => expect(doc.querySelectorAll('.node').length).toBeGreaterThan(0));
-    view.stop();
 
-    const svg = doc.getElementById('graph')!;
-    svg.innerHTML = '';
-    doc.defaultView!.dispatchEvent(new window.Event('resize'));
-    expect(svg.querySelectorAll('.node')).toHaveLength(0);
+    const remove = vi.spyOn(doc.defaultView!, 'removeEventListener');
+    try {
+      view.stop();
+      expect(remove).toHaveBeenCalledWith('resize', expect.any(Function));
+    } finally {
+      remove.mockRestore();
+    }
   });
 
   it('still renders when the host page ships no controls at all', async () => {

--- a/tests/web/tierLayout.test.ts
+++ b/tests/web/tierLayout.test.ts
@@ -5,10 +5,16 @@
 
 import { describe, expect, it } from 'vitest';
 // @ts-expect-error — browser ESM asset without type declarations
-import { layoutTiers, tierOf, TIERS } from '../../web/static/js/tierLayout.mjs';
+import { layoutTiers, planBands, slotHash, tierOf, TIERS } from '../../web/static/js/tierLayout.mjs';
 
+type Band = { id: string; label: string; kind: string; count: number; taskId: string | null };
+
+let born = 0;
 function node(over: Record<string, unknown> = {}) {
-  return { id: `n-${Math.random()}`, name: 'X', role: 'worker', ...over };
+  born += 1;
+  // `firstSeen` ascending in declaration order unless a test pins it: the
+  // layout seats oldest first, so "who arrived when" is the interesting axis.
+  return { id: `n-${born}`, name: 'X', role: 'worker', firstSeen: born, lastSeen: born, ...over };
 }
 
 describe('tierOf', () => {
@@ -35,26 +41,158 @@ describe('layoutTiers', () => {
     expect(positions.get('human')!.y).toBeLessThan(positions.get('daemon')!.y);
     expect(positions.get('daemon')!.y).toBeLessThan(positions.get('orch')!.y);
     expect(positions.get('orch')!.y).toBeLessThan(positions.get('w')!.y);
-    expect(bands.map((band: { label: string }) => band.label)).toEqual(
-      TIERS.map((tier: { label: string }) => tier.label));
+    // The rails keep their fixed bands; below them the execution tier is no
+    // longer one band but a lane per task.
+    expect(bands.slice(0, 3).map((band: Band) => band.label)).toEqual(
+      TIERS.slice(0, 3).map((tier: { label: string }) => tier.label));
+    expect(bands.slice(0, 3).every((band: Band) => band.kind === 'rail')).toBe(true);
+    expect(bands.slice(3).every((band: Band) => band.kind === 'lane')).toBe(true);
   });
 
-  it('draws every tier band even when empty — an empty row is information', () => {
+  it('draws every rail band even when empty — an empty row is information', () => {
     const { bands } = layoutTiers([node({ id: 'w', role: 'worker' })], { width: 900, height: 600 });
-    expect(bands).toHaveLength(4);
+    expect(bands.filter((band: Band) => band.kind === 'rail')).toHaveLength(3);
     expect(bands[2]).toMatchObject({ label: 'COORDINATION', count: 0 });
   });
 
-  it('seats a task\'s worker and reviewer adjacent in the execution row', () => {
-    const { positions } = layoutTiers([
-      node({ id: 'w2', name: 'Zeta', role: 'worker', taskId: 'task-2' }),
+  // The headline of AGT-4066: a live task is one lane holding its own
+  // participants, so six conversations read as six lanes and not as forty
+  // dots sharing one band.
+  it('gives each task its own lane and seats its participants together', () => {
+    const nodes = [
+      node({ id: 'w2', name: 'Zeta', role: 'worker', taskId: 'task-2', taskLabel: 'AGT-2' }),
       node({ id: 'r1', name: 'Adept', role: 'reviewer', taskId: 'task-1' }),
-      node({ id: 'w1', name: 'Enginseer', role: 'worker', taskId: 'task-1' }),
+      node({ id: 'w1', name: 'Enginseer', role: 'worker', taskId: 'task-1', taskLabel: 'AGT-1' }),
       node({ id: 'r2', name: 'Vindicator', role: 'reviewer', taskId: 'task-2' }),
-    ], { width: 1200, height: 600 });
-    const xs = ['w1', 'r1', 'w2', 'r2'].map((id) => positions.get(id)!.x);
-    // task-1 pair first (worker then reviewer), then task-2 pair.
-    expect([...xs].sort((a, b) => a - b)).toEqual(xs);
+    ];
+    const { positions, bands } = layoutTiers(nodes, { width: 1200, height: 600 });
+
+    // Same task ⇒ same band; different task ⇒ different band.
+    expect(positions.get('w1')!.y).toBe(positions.get('r1')!.y);
+    expect(positions.get('w2')!.y).toBe(positions.get('r2')!.y);
+    expect(positions.get('w1')!.y).not.toBe(positions.get('w2')!.y);
+
+    const lanes = bands.filter((band: Band) => band.kind === 'lane');
+    expect(lanes.map((lane: Band) => lane.taskId)).toEqual(['task-2', 'task-1']);
+    // The publisher's label names the lane; the raw uuid is the fallback.
+    expect(lanes.map((lane: Band) => lane.label)).toEqual(['AGT-2', 'AGT-1']);
+    expect(lanes.map((lane: Band) => lane.count)).toEqual([2, 2]);
+  });
+
+  it('lands untasked execution nodes in one shared lane, not a lane each', () => {
+    const bands = planBands([
+      node({ id: 'a', role: 'agent' }),
+      node({ id: 'b', role: 'agent' }),
+    ]) as Array<Band & { members: unknown[] }>;
+    const lanes = bands.filter((band) => band.kind === 'lane');
+    expect(lanes).toHaveLength(1);
+    expect(lanes[0]).toMatchObject({ label: 'NO TASK' });
+    expect(lanes[0].members).toHaveLength(2);
+  });
+
+  // Cause #2 in the issue: x was `(index + 0.5) / rowMembers.length`, so one
+  // arrival re-indexed and slid every node in the band sideways.
+  it('does not move anyone already on screen when a new agent joins', () => {
+    const opts = { width: 1200, height: 600 };
+    const settled = [
+      node({ id: 'alpha', taskId: 'task-1', firstSeen: 10, lastSeen: 10 }),
+      node({ id: 'bravo', taskId: 'task-1', firstSeen: 20, lastSeen: 20 }),
+      node({ id: 'charlie', taskId: 'task-1', firstSeen: 30, lastSeen: 30 }),
+    ];
+    const before = layoutTiers(settled, opts);
+    // A name that sorts first, so the old index-based placement would have
+    // pushed every incumbent one slot to the right.
+    const joiner = node({ id: 'aaaaa-newcomer', name: 'Aaaa', taskId: 'task-1', firstSeen: 40, lastSeen: 40 });
+    const after = layoutTiers([joiner, ...settled], opts);
+
+    for (const member of settled) {
+      expect(after.positions.get(member.id)).toEqual(before.positions.get(member.id));
+    }
+    expect(after.positions.get('aaaaa-newcomer')).toBeDefined();
+  });
+
+  // The same guarantee under the worst case the hash can produce: the joiner
+  // wants a slot an incumbent already holds. Seating oldest-first is what
+  // makes the newcomer yield rather than evict.
+  it('makes a colliding newcomer yield the slot, not the incumbent', () => {
+    const opts = { width: 1200, height: 600, minSpacing: 96 };
+    const perRow = Math.floor((1200 - 120 - 24) / 96);
+    const incumbent = node({ id: 'incumbent', taskId: 't', firstSeen: 1, lastSeen: 1 });
+    // Search for an id that hashes onto the incumbent's slot.
+    // The id deliberately sorts BEFORE the incumbent's: under the old
+    // name-ordered placement it would have been seated first and taken the
+    // slot. Only seating by age keeps the incumbent put.
+    const wanted = slotHash('incumbent', perRow);
+    let collider = '';
+    for (let n = 0; n < 5000 && !collider; n += 1) {
+      if (slotHash(`aaa-${n}`, perRow) === wanted) collider = `aaa-${n}`;
+    }
+    expect(collider).not.toBe('');
+    expect(collider < 'incumbent').toBe(true);
+
+    const before = layoutTiers([incumbent], opts);
+    const after = layoutTiers([
+      node({ id: collider, taskId: 't', firstSeen: 99, lastSeen: 99 }), incumbent,
+    ], opts);
+    expect(after.positions.get('incumbent')).toEqual(before.positions.get('incumbent'));
+    expect(after.positions.get(collider)!.x).not.toBe(before.positions.get('incumbent')!.x);
+  });
+
+  // A lane's age is the minimum over the members it can see, so filtering away
+  // a lane's earliest member raises it and every lane below shifts. `laneOrder`
+  // comes from the unfiltered board and pins the stack.
+  it('keeps the lane stack put when a filter hides a lane\'s earliest member', () => {
+    const all = [
+      node({ id: 'veteran', taskId: 't-old', firstSeen: 1, lastSeen: 1 }),
+      node({ id: 'latecomer', taskId: 't-old', firstSeen: 90, lastSeen: 90 }),
+      node({ id: 'other', taskId: 't-new', firstSeen: 50, lastSeen: 50 }),
+    ];
+    const laneOrder = ['t-old', 't-new'];
+    const opts = { width: 1200, height: 600, laneOrder };
+    const labelsOf = (bands: Band[]) =>
+      bands.filter((band) => band.kind === 'lane').map((band) => band.taskId);
+
+    const full = layoutTiers(all, opts);
+    // 'veteran' goes idle and drops out; without laneOrder t-old would now
+    // look younger than t-new and swap below it.
+    const filtered = layoutTiers(all.slice(1), opts);
+
+    expect(labelsOf(full.bands)).toEqual(['t-old', 't-new']);
+    expect(labelsOf(filtered.bands)).toEqual(['t-old', 't-new']);
+    expect(labelsOf(layoutTiers(all.slice(1), { width: 1200, height: 600 }).bands))
+      .toEqual(['t-new', 't-old']); // the unpinned ordering this guards against
+  });
+
+  it('folds the least recently active tasks into one lane past the cap', () => {
+    const nodes = Array.from({ length: 8 }, (_, index) =>
+      node({ id: `w${index}`, taskId: `t${index}`, firstSeen: index, lastSeen: index }));
+    const bands = planBands(nodes, { maxLanes: 4 }) as Array<Band & { members: unknown[] }>;
+    const lanes = bands.filter((band) => band.kind === 'lane');
+    expect(lanes).toHaveLength(4);
+    // The three most recent tasks keep their own lane; the rest share one.
+    expect(lanes.slice(0, 3).map((lane) => lane.taskId)).toEqual(['t5', 't6', 't7']);
+    expect(lanes[3].label).toBe('5 OLDER TASKS');
+    expect(lanes[3].members).toHaveLength(5);
+  });
+
+  // Seating is by age. A node from before `firstSeen` existed compares as NaN
+  // against a dated one, and a NaN comparison is not merely wrong — it is
+  // non-transitive, which makes the whole sort arbitrary. Treating an undated
+  // node as the oldest keeps the comparator total.
+  it('seats a legacy node as the oldest rather than comparing NaN', () => {
+    // `minSpacing` past the usable width forces one seat per row, so the row a
+    // node lands in IS its seating order — otherwise the hash hides it.
+    const opts = { width: 400, height: 600, minSpacing: 1000 };
+    const { positions } = layoutTiers([
+      { id: 'zzz-legacy', name: 'Z', role: 'worker', taskId: 't' },
+      { id: 'aaa-dated', name: 'A', role: 'worker', taskId: 't', firstSeen: 5, lastSeen: 5 },
+    ], opts);
+
+    const legacy = positions.get('zzz-legacy')!;
+    const dated = positions.get('aaa-dated')!;
+    expect(Number.isFinite(legacy.x) && Number.isFinite(legacy.y)).toBe(true);
+    // Undated ⇒ oldest ⇒ seated first, despite an id that sorts last.
+    expect(legacy.y).toBeLessThan(dated.y);
   });
 
   it('is deterministic and keeps everyone inside the drawable area', () => {

--- a/web/static/js/orchestrationModel.mjs
+++ b/web/static/js/orchestrationModel.mjs
@@ -18,6 +18,15 @@ const SYSTEM_ROLES = new Map([
   ['human', 'human'],
 ]);
 
+/**
+ * Roles drawn as shared rails rather than as participants in one task.
+ *
+ * They are exempt from the liveness filter: the operator rail vanishing
+ * because nobody spoke to them for half an hour would read as a broken page,
+ * and their whole job is to be the fixed reference the lanes hang from.
+ */
+export const RAIL_ROLES = new Set(['human', 'daemon', 'orchestrator', 'review-agent']);
+
 function roleOf(id, explicit) {
   if (explicit) return explicit;
   return SYSTEM_ROLES.get(id) ?? 'agent';
@@ -31,44 +40,82 @@ function roleOf(id, explicit) {
  * an answered question must not keep pulsing as pending because its older
  * waiting event still exists.
  */
-export function buildOrchestrationModel(events, { now = Date.now(), activeWindowMs = 30 * 60_000 } = {}) {
+/** How long after its last event an identity still counts as active. */
+export const ACTIVE_WINDOW_MS = 30 * 60_000;
+
+export function buildOrchestrationModel(events, { now = Date.now(), activeWindowMs = ACTIVE_WINDOW_MS } = {}) {
   const nodes = new Map();
   const edges = new Map();
   const latestByCorrelation = new Map();
 
-  const touch = (id, name, role, timestamp, taskId) => {
+  // Acting inside a task is a claim; being addressed inside one is only a
+  // hint. Both are recorded, and `actedTaskId` always wins, so cross-task
+  // advice cannot drag a working agent out of its own lane — while an agent
+  // that has never acted anywhere still gets seated with the people talking
+  // to it instead of stranded in a "no task" lane of one.
+  const touch = (id, name, role, timestamp, taskId, taskLabel, acting) => {
     if (!id) return null;
+    const claim = (node) => {
+      if (!taskId) return;
+      if (acting) {
+        // >= : a node first sighted as a recipient in the same millisecond as
+        // its own acting event must still join its task cluster.
+        if (timestamp >= node.actedAt) {
+          node.actedTaskId = taskId;
+          node.actedTaskLabel = taskLabel;
+          node.actedAt = timestamp;
+        }
+        return;
+      }
+      if (timestamp >= node.addressedAt) {
+        node.addressedTaskId = taskId;
+        node.addressedTaskLabel = taskLabel;
+        node.addressedAt = timestamp;
+      }
+    };
     const existing = nodes.get(id);
     if (!existing) {
-      nodes.set(id, {
+      const created = {
         id,
         name: name || id,
         role: roleOf(id, role),
         eventCount: 0,
+        // `firstSeen` is written once and never updated. The layout places
+        // nodes oldest-first so a newcomer can only take a free slot, which is
+        // what keeps an arrival from shoving everyone already on screen; a
+        // field that moved would destroy that ordering.
+        firstSeen: timestamp,
         lastSeen: timestamp,
         pendingCount: 0,
-        taskId,
-      });
-      return nodes.get(id);
+        actedTaskId: undefined,
+        actedTaskLabel: undefined,
+        actedAt: -Infinity,
+        addressedTaskId: undefined,
+        addressedTaskLabel: undefined,
+        addressedAt: -Infinity,
+      };
+      nodes.set(id, created);
+      claim(created);
+      return created;
     }
     // A named sighting upgrades an address-only one; an explicit role upgrades
     // the generic fallback (legacy events carry no role).
     if (name && existing.name === existing.id) existing.name = name;
     if (role && existing.role === 'agent') existing.role = role;
     if (timestamp > existing.lastSeen) existing.lastSeen = timestamp;
-    // >= for task adoption: a node first sighted as a recipient in the same
-    // millisecond as its own acting event must still join its task cluster.
-    if (taskId && timestamp >= existing.lastSeen) existing.taskId = taskId;
+    if (timestamp < existing.firstSeen) existing.firstSeen = timestamp;
+    claim(existing);
     return existing;
   };
 
   for (const event of events) {
-    // Only the actor is acting inside event.taskId — a recipient may be
-    // getting cross-task advice, and adopting the sender's task would drag it
-    // into the wrong execution cluster.
-    const from = touch(event.actor, event.actorName, event.actorRole, event.timestamp, event.taskId);
+    const from = touch(
+      event.actor, event.actorName, event.actorRole, event.timestamp,
+      event.taskId, event.taskLabel, true);
     if (from) from.eventCount += 1;
-    const to = touch(event.recipient, event.recipientName, event.recipientRole, event.timestamp, undefined);
+    const to = touch(
+      event.recipient, event.recipientName, event.recipientRole, event.timestamp,
+      event.taskId, event.taskLabel, false);
 
     if (from && to && from.id !== to.id) {
       const key = `${from.id}→${to.id}`;
@@ -89,13 +136,31 @@ export function buildOrchestrationModel(events, { now = Date.now(), activeWindow
     if (owner) owner.pendingCount += 1;
   }
 
+  // Spelled out rather than spread: this is the node shape the layout and the
+  // view consume, and the acted/addressed bookkeeping above is private to the
+  // aggregation.
   const nodeList = [...nodes.values()].map((node) => ({
-    ...node,
+    id: node.id,
+    name: node.name,
+    role: node.role,
+    eventCount: node.eventCount,
+    firstSeen: node.firstSeen,
+    lastSeen: node.lastSeen,
+    pendingCount: node.pendingCount,
+    taskId: node.actedTaskId ?? node.addressedTaskId,
+    taskLabel: node.actedTaskId ? node.actedTaskLabel : node.addressedTaskLabel,
     active: now - node.lastSeen <= activeWindowMs,
   }));
 
   const byRole = {};
   for (const node of nodeList) byRole[node.role] = (byRole[node.role] ?? 0) + 1;
+
+  // Distinct askers, not question count: the operator wants to know how many
+  // agents are parked on them, and one agent asking three times is one agent
+  // to unblock.
+  const awaiting = new Set(
+    pending.filter((event) => event.kind === 'human-question')
+      .map((event) => event.actor).filter(Boolean));
 
   return {
     nodes: nodeList,
@@ -104,12 +169,86 @@ export function buildOrchestrationModel(events, { now = Date.now(), activeWindow
       totalEvents: events.length,
       agentsByRole: byRole,
       activeAgents: nodeList.filter((node) => node.active && node.role !== 'human').length,
+      idleAgents: nodeList.filter((node) => !node.active && !RAIL_ROLES.has(node.role)).length,
+      agentsAwaitingOperator: awaiting.size,
       pendingQuestions: pending.filter((event) => event.kind === 'human-question').length,
       pendingTotal: pending.length,
       routes: events.filter((event) => event.kind === 'adapter-route').length,
       lastSeq: events.reduce((max, event) => Math.max(max, event.seq ?? 0), 0),
     },
   };
+}
+
+/**
+ * The nodes the graph should actually draw.
+ *
+ * The client keeps every event the server ring ever handed it, so without this
+ * the population only grows: an agent that spoke once at 09:00 is still a dot
+ * at 17:00. Idle participants drop out unless `showIdle` asks for them; the
+ * task/role/query filters are the operator's way of narrowing a busy board.
+ */
+export function filterGraphNodes(nodes, { showIdle = false, taskId = null, role = null, query = '' } = {}) {
+  const needle = query.trim().toLowerCase();
+  return nodes.filter((node) => {
+    const isRail = RAIL_ROLES.has(node.role);
+    if (!showIdle && !node.active && !isRail) return false;
+    // Rails belong to every task and every role view — filtering them out
+    // would strand the lanes with nothing above them to hang from.
+    if (taskId && !isRail && node.taskId !== taskId) return false;
+    if (role && node.role !== role) return false;
+    if (needle && !isRail) {
+      const haystack = `${node.name} ${node.id} ${node.taskLabel ?? ''}`.toLowerCase();
+      if (!haystack.includes(needle)) return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * The task lanes present in a node set, oldest task first.
+ *
+ * Ordering by `firstSeen` and not by recency is deliberate: recency ordering
+ * would re-stack every lane the moment any task spoke, which is the vertical
+ * version of the sliding-row defect this view had.
+ *
+ * A lane's `firstSeen` is the minimum over the members it was handed, so it
+ * moves if the earliest member is not in that set. Callers that filter their
+ * nodes must therefore derive the ORDER from the unfiltered model and pass it
+ * to the layout — see `laneOrder` in tierLayout — or hiding one idle agent
+ * would re-stack every lane below it.
+ */
+export function taskLanesOf(nodes) {
+  const lanes = new Map();
+  for (const node of nodes) {
+    if (!node.taskId || RAIL_ROLES.has(node.role)) continue;
+    // Legacy nodes predate `firstSeen`; falling back beats propagating NaN
+    // into the comparator, where it would make the order arbitrary.
+    const first = node.firstSeen ?? node.lastSeen ?? 0;
+    const last = node.lastSeen ?? node.firstSeen ?? 0;
+    const lane = lanes.get(node.taskId);
+    if (!lane) {
+      lanes.set(node.taskId, {
+        taskId: node.taskId,
+        label: node.taskLabel || shortTaskLabel(node.taskId),
+        firstSeen: first,
+        lastSeen: last,
+        count: 1,
+      });
+      continue;
+    }
+    if (node.taskLabel && lane.label !== node.taskLabel) lane.label = node.taskLabel;
+    lane.firstSeen = Math.min(lane.firstSeen, first);
+    lane.lastSeen = Math.max(lane.lastSeen, last);
+    lane.count += 1;
+  }
+  return [...lanes.values()].sort((a, b) =>
+    a.firstSeen - b.firstSeen || (a.taskId < b.taskId ? -1 : a.taskId > b.taskId ? 1 : 0));
+}
+
+/** Task ids are issue UUIDs; a lane header has room for a stub, not all of it. */
+export function shortTaskLabel(taskId) {
+  if (!taskId) return '';
+  return taskId.length > 12 ? `${taskId.slice(0, 8)}…` : taskId;
 }
 
 /** Per-kind edge colors — one hue per interaction family, stable for the legend. */

--- a/web/static/js/orchestrationView.mjs
+++ b/web/static/js/orchestrationView.mjs
@@ -623,7 +623,15 @@ export function startOrchestrationView(doc, { fetchImpl, eventSourceImpl, pollMs
     return null;
   };
 
+  // Every path back into the DOM funnels through `redraw`, so one guard here
+  // covers them all: a fetch that was already in flight when `stop()` was
+  // called, a late SSE frame, a resize, a control change. Without it the
+  // resolving fetch would rebuild the graph and arm a fresh liveness timer
+  // that nothing is left to clear.
+  let stopped = false;
+
   const redraw = () => {
+    if (stopped) return;
     const events = [...byId.values()].sort((a, b) => a.seq - b.seq);
     const model = buildOrchestrationModel(events);
     // Only what is drawn can be selected: a node hidden by the liveness filter
@@ -742,6 +750,7 @@ export function startOrchestrationView(doc, { fetchImpl, eventSourceImpl, pollMs
   return {
     redraw,
     stop: () => {
+      stopped = true;
       clearInterval(timer);
       if (livenessTimer) clearTimeout(livenessTimer);
       source?.close();

--- a/web/static/js/orchestrationView.mjs
+++ b/web/static/js/orchestrationView.mjs
@@ -7,7 +7,10 @@
 // full current event set every time — the model is cheap at board scale
 // (≤2000 events) and idempotent redraw avoids incremental-DOM drift.
 
-import { buildOrchestrationModel, dominantKind, KIND_COLORS } from './orchestrationModel.mjs';
+import {
+  ACTIVE_WINDOW_MS, buildOrchestrationModel, dominantKind, filterGraphNodes, KIND_COLORS,
+  RAIL_ROLES, taskLanesOf,
+} from './orchestrationModel.mjs';
 import { layoutTiers } from './tierLayout.mjs';
 import {
   buildThreads, chatLineOf, isUtterance, metadataPairs, openQuestionFor, taskLabelOf, threadFor,
@@ -38,6 +41,79 @@ function escapeHtml(text) {
   ));
 }
 
+/**
+ * A drawing layer that survives redraws.
+ *
+ * The view used to open every render with `svg.innerHTML = ''`, throwing the
+ * previous picture away wholesale — so any position change, however small,
+ * arrived as a hard jump with no chance of a transition. Keeping the layers
+ * and reconciling their children by key is what lets CSS animate a move.
+ */
+function layerOf(doc, svg, name) {
+  const existing = svg.querySelector(`g[data-layer="${name}"]`);
+  if (existing) return existing;
+  const layer = el(doc, 'g', { 'data-layer': name });
+  svg.appendChild(layer);
+  return layer;
+}
+
+function clearChildren(node) {
+  while (node.firstChild) node.removeChild(node.firstChild);
+}
+
+/**
+ * Enter/update/exit one keyed layer.
+ *
+ * `create` builds a fresh element for a key it has never seen, `paint`
+ * refreshes one already on screen. Keys that vanished are removed, so the DOM
+ * tracks the model rather than accumulating orphans.
+ */
+function reconcile(layer, keyAttr, items, create, paint) {
+  const alive = new Set();
+  const existing = new Map();
+  for (const child of layer.children) {
+    const key = child.getAttribute(keyAttr);
+    if (key !== null) existing.set(key, child);
+  }
+  for (const item of items) {
+    alive.add(item.key);
+    let node = existing.get(item.key);
+    if (!node) {
+      node = create(item);
+      node.setAttribute(keyAttr, item.key);
+      layer.appendChild(node);
+    }
+    paint(node, item);
+  }
+  for (const [key, node] of existing) {
+    if (!alive.has(key)) node.remove();
+  }
+}
+
+/**
+ * Reconciliation key for one directed edge, safe to carry in an attribute.
+ *
+ * The two addresses have to be joined by something that cannot occur inside
+ * either of them, or `a→b` and `a→b` built from different pairs could collide.
+ * Percent-encoding guarantees that: `>` always encodes to `%3E`, so the `->`
+ * separator can never appear within an encoded address. An out-of-band
+ * delimiter such as NUL would do the same job but makes the served asset a
+ * binary file to every tool that touches it.
+ */
+export function edgeKey(from, to) {
+  return `${encodeURIComponent(from)}->${encodeURIComponent(to)}`;
+}
+
+/**
+ * The click handler in force for one graph, looked up at click time.
+ *
+ * Node groups are created once and then reused across redraws, but `onSelect`
+ * closes over the current redraw and is a different function each time. Adding
+ * a listener per render would stack them; keeping the live handler here lets a
+ * group bind exactly one listener for its whole lifetime.
+ */
+const selectHandlers = new WeakMap();
+
 /** Node radius grows with activity but stays readable: 10..26px. */
 export function nodeRadius(node) {
   return Math.min(26, 10 + Math.sqrt(node.eventCount) * 2.5);
@@ -46,6 +122,7 @@ export function nodeRadius(node) {
 export function renderStats(doc, stats) {
   const holder = doc.getElementById('stats');
   const cells = [
+    ['waiting on you', stats.agentsAwaitingOperator ?? 0, (stats.agentsAwaitingOperator ?? 0) > 0],
     ['active agents', stats.activeAgents, false],
     ['pending questions', stats.pendingQuestions, stats.pendingQuestions > 0],
     ['open exchanges', stats.pendingTotal, false],
@@ -57,17 +134,49 @@ export function renderStats(doc, stats) {
     .join('');
 }
 
+/**
+ * The one line on this screen the operator can act on.
+ *
+ * `pendingTotal` was already computed and already rendered as a stat chip, but
+ * a chip among six chips is not the same as being told. An agent parked on a
+ * question is blocked until somebody answers, so the count of *agents* — not
+ * of questions — gets its own banner above the graph.
+ */
+export function renderWaitingBanner(doc, stats) {
+  const holder = doc.getElementById('waiting');
+  if (!holder) return;
+  const waiting = stats.agentsAwaitingOperator ?? 0;
+  const open = stats.pendingTotal ?? 0;
+  if (waiting > 0) {
+    holder.className = 'waiting is-blocking';
+    holder.textContent = waiting === 1
+      ? '1 agent is waiting on you'
+      : `${waiting} agents are waiting on you`;
+    return;
+  }
+  holder.className = 'waiting';
+  holder.textContent = open > 0
+    ? `${open} exchange${open === 1 ? '' : 's'} open · nothing needs you`
+    : 'nothing is waiting on you';
+}
+
 export function renderGraph(doc, model, layout, selected, onSelect, spotlight = null) {
   const { positions, bands, labelGutter } = layout;
   const svg = doc.getElementById('graph');
   const width = svg.clientWidth || 900;
   const height = svg.clientHeight || 600;
   svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
-  svg.innerHTML = '';
+  selectHandlers.set(svg, onSelect);
 
-  // Hierarchy furniture below everything: alternating band fills, separators,
-  // and a tier label with its head-count — the pyramid reading at a glance.
-  const bandLayer = el(doc, 'g');
+  // Layers are created once and kept. Order of first creation is paint order:
+  // furniture under edges under nodes.
+  const bandLayer = layerOf(doc, svg, 'bands');
+  const edgeLayer = layerOf(doc, svg, 'edges');
+  const nodeLayer = layerOf(doc, svg, 'nodes');
+
+  // Band furniture is redrawn wholesale — it is static decoration that carries
+  // no transition and no listener, so keying it would buy nothing.
+  clearChildren(bandLayer);
   bands.forEach((band, index) => {
     if (index % 2 === 1) {
       bandLayer.appendChild(el(doc, 'rect', {
@@ -78,25 +187,29 @@ export function renderGraph(doc, model, layout, selected, onSelect, spotlight = 
     if (index > 0) {
       bandLayer.appendChild(el(doc, 'line', {
         x1: 0, y1: band.y0, x2: width, y2: band.y0,
-        stroke: '#1f2633', 'stroke-dasharray': '4 6',
+        stroke: '#1f2633', 'stroke-dasharray': band.kind === 'lane' ? '2 4' : '4 6',
       }));
     }
     const label = el(doc, 'text', {
-      x: 12, y: (band.y0 + band.y1) / 2, class: 'tier-label', 'data-tier-label': band.id,
+      x: 12,
+      y: (band.y0 + band.y1) / 2,
+      class: band.kind === 'lane' ? 'tier-label lane-label' : 'tier-label',
+      'data-tier-label': band.id,
     });
     label.textContent = band.label;
     bandLayer.appendChild(label);
     const count = el(doc, 'text', {
       x: 12, y: (band.y0 + band.y1) / 2 + 13, class: 'tier-count',
     });
-    count.textContent = band.count === 0 ? 'none' : `${band.count} placed`;
+    count.textContent = band.count === 0
+      ? 'none'
+      : `${band.count} ${band.kind === 'lane' ? 'in task' : 'placed'}`;
     bandLayer.appendChild(count);
   });
   bandLayer.appendChild(el(doc, 'line', {
     x1: labelGutter - 14, y1: bands[0].y0, x2: labelGutter - 14, y2: bands[bands.length - 1].y1,
     stroke: '#1f2633',
   }));
-  svg.appendChild(bandLayer);
 
   const neighbors = new Set();
   if (selected) {
@@ -110,69 +223,84 @@ export function renderGraph(doc, model, layout, selected, onSelect, spotlight = 
   // the addressee a quieter one, so a single message reads off the hierarchy.
   const speaking = spotlight?.actor ?? null;
   const spokenTo = spotlight?.recipient ?? null;
+  // Agents now carry assigned handles (AGT-4064). A tooltip that prints the
+  // routing address instead is naming something the operator never sees
+  // anywhere else on the page.
+  const displayName = new Map(model.nodes.map((node) => [node.id, node.name]));
+  const nameOf = (id) => displayName.get(id) ?? id;
 
-  const edgeLayer = el(doc, 'g');
-  for (const edge of model.edges) {
-    const a = positions.get(edge.from);
-    const b = positions.get(edge.to);
-    if (!a || !b) continue;
-    // A gentle quadratic bend keeps A→B and B→A visually distinct.
-    const mx = (a.x + b.x) / 2 + (b.y - a.y) * 0.12;
-    const my = (a.y + b.y) / 2 + (a.x - b.x) * 0.12;
-    const path = el(doc, 'path', {
-      d: `M ${a.x} ${a.y} Q ${mx} ${my} ${b.x} ${b.y}`,
-      class: `edge${selected && edge.from !== selected && edge.to !== selected ? ' dimmed' : ''}`,
-      stroke: KIND_COLORS[dominantKind(edge)] ?? '#6c7086',
-      'stroke-width': Math.min(6, 1 + Math.log2(1 + edge.count)),
+  const drawnEdges = model.edges
+    .filter((edge) => positions.has(edge.from) && positions.has(edge.to))
+    .map((edge) => ({ key: edgeKey(edge.from, edge.to), edge }));
+  reconcile(edgeLayer, 'data-edge', drawnEdges,
+    () => {
+      const path = el(doc, 'path', {});
+      path.appendChild(el(doc, 'title'));
+      return path;
+    },
+    (path, { edge }) => {
+      const a = positions.get(edge.from);
+      const b = positions.get(edge.to);
+      // A gentle quadratic bend keeps A→B and B→A visually distinct.
+      const mx = (a.x + b.x) / 2 + (b.y - a.y) * 0.12;
+      const my = (a.y + b.y) / 2 + (a.x - b.x) * 0.12;
+      path.setAttribute('d', `M ${a.x} ${a.y} Q ${mx} ${my} ${b.x} ${b.y}`);
+      path.setAttribute('class', `edge${selected && edge.from !== selected && edge.to !== selected ? ' dimmed' : ''}`);
+      path.setAttribute('stroke', KIND_COLORS[dominantKind(edge)] ?? '#6c7086');
+      path.setAttribute('stroke-width', String(Math.min(6, 1 + Math.log2(1 + edge.count))));
+      path.querySelector('title').textContent =
+        `${nameOf(edge.from)} → ${nameOf(edge.to)}: ${edge.count} (${Object.entries(edge.kinds).map(([k, n]) => `${k}×${n}`).join(', ')})`;
     });
-    path.appendChild(el(doc, 'title')).textContent =
-      `${edge.from} → ${edge.to}: ${edge.count} (${Object.entries(edge.kinds).map(([k, n]) => `${k}×${n}`).join(', ')})`;
-    edgeLayer.appendChild(path);
-  }
-  svg.appendChild(edgeLayer);
 
-  const nodeLayer = el(doc, 'g');
-  for (const node of model.nodes) {
-    const p = positions.get(node.id);
-    if (!p) continue;
-    const group = el(doc, 'g', {
-      class: `node${selected && !neighbors.has(node.id) ? ' dimmed' : ''}`,
-      transform: `translate(${p.x} ${p.y})`,
-      'data-node': node.id,
+  const drawnNodes = model.nodes
+    .filter((node) => positions.has(node.id))
+    .map((node) => ({ key: node.id, node }));
+  reconcile(nodeLayer, 'data-node', drawnNodes,
+    ({ node }) => {
+      const group = el(doc, 'g', {});
+      // Bound once for the group's whole life; the live handler is looked up
+      // through `selectHandlers` so redraws cannot stack listeners here.
+      group.addEventListener('click', () => selectHandlers.get(svg)?.(node.id));
+      return group;
+    },
+    (group, { node }) => {
+      const p = positions.get(node.id);
+      group.setAttribute('class', `node${selected && !neighbors.has(node.id) ? ' dimmed' : ''}`);
+      group.setAttribute('transform', `translate(${p.x} ${p.y})`);
+      group.removeAttribute('data-speaking');
+      group.removeAttribute('data-spoken-to');
+      clearChildren(group);
+
+      const radius = nodeRadius(node);
+      if (node.pendingCount > 0) {
+        group.appendChild(el(doc, 'circle', { r: radius + 6, fill: 'none', stroke: '#e8b339', 'stroke-width': 2, class: 'pulse' }));
+      }
+      if (node.id === speaking) {
+        group.setAttribute('data-speaking', 'true');
+        group.appendChild(el(doc, 'circle', {
+          r: radius + 10, fill: 'none', stroke: '#e6e9ef', 'stroke-width': 2.5, class: 'speaking',
+        }));
+      } else if (node.id === spokenTo) {
+        group.setAttribute('data-spoken-to', 'true');
+        group.appendChild(el(doc, 'circle', {
+          r: radius + 10, fill: 'none', stroke: '#e6e9ef', 'stroke-width': 1.5,
+          'stroke-opacity': 0.45, 'stroke-dasharray': '3 4', class: 'spoken-to',
+        }));
+      }
+      group.appendChild(el(doc, 'circle', {
+        r: radius,
+        fill: ROLE_COLORS[node.role] ?? ROLE_COLORS.agent,
+        'fill-opacity': node.active ? 0.9 : 0.35,
+        stroke: node.id === selected ? '#e6e9ef' : 'transparent',
+        'stroke-width': 2,
+      }));
+      const label = el(doc, 'text', { y: radius + 12 });
+      label.textContent = node.name;
+      group.appendChild(label);
+      const roleLabel = el(doc, 'text', { y: radius + 22, class: 'role-label' });
+      roleLabel.textContent = node.role;
+      group.appendChild(roleLabel);
     });
-    const radius = nodeRadius(node);
-    if (node.pendingCount > 0) {
-      group.appendChild(el(doc, 'circle', { r: radius + 6, fill: 'none', stroke: '#e8b339', 'stroke-width': 2, class: 'pulse' }));
-    }
-    if (node.id === speaking) {
-      group.setAttribute('data-speaking', 'true');
-      group.appendChild(el(doc, 'circle', {
-        r: radius + 10, fill: 'none', stroke: '#e6e9ef', 'stroke-width': 2.5, class: 'speaking',
-      }));
-    } else if (node.id === spokenTo) {
-      group.setAttribute('data-spoken-to', 'true');
-      group.appendChild(el(doc, 'circle', {
-        r: radius + 10, fill: 'none', stroke: '#e6e9ef', 'stroke-width': 1.5,
-        'stroke-opacity': 0.45, 'stroke-dasharray': '3 4', class: 'spoken-to',
-      }));
-    }
-    group.appendChild(el(doc, 'circle', {
-      r: radius,
-      fill: ROLE_COLORS[node.role] ?? ROLE_COLORS.agent,
-      'fill-opacity': node.active ? 0.9 : 0.35,
-      stroke: node.id === selected ? '#e6e9ef' : 'transparent',
-      'stroke-width': 2,
-    }));
-    const label = el(doc, 'text', { y: radius + 12 });
-    label.textContent = node.name;
-    group.appendChild(label);
-    const roleLabel = el(doc, 'text', { y: radius + 22, class: 'role-label' });
-    roleLabel.textContent = node.role;
-    group.appendChild(roleLabel);
-    group.addEventListener('click', () => onSelect(node.id));
-    nodeLayer.appendChild(group);
-  }
-  svg.appendChild(nodeLayer);
 }
 
 export function renderLegend(doc) {
@@ -185,6 +313,65 @@ export function renderLegend(doc) {
     `<div class="row"><span class="line" style="background:${KIND_COLORS['adapter-route']}"></span>route / mcp</div>`,
   ];
   doc.getElementById('legend').innerHTML = rows.join('');
+}
+
+/**
+ * Refresh the filter controls from the current model.
+ *
+ * Deliberately does NOT touch the search box or rebuild a select whose options
+ * are unchanged: this runs on every SSE event, and replacing an input the
+ * operator is typing into would eat the caret. Only the task options and the
+ * idle count actually change with the data.
+ */
+export function renderControls(doc, model, filters) {
+  const taskSelect = doc.getElementById('filter-task');
+  if (taskSelect) {
+    const lanes = taskLanesOf(model.nodes);
+    const signature = lanes.map((lane) => `${lane.taskId}:${lane.label}`).join('|');
+    if (taskSelect.getAttribute('data-options') !== signature) {
+      taskSelect.setAttribute('data-options', signature);
+      taskSelect.innerHTML = ['<option value="">all tasks</option>', ...lanes.map((lane) =>
+        `<option value="${escapeHtml(lane.taskId)}">${escapeHtml(lane.label)}</option>`)].join('');
+    }
+    // The selected task can be evicted with its lane; fall back to "all" so the
+    // control never points at something that is no longer on the board.
+    const wanted = filters.taskId ?? '';
+    const known = wanted === '' || lanes.some((lane) => lane.taskId === wanted);
+    if (!known) filters.taskId = null;
+    const value = filters.taskId ?? '';
+    if (taskSelect.value !== value) taskSelect.value = value;
+  }
+
+  const roleSelect = doc.getElementById('filter-role');
+  if (roleSelect && roleSelect.value !== (filters.role ?? '')) roleSelect.value = filters.role ?? '';
+
+  const idleToggle = doc.getElementById('filter-idle');
+  if (idleToggle && idleToggle.checked !== filters.showIdle) idleToggle.checked = filters.showIdle;
+  const idleCount = doc.getElementById('idle-count');
+  if (idleCount) {
+    const idle = model.stats.idleAgents ?? 0;
+    idleCount.textContent = idle === 0 ? '' : `(${idle})`;
+  }
+}
+
+/**
+ * Bind the controls once.
+ *
+ * Attaching these inside the render would add a listener per redraw, and a
+ * redraw happens on every coordination event — the toggle would eventually
+ * fire dozens of times per click.
+ */
+export function wireControls(doc, filters, onChange) {
+  const bind = (id, type, read) => {
+    const node = doc.getElementById(id);
+    if (!node || node.getAttribute('data-bound') === 'true') return;
+    node.setAttribute('data-bound', 'true');
+    node.addEventListener(type, () => { read(node); onChange(); });
+  };
+  bind('filter-search', 'input', (node) => { filters.query = node.value; });
+  bind('filter-task', 'change', (node) => { filters.taskId = node.value || null; });
+  bind('filter-role', 'change', (node) => { filters.role = node.value || null; });
+  bind('filter-idle', 'change', (node) => { filters.showIdle = node.checked; });
 }
 
 export function renderDetail(doc, model, events, selected) {
@@ -372,6 +559,7 @@ export function startOrchestrationView(doc, { fetchImpl, eventSourceImpl, pollMs
   let selected = null;
   let focusedEventId = null;
   const composerStates = new Map();
+  const filters = { showIdle: false, taskId: null, role: null, query: '' };
 
   // Returns the failure reason, or null when the message was accepted. `fetch`
   // resolves on 400/409, so the server's "cannot address this" and "already
@@ -438,16 +626,26 @@ export function startOrchestrationView(doc, { fetchImpl, eventSourceImpl, pollMs
   const redraw = () => {
     const events = [...byId.values()].sort((a, b) => a.seq - b.seq);
     const model = buildOrchestrationModel(events);
-    if (selected && !model.nodes.some((node) => node.id === selected)) selected = null;
+    // Only what is drawn can be selected: a node hidden by the liveness filter
+    // would otherwise stay selected invisibly and keep the feed narrowed to it
+    // with nothing on screen explaining why.
+    const visible = filterGraphNodes(model.nodes, filters);
+    if (selected && !visible.some((node) => node.id === selected)) selected = null;
     const focused = focusedEventId ? byId.get(focusedEventId) ?? null : null;
     if (focusedEventId && !focused) focusedEventId = null;
     const threads = buildThreads(events);
     const svg = doc.getElementById('graph');
-    const layout = layoutTiers(model.nodes, {
+    const layout = layoutTiers(visible, {
       width: svg.clientWidth || 900,
       height: svg.clientHeight || 600,
+      // Derived from the FULL board, not the filtered set: a lane's age is a
+      // property of the task, and hiding one idle member must not restack the
+      // conversations above and below it.
+      laneOrder: taskLanesOf(model.nodes).map((lane) => lane.taskId),
     });
     renderStats(doc, model.stats);
+    renderWaitingBanner(doc, model.stats);
+    renderControls(doc, model, filters);
     renderGraph(doc, model, layout, selected, (id) => {
       selected = selected === id ? null : id;
       redraw();
@@ -459,10 +657,53 @@ export function startOrchestrationView(doc, { fetchImpl, eventSourceImpl, pollMs
     });
     const shownThread = threadFor(threads, focused);
     renderThread(doc, shownThread, send, composerStates.get(shownThread?.correlationId ?? null) ?? null);
+    scheduleLivenessSweep(model.nodes);
+  };
+
+  // Liveness is measured against wall time, but only an event, a poll change,
+  // a resize or a control action redraws — so on a quiet board an agent that
+  // went idle stayed on screen indefinitely, which is exactly the unbounded
+  // population this change exists to remove. Wake once, at the moment the next
+  // still-active agent crosses the window, rather than polling for it.
+  let livenessTimer = null;
+  const scheduleLivenessSweep = (nodes) => {
+    if (livenessTimer) clearTimeout(livenessTimer);
+    livenessTimer = null;
+    // Rails never age out of the picture, so their expiry is not a wake reason.
+    const expiries = nodes
+      .filter((node) => node.active && !RAIL_ROLES.has(node.role))
+      .map((node) => node.lastSeen + ACTIVE_WINDOW_MS);
+    if (expiries.length === 0) return;
+    const due = Math.min(...expiries) - Date.now();
+    // A small margin past the boundary: waking exactly on it can still read as
+    // active by a millisecond and schedule the same wake again.
+    livenessTimer = setTimeout(redraw, Math.max(250, due + 250));
+  };
+
+  // The server ring drops coordination events at 2000; this map used to keep
+  // every one it was ever handed, so a dashboard left open for a shift held
+  // more history than the daemon does and every agent that ever spoke stayed a
+  // node forever.
+  //
+  // `MAX_EVENTS` is a ceiling, not an average: pruning triggers the moment the
+  // map exceeds it, so `byId.size <= MAX_EVENTS` holds after every absorb. The
+  // batch is what makes it cheap — each prune frees `PRUNE_BATCH` slots, so the
+  // sort is paid for once per batch of arrivals rather than once per event.
+  const MAX_EVENTS = 2000;
+  const PRUNE_BATCH = 256;
+  const prune = () => {
+    if (byId.size <= MAX_EVENTS) return;
+    const ordered = [...byId.values()].sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0));
+    const target = Math.max(0, MAX_EVENTS - PRUNE_BATCH);
+    for (const event of ordered.slice(0, byId.size - target)) byId.delete(event.id);
   };
 
   const absorb = (event) => {
-    if (event && event.id && !byId.has(event.id)) { byId.set(event.id, event); return true; }
+    if (event && event.id && !byId.has(event.id)) {
+      byId.set(event.id, event);
+      prune();
+      return true;
+    }
     return false;
   };
 
@@ -493,6 +734,18 @@ export function startOrchestrationView(doc, { fetchImpl, eventSourceImpl, pollMs
   }
 
   renderLegend(doc);
+  wireControls(doc, filters, redraw);
+  // Removed on stop with the same reference it was added with. Leaving it
+  // attached kept a stopped view repainting the graph — and holding the whole
+  // event map and its closures — for as long as the page lived.
   doc.defaultView?.addEventListener('resize', redraw);
-  return { redraw, stop: () => { clearInterval(timer); source?.close(); } };
+  return {
+    redraw,
+    stop: () => {
+      clearInterval(timer);
+      if (livenessTimer) clearTimeout(livenessTimer);
+      source?.close();
+      doc.defaultView?.removeEventListener('resize', redraw);
+    },
+  };
 }

--- a/web/static/js/tierLayout.mjs
+++ b/web/static/js/tierLayout.mjs
@@ -1,13 +1,20 @@
 // ============================================
-// OpenSwarm - Hierarchical tier layout (pure)
+// OpenSwarm - Task-lane layout (pure)
 // ============================================
 //
-// The swarm has a real chain of command, and the layout states it instead of
-// letting a force simulation scatter it: operator on top, control plane under
-// them, the coordination/oversight layer next, and the execution tier as the
-// wide base of the pyramid. Tier width IS the deployment picture. Positions
-// are fully deterministic — sorted placement, no simulation — so a node never
-// moves unless the population changes.
+// The swarm has a real chain of command AND a real set of conversations, and
+// the layout states both. Operator, control plane and the coordination layer
+// are shared RAILS across the top — they belong to every task, so they get
+// fixed bands. Everything below is one LANE per task: the worker, its reviewer
+// and whoever they pulled in sit together, so a reader can see which agents
+// are talking about the same thing instead of forty dots in one band.
+//
+// Positions are fully deterministic — no simulation — and, more importantly,
+// stable: a node's slot comes from a hash of its address, and nodes are seated
+// oldest-first, so an arriving agent can only take a slot nobody holds. It
+// never shoves the agents already on screen sideways.
+
+import { taskLanesOf } from './orchestrationModel.mjs';
 
 export const TIERS = [
   { id: 'operator', label: 'OPERATOR', roles: ['human'] },
@@ -18,27 +25,148 @@ export const TIERS = [
 
 const EXECUTION = TIERS.length - 1;
 
+/** Lane holding execution nodes that never carried a task id. */
+const NO_TASK = '~no-task';
+
 export function tierOf(role) {
   const index = TIERS.findIndex((tier) => tier.roles.includes(role));
   return index === -1 ? EXECUTION : index;
 }
 
-/** Worker before its reviewer inside a task cluster. */
-const ROLE_ORDER = { worker: 0, reviewer: 1, agent: 2 };
+/** Legacy nodes predate `firstSeen`; fall back rather than sorting on NaN. */
+function seenFirst(node) {
+  return node.firstSeen ?? node.lastSeen ?? 0;
+}
 
-function executionSortKey(node) {
-  // Task first, so a task's worker/reviewer pair sits adjacent — the pair is
-  // the unit the operator thinks in.
-  return `${node.taskId ?? '~'}\u0000${ROLE_ORDER[node.role] ?? 9}\u0000${node.name}`;
+// Codepoint comparison, not localeCompare: the browser's locale must not be
+// able to reorder the pyramid.
+function byCodepoint(a, b) {
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 /**
- * Place nodes into fixed tier bands.
+ * FNV-1a (32-bit) over the node address.
  *
- * Every tier band is always drawn, populated or not — an empty COORDINATION
- * row saying "nothing is coordinating right now" is information, and a
- * hierarchy that reshuffles its rows as agents come and go is unreadable.
- * Crowded tiers wrap into sub-rows instead of squeezing below `minSpacing`.
+ * The point is not cryptographic spread, it is that the slot is a property of
+ * the identity alone: it does not depend on who else is on the board, so a
+ * node keeps its column when its neighbours come and go.
+ */
+export function slotHash(id, slots) {
+  if (slots <= 1) return 0;
+  let hash = 0x811c9dc5;
+  const text = String(id);
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash % slots;
+}
+
+/**
+ * Seat one band's members into (row, slot) pairs.
+ *
+ * Oldest first is what makes this stable. A newly sighted agent has the
+ * largest `firstSeen`, so it is seated last, so every probe it makes lands on
+ * a slot no incumbent holds — the arrival cannot displace anyone. Seating in
+ * name order (what this used to do, via `(index + 0.5) / rowMembers.length`)
+ * gave the opposite property: one arrival re-indexed the whole row.
+ */
+function seat(members, slots) {
+  const ordered = [...members].sort((a, b) =>
+    seenFirst(a) - seenFirst(b) || byCodepoint(a.id, b.id));
+  const seats = new Map();
+  const takenByRow = new Map();
+  ordered.forEach((node, position) => {
+    const row = Math.floor(position / slots);
+    let taken = takenByRow.get(row);
+    if (!taken) { taken = new Set(); takenByRow.set(row, taken); }
+    let slot = slotHash(node.id, slots);
+    for (let probe = 0; probe < slots && taken.has(slot); probe += 1) slot = (slot + 1) % slots;
+    taken.add(slot);
+    seats.set(node.id, { row, slot });
+  });
+  return seats;
+}
+
+/**
+ * Split nodes into the rail bands and the per-task lanes.
+ *
+ * `maxLanes` bounds the number of TASK lanes: past it, the least recently
+ * active tasks fold into one overflow lane rather than shrinking every band
+ * toward zero. The shared "no task" lane sits outside that budget, since it
+ * exists to stop untasked nodes becoming a lane each. Kept lanes are ordered
+ * by `firstSeen`, so a new task appends at the bottom instead of re-stacking
+ * the ones above it.
+ */
+export function planBands(nodes, { maxLanes = 12, laneOrder = null } = {}) {
+  const rails = TIERS.slice(0, EXECUTION).map((tier) => ({
+    id: tier.id, label: tier.label, kind: 'rail', taskId: null, members: [],
+  }));
+  const execution = [];
+  for (const node of nodes) {
+    // The tier table is the layout's own authority on what is a rail; the
+    // model's RAIL_ROLES answers a different question (who survives the
+    // liveness filter), and conflating them would couple two decisions.
+    const tier = tierOf(node.role);
+    if (tier < EXECUTION) rails[tier].members.push(node);
+    else execution.push(node);
+  }
+
+  let lanes = taskLanesOf(execution);
+  // A lane's own `firstSeen` is the minimum over the members it can see, so it
+  // rises when the earliest one is filtered away — and every lane below it
+  // would shift. `laneOrder`, derived once from the unfiltered board, pins the
+  // stack so hiding an idle agent cannot re-order the conversations.
+  if (laneOrder) {
+    const rank = new Map(laneOrder.map((taskId, index) => [taskId, index]));
+    lanes = [...lanes].sort((a, b) =>
+      (rank.get(a.taskId) ?? Number.MAX_SAFE_INTEGER) - (rank.get(b.taskId) ?? Number.MAX_SAFE_INTEGER)
+      || a.firstSeen - b.firstSeen
+      || byCodepoint(a.taskId, b.taskId));
+  }
+  let overflow = new Set();
+  if (lanes.length > maxLanes) {
+    const keep = [...lanes].sort((a, b) => b.lastSeen - a.lastSeen).slice(0, maxLanes - 1);
+    const kept = new Set(keep.map((lane) => lane.taskId));
+    overflow = new Set(lanes.filter((lane) => !kept.has(lane.taskId)).map((lane) => lane.taskId));
+    lanes = lanes.filter((lane) => kept.has(lane.taskId));
+  }
+
+  const laneBands = lanes.map((lane) => ({
+    id: `lane:${lane.taskId}`, label: lane.label, kind: 'lane', taskId: lane.taskId, members: [],
+  }));
+  const byTask = new Map(laneBands.map((band) => [band.taskId, band]));
+  const spillover = [];
+  const untasked = [];
+  for (const node of execution) {
+    const band = node.taskId ? byTask.get(node.taskId) : null;
+    if (band) band.members.push(node);
+    else if (node.taskId && overflow.has(node.taskId)) spillover.push(node);
+    else untasked.push(node);
+  }
+  if (spillover.length) {
+    laneBands.push({
+      id: `lane:${NO_TASK}-overflow`, label: `${overflow.size} OLDER TASKS`, kind: 'lane',
+      taskId: null, members: spillover,
+    });
+  }
+  if (untasked.length) {
+    laneBands.push({ id: `lane:${NO_TASK}`, label: 'NO TASK', kind: 'lane', taskId: null, members: untasked });
+  }
+  // An empty execution area still gets one band: a hierarchy whose bottom half
+  // silently disappears when the swarm goes quiet reads as a broken page.
+  if (laneBands.length === 0) {
+    laneBands.push({ id: `lane:${NO_TASK}`, label: 'TASKS', kind: 'lane', taskId: null, members: [] });
+  }
+  return [...rails, ...laneBands];
+}
+
+/**
+ * Place nodes into rail bands and task lanes.
+ *
+ * Every rail band is always drawn, populated or not — an empty COORDINATION
+ * row saying "nothing is coordinating right now" is information. Crowded bands
+ * wrap into sub-rows instead of squeezing below `minSpacing`.
  */
 export function layoutTiers(nodes, {
   width = 900,
@@ -46,43 +174,40 @@ export function layoutTiers(nodes, {
   labelGutter = 120,
   margin = 24,
   minSpacing = 96,
+  maxLanes = 12,
+  laneOrder = null,
 } = {}) {
-  const byTier = TIERS.map(() => []);
-  for (const node of nodes) byTier[tierOf(node.role)].push(node);
-  // Codepoint comparison, not localeCompare: the browser's locale must not be
-  // able to reorder the pyramid.
-  const byCodepoint = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
-  byTier[EXECUTION].sort((a, b) => byCodepoint(executionSortKey(a), executionSortKey(b)));
-  for (let tier = 0; tier < EXECUTION; tier += 1) {
-    byTier[tier].sort((a, b) => byCodepoint(a.name, b.name));
-  }
+  const planned = planBands(nodes, { maxLanes, laneOrder });
 
   const usable = Math.max(width - labelGutter - margin, minSpacing);
   const perRow = Math.max(1, Math.floor(usable / minSpacing));
-  const subRows = byTier.map((members) => Math.max(1, Math.ceil(members.length / perRow)));
+  const subRows = planned.map((band) => Math.max(1, Math.ceil(band.members.length / perRow)));
   const totalUnits = subRows.reduce((sum, rows) => sum + rows, 0);
   const unitHeight = (height - margin * 2) / totalUnits;
 
   const positions = new Map();
   const bands = [];
   let y = margin;
-  for (let tier = 0; tier < TIERS.length; tier += 1) {
-    const members = byTier[tier];
-    const bandHeight = unitHeight * subRows[tier];
-    bands.push({ id: TIERS[tier].id, label: TIERS[tier].label, y0: y, y1: y + bandHeight, count: members.length });
-
-    for (let row = 0; row < subRows[tier]; row += 1) {
-      const rowMembers = members.slice(row * perRow, (row + 1) * perRow);
-      const rowY = y + (row + 0.5) * (bandHeight / subRows[tier]);
-      rowMembers.forEach((node, index) => {
-        positions.set(node.id, {
-          x: labelGutter + ((index + 0.5) / rowMembers.length) * usable,
-          y: rowY,
-        });
+  planned.forEach((band, index) => {
+    const bandHeight = unitHeight * subRows[index];
+    bands.push({
+      id: band.id,
+      label: band.label,
+      kind: band.kind,
+      taskId: band.taskId,
+      y0: y,
+      y1: y + bandHeight,
+      count: band.members.length,
+    });
+    const rowHeight = bandHeight / subRows[index];
+    for (const [id, place] of seat(band.members, perRow)) {
+      positions.set(id, {
+        x: labelGutter + ((place.slot + 0.5) / perRow) * usable,
+        y: y + (place.row + 0.5) * rowHeight,
       });
     }
     y += bandHeight;
-  }
+  });
 
   return { positions, bands, labelGutter };
 }

--- a/web/static/orchestration.html
+++ b/web/static/orchestration.html
@@ -75,8 +75,30 @@
     .composer-status.is-error { color: var(--red, #f85149); }
     .empty { color: var(--dim); padding: 14px; font-size: 12px; }
     .tier-label { fill: var(--dim); font-size: 10px; letter-spacing: 2px; font-weight: 700; }
+    /* A lane header names a task, not a rank: cyan like every other task chip,
+       and unspaced so a real issue key stays readable in the gutter. */
+    .lane-label { fill: var(--cyan); letter-spacing: 0.5px; }
     .tier-count { fill: #3d4454; font-size: 9px; }
-    .node { cursor: pointer; }
+    /* The one line on the page an operator can act on, so it sits above the
+       graph rather than being a sixth chip in the stat row. */
+    .waiting { padding: 5px 16px; font-size: 11px; color: var(--dim); border-bottom: 1px solid var(--border); }
+    .waiting.is-blocking { color: #0d1117; background: var(--amber); font-weight: 700; }
+    #controls { display: flex; align-items: center; gap: 8px; padding: 6px 16px; border-bottom: 1px solid var(--border); flex-wrap: wrap; }
+    #controls input[type="search"], #controls select {
+      background: #0d1117; border: 1px solid var(--border); border-radius: 4px;
+      color: var(--white); font: inherit; font-size: 11px; padding: 3px 6px;
+    }
+    #controls input[type="search"] { min-width: 150px; }
+    #controls label { display: flex; align-items: center; gap: 4px; font-size: 11px; color: var(--dim); }
+    #idle-count { color: #3d4454; }
+    /* Positions are stable now (a node's column comes from its address, not its
+       index), so the rare move a node does make is worth animating rather than
+       cutting to. Anyone who asked for less motion gets none. */
+    .node { cursor: pointer; transition: transform 260ms cubic-bezier(0.22, 1, 0.36, 1); }
+    @media (prefers-reduced-motion: reduce) {
+      .node { transition: none; }
+      .pulse, .speaking { animation: none; }
+    }
     .node text { fill: var(--white); font-size: 10px; text-anchor: middle; pointer-events: none; }
     .node .role-label { fill: var(--dim); font-size: 8px; }
     .node.dimmed { opacity: 0.25; }
@@ -94,6 +116,25 @@
     <a href="/chat">chat room →</a>
     <div id="stats"></div>
   </header>
+  <div id="waiting" class="waiting" role="status" aria-live="polite"></div>
+  <div id="controls">
+    <input id="filter-search" type="search" autocomplete="off" placeholder="search agents…" aria-label="Search agents" />
+    <select id="filter-task" aria-label="Filter by task" data-options="">
+      <option value="">all tasks</option>
+    </select>
+    <select id="filter-role" aria-label="Filter by role">
+      <option value="">all roles</option>
+      <option value="worker">worker</option>
+      <option value="reviewer">reviewer</option>
+      <option value="orchestrator">orchestrator</option>
+      <option value="review-agent">review agent</option>
+      <option value="daemon">daemon</option>
+      <option value="human">operator</option>
+    </select>
+    <label for="filter-idle">
+      <input id="filter-idle" type="checkbox" /> show idle <span id="idle-count"></span>
+    </label>
+  </div>
   <main>
     <div id="graph-wrap">
       <svg id="graph" role="img" aria-label="Agent interaction graph"></svg>


### PR DESCRIPTION
Closes AGT-4066.

The orchestration view drew every identity it had ever seen as a floating dot in one `EXECUTION` band, so six live tasks read as forty agents. This makes the graph read as a set of conversations instead.

## What changed

**Task lanes.** The execution tier is now one lane per task, holding that task's own participants; operator, control plane and coordination stay as shared rails above. `node.taskId` already carried the grouping and was simply never drawn.

A node that has only ever been *addressed* now joins the task it was addressed within, so a reviewer who never speaks first still sits with its worker. A node that has *acted* keeps its own task, so cross-task advice still cannot drag a working agent out of its lane — the existing invariant is unchanged and still tested.

**Bounded by liveness, not history.** The client kept every event the server ring ever handed it, so a dashboard left open for a shift held more history than the daemon does. `byId` now holds at most the ring's own 2000 events (a ceiling checked after every absorb, pruned in batches so the sort is amortised). Agents outside the 30-minute window drop out of the graph behind a `show idle (N)` toggle. A scheduled sweep wakes at the moment the next agent ages out, so a silent board still sheds them rather than freezing whatever was last drawn.

**Stable positions.** `x` was `(index + 0.5) / rowMembers.length`, so one arrival re-indexed and slid everyone. A node's column now comes from a hash of its address, and nodes are seated oldest-first — so an arrival can only take a free slot and never displaces an incumbent, even when it hashes onto one. Lane order is pinned from the *unfiltered* board, so hiding an idle agent cannot re-stack the lanes either (the vertical version of the same defect).

**No more teardown.** `svg.innerHTML = ''` on every SSE event is replaced by keyed enter/update/exit over persistent layers, so the rare real move can transition instead of jumping. One delegated-lifetime listener per node group, so redraws cannot stack listeners.

**Interaction floor.** An "N agents are waiting on you" banner above the graph (`stats` already had the data, buried among six chips); search, task and role filters, and the idle collapse. Edge tooltips name agents by handle rather than by routing address (AGT-4064).

## Verification

`npx tsc --noEmit` clean, `oxlint web/ src/` clean (2 warnings, both pre-existing on `main` in files this PR does not touch), 210 web tests pass.

Every new test was mutation-checked: the production change it covers was reverted and the test confirmed to turn red. 27/27 mutations killed, including reverting `x` to the index formula, seating by name instead of age, removing the eviction, restoring `svg.innerHTML = ''`, dropping the lane-order pin, and reintroducing a raw NUL byte into the served asset.

Two defects were found by the commit gate and fixed here rather than deferred: the batch eviction let steady state sit above its stated 2000 bound, and the liveness window was never re-evaluated on a quiet board. A third — the resize listener outliving `stop()` — predates this branch but is fixed since it is in a file this PR owns.

## Deliberately not done

- **Zoom/pan.** There is no viewBox transform today; it is a larger change than it looks and the issue marks it optional.
- **`src/support/dashboardHtml.ts`.** Its inline ES5 duplicates some of this derivation. Out of scope per the issue, and verified independent — it imports none of these modules.
- **Composer draft preservation.** A redraw rebuilds the thread panel and loses unsent text. Pre-existing (any SSE event already does this) and entangled with tested send/accept semantics, so out of scope here.
