### PR TITLE
fix(worktree): stop a container restart wedging the admission cap for 24h (AGT-4067)

### DIFF
--- a/src/support/worktreeManager.coverage.test.ts
+++ b/src/support/worktreeManager.coverage.test.ts
@@ -286,6 +286,84 @@ describe('createWorktree retry/resume error paths', () => {
     }
   });
 
+  // The regression this fix must not introduce: `openswarm attach`, a manual
+  // `openswarm run` and a second daemon are all "not this process", so a
+  // differing owner id cannot be read as proof of death. Doing so would put
+  // two owners on one worktree. (Caught by the commit-gate review.)
+  it('respects a marker from another live OpenSwarm process even though its owner id differs (AGT-4067)', async () => {
+    const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-sibling-process');
+    const markerPath = join(
+      repo, '.git', 'openswarm', 'active-worktrees', 'INT-1', `${info.activeMarkerToken}.json`,
+    );
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
+    // A different process that is genuinely running: our own parent. Its id
+    // differs from ours and its marker predates nothing — it must be kept.
+    marker.ownerInstanceId = 'sibling-process-00000000-0000-4000-8000-000000000000';
+    marker.ownerPid = process.ppid;
+    marker.createdAt = new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString();
+    writeFileSync(markerPath, JSON.stringify(marker));
+
+    await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
+      state: 'active_owner',
+      marker: { ownerPid: process.ppid },
+    });
+  });
+
+  // The live incident this was written for: the markers already on disk were
+  // written before `ownerInstanceId` existed, so the boot comparison cannot
+  // reach them. A pid is unique among live processes, which is proof enough —
+  // a marker carrying our own pid that predates our start belongs to a process
+  // that has since exited, whatever the pid table now says.
+  it('abandons a marker that carries our pid but predates this process (AGT-4067)', async () => {
+    const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-legacy-prior-boot');
+    const markerPath = join(
+      repo, '.git', 'openswarm', 'active-worktrees', 'INT-1', `${info.activeMarkerToken}.json`,
+    );
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
+    delete marker.ownerInstanceId; // written before the field existed
+    expect(marker.ownerPid).toBe(process.pid);
+    // Comfortably inside the 24h abandon window, so age alone still says live.
+    marker.createdAt = new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString();
+    writeFileSync(markerPath, JSON.stringify(marker));
+
+    await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
+      state: 'orphaned',
+    });
+  });
+
+  it('keeps a marker from this boot for the full window so a live stage cannot lose its worktree (AGT-4067)', async () => {
+    const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-this-boot');
+    const markerPath = join(
+      repo, '.git', 'openswarm', 'active-worktrees', 'INT-1', `${info.activeMarkerToken}.json`,
+    );
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
+    expect(marker.ownerInstanceId).toBeTruthy();
+    // An hour in — long enough that shortening the abandon window (the unsafe
+    // workaround this replaces) would expire it, but this boot wrote it, so a
+    // long-running worker stage must keep its worktree.
+    marker.createdAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    writeFileSync(markerPath, JSON.stringify(marker));
+
+    await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
+      state: 'active_owner',
+      marker: { ownerInstanceId: marker.ownerInstanceId },
+    });
+  });
+
+  it('falls back to the pid + age test for a legacy marker with no boot recorded (AGT-4067)', async () => {
+    const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-legacy-marker');
+    const markerPath = join(
+      repo, '.git', 'openswarm', 'active-worktrees', 'INT-1', `${info.activeMarkerToken}.json`,
+    );
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
+    delete marker.ownerInstanceId; // written before this field existed
+    writeFileSync(markerPath, JSON.stringify(marker));
+
+    await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
+      state: 'active_owner',
+    });
+  });
+
   it('distinguishes a live owner, a dead owner, and a safely preserved worktree', async () => {
     const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-recovery');
     await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
@@ -564,6 +642,21 @@ describe('pruneWorktrees (INT-1810 R4 / INT-2503 / INT-2506)', () => {
     );
     const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
     marker.createdAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    writeFileSync(markerPath, JSON.stringify(marker));
+
+    await pruneWorktrees(repo, new Set(), new Set([orphan.worktreePath]));
+
+    expect(existsSync(orphan.worktreePath)).toBe(false);
+  });
+
+  it('sweeps a proven orphan whose marker predates this process, well inside the age window (AGT-4067)', async () => {
+    const orphan = await createWorktree(repo, 'INT-7', 'swarm/INT-7-prior-boot');
+    const markerPath = join(
+      repo, '.git', 'openswarm', 'active-worktrees', 'INT-7', `${orphan.activeMarkerToken}.json`,
+    );
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
+    delete marker.ownerInstanceId; // as a crashed pre-AGT-4067 boot left it
+    marker.createdAt = new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString();
     writeFileSync(markerPath, JSON.stringify(marker));
 
     await pruneWorktrees(repo, new Set(), new Set([orphan.worktreePath]));

--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -423,6 +423,35 @@ describe('removePreservedWorktreeAt (INT-2506)', () => {
     expect(existsSync(info.worktreePath)).toBe(false);
   });
 
+  // AGT-4067: the daemon calls this itself when a run concludes. A marker left
+  // behind by a boot that crashed mid-run kept reading as live — pids repeat in
+  // a container, so `processAppearsAlive` finds the recorded pid alive again as
+  // something unrelated — and this site has no age check to eventually release
+  // it. The daemon then skipped its own cleanup forever and leaked the tree.
+  it('cleans up when the only active marker predates this process (AGT-4067)', async () => {
+    const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+    writeFileSync(join(info.worktreePath, 'app.py'), 'base\npartial\n');
+    await preserveWorktree(info, 'daemon died mid-run');
+
+    // Re-create the marker the crashed boot never got to clear: our own pid
+    // (as a container hands back), written before this process started.
+    const markerDir = join(repo, '.git', 'openswarm', 'active-worktrees', 'INT-9');
+    mkdirSync(markerDir, { recursive: true });
+    writeFileSync(join(markerDir, 'crashed-boot-token.json'), JSON.stringify({
+      issueId: 'INT-9',
+      branchName: info.branchName,
+      worktreePath: info.worktreePath,
+      originalPath: repo,
+      ownerPid: process.pid,
+      ownerToken: 'crashed-boot-token',
+      createdAt: new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString(),
+    }));
+
+    await removePreservedWorktreeAt(info.worktreePath);
+
+    expect(existsSync(info.worktreePath)).toBe(false);
+  });
+
   it('no-ops on paths that are not managed worktrees', async () => {
     await removePreservedWorktreeAt(repo); // repo root — no /worktree/ segment
     expect(existsSync(repo)).toBe(true);

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -7,6 +7,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
+import { getInstanceId } from './healthEndpoint.js';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import Database from 'better-sqlite3';
 import { registerOwnedPR } from '../automation/prOwnership.js';
@@ -264,6 +265,15 @@ export interface ActiveWorktreeMarker {
   ownerPid: number;
   /** Missing only on legacy single-file markers written before token fencing. */
   ownerToken?: string;
+  /**
+   * The process that wrote this marker, as a per-process id.
+   *
+   * Used in one direction only: a marker whose id matches ours is positively
+   * ours, and therefore live. A differing id is NOT evidence of death — every
+   * concurrently running OpenSwarm process would fail that comparison too.
+   * Missing on markers written before this field existed.
+   */
+  ownerInstanceId?: string;
   createdAt: string;
 }
 
@@ -333,6 +343,7 @@ async function writeActiveWorktreeMarker(info: WorktreeInfo): Promise<string> {
     ...info,
     ownerPid: process.pid,
     ownerToken,
+    ownerInstanceId: getInstanceId(),
     createdAt: new Date().toISOString(),
   };
   const tempPath = `${markerPath}.${process.pid}.${randomUUID()}.tmp`;
@@ -449,6 +460,72 @@ function activeMarkerAbandonMs(): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_ACTIVE_MARKER_ABANDON_MS;
 }
 
+/**
+ * Whether a marker's writer can still be running.
+ *
+ * A marker stamped with a *different* daemon boot is abandoned outright: that
+ * process is provably gone, whatever the pid table now says. `ownerPid` alone
+ * cannot decide this in a container, where pids repeat and a restarted daemon
+ * finds the recorded pid alive again — which left every restart's orphans
+ * looking live for the full 24-hour window and wedged the admission cap.
+ *
+ * Markers from this boot, and legacy markers with no boot recorded, keep the
+ * original pid + age test so a live long-running stage is still protected.
+ */
+/** Epoch ms at which THIS process started. `process.uptime()` counts from
+ * process start, so sampling it at module load is both cheap and accurate. */
+const PROCESS_STARTED_AT_MS = Date.now() - Math.round(process.uptime() * 1000);
+
+/** Slack for clock resolution when comparing a marker's timestamp to our own
+ * start. Erring towards "still ours" only costs a fallback to the age window. */
+const PROCESS_START_JITTER_MS = 1_000;
+
+/**
+ * A marker that records OUR pid but was written before we started running.
+ *
+ * A pid is unique among live processes, so a marker carrying this process's own
+ * pid was written either by this process or by one that has since exited. If it
+ * predates our start it cannot be ours, which makes its writer provably gone
+ * however alive the pid table claims that pid to be.
+ *
+ * Unlike `ownerInstanceId` this needs no field on the marker, so it also
+ * releases the markers a crashed daemon left behind before that field existed.
+ */
+function markerPredatesThisProcess(marker: ActiveWorktreeMarker): boolean {
+  if (marker.ownerPid !== process.pid) return false;
+  const createdAt = Date.parse(marker.createdAt);
+  if (!Number.isFinite(createdAt)) return false; // unreadable — never claim proof
+  return createdAt < PROCESS_STARTED_AT_MS - PROCESS_START_JITTER_MS;
+}
+
+/**
+ * Whether the marker's writer is *provably* gone — not merely unresponsive.
+ *
+ * `processAppearsAlive` cannot answer this in a container, where pids are handed
+ * out deterministically and a restarted daemon very often finds the recorded pid
+ * alive again as something unrelated. The 24-hour age was then the only thing
+ * that could ever release such a marker, so every restart left each in-flight
+ * run looking active for a full day; a NEEDS_RECONCILE row still occupies an
+ * admission slot, so the autonomous loop stopped taking work altogether.
+ *
+ * Note the asymmetry in how `ownerInstanceId` is read. A *matching* id is
+ * positive identification — we wrote it, so its writer is obviously alive. A
+ * *differing* id proves nothing at all: a concurrently running OpenSwarm
+ * process (`openswarm attach`, a manual `openswarm run`, a second daemon) is
+ * equally "not us", and taking its worktree would put two owners on one tree.
+ * Only the pid test below is proof, and it holds however many processes run.
+ * (Caught by the commit-gate review.)
+ */
+function markerWriterProvablyGone(marker: ActiveWorktreeMarker): boolean {
+  if (marker.ownerInstanceId === getInstanceId()) return false;
+  return markerPredatesThisProcess(marker);
+}
+
+function markerLooksLive(marker: ActiveWorktreeMarker): boolean {
+  if (markerWriterProvablyGone(marker)) return false;
+  return processAppearsAlive(marker.ownerPid) && (activeMarkerAgeMs(marker) ?? 0) < activeMarkerAbandonMs();
+}
+
 /** Null on an unreadable/unparseable timestamp — callers must treat that as
  * "not provably abandoned" (mirrors preserveMarkerAgeMs's fail-safe null). */
 function activeMarkerAgeMs(marker: ActiveWorktreeMarker): number | null {
@@ -469,9 +546,7 @@ export async function inspectWorktreeRecovery(
     : resolveWorktreePath(repoPath, issueId);
   if (!existsSync(worktreePath)) return { state: 'missing', worktreePath };
   const active = await readActiveWorktreeMarkers(repoPath, worktreePath);
-  const liveMarker = active.markers.find(
-    (marker) => processAppearsAlive(marker.ownerPid) && (activeMarkerAgeMs(marker) ?? 0) < activeMarkerAbandonMs(),
-  );
+  const liveMarker = active.markers.find(markerLooksLive);
   if (liveMarker) return { state: 'active_owner', worktreePath, marker: liveMarker };
   if (existsSync(join(worktreePath, PRESERVE_MARKER))) {
     return preserveMarkerAgeMs(worktreePath) === null
@@ -520,7 +595,8 @@ export async function removePreservedWorktreeAt(worktreePath: string): Promise<v
     // issue. Re-check ownership under the lock; a resumed worker publishes its
     // active marker before releasing this same lock.
     const active = await readActiveWorktreeMarkers(match[1], normalized);
-    if (active.unreadable || active.markers.some((marker) => processAppearsAlive(marker.ownerPid))) return;
+    if (active.unreadable
+      || active.markers.some((marker) => !markerWriterProvablyGone(marker) && processAppearsAlive(marker.ownerPid))) return;
     await removePreservedWorktreeAtUnlocked(normalized);
   });
 }
@@ -1284,10 +1360,7 @@ export async function pruneWorktrees(
           // owner either writes its marker first (and is retained), or waits
           // until this proven-orphan cleanup has finished.
           const active = await readActiveWorktreeMarkers(repoPath, p);
-          const liveMarker = active.markers.find(
-            (candidate) => processAppearsAlive(candidate.ownerPid)
-              && (activeMarkerAgeMs(candidate) ?? 0) < activeMarkerAbandonMs(),
-          );
+          const liveMarker = active.markers.find(markerLooksLive);
           if (liveMarker) {
             console.log(`[Worktree] Retaining live owner ${liveMarker.ownerPid}: ${p}`);
             return;


### PR DESCRIPTION
Closes AGT-4067.

## The wedge

vela, 2026-08-29, 80 minutes after a redeploy: **6 `NEEDS_RECONCILE` rows holding all 6 admission slots**, 24 `READY` tasks unable to be admitted, reconciler logging `Keeping … in NEEDS_RECONCILE (active_owner)` 67× per row.

The marker on disk for AX-858:

```json
{ "ownerPid": 7, "createdAt": "2026-08-29T01:21:00.946Z" }
```

Written at 10:21 KST by the *previous* container. The new daemon was handed **pid 7 again** — container pid assignment is deterministic — so `processAppearsAlive(7)` returned true. The only remaining guard was the 24-hour `activeMarkerAbandonMs` window (AGT-4053), and the marker was 4 hours old.

AGT-4056 built the exit path out of `NEEDS_RECONCILE`. It was deployed and running. It never fired, because the evidence it consults said the dead owner was alive.

## The fix

A pid is unique among live processes. A marker recording **this process's own pid** was written either by us or by a process that has since exited; if its `createdAt` predates our start it cannot be ours, so its writer is provably gone. No new field required — which is why it also releases the markers already on disk.

`ownerInstanceId` is written alongside and read in **one direction only**: a *matching* id positively identifies a marker as ours. A *differing* id proves nothing (`openswarm attach`, a manual `openswarm run`, a second daemon are all "not us"), and treating it as proof would put two owners on one worktree.

Applied at all three liveness sites: `inspectWorktreeRecovery`, the `pruneWorktrees` orphan sweep, and `removePreservedWorktreeAt`'s re-claim guard — the last of which the daemon calls itself on every run conclusion, so a stale marker there silently leaked preserved worktrees.

Shortening `OPENSWARM_ACTIVE_MARKER_ABANDON_MS` was considered and rejected: it is a blunt age cutoff applied to every marker including a live 20-minute stage's, so it takes worktrees away from running executors.

## Tests — 5 mutations, each verified to fail

| Mutation | Test that dies |
|---|---|
| predates-proof removed | all 3 "predates this process" tests (recovery / prune / removePreserved) |
| differing id treated as dead (the first draft's bug) | "respects a marker from another live OpenSwarm process" |
| any id treated as dead | "keeps a marker from this boot for the full window" + 2 pre-existing |
| legacy (no id) treated as dead | "falls back to the pid + age test" + 1 pre-existing |
| third site's boot check removed | "cleans up when the only active marker predates this process" |

78/78 in `worktreeManager.test.ts` + `worktreeManager.coverage.test.ts`; 98/98 across the reconciler-adjacent suites (`autonomousRunner.durable`, `runLedger`, `durableRunCoordinator`). `tsc` clean.

## Gate

Commit gate `openswarm review` (tier 1): **REVISE** round 1 — the first draft read a *differing* `ownerInstanceId` as proof of death, which would let any concurrent OpenSwarm process take a live worktree. Fixed as described. **APPROVE** round 2.

## Remaining verification

The DoD's last item is deliberately not yet checked: the six wedged rows must leave `NEEDS_RECONCILE` **without a manual DB write** after deploy. They are being left in place on purpose — letting the fix clear them is the test.