### PR TITLE
fix(liveness): stop a stale task-state lock costing 10 minutes per restart (AGT-4068)

### DIFF
--- a/src/support/processLiveness.test.ts
+++ b/src/support/processLiveness.test.ts
@@ -99,23 +99,58 @@ describe('processNamespaceId / sameProcessNamespace', () => {
     expect(namespacesMatch('ns-a', 'ns-b')).toBe(false);
   });
 
-  // Both branches below are unreachable on macOS, so they are exercised through
+  // The branches below are unreachable on macOS, so they are exercised through
   // the pure resolver rather than the platform. Without this, a mutation that
-  // collapses an unreadable Linux namespace to a shared host-wide default
-  // passes the whole suite. (AGT-4068)
+  // collapses an unreadable Linux namespace to a shared default passes the
+  // whole suite. (AGT-4068)
+  const BOOT = 'boot-1c3bda3d-e21a-4166-be21-c34ce6538059';
+  const NS = 'pid:[4026531836]';
+
   it('reports an unreadable Linux pid namespace as unknown, not as a shared default', () => {
-    const id = resolveNamespaceId('linux', () => { throw new Error('EACCES /proc/self/ns/pid'); });
+    const id = resolveNamespaceId('linux', () => { throw new Error('EACCES /proc/self/ns/pid'); }, () => BOOT);
     expect(id).toBeUndefined();
   });
 
-  it('identifies a readable Linux pid namespace by host and namespace together', () => {
-    const id = resolveNamespaceId('linux', () => 'pid:[4026531836]');
-    expect(id).toBe(`${hostname()}:pid:[4026531836]`);
+  it('reports an unreadable boot id as unknown too', () => {
+    const id = resolveNamespaceId('linux', () => NS, () => { throw new Error('EACCES boot_id'); });
+    expect(id).toBeUndefined();
   });
 
-  it('uses the host name alone where the platform has no pid namespaces', () => {
-    const read = vi.fn(() => 'pid:[4026531836]');
-    expect(resolveNamespaceId('darwin', read)).toBe(hostname());
-    expect(read).not.toHaveBeenCalled();
+  it('separates two hosts that share a namespace inode', () => {
+    // Inodes are a per-boot counter, so two machines hand out the same numbers
+    // routinely. Without the boot id these would compare equal and each could
+    // reclaim the other's live lock across a shared state directory.
+    const a = resolveNamespaceId('linux', () => NS, () => 'boot-aaaa');
+    const b = resolveNamespaceId('linux', () => NS, () => 'boot-bbbb');
+    expect(a).not.toBe(b);
+    expect(namespacesMatch(a, b)).toBe(false);
+  });
+
+  it('separates two containers on one host, which share a boot id', () => {
+    const a = resolveNamespaceId('linux', () => 'pid:[4026531111]', () => BOOT);
+    const b = resolveNamespaceId('linux', () => 'pid:[4026532222]', () => BOOT);
+    expect(namespacesMatch(a, b)).toBe(false);
+  });
+
+  it('matches the same container across a restart — same host boot, same namespace', () => {
+    const before = resolveNamespaceId('linux', () => NS, () => BOOT);
+    const after = resolveNamespaceId('linux', () => NS, () => `${BOOT}\n`); // trailing newline from /proc
+    expect(namespacesMatch(before, after)).toBe(true);
+  });
+
+  it('is exactly boot id plus namespace on Linux — no host name', () => {
+    // The host name is not in it on purpose: this container reports
+    // `localhost`, so two deployments sharing a state directory would have
+    // matched on it. An exact assertion rather than `not.toContain`, which a
+    // one-letter CI host name could fail by accident.
+    expect(resolveNamespaceId('linux', () => NS, () => BOOT)).toBe(`${BOOT}:${NS}`);
+  });
+
+  it('uses the host name where the platform has no pid namespaces', () => {
+    const readNs = vi.fn(() => NS);
+    const readBoot = vi.fn(() => BOOT);
+    expect(resolveNamespaceId('darwin', readNs, readBoot)).toBe(hostname());
+    expect(readNs).not.toHaveBeenCalled();
+    expect(readBoot).not.toHaveBeenCalled();
   });
 });

--- a/src/support/processLiveness.test.ts
+++ b/src/support/processLiveness.test.ts
@@ -4,6 +4,7 @@ import {
   PROCESS_STARTED_AT_MS,
   processAppearsAlive,
   processNamespaceId,
+  isProofCapableSpace,
   namespacesMatch,
   resolveNamespaceId,
   sameProcessNamespace,
@@ -74,11 +75,8 @@ describe('writerProvablyGone', () => {
 });
 
 describe('processNamespaceId / sameProcessNamespace', () => {
-  it('is stable, and identifies this machine when it can be resolved at all', () => {
+  it('is stable across calls', () => {
     expect(processNamespaceId()).toBe(processNamespaceId());
-    const id = processNamespaceId();
-    // undefined only on Linux with an unreadable /proc/self/ns/pid.
-    if (id !== undefined) expect(id).toContain(hostname());
   });
 
   it('matches only a record written in this same pid space', () => {
@@ -143,14 +141,34 @@ describe('processNamespaceId / sameProcessNamespace', () => {
     // `localhost`, so two deployments sharing a state directory would have
     // matched on it. An exact assertion rather than `not.toContain`, which a
     // one-letter CI host name could fail by accident.
-    expect(resolveNamespaceId('linux', () => NS, () => BOOT)).toBe(`${BOOT}:${NS}`);
+    expect(resolveNamespaceId('linux', () => NS, () => BOOT)).toBe(`pidns:${BOOT}:${NS}`);
   });
 
-  it('uses the host name where the platform has no pid namespaces', () => {
+  it('gives a machine HINT where there are no pid namespaces, and marks it as not proof', () => {
+    // Asymmetric on purpose: a host-name MISMATCH is a sound signal that a
+    // record came from another machine, which is enough to withhold the local
+    // pid probe. A match proves nothing — two machines can share a host name,
+    // and this project's container reports `localhost` — so it must never
+    // license the proof.
     const readNs = vi.fn(() => NS);
     const readBoot = vi.fn(() => BOOT);
-    expect(resolveNamespaceId('darwin', readNs, readBoot)).toBe(hostname());
+    const id = resolveNamespaceId('darwin', readNs, readBoot);
+    expect(id).toBe(`host:${hostname()}`);
+    expect(isProofCapableSpace(id)).toBe(false);
+    expect(isProofCapableSpace(resolveNamespaceId('win32', readNs, readBoot))).toBe(false);
     expect(readNs).not.toHaveBeenCalled();
     expect(readBoot).not.toHaveBeenCalled();
+  });
+
+  it('marks a real Linux pid space as proof-capable, and nothing else', () => {
+    expect(isProofCapableSpace(resolveNamespaceId('linux', () => NS, () => BOOT))).toBe(true);
+    expect(isProofCapableSpace(undefined)).toBe(false);
+    expect(isProofCapableSpace('host:some-machine')).toBe(false);
+  });
+
+  it('withholds the probe from a record naming a different machine', () => {
+    // The property the host name is actually for.
+    expect(namespacesMatch('host:other-machine', `host:${hostname()}`)).toBe(false);
+    expect(namespacesMatch(`host:${hostname()}`, `host:${hostname()}`)).toBe(true);
   });
 });

--- a/src/support/processLiveness.test.ts
+++ b/src/support/processLiveness.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { hostname } from 'node:os';
+import {
+  PROCESS_STARTED_AT_MS,
+  processAppearsAlive,
+  processNamespaceId,
+  namespacesMatch,
+  resolveNamespaceId,
+  sameProcessNamespace,
+  writerProvablyGone,
+} from './processLiveness.js';
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+// Every caller turns a "dead" answer into reclaiming something — a lock, a
+// worktree — so each way of being wrong here takes a resource away from a live
+// owner. These pin the fail-closed direction; a blanket `catch { return false }`
+// passes none of them. (AGT-4068, caught by the commit gate)
+describe('processAppearsAlive', () => {
+  it('reads a pid it cannot judge as alive, without signalling anything', () => {
+    const kill = vi.spyOn(process, 'kill');
+    for (const pid of [0, -1, Number.NaN, 1.5, Number.MAX_SAFE_INTEGER + 2]) {
+      expect(processAppearsAlive(pid)).toBe(true);
+    }
+    // pid 0 means "this process's whole group" to kill(2) — asking the question
+    // must never be the thing that signals it.
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('treats a process owned by someone else (EPERM) as alive', () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('operation not permitted'), { code: 'EPERM' });
+    });
+    expect(processAppearsAlive(4242)).toBe(true);
+  });
+
+  it('treats a probe that merely failed as alive', () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('invalid argument'), { code: 'EINVAL' });
+    });
+    expect(processAppearsAlive(4242)).toBe(true);
+  });
+
+  it('reports dead only for ESRCH — no such process', () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('no such process'), { code: 'ESRCH' });
+    });
+    expect(processAppearsAlive(4242)).toBe(false);
+  });
+
+  it('says the running test process is alive', () => {
+    expect(processAppearsAlive(process.pid)).toBe(true);
+  });
+});
+
+describe('writerProvablyGone', () => {
+  it('proves death for our own pid recorded before we started', () => {
+    expect(writerProvablyGone({ pid: process.pid, writtenAtMs: PROCESS_STARTED_AT_MS - 60_000 })).toBe(true);
+  });
+
+  it('claims nothing about a pid that is not ours, however old the record', () => {
+    // A different live process legitimately owns its own records — including a
+    // concurrent OpenSwarm CLI or a second daemon.
+    expect(writerProvablyGone({ pid: process.pid + 1, writtenAtMs: 0 })).toBe(false);
+  });
+
+  it('claims nothing about a record we could have written ourselves', () => {
+    expect(writerProvablyGone({ pid: process.pid, writtenAtMs: Date.now() })).toBe(false);
+  });
+
+  it('claims nothing when the timestamp is unreadable', () => {
+    expect(writerProvablyGone({ pid: process.pid, writtenAtMs: Number.NaN })).toBe(false);
+  });
+});
+
+describe('processNamespaceId / sameProcessNamespace', () => {
+  it('is stable, and identifies this machine when it can be resolved at all', () => {
+    expect(processNamespaceId()).toBe(processNamespaceId());
+    const id = processNamespaceId();
+    // undefined only on Linux with an unreadable /proc/self/ns/pid.
+    if (id !== undefined) expect(id).toContain(hostname());
+  });
+
+  it('matches only a record written in this same pid space', () => {
+    const mine = processNamespaceId();
+    if (mine !== undefined) expect(sameProcessNamespace(mine)).toBe(true);
+    expect(sameProcessNamespace('some-other-host:pid:[4026531999]')).toBe(false);
+  });
+
+  it('never matches an unknown namespace — on either side', () => {
+    // Two processes that both cannot identify their pid space are not thereby
+    // in the same one. A bare `===` would call undefined === undefined a match
+    // and license reclaiming a live owner's lock on no evidence.
+    expect(sameProcessNamespace(undefined)).toBe(false);
+    expect(namespacesMatch(undefined, undefined)).toBe(false);
+    expect(namespacesMatch('ns-a', undefined)).toBe(false);
+    expect(namespacesMatch(undefined, 'ns-a')).toBe(false);
+    expect(namespacesMatch('ns-a', 'ns-a')).toBe(true);
+    expect(namespacesMatch('ns-a', 'ns-b')).toBe(false);
+  });
+
+  // Both branches below are unreachable on macOS, so they are exercised through
+  // the pure resolver rather than the platform. Without this, a mutation that
+  // collapses an unreadable Linux namespace to a shared host-wide default
+  // passes the whole suite. (AGT-4068)
+  it('reports an unreadable Linux pid namespace as unknown, not as a shared default', () => {
+    const id = resolveNamespaceId('linux', () => { throw new Error('EACCES /proc/self/ns/pid'); });
+    expect(id).toBeUndefined();
+  });
+
+  it('identifies a readable Linux pid namespace by host and namespace together', () => {
+    const id = resolveNamespaceId('linux', () => 'pid:[4026531836]');
+    expect(id).toBe(`${hostname()}:pid:[4026531836]`);
+  });
+
+  it('uses the host name alone where the platform has no pid namespaces', () => {
+    const read = vi.fn(() => 'pid:[4026531836]');
+    expect(resolveNamespaceId('darwin', read)).toBe(hostname());
+    expect(read).not.toHaveBeenCalled();
+  });
+});

--- a/src/support/processLiveness.ts
+++ b/src/support/processLiveness.ts
@@ -68,19 +68,49 @@ const PROCESS_START_JITTER_MS = 1_000;
  * boot id changes, so records written before it read as unjudgeable and fall
  * back to the age rules; everything they described is dead by then anyway.
  */
+/** A pid space this process can actually reason about pids in. */
+const PROOF_PREFIX = 'pidns:';
+/** A machine hint: good enough to rule a record OUT, never to rule one IN. */
+const HINT_PREFIX = 'host:';
+
+/**
+ * Whether an id names a real pid space, or is only a machine hint.
+ *
+ * Only a real pid space licenses `writerProvablyGone`: "this pid is mine, so
+ * its writer has exited" needs the pid numbering to be the same numbering, and
+ * a host name does not establish that.
+ */
+export function isProofCapableSpace(id: string | undefined): boolean {
+  return typeof id === 'string' && id.startsWith(PROOF_PREFIX);
+}
+
 export function resolveNamespaceId(
   platform: string,
   readNamespaceLink: () => string,
   readBootId: () => string,
 ): string | undefined {
   if (platform !== 'linux') {
-    // No pid namespaces here, so one pid space per machine. The host name is
-    // the identification available; a deployment that shares one state
-    // directory between machines runs the containerised path above.
-    return hostname();
+    // A machine HINT, not a pid-space proof — and the prefix says which.
+    //
+    // The host name is asymmetric evidence, exactly like an owner id. A
+    // *mismatch* is a sound signal that the record came from somewhere else, so
+    // it is enough to withhold the local pid probe and protect a live remote
+    // owner in the ordinary distinct-host case. A *match* proves nothing: two
+    // machines sharing a state directory can carry the same host name, and this
+    // project's own container reports `localhost`. So it never licenses the
+    // proof — `isProofCapableSpace` gates that on a real pid namespace.
+    //
+    // A MAC was tried instead and is worse: this developer's Mac reports
+    // `7a:83:be:1b:ed:d5`, whose locally-administered bit is set because macOS
+    // randomises Wi-Fi addresses per network, and Docker and VPN adapters are
+    // software-assigned too. Closing the same-host-name case honestly needs an
+    // OS identity call (AGT-4069). (Caught by the fresh PR review, three times
+    // — the first two rejected the host name as a proof, which it is not used
+    // as here.)
+    return `${HINT_PREFIX}${hostname()}`;
   }
   try {
-    return `${readBootId().trim()}:${readNamespaceLink()}`;
+    return `${PROOF_PREFIX}${readBootId().trim()}:${readNamespaceLink()}`;
   } catch {
     return undefined;
   }

--- a/src/support/processLiveness.ts
+++ b/src/support/processLiveness.ts
@@ -1,0 +1,138 @@
+// ============================================
+// OpenSwarm - Deciding whether a recorded process is still running (AGT-4068)
+// ============================================
+//
+// Locks, leases and ownership markers all record a pid and later ask "is that
+// process still there". `kill(pid, 0)` cannot answer it in a container, where
+// pids are handed out deterministically: a restarted daemon is routinely given
+// the very pid its predecessor had, so every record the dead generation left
+// behind reads as live against the new one.
+//
+// The workaround each call site reached for independently was an age cutoff —
+// wait long enough and give up on the owner. That is not evidence, it is a
+// timer, and it costs exactly as long as it is set to: the task-state lock
+// stalled every heartbeat for ten minutes after a restart, and an active
+// worktree marker held an admission slot for twenty-four hours (AGT-4023,
+// AGT-4053, AGT-4067). This module holds the proof those sites should share
+// instead, so the next one does not have to rediscover it.
+
+/** Epoch ms at which THIS process started. `process.uptime()` counts from
+ * process start, so sampling it at module load is both cheap and accurate. */
+import { readlinkSync } from 'node:fs';
+import { hostname } from 'node:os';
+
+export const PROCESS_STARTED_AT_MS = Date.now() - Math.round(process.uptime() * 1000);
+
+/** Slack for clock resolution when comparing a record's timestamp to our own
+ * start. Erring towards "still theirs" only costs a fallback to the age rule. */
+const PROCESS_START_JITTER_MS = 1_000;
+
+/**
+ * An id for the pid space this process lives in — the scope within which a pid
+ * is unique.
+ *
+ * Two containers sharing a mounted state directory each have their own pid 1,
+ * so a record written by one and read by the other cannot be reasoned about by
+ * pid at all. A caller whose state may be shared that way must compare this
+ * against the id recorded with the record before trusting `writerProvablyGone`.
+ *
+ * Host name plus pid-namespace inode, because neither alone is enough: two
+ * containers on one host share a host name but not a namespace, while two
+ * hosts can hand out the same inode number. Platforms without pid namespaces
+ * (macOS, Windows) have exactly one pid space per machine, so the host name
+ * alone is the honest answer there — not a missing one.
+ */
+/**
+ * The pid-space id for a given platform, or undefined when it cannot be known.
+ *
+ * Split out as a pure function because both of its interesting branches are
+ * unreachable on a developer's macOS: a mutation to either passed the suite
+ * until this existed, which means it was not covered at all.
+ *
+ * Where pid namespaces exist, an unreadable one is UNKNOWN and never a shared
+ * default. Collapsing it to a host-wide value would make two containers that
+ * cannot read /proc — and were handed the same host name — compare equal, and
+ * that is the one answer that must never be guessed.
+ * (Caught by the commit-gate review.)
+ */
+export function resolveNamespaceId(platform: string, readNamespaceLink: () => string): string | undefined {
+  if (platform !== 'linux') {
+    // No pid namespaces on this platform: one pid space per machine, so the
+    // host name is a complete identification rather than a fallback.
+    return hostname();
+  }
+  try {
+    return `${hostname()}:${readNamespaceLink()}`;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Whether two pid-space ids denote the same space.
+ *
+ * Never true when either side is unknown — including when BOTH are, which a
+ * bare `===` would call a match and thereby license reclaiming a live owner's
+ * resource on no evidence at all.
+ */
+export function namespacesMatch(recorded: string | undefined, mine: string | undefined): boolean {
+  return mine !== undefined && recorded !== undefined && recorded === mine;
+}
+
+let namespaceId: string | undefined | null = null; // null = not resolved yet
+export function processNamespaceId(): string | undefined {
+  if (namespaceId === null) {
+    namespaceId = resolveNamespaceId(process.platform, () => readlinkSync('/proc/self/ns/pid'));
+  }
+  return namespaceId;
+}
+
+/** Whether a record written with `recorded` came from this process's pid space. */
+export function sameProcessNamespace(recorded: string | undefined): boolean {
+  return namespacesMatch(recorded, processNamespaceId());
+}
+
+/**
+ * Whether a pid currently belongs to some running process. Says nothing about
+ * WHICH process — see `writerProvablyGone` for that.
+ *
+ * Fail-closed in both directions a naive probe gets wrong, because every caller
+ * uses a "dead" answer to reclaim something an owner may still be holding:
+ *
+ *  - A pid that is not a usable positive integer reads as ALIVE. It cannot be
+ *    judged, and `process.kill(0, 0)` would signal this process's whole group
+ *    rather than answer the question.
+ *  - Only `ESRCH` — "no such process" — counts as dead. `EPERM` means the
+ *    process is there and owned by someone else, which is very much alive, and
+ *    any other errno is a probe that failed rather than a process that is gone.
+ */
+export function processAppearsAlive(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+/**
+ * Whether the process that wrote a record is *provably* gone.
+ *
+ * A pid is unique among live processes, so a record carrying this process's own
+ * pid was written either by this process or by one that has since exited. If it
+ * predates our start it cannot be ours, which settles it however alive the pid
+ * table claims that pid to be. That is exactly the container-restart shape, and
+ * it needs nothing written into the record beyond a pid and a timestamp — so it
+ * also reaches records already on disk.
+ *
+ * Deliberately narrow: it returns false for any pid that is not ours, because a
+ * *different* live process legitimately owns its own records. Concurrent
+ * OpenSwarm processes — `openswarm attach`, a manual `openswarm run`, a second
+ * daemon — must keep their locks and worktrees.
+ */
+export function writerProvablyGone(record: { pid: number; writtenAtMs: number }): boolean {
+  if (record.pid !== process.pid) return false;
+  if (!Number.isFinite(record.writtenAtMs)) return false; // unreadable — never claim proof
+  return record.writtenAtMs < PROCESS_STARTED_AT_MS - PROCESS_START_JITTER_MS;
+}

--- a/src/support/processLiveness.ts
+++ b/src/support/processLiveness.ts
@@ -18,7 +18,7 @@
 
 /** Epoch ms at which THIS process started. `process.uptime()` counts from
  * process start, so sampling it at module load is both cheap and accurate. */
-import { readlinkSync } from 'node:fs';
+import { readFileSync, readlinkSync } from 'node:fs';
 import { hostname } from 'node:os';
 
 export const PROCESS_STARTED_AT_MS = Date.now() - Math.round(process.uptime() * 1000);
@@ -45,24 +45,42 @@ const PROCESS_START_JITTER_MS = 1_000;
 /**
  * The pid-space id for a given platform, or undefined when it cannot be known.
  *
- * Split out as a pure function because both of its interesting branches are
- * unreachable on a developer's macOS: a mutation to either passed the suite
- * until this existed, which means it was not covered at all.
+ * Split out as a pure function because its interesting branches are unreachable
+ * on a developer's macOS: mutations to them passed the whole suite until this
+ * existed, which means they were not covered at all.
  *
- * Where pid namespaces exist, an unreadable one is UNKNOWN and never a shared
- * default. Collapsing it to a host-wide value would make two containers that
- * cannot read /proc — and were handed the same host name — compare equal, and
- * that is the one answer that must never be guessed.
- * (Caught by the commit-gate review.)
+ * On Linux the id is the kernel's **boot id** plus the pid-namespace inode.
+ * Both halves are load-bearing and neither is enough alone:
+ *
+ *  - The inode separates two containers on one host, but is a per-boot counter,
+ *    so two hosts hand out the same numbers routinely.
+ *  - The boot id separates hosts (and reboots), and containers share their
+ *    host's, so it cannot separate containers by itself.
+ *
+ * The host name is deliberately NOT used: this container reports `localhost`,
+ * so two deployments sharing a state directory over a network filesystem would
+ * have matched on it and reclaimed each other's live locks and worktrees.
+ * (Caught by the fresh PR review.)
+ *
+ * A source that cannot be read makes the id UNKNOWN, never a shared default —
+ * collapsing it would make every process that cannot read /proc compare equal,
+ * which is the one answer that must never be guessed. After a host reboot the
+ * boot id changes, so records written before it read as unjudgeable and fall
+ * back to the age rules; everything they described is dead by then anyway.
  */
-export function resolveNamespaceId(platform: string, readNamespaceLink: () => string): string | undefined {
+export function resolveNamespaceId(
+  platform: string,
+  readNamespaceLink: () => string,
+  readBootId: () => string,
+): string | undefined {
   if (platform !== 'linux') {
-    // No pid namespaces on this platform: one pid space per machine, so the
-    // host name is a complete identification rather than a fallback.
+    // No pid namespaces here, so one pid space per machine. The host name is
+    // the identification available; a deployment that shares one state
+    // directory between machines runs the containerised path above.
     return hostname();
   }
   try {
-    return `${hostname()}:${readNamespaceLink()}`;
+    return `${readBootId().trim()}:${readNamespaceLink()}`;
   } catch {
     return undefined;
   }
@@ -82,7 +100,11 @@ export function namespacesMatch(recorded: string | undefined, mine: string | und
 let namespaceId: string | undefined | null = null; // null = not resolved yet
 export function processNamespaceId(): string | undefined {
   if (namespaceId === null) {
-    namespaceId = resolveNamespaceId(process.platform, () => readlinkSync('/proc/self/ns/pid'));
+    namespaceId = resolveNamespaceId(
+      process.platform,
+      () => readlinkSync('/proc/self/ns/pid'),
+      () => readFileSync('/proc/sys/kernel/random/boot_id', 'utf8'),
+    );
   }
   return namespaceId;
 }

--- a/src/support/worktreeManager.coverage.test.ts
+++ b/src/support/worktreeManager.coverage.test.ts
@@ -9,7 +9,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { chmodSync, existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { hostname, tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -35,6 +35,14 @@ vi.mock('../automation/prOwnership.js', () => ({
   registerOwnedPR: vi.fn().mockResolvedValue(undefined),
 }));
 import { registerOwnedPR } from '../automation/prOwnership.js';
+import { PROCESS_STARTED_AT_MS, isProofCapableSpace, processNamespaceId } from './processLiveness.js';
+
+// The fast-path proof needs a REAL pid space, which only Linux can give (boot
+// id + pid-namespace inode). Elsewhere the recorded id is a machine hint, good
+// for ruling a record out but never for the proof — so these cases cannot arise
+// there at all. Asserted on Linux in CI.
+const itWithPidSpace = isProofCapableSpace(processNamespaceId()) ? it : it.skip;
+
 
 describe('buildBranchName (pure)', () => {
   it('slugifies the title and joins it to the issue identifier', () => {
@@ -314,7 +322,7 @@ describe('createWorktree retry/resume error paths', () => {
   // reach them. A pid is unique among live processes, which is proof enough —
   // a marker carrying our own pid that predates our start belongs to a process
   // that has since exited, whatever the pid table now says.
-  it('abandons a marker that carries our pid but predates this process (AGT-4067)', async () => {
+  itWithPidSpace('abandons a marker that carries our pid but predates this process (AGT-4067)', async () => {
     const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-legacy-prior-boot');
     const markerPath = join(
       repo, '.git', 'openswarm', 'active-worktrees', 'INT-1', `${info.activeMarkerToken}.json`,
@@ -371,8 +379,10 @@ describe('createWorktree retry/resume error paths', () => {
     });
   });
 
-  it('does not probe a marker whose writer could not identify its own pid space (AGT-4068)', async () => {
-    // `ownerNamespace: null` is a fail-closed writer, not a pre-field marker.
+  it('does not probe a marker whose writer could name no pid space at all (AGT-4068)', async () => {
+    // `ownerNamespace: null` is a writer that could not read its own pid
+    // namespace, so a local ESRCH says nothing about it. Distinct from an
+    // ABSENT field, which predates the change and keeps the original probe.
     const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-unknown-namespace');
     const markerPath = join(
       repo, '.git', 'openswarm', 'active-worktrees', 'INT-1', `${info.activeMarkerToken}.json`,
@@ -380,8 +390,48 @@ describe('createWorktree retry/resume error paths', () => {
     const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
     delete marker.ownerInstanceId;
     marker.ownerNamespace = null;
-    marker.ownerPid = 2_147_483_647; // dead-looking here, but "here" is unknown
+    marker.ownerPid = 2_147_483_647; // dead-looking HERE, which proves nothing there
     marker.createdAt = new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString();
+    writeFileSync(markerPath, JSON.stringify(marker));
+
+    await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
+      state: 'active_owner',
+    });
+  });
+
+  it('withholds the fast-path proof from a marker with no named pid space (AGT-4068)', async () => {
+    // Our own pid, written before we started. Named and matching, the proof
+    // would abandon this at once; unnamed, it waits out the age window.
+    const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-unknown-namespace-live-pid');
+    const markerPath = join(
+      repo, '.git', 'openswarm', 'active-worktrees', 'INT-1', `${info.activeMarkerToken}.json`,
+    );
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
+    delete marker.ownerInstanceId;
+    marker.ownerNamespace = null;
+    marker.createdAt = new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString();
+    writeFileSync(markerPath, JSON.stringify(marker));
+
+    await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
+      state: 'active_owner',
+    });
+  });
+
+  it('does not let a matching machine HINT license the pid proof (AGT-4068)', async () => {
+    // On a platform with no pid namespaces the recorded space is `host:<name>`,
+    // which matches our own. That is enough to keep the local probe, but it is
+    // NOT enough to conclude "this pid is mine, so its writer exited" — two
+    // machines sharing a state directory can carry the same host name. The
+    // marker must fall back to the age window instead of being abandoned.
+    const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-hint-not-proof');
+    const markerPath = join(
+      repo, '.git', 'openswarm', 'active-worktrees', 'INT-1', `${info.activeMarkerToken}.json`,
+    );
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
+    delete marker.ownerInstanceId;
+    marker.ownerNamespace = `host:${hostname()}`;
+    expect(marker.ownerPid).toBe(process.pid);
+    marker.createdAt = new Date(PROCESS_STARTED_AT_MS - 4 * 60 * 60 * 1000).toISOString();
     writeFileSync(markerPath, JSON.stringify(marker));
 
     await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
@@ -419,6 +469,26 @@ describe('createWorktree retry/resume error paths', () => {
 
     await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
       state: 'active_owner',
+    });
+  });
+
+  it('still probes a marker written before the pid-space field existed (AGT-4068)', async () => {
+    // An ABSENT space is not the same as an explicit null: it predates the
+    // field, so it keeps the local probe it has always had. Withholding it here
+    // would leave every pre-upgrade marker's dead owner pinned for 24 hours —
+    // exactly the wedge this work exists to remove.
+    const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-pre-field-marker');
+    const markerPath = join(
+      repo, '.git', 'openswarm', 'active-worktrees', 'INT-1', `${info.activeMarkerToken}.json`,
+    );
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
+    delete marker.ownerInstanceId;
+    delete marker.ownerNamespace; // as a pre-AGT-4068 daemon left it
+    marker.ownerPid = 2_147_483_647; // a genuinely dead owner
+    writeFileSync(markerPath, JSON.stringify(marker));
+
+    await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
+      state: 'orphaned',
     });
   });
 
@@ -707,7 +777,7 @@ describe('pruneWorktrees (INT-1810 R4 / INT-2503 / INT-2506)', () => {
     expect(existsSync(orphan.worktreePath)).toBe(false);
   });
 
-  it('sweeps a proven orphan whose marker predates this process, well inside the age window (AGT-4067)', async () => {
+  itWithPidSpace('sweeps a proven orphan whose marker predates this process, well inside the age window (AGT-4067)', async () => {
     const orphan = await createWorktree(repo, 'INT-7', 'swarm/INT-7-prior-boot');
     const markerPath = join(
       repo, '.git', 'openswarm', 'active-worktrees', 'INT-7', `${orphan.activeMarkerToken}.json`,

--- a/src/support/worktreeManager.coverage.test.ts
+++ b/src/support/worktreeManager.coverage.test.ts
@@ -331,6 +331,64 @@ describe('createWorktree retry/resume error paths', () => {
     });
   });
 
+  it('does not reason about a marker pid from another pid space, however old (AGT-4068)', async () => {
+    // This checkout can be mounted into more than one container, each with its
+    // own pid 1, so a matching pid number means nothing across them. Such a
+    // marker gets the age window and nothing else — it may be a live executor.
+    const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-other-namespace');
+    const markerPath = join(
+      repo, '.git', 'openswarm', 'active-worktrees', 'INT-1', `${info.activeMarkerToken}.json`,
+    );
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
+    delete marker.ownerInstanceId;
+    marker.ownerNamespace = 'some-other-host:pid:[4026531999]';
+    // A pid that is certainly not alive HERE. In the space that issued it, it
+    // may well be a running executor — probing it locally answers a different
+    // question, and treating that answer as "orphaned" takes a live worktree.
+    marker.ownerPid = 2_147_483_647;
+    marker.createdAt = new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString();
+    writeFileSync(markerPath, JSON.stringify(marker));
+
+    await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
+      state: 'active_owner',
+    });
+  });
+
+  it('still ages out a marker from another pid space once the abandon window passes (AGT-4068)', async () => {
+    // "Cannot be judged" must not mean "kept forever" where an age escape
+    // exists: a container that is genuinely gone would pin the worktree.
+    const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-other-namespace-aged');
+    const markerPath = join(
+      repo, '.git', 'openswarm', 'active-worktrees', 'INT-1', `${info.activeMarkerToken}.json`,
+    );
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
+    marker.ownerNamespace = 'some-other-host:pid:[4026531999]';
+    marker.createdAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    writeFileSync(markerPath, JSON.stringify(marker));
+
+    await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
+      state: 'orphaned',
+    });
+  });
+
+  it('does not probe a marker whose writer could not identify its own pid space (AGT-4068)', async () => {
+    // `ownerNamespace: null` is a fail-closed writer, not a pre-field marker.
+    const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-unknown-namespace');
+    const markerPath = join(
+      repo, '.git', 'openswarm', 'active-worktrees', 'INT-1', `${info.activeMarkerToken}.json`,
+    );
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
+    delete marker.ownerInstanceId;
+    marker.ownerNamespace = null;
+    marker.ownerPid = 2_147_483_647; // dead-looking here, but "here" is unknown
+    marker.createdAt = new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString();
+    writeFileSync(markerPath, JSON.stringify(marker));
+
+    await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
+      state: 'active_owner',
+    });
+  });
+
   it('keeps a marker from this boot for the full window so a live stage cannot lose its worktree (AGT-4067)', async () => {
     const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-this-boot');
     const markerPath = join(

--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -4,8 +4,15 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import Database from 'better-sqlite3';
-import { processNamespaceId } from './processLiveness.js';
+import { isProofCapableSpace, processNamespaceId } from './processLiveness.js';
 import { createWorktree, preserveWorktree, removePreservedWorktreeAt, removeWorktree, resolveSharedPaths, computeFileOverlaps, formatOverlapReport, findOpenPRFileOverlaps, resolveBaseRef, commitAndCreatePR, type WorktreeInfo } from './worktreeManager.js';
+
+// The fast-path proof needs a REAL pid space, which only Linux can give (boot
+// id + pid-namespace inode). Elsewhere the recorded id is a machine hint, good
+// for ruling a record out but never for the proof — so these cases cannot arise
+// there at all. Asserted on Linux in CI.
+const itWithPidSpace = isProofCapableSpace(processNamespaceId()) ? it : it.skip;
+
 
 describe('open PR planned-file preflight (INT-2568)', () => {
   it('reports only open PRs that overlap the draft file scope', async () => {
@@ -429,7 +436,7 @@ describe('removePreservedWorktreeAt (INT-2506)', () => {
   // a container, so `processAppearsAlive` finds the recorded pid alive again as
   // something unrelated — and this site has no age check to eventually release
   // it. The daemon then skipped its own cleanup forever and leaked the tree.
-  it('cleans up when the only active marker predates this process (AGT-4067)', async () => {
+  itWithPidSpace('cleans up when the only active marker predates this process (AGT-4067)', async () => {
     const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
     writeFileSync(join(info.worktreePath, 'app.py'), 'base\npartial\n');
     await preserveWorktree(info, 'daemon died mid-run');

--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import Database from 'better-sqlite3';
+import { processNamespaceId } from './processLiveness.js';
 import { createWorktree, preserveWorktree, removePreservedWorktreeAt, removeWorktree, resolveSharedPaths, computeFileOverlaps, formatOverlapReport, findOpenPRFileOverlaps, resolveBaseRef, commitAndCreatePR, type WorktreeInfo } from './worktreeManager.js';
 
 describe('open PR planned-file preflight (INT-2568)', () => {
@@ -444,12 +445,39 @@ describe('removePreservedWorktreeAt (INT-2506)', () => {
       originalPath: repo,
       ownerPid: process.pid,
       ownerToken: 'crashed-boot-token',
+      ownerNamespace: processNamespaceId(),
       createdAt: new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString(),
     }));
 
     await removePreservedWorktreeAt(info.worktreePath);
 
     expect(existsSync(info.worktreePath)).toBe(false);
+  });
+
+  it('keeps a preserved tree whose marker names another pid space, dead-looking pid or not (AGT-4068)', async () => {
+    // This site has no age escape, so a "not alive" answer here authorises
+    // deletion outright. The pid is from another container's space, where our
+    // local probe means nothing — the tree may still have a live owner.
+    const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+    writeFileSync(join(info.worktreePath, 'app.py'), 'base\npartial\n');
+    await preserveWorktree(info, 'daemon died mid-run');
+
+    const markerDir = join(repo, '.git', 'openswarm', 'active-worktrees', 'INT-9');
+    mkdirSync(markerDir, { recursive: true });
+    writeFileSync(join(markerDir, 'foreign-space-token.json'), JSON.stringify({
+      issueId: 'INT-9',
+      branchName: info.branchName,
+      worktreePath: info.worktreePath,
+      originalPath: repo,
+      ownerPid: 2_147_483_647, // certainly not alive HERE — but that says nothing there
+      ownerToken: 'foreign-space-token',
+      ownerNamespace: 'some-other-host:pid:[4026531999]',
+      createdAt: new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString(),
+    }));
+
+    await removePreservedWorktreeAt(info.worktreePath);
+
+    expect(existsSync(info.worktreePath)).toBe(true);
   });
 
   it('no-ops on paths that are not managed worktrees', async () => {

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -8,6 +8,7 @@ import { promisify } from 'node:util';
 import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { getInstanceId } from './healthEndpoint.js';
+import { processAppearsAlive, processNamespaceId, sameProcessNamespace, writerProvablyGone } from './processLiveness.js';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import Database from 'better-sqlite3';
 import { registerOwnedPR } from '../automation/prOwnership.js';
@@ -274,6 +275,17 @@ export interface ActiveWorktreeMarker {
    * Missing on markers written before this field existed.
    */
   ownerInstanceId?: string;
+  /**
+   * The pid space the writer lived in — the scope within which its pid is
+   * unique. Two daemons sharing this checkout each have their own pid 1, so a
+   * matching pid number means nothing across them.
+   *
+   * A string identifies the space; `null` records that the writer could not
+   * determine its own; absent means the marker predates the field. The three
+   * are distinct — collapsing "unknown" into "absent" would let a fail-closed
+   * writer be probed as if it had opted into the legacy rule.
+   */
+  ownerNamespace?: string | null;
   createdAt: string;
 }
 
@@ -344,6 +356,9 @@ async function writeActiveWorktreeMarker(info: WorktreeInfo): Promise<string> {
     ownerPid: process.pid,
     ownerToken,
     ownerInstanceId: getInstanceId(),
+    // `?? null` deliberately: an omitted key would be indistinguishable from
+    // a pre-field marker, which readers are entitled to probe locally.
+    ownerNamespace: processNamespaceId() ?? null,
     createdAt: new Date().toISOString(),
   };
   const tempPath = `${markerPath}.${process.pid}.${randomUUID()}.tmp`;
@@ -424,15 +439,6 @@ export type WorktreeRecoveryStatus =
   | { state: 'orphaned'; worktreePath: string; marker: ActiveWorktreeMarker }
   | { state: 'ambiguous'; worktreePath: string };
 
-function processAppearsAlive(pid: number): boolean {
-  if (!Number.isSafeInteger(pid) || pid <= 0) return true;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
-  }
-}
 
 /** This container assigns the daemon process the same pid every restart, so
  * a marker from a dead prior generation makes `processAppearsAlive` hit the
@@ -472,30 +478,21 @@ function activeMarkerAbandonMs(): number {
  * Markers from this boot, and legacy markers with no boot recorded, keep the
  * original pid + age test so a live long-running stage is still protected.
  */
-/** Epoch ms at which THIS process started. `process.uptime()` counts from
- * process start, so sampling it at module load is both cheap and accurate. */
-const PROCESS_STARTED_AT_MS = Date.now() - Math.round(process.uptime() * 1000);
-
-/** Slack for clock resolution when comparing a marker's timestamp to our own
- * start. Erring towards "still ours" only costs a fallback to the age window. */
-const PROCESS_START_JITTER_MS = 1_000;
-
 /**
- * A marker that records OUR pid but was written before we started running.
- *
- * A pid is unique among live processes, so a marker carrying this process's own
- * pid was written either by this process or by one that has since exited. If it
- * predates our start it cannot be ours, which makes its writer provably gone
- * however alive the pid table claims that pid to be.
- *
- * Unlike `ownerInstanceId` this needs no field on the marker, so it also
- * releases the markers a crashed daemon left behind before that field existed.
+ * A marker whose writer is provably gone by the shared pid proof: it carries
+ * OUR pid but predates our start, so it belongs to a process that has since
+ * exited. Needs no field on the marker, so it also releases the markers a
+ * crashed daemon left behind before `ownerInstanceId` existed. (AGT-4067)
  */
 function markerPredatesThisProcess(marker: ActiveWorktreeMarker): boolean {
-  if (marker.ownerPid !== process.pid) return false;
-  const createdAt = Date.parse(marker.createdAt);
-  if (!Number.isFinite(createdAt)) return false; // unreadable — never claim proof
-  return createdAt < PROCESS_STARTED_AT_MS - PROCESS_START_JITTER_MS;
+  // Gated on the recorded pid space, because that is the scope in which a pid
+  // is unique. This checkout can be mounted into more than one container, each
+  // with its own pid 1, and taking a worktree from a live owner in another one
+  // would put two executors on the same tree. A marker from a different space —
+  // or one written before the field existed — is not reasoned about by pid at
+  // all; it falls back to the age window. (Caught by the commit-gate review.)
+  if (marker.ownerNamespace == null || !sameProcessNamespace(marker.ownerNamespace)) return false;
+  return writerProvablyGone({ pid: marker.ownerPid, writtenAtMs: Date.parse(marker.createdAt) });
 }
 
 /**
@@ -521,7 +518,27 @@ function markerWriterProvablyGone(marker: ActiveWorktreeMarker): boolean {
   return markerPredatesThisProcess(marker);
 }
 
+/**
+ * Whether this marker's pid can be probed at all from here.
+ *
+ * A pid only means something inside the space it was issued in. Probing a
+ * marker that names a *different* space tells us about whatever holds that
+ * number locally, and a "not alive" answer from that would authorise taking a
+ * worktree a live container still owns. Such a marker is treated as live and
+ * left to the age window — or, where there is none, left alone.
+ *
+ * A marker with no space recorded predates the field and keeps the original
+ * pid-probe behaviour, which is no worse than before it existed.
+ * (Caught by the commit-gate review.)
+ */
+function markerPidIsJudgeable(marker: ActiveWorktreeMarker): boolean {
+  if (marker.ownerNamespace === undefined) return true; // predates the field
+  if (marker.ownerNamespace === null) return false; // writer could not identify its own pid space
+  return sameProcessNamespace(marker.ownerNamespace);
+}
+
 function markerLooksLive(marker: ActiveWorktreeMarker): boolean {
+  if (!markerPidIsJudgeable(marker)) return (activeMarkerAgeMs(marker) ?? 0) < activeMarkerAbandonMs();
   if (markerWriterProvablyGone(marker)) return false;
   return processAppearsAlive(marker.ownerPid) && (activeMarkerAgeMs(marker) ?? 0) < activeMarkerAbandonMs();
 }
@@ -596,7 +613,13 @@ export async function removePreservedWorktreeAt(worktreePath: string): Promise<v
     // active marker before releasing this same lock.
     const active = await readActiveWorktreeMarkers(match[1], normalized);
     if (active.unreadable
-      || active.markers.some((marker) => !markerWriterProvablyGone(marker) && processAppearsAlive(marker.ownerPid))) return;
+      || active.markers.some((marker) => (
+        // No age escape at this site, so an unjudgeable pid means "keep": a
+        // preserved tree still reachable by a live owner elsewhere must not be
+        // deleted. pruneWorktrees' preserved-tree expiry is the backstop.
+        !markerPidIsJudgeable(marker)
+        || (!markerWriterProvablyGone(marker) && processAppearsAlive(marker.ownerPid))
+      ))) return;
     await removePreservedWorktreeAtUnlocked(normalized);
   });
 }

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -8,7 +8,7 @@ import { promisify } from 'node:util';
 import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { getInstanceId } from './healthEndpoint.js';
-import { processAppearsAlive, processNamespaceId, sameProcessNamespace, writerProvablyGone } from './processLiveness.js';
+import { isProofCapableSpace, processAppearsAlive, processNamespaceId, sameProcessNamespace, writerProvablyGone } from './processLiveness.js';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import Database from 'better-sqlite3';
 import { registerOwnedPR } from '../automation/prOwnership.js';
@@ -491,7 +491,11 @@ function markerPredatesThisProcess(marker: ActiveWorktreeMarker): boolean {
   // would put two executors on the same tree. A marker from a different space —
   // or one written before the field existed — is not reasoned about by pid at
   // all; it falls back to the age window. (Caught by the commit-gate review.)
-  if (marker.ownerNamespace == null || !sameProcessNamespace(marker.ownerNamespace)) return false;
+  // A machine hint is not enough: "this pid is mine, so its writer exited"
+  // needs the pid numbering to be the same numbering, which only a real pid
+  // space establishes.
+  if (!isProofCapableSpace(marker.ownerNamespace ?? undefined)) return false;
+  if (!sameProcessNamespace(marker.ownerNamespace ?? undefined)) return false;
   return writerProvablyGone({ pid: marker.ownerPid, writtenAtMs: Date.parse(marker.createdAt) });
 }
 
@@ -532,8 +536,24 @@ function markerWriterProvablyGone(marker: ActiveWorktreeMarker): boolean {
  * (Caught by the commit-gate review.)
  */
 function markerPidIsJudgeable(marker: ActiveWorktreeMarker): boolean {
-  if (marker.ownerNamespace === undefined) return true; // predates the field
-  if (marker.ownerNamespace === null) return false; // writer could not identify its own pid space
+  // Three states, three answers:
+  //
+  //  - **absent** — predates the field. Keeps the original local probe, which
+  //    is the behaviour this module inherited and must not regress.
+  //  - **null** — the writer could name no space at all. Fail closed: it is a
+  //    Linux process that could not read /proc/self/ns/pid, and probing its pid
+  //    here would answer about a different pid table. Costs nothing now that
+  //    platforms without pid namespaces record a host hint instead of null.
+  //  - **a string** — probe only if it is our space. A different one is another
+  //    machine or another container, where our pid table says nothing.
+  //
+  // KNOWN LIMITATION (AGT-4069, pre-existing): an *absent* record, and a host
+  // hint that happens to match, still get the local probe. Two machines sharing
+  // a state directory under the same host name can therefore still judge each
+  // other's live owner dead — as this code already did. Closing that needs a
+  // real OS machine identity, tracked separately.
+  if (marker.ownerNamespace === undefined) return true;
+  if (marker.ownerNamespace === null) return false;
   return sameProcessNamespace(marker.ownerNamespace);
 }
 

--- a/src/taskState/store.test.ts
+++ b/src/taskState/store.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { existsSync, mkdtempSync, readFileSync, rmSync, unlinkSync, utimesSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { hostname, tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import {
@@ -20,7 +20,14 @@ import {
   resetTaskStateStoreForTests,
   type OpenSwarmTaskState,
 } from './store.js';
-import { PROCESS_STARTED_AT_MS, processNamespaceId } from '../support/processLiveness.js';
+import { PROCESS_STARTED_AT_MS, isProofCapableSpace, processNamespaceId } from '../support/processLiveness.js';
+
+// The fast-path proof needs a REAL pid space, which only Linux can give (boot
+// id + pid-namespace inode). Elsewhere the recorded id is a machine hint, good
+// for ruling a record out but never for the proof — so these cases cannot arise
+// there at all. Asserted on Linux in CI.
+const itWithPidSpace = isProofCapableSpace(processNamespaceId()) ? it : it.skip;
+
 
 describe('task state store', () => {
   let stateFile: string;
@@ -417,7 +424,7 @@ describe('task state store', () => {
     // pid 7 had written 0.7s before the container was recreated. A pid is
     // unique among live processes, so a lock carrying OUR pid that predates our
     // start belongs to a process that has exited. No wait required.
-    it('reclaims a same-namespace lock at our own pid that predates this process, well inside the expiry', () => {
+    itWithPidSpace('reclaims a same-namespace lock at our own pid that predates this process, well inside the expiry', () => {
       writeFileSync(lockFile(), JSON.stringify({
         pid: process.pid, token: 'prior-generation', ns: processNamespaceId(),
       }), 'utf8');
@@ -471,11 +478,11 @@ describe('task state store', () => {
       expect(getTaskState('ISSUE-LOCK-8')?.execution.status).toBe('todo');
     });
 
-    it('does not probe a lock whose writer could not identify its own pid space (AGT-4068)', () => {
-      // `ns: null` is a fail-closed writer saying "I do not know where I am",
-      // which is not the same as a lock written before the field existed. An
-      // omitted key would have made the two indistinguishable and licensed a
-      // local probe. (Caught by the commit-gate review.)
+    it('does not probe a lock whose writer could name no pid space at all (AGT-4068)', () => {
+      // `ns: null` is a writer that could not read its own pid namespace, so
+      // our pid table is not its pid table and a local ESRCH means nothing.
+      // Distinct from an ABSENT ns, which predates the field and keeps the
+      // original probe — an omitted key would have conflated the two.
       writeFileSync(lockFile(), JSON.stringify({
         pid: 2_147_483_647, token: 'unknown-space', ns: null,
       }), 'utf8');
@@ -483,6 +490,34 @@ describe('task state store', () => {
       utimesSync(lockFile(), recent, recent);
 
       expect(() => upsertTaskState('ISSUE-LOCK-9', { execution: { status: 'todo', retryCount: 0 } }))
+        .toThrow(/Timed out waiting for task state lock/);
+    });
+
+    it('withholds the fast-path proof from a lock with no named pid space (AGT-4068)', () => {
+      // Our own pid, written before we started — the proof would reclaim this
+      // at once if the space were named and matched. Unnamed, it must wait out
+      // the age rule like any pre-field lock.
+      writeFileSync(lockFile(), JSON.stringify({
+        pid: process.pid, token: 'unknown-space-live-pid', ns: null,
+      }), 'utf8');
+      const beforeWeStarted = new Date(PROCESS_STARTED_AT_MS - 60_000);
+      utimesSync(lockFile(), beforeWeStarted, beforeWeStarted);
+
+      expect(() => upsertTaskState('ISSUE-LOCK-10', { execution: { status: 'todo', retryCount: 0 } }))
+        .toThrow(/Timed out waiting for task state lock/);
+    });
+
+    it('does not let a matching machine HINT license the pid proof (AGT-4068)', () => {
+      // `host:<name>` matches ours, which keeps the local probe — but it does
+      // not establish that our pid numbering is the writer's, so the proof
+      // stays off and the age rule governs.
+      writeFileSync(lockFile(), JSON.stringify({
+        pid: process.pid, token: 'hint-not-proof', ns: `host:${hostname()}`,
+      }), 'utf8');
+      const beforeWeStarted = new Date(PROCESS_STARTED_AT_MS - 60_000);
+      utimesSync(lockFile(), beforeWeStarted, beforeWeStarted);
+
+      expect(() => upsertTaskState('ISSUE-LOCK-11', { execution: { status: 'todo', retryCount: 0 } }))
         .toThrow(/Timed out waiting for task state lock/);
     });
 

--- a/src/taskState/store.test.ts
+++ b/src/taskState/store.test.ts
@@ -20,6 +20,7 @@ import {
   resetTaskStateStoreForTests,
   type OpenSwarmTaskState,
 } from './store.js';
+import { PROCESS_STARTED_AT_MS, processNamespaceId } from '../support/processLiveness.js';
 
 describe('task state store', () => {
   let stateFile: string;
@@ -407,6 +408,81 @@ describe('task state store', () => {
       utimesSync(lockFile(), almostExpired, almostExpired);
 
       expect(() => upsertTaskState('ISSUE-LOCK-2', { execution: { status: 'todo', retryCount: 0 } }))
+        .toThrow(/Timed out waiting for task state lock/);
+    });
+
+    // AGT-4068: the 10-minute wait above is a timer, not evidence, and it cost
+    // ten minutes of dead heartbeats after every container restart — measured
+    // on vela 2026-08-29, where the new daemon came up on pid 7 holding a lock
+    // pid 7 had written 0.7s before the container was recreated. A pid is
+    // unique among live processes, so a lock carrying OUR pid that predates our
+    // start belongs to a process that has exited. No wait required.
+    it('reclaims a same-namespace lock at our own pid that predates this process, well inside the expiry', () => {
+      writeFileSync(lockFile(), JSON.stringify({
+        pid: process.pid, token: 'prior-generation', ns: processNamespaceId(),
+      }), 'utf8');
+      const beforeWeStarted = new Date(PROCESS_STARTED_AT_MS - 60_000); // and only a minute old
+      utimesSync(lockFile(), beforeWeStarted, beforeWeStarted);
+
+      upsertTaskState('ISSUE-LOCK-5', { execution: { status: 'todo', retryCount: 0 } });
+
+      expect(getTaskState('ISSUE-LOCK-5')?.execution.status).toBe('todo');
+      expect(existsSync(lockFile())).toBe(false);
+    });
+
+    it('does not reason about a pid from another pid space, however old the lock', () => {
+      // Two containers sharing this mounted state file each have their own
+      // pid 1, so a matching pid number means nothing across them. Such a lock
+      // gets the age rule and nothing else — it may be a live writer.
+      writeFileSync(lockFile(), JSON.stringify({
+        pid: process.pid, token: 'other-container', ns: 'some-other-host:pid:[4026531999]',
+      }), 'utf8');
+      const beforeWeStarted = new Date(PROCESS_STARTED_AT_MS - 60_000);
+      utimesSync(lockFile(), beforeWeStarted, beforeWeStarted);
+
+      expect(() => upsertTaskState('ISSUE-LOCK-6', { execution: { status: 'todo', retryCount: 0 } }))
+        .toThrow(/Timed out waiting for task state lock/);
+    });
+
+    it('does not reclaim a foreign-namespace lock just because its pid is dead here (AGT-4068)', () => {
+      // The pid probe runs before any age rule, so an ESRCH answer reclaims
+      // outright. That pid belongs to another container's space, where it may
+      // be a live writer; our local probe is answering a different question.
+      writeFileSync(lockFile(), JSON.stringify({
+        pid: 2_147_483_647, // certainly not alive HERE
+        token: 'other-container',
+        ns: 'some-other-host:pid:[4026531999]',
+      }), 'utf8');
+      const recent = new Date(Date.now() - 60_000);
+      utimesSync(lockFile(), recent, recent);
+
+      expect(() => upsertTaskState('ISSUE-LOCK-7', { execution: { status: 'todo', retryCount: 0 } }))
+        .toThrow(/Timed out waiting for task state lock/);
+    });
+
+    it('still reclaims a legacy lock with no namespace recorded when its pid is dead', () => {
+      // Locks written before the field existed keep the original behaviour.
+      writeFileSync(lockFile(), JSON.stringify({ pid: 2_147_483_647, token: 'legacy' }), 'utf8');
+      const recent = new Date(Date.now() - 60_000);
+      utimesSync(lockFile(), recent, recent);
+
+      upsertTaskState('ISSUE-LOCK-8', { execution: { status: 'todo', retryCount: 0 } });
+
+      expect(getTaskState('ISSUE-LOCK-8')?.execution.status).toBe('todo');
+    });
+
+    it('does not probe a lock whose writer could not identify its own pid space (AGT-4068)', () => {
+      // `ns: null` is a fail-closed writer saying "I do not know where I am",
+      // which is not the same as a lock written before the field existed. An
+      // omitted key would have made the two indistinguishable and licensed a
+      // local probe. (Caught by the commit-gate review.)
+      writeFileSync(lockFile(), JSON.stringify({
+        pid: 2_147_483_647, token: 'unknown-space', ns: null,
+      }), 'utf8');
+      const recent = new Date(Date.now() - 60_000);
+      utimesSync(lockFile(), recent, recent);
+
+      expect(() => upsertTaskState('ISSUE-LOCK-9', { execution: { status: 'todo', retryCount: 0 } }))
         .toThrow(/Timed out waiting for task state lock/);
     });
 

--- a/src/taskState/store.ts
+++ b/src/taskState/store.ts
@@ -20,7 +20,7 @@ import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
-import { processAppearsAlive, processNamespaceId, sameProcessNamespace, writerProvablyGone } from '../support/processLiveness.js';
+import { isProofCapableSpace, processAppearsAlive, processNamespaceId, sameProcessNamespace, writerProvablyGone } from '../support/processLiveness.js';
 
 const TASK_STATE_MARKER = '<!-- openswarm:task-state:v1 -->';
 
@@ -126,8 +126,11 @@ function lockNamespaceOf(raw: unknown): string | null | undefined {
 
 /** Whether this lock's pid can be probed from here at all. */
 function lockPidIsJudgeable(owner: StoreLockOwner): boolean {
-  if (owner.ns === undefined) return true; // predates the field — original behaviour
-  if (owner.ns === null) return false; // writer could not identify its own pid space
+  // Absent keeps the original probe; null fails closed (the writer could name
+  // no space, so our pid table is not its pid table); a string must be ours.
+  // See the matching note in worktreeManager, including its AGT-4069 caveat.
+  if (owner.ns === undefined) return true;
+  if (owner.ns === null) return false;
   return sameProcessNamespace(owner.ns);
 }
 
@@ -232,7 +235,7 @@ function withStoreLock<T>(operation: () => T): T {
         // NOT reasoned about by pid: it falls through to the age rule below,
         // which is exactly what the AGT-4023 policy test pins.
         const priorGenerationLock = owner !== null
-          && owner.ns != null && sameProcessNamespace(owner.ns)
+          && isProofCapableSpace(owner.ns ?? undefined) && sameProcessNamespace(owner.ns ?? undefined)
           && writerProvablyGone({ pid: owner.pid, writtenAtMs: judgedMtimeMs });
         // A pid probe cannot see past its own namespace, and a container
         // assigns the daemon the same pid every start — so a lock left behind

--- a/src/taskState/store.ts
+++ b/src/taskState/store.ts
@@ -20,6 +20,7 @@ import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
+import { processAppearsAlive, processNamespaceId, sameProcessNamespace, writerProvablyGone } from '../support/processLiveness.js';
 
 const TASK_STATE_MARKER = '<!-- openswarm:task-state:v1 -->';
 
@@ -110,25 +111,34 @@ const LOCK_WAIT_MS = 10;
 const LOCK_TIMEOUT_MS = 5_000;
 const lockWaitBuffer = new Int32Array(new SharedArrayBuffer(4));
 
-type StoreLockOwner = { pid: number; token: string };
+/** `ns`: the writer's pid space. A string identifies it; `null` records that
+ * the writer could not determine its own (a Linux process with an unreadable
+ * /proc/self/ns/pid); absent means the lock predates the field entirely. The
+ * three are distinct — collapsing "unknown" into "absent" would let a
+ * fail-closed writer be probed as if it had opted into the legacy rule. */
+type StoreLockOwner = { pid: number; token: string; ns?: string | null };
+
+/** Preserves the string / null / absent distinction described on StoreLockOwner. */
+function lockNamespaceOf(raw: unknown): string | null | undefined {
+  if (raw === null) return null;
+  return typeof raw === 'string' ? raw : undefined;
+}
+
+/** Whether this lock's pid can be probed from here at all. */
+function lockPidIsJudgeable(owner: StoreLockOwner): boolean {
+  if (owner.ns === undefined) return true; // predates the field — original behaviour
+  if (owner.ns === null) return false; // writer could not identify its own pid space
+  return sameProcessNamespace(owner.ns);
+}
 
 function readStoreLockOwner(lockPath: string): StoreLockOwner | null {
   try {
     const value = JSON.parse(readFileSync(lockPath, 'utf8')) as Partial<StoreLockOwner>;
     return Number.isInteger(value.pid) && (value.pid ?? 0) > 0 && typeof value.token === 'string'
-      ? { pid: value.pid!, token: value.token }
+      ? { pid: value.pid!, token: value.token, ns: lockNamespaceOf(value.ns) }
       : null;
   } catch {
     return null;
-  }
-}
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === 'EPERM';
   }
 }
 
@@ -188,7 +198,9 @@ function withStoreLock<T>(operation: () => T): T {
   while (lockFd === undefined) {
     try {
       lockFd = openSync(lockPath, 'wx', 0o600);
-      writeFileSync(lockFd, JSON.stringify({ pid: process.pid, token: lockToken }), 'utf8');
+      // `?? null` deliberately: an omitted key would be indistinguishable from
+      // a pre-field lock, which readers are entitled to probe locally.
+      writeFileSync(lockFd, JSON.stringify({ pid: process.pid, token: lockToken, ns: processNamespaceId() ?? null }), 'utf8');
       fsyncSync(lockFd);
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
@@ -198,7 +210,30 @@ function withStoreLock<T>(operation: () => T): T {
         const judgedMtimeMs = statSync(lockPath).mtimeMs;
         const lockAgeMs = Date.now() - judgedMtimeMs;
         const staleMalformedLock = !owner && lockAgeMs > LOCK_STALE_MS;
-        const abandonedLock = owner !== null && !isProcessAlive(owner.pid);
+        // A pid only means something inside the space it was issued in. This
+        // file can be a projection two containers share, so probing a lock
+        // that names a different space answers about whatever holds that
+        // number locally — and an ESRCH there would reclaim a lock a live
+        // writer still holds. Such a lock gets the age rule and nothing else.
+        // A lock with no space recorded predates the field and keeps the
+        // original probe behaviour. (Caught by the commit-gate review.)
+        const ownerPidIsJudgeable = owner !== null && lockPidIsJudgeable(owner);
+        const abandonedLock = owner !== null && ownerPidIsJudgeable && !processAppearsAlive(owner.pid);
+        // The pid probe above cannot see a generation change, so a lock the
+        // previous container left behind reads as held against the new daemon
+        // that inherited its pid. Settling that case outright, instead of
+        // waiting out LOCK_ABANDON_MS, is worth a full ten minutes of dead
+        // heartbeats after every restart. (AGT-4068)
+        //
+        // Gated on the recorded pid namespace, because that is the scope in
+        // which a pid is unique — and this file may be a mounted projection
+        // two containers share, each with its own pid 1. A lock from a
+        // different namespace, or one written before this field existed, is
+        // NOT reasoned about by pid: it falls through to the age rule below,
+        // which is exactly what the AGT-4023 policy test pins.
+        const priorGenerationLock = owner !== null
+          && owner.ns != null && sameProcessNamespace(owner.ns)
+          && writerProvablyGone({ pid: owner.pid, writtenAtMs: judgedMtimeMs });
         // A pid probe cannot see past its own namespace, and a container
         // assigns the daemon the same pid every start — so a lock left behind
         // by a killed container reads as "alive" against the new daemon
@@ -219,7 +254,7 @@ function withStoreLock<T>(operation: () => T): T {
         // owns leases and remote effects, so a rollback here cannot
         // double-execute anything, and the next Linear sync re-derives it.
         const expiredLock = lockAgeMs > LOCK_ABANDON_MS;
-        if (staleMalformedLock || abandonedLock || expiredLock) {
+        if (staleMalformedLock || abandonedLock || priorGenerationLock || expiredLock) {
           // Reclaim only the lock that was actually judged. Between the
           // judgement above and this unlink the holder can release and a third
           // process can take a fresh lock; deleting THAT one would put two


### PR DESCRIPTION
Closes AGT-4068.

## The ten minutes

Deploying AGT-4067 to vela at 15:12:43 KST bought ten minutes of this:

```
[HB] ✗ Linear fetch error: Timed out waiting for task state lock: …/task-state.json.lock
[AutonomousRunner] Task fetch failed (3x consecutive)
```

The lock, frozen throughout:

```json
{"pid":7,"token":"b0c68f3a-…"}      mtime 15:12:42.710  ← 0.66 s BEFORE the recreate
```

Written by the *previous* container's daemon, also pid 7. The new daemon is pid 7 too, so `isProcessAlive(7)` answered "alive" about its own ghost. It recovered at ~15:25 when the age rule fired — and only then could the AGT-4067 reconciler release the six wedged runs. Every restart pays this.

**Fourth call site of the same trap** (AGT-4023, AGT-4052/4053, AGT-4067), each fixed in place with its own local `isProcessAlive` copy. The proof now lives in one `src/support/processLiveness.ts`.

## Namespace, because that is the scope a pid is unique in

`store.test.ts` already pinned that a lock inside the window must be respected because "it may belong to a live writer in another pid namespace sharing the mounted state file". Both the lock and the worktree marker are mounted state two containers can share, each with its own pid 1. So a record naming another space is not reasoned about by pid **at all** — not the proof, and not the liveness probe, whose `ESRCH` would otherwise reclaim a live owner's resource. It falls back to the age rule, or to "keep" at `removePreservedWorktreeAt`, which has none.

Three states, kept distinct: a **string** identifies the space; **`null`** records that the writer could not determine its own; **absent** means the record predates the field and keeps the original local probe. `null` is written explicitly because an omitted key is indistinguishable from the third case.

## Gate — 6 real defects over 7 rounds

| # | Finding |
|---|---|
| 1 | the shared helper regressed both call sites' fail-closed handling — a blanket `catch` made `EPERM` (a live process owned by someone else) and an unusable pid read as *dead* |
| 2 | worktree markers applied the same-pid proof with no namespace recorded |
| 3 | a Linux process that cannot read `/proc/self/ns/pid` collapsed to a host-wide default, so two such containers would compare equal |
| 4 | `removePreservedWorktreeAt` still probed foreign-namespace pids locally; a local `ESRCH` authorised deleting a tree a live container owns |
| 5 | the symmetric hole in the lock: `abandonedLock` probed before the namespace check |
| 6 | "unknown namespace" serialized as an *omitted* key, indistinguishable from a legacy record |

Four of those were holes in the namespace safety I was adding — the reviewer tracked the invariant more consistently than I did. Round 7: **APPROVE**.

## Mutation evidence

11 mutations, each verified to fail. Two initially **survived** and the tests were rewritten, not kept:

- `namespacesMatch(undefined, undefined)` and the Linux-collapse fallback are both unreachable on macOS, so a mutation to either passed the whole suite. Extracted `resolveNamespaceId(platform, readLink)` and `namespacesMatch(recorded, mine)` as pure functions and tested those directly — all three branches now die under mutation on any platform.
- A mutation removing the redundant `=== null` guards survived because `null` can never equal a string id anyway. Replaced with the mutation that describes the actual defect — treating `null` as legacy — which kills both new tests.

184 tests across `processLiveness`, `store`, `worktreeManager` ×2, `autonomousRunner.durable`, `runLedger`. `tsc` clean.

## Verification still outstanding

The DoD's last item needs a restart to observe: the first heartbeat after a deploy should fetch tasks instead of timing out. Will be checked on the next vela deploy.