### PR TITLE
fix(discord): let a reply to an agent's question answer it (AGT-4070)

### DIFF
--- a/src/coordination/answerHint.test.ts
+++ b/src/coordination/answerHint.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { answerHint, correlationIdFromHint } from './answerHint.js';
+
+// AGT-4070: a posted question is the agent's own words followed by a generated
+// instruction, and a reply is matched back by reading that instruction. The
+// agent's text comes FIRST, so an unanchored scan would let a question that
+// merely discusses `!answer` hand the reply the wrong correlation id.
+// (Caught by the commit-gate review.)
+describe('answerHint / correlationIdFromHint', () => {
+  it('round-trips the correlation id it wrote', () => {
+    expect(correlationIdFromHint(answerHint('hq-abc123'))).toBe('hq-abc123');
+  });
+
+  it('reads the generated line, not a correlation id mentioned in the question body', () => {
+    const posted = [
+      'OpenSwarm needs a decision for AX-1 (asked by kestrel_build).',
+      'The runbook says to use !answer hq-WRONG when a job stalls — should we keep that?',
+      '',
+      answerHint('hq-RIGHT'),
+    ].join('\n');
+    expect(correlationIdFromHint(posted)).toBe('hq-RIGHT');
+  });
+
+  it('ignores a hint-shaped line the body only quotes in passing', () => {
+    // A prefix match is not enough: the whole line has to be the hint.
+    const posted = `See the note: ${answerHint('hq-QUOTED')} (do not do this yet)\n\n${answerHint('hq-REAL')}`;
+    expect(correlationIdFromHint(posted)).toBe('hq-REAL');
+  });
+
+  it('prefers the generated line over an earlier one the body reproduces in full', () => {
+    // An agent that quotes a previous question verbatim puts a complete,
+    // well-formed hint line in the body — above the generated one. The last
+    // line wins because ours is always appended last.
+    const posted = [
+      'OpenSwarm needs a decision for AX-1.',
+      'Last time you told me:',
+      answerHint('hq-OLD'),
+      'Does that still apply?',
+      '',
+      answerHint('hq-CURRENT'),
+    ].join('\n');
+    expect(correlationIdFromHint(posted)).toBe('hq-CURRENT');
+  });
+
+  it('rejects a line that opens like the hint but does not end like it', () => {
+    // Agent text is untrusted and can start with anything, including our own
+    // prefix. Without the closing anchor this hands back `hq-BAD`.
+    expect(correlationIdFromHint(
+      'Reply to this message with your answer, or: !answer hq-BAD and hurry',
+    )).toBeUndefined();
+  });
+
+  it('finds nothing in a message that carries no hint', () => {
+    expect(correlationIdFromHint('Build finished in 41s')).toBeUndefined();
+    expect(correlationIdFromHint('!answer hq-abc123 yes')).toBeUndefined();
+    expect(correlationIdFromHint(undefined)).toBeUndefined();
+    expect(correlationIdFromHint('')).toBeUndefined();
+  });
+});

--- a/src/coordination/answerHint.ts
+++ b/src/coordination/answerHint.ts
@@ -1,0 +1,46 @@
+// ============================================
+// OpenSwarm - The one place the operator answer hint is written and read (AGT-4070)
+// ============================================
+//
+// A posted question is agent-authored text followed by a generated instruction,
+// and a reply is matched back to its question by reading that instruction out of
+// the message Discord stores. So the two sides must agree exactly, and the match
+// must be anchored to the generated line rather than scanning the whole message:
+// the agent's own words come FIRST, and a question that happens to discuss
+// `!answer <something>` would otherwise hand the reply a different correlation
+// id — or none. (Caught by the commit-gate review.)
+//
+// Imports nothing on purpose: both the coordination and Discord layers take it
+// statically, and anything heavier here would close a cycle between them.
+
+const HINT_PREFIX = 'Reply to this message with your answer, or: !answer ';
+const HINT_SUFFIX = ' <your answer>';
+
+/** The instruction appended to a question posted to the operator. */
+export function answerHint(correlationId: string): string {
+  return `${HINT_PREFIX}${correlationId}${HINT_SUFFIX}`;
+}
+
+/**
+ * The correlation id carried by a posted question, or undefined if the text
+ * carries no hint of ours.
+ *
+ * Anchored to a whole line, and the LAST such line wins: the generated hint is
+ * appended after the agent's text, so a body that quotes an older hint cannot
+ * outrank the real one.
+ */
+export function correlationIdFromHint(text: string | undefined): string | undefined {
+  if (!text) return undefined;
+  const pattern = new RegExp(
+    `^${escapeRegExp(HINT_PREFIX)}(\\S+)${escapeRegExp(HINT_SUFFIX)}$`,
+  );
+  for (const line of text.split('\n').reverse()) {
+    const match = pattern.exec(line.trim());
+    if (match) return match[1];
+  }
+  return undefined;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/coordination/humanQuestions.ts
+++ b/src/coordination/humanQuestions.ts
@@ -11,6 +11,7 @@
 
 import { createHash } from 'node:crypto';
 import { getCoordinationStore, type CoordinationEvent } from './coordinationStore.js';
+import { answerHint } from './answerHint.js';
 
 export interface HumanQuestionInput {
   repository: string;
@@ -146,7 +147,7 @@ export async function postHumanQuestion(input: HumanQuestionInput): Promise<Huma
   const delivered = await notify(
     `OpenSwarm needs a decision for ${input.taskId}` +
       `${input.actorName ? ` (asked by ${input.actorName})` : ''}.\n${input.question}\n\n` +
-      `Reply with: !answer ${correlationId} <your answer>`,
+      answerHint(correlationId),
   );
   if (delivered) {
     await store.publish({

--- a/src/discord/discordCore.helpers.test.ts
+++ b/src/discord/discordCore.helpers.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, statSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { clampDiscordText, getChatHistory, saveChatHistory, startTypingIndicator } from './discordCore.js';
+import { clampDiscordText, getChatHistory, questionCorrelationIdFrom, saveChatHistory, startTypingIndicator } from './discordCore.js';
 
 afterEach(() => {
   vi.useRealTimers();
@@ -49,5 +49,42 @@ describe('Discord outbound bounds', () => {
     clearInterval(timer);
     expect(sendTyping.mock.calls.length).toBeGreaterThanOrEqual(2);
     expect(warn).toHaveBeenCalled();
+  });
+});
+
+// AGT-4070: replying to an agent's question is how an operator naturally
+// answers it. Until this existed the reply fell through to the chat handler and
+// the asking agent never saw it — 28 runs sat parked on questions that had been
+// replied to. The link lives in the message Discord already stores, so a parked
+// question that outlives the daemon still resolves after a restart.
+describe('questionCorrelationIdFrom (AGT-4070)', () => {
+  const BOT = 'bot-user-1';
+  const posted = (content: string, authorId = BOT) => ({ author: { id: authorId }, content });
+
+  it('reads the correlation id out of a question we posted', () => {
+    const id = questionCorrelationIdFrom(
+      posted('OpenSwarm needs a decision for AX-1.\nShip v2?\n\nReply to this message with your answer, or: !answer hq-abc123 <your answer>'),
+      BOT,
+    );
+    expect(id).toBe('hq-abc123');
+  });
+
+  it('ignores a message somebody else wrote, however it is worded', () => {
+    // Otherwise an operator could reply to their OWN message containing
+    // `!answer <id>` and answer through a path that never checked who asked.
+    expect(questionCorrelationIdFrom(posted('!answer hq-abc123 yes', 'someone-else'), BOT)).toBeUndefined();
+  });
+
+  it('ignores one of our messages that is not a question', () => {
+    expect(questionCorrelationIdFrom(posted('Build finished in 41s'), BOT)).toBeUndefined();
+  });
+
+  it('claims nothing when the reference could not be fetched, or we do not know who we are', () => {
+    expect(questionCorrelationIdFrom(null, BOT)).toBeUndefined();
+    expect(questionCorrelationIdFrom(posted('!answer hq-abc123 <your answer>'), undefined)).toBeUndefined();
+    // Both sides unknown must NOT compare equal: `undefined !== undefined` is
+    // false, so without the explicit guard an author-less message would be
+    // read as ours and answer a question on nobody's authority.
+    expect(questionCorrelationIdFrom({ author: null, content: '!answer hq-abc123 yes' }, undefined)).toBeUndefined();
   });
 });

--- a/src/discord/discordCore.ts
+++ b/src/discord/discordCore.ts
@@ -14,6 +14,7 @@ import {
   ThreadChannel,
 } from 'discord.js';
 import fs from 'node:fs/promises';
+import { correlationIdFromHint } from '../coordination/answerHint.js';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { SwarmEvent, AgentStatus } from '../core/types.js';
@@ -353,11 +354,69 @@ import {
   handleTurbo,
 } from './discordHandlers.js';
 
+
+/**
+ * The correlation id a posted question carries, or undefined if this is not one
+ * of our question messages.
+ *
+ * The link between a reply and the question it answers lives in the message
+ * Discord already stores — the `!answer <id>` line we posted — rather than in a
+ * map this process keeps. That matters because a parked question routinely
+ * outlives the daemon: it is asked twice, parked, and answered hours later,
+ * possibly after a restart, and an in-memory map would have lost it.
+ *
+ * Only OUR OWN messages are read for this. Otherwise an operator could reply to
+ * any message that happens to contain the text `!answer <id>` — including one
+ * they wrote themselves — and answer a question through a route that never
+ * passed the allowed-user check on the question itself.
+ */
+export function questionCorrelationIdFrom(
+  referenced: { author?: { id?: string } | null; content?: string } | null,
+  botUserId: string | undefined,
+): string | undefined {
+  if (!referenced || !botUserId) return undefined;
+  if (referenced.author?.id !== botUserId) return undefined;
+  return correlationIdFromHint(referenced.content ?? undefined);
+}
+
+/** Returns true when the reply was handled as an answer — handled including
+ * "we told the operator why it was not accepted", since falling through to the
+ * chat handler after that would answer their reply twice. */
+async function tryAnswerByReply(msg: Message): Promise<boolean> {
+  if (!msg.reference?.messageId) return false;
+  const referenced = await msg.fetchReference().catch(() => null);
+  const correlationId = questionCorrelationIdFrom(referenced, client?.user?.id);
+  if (!correlationId) return false;
+
+  const answer = msg.content.trim();
+  if (!answer) return false;
+  const { answerHumanQuestion } = await import('../coordination/humanQuestions.js');
+  const result = await answerHumanQuestion(correlationId, answer, `discord:${msg.author.id}`);
+  await msg.reply(result.accepted
+    ? `Answer accepted for ${correlationId}.`
+    : `Answer not accepted: ${result.reason}`);
+  return true;
+}
+
 /**
  * Message handler
  */
 async function handleMessage(msg: Message): Promise<void> {
   if (msg.author.bot) return;
+
+  // A reply to a question we posted answers that question.
+  //
+  // Replying is the obvious gesture, and until now it silently was not an
+  // answer: the message did not start with `!`, so it fell through to
+  // handleChat and the asking agent never saw it. Operators were expected to
+  // copy a correlation id by hand into `!answer <id> <text>`, and 28 runs sat
+  // parked on questions that had in fact been replied to. (AGT-4070)
+  if (ALLOWED_USER_IDS.length > 0
+      && ALLOWED_USER_IDS.includes(msg.author.id)
+      && !msg.content.startsWith('!')
+      && await tryAnswerByReply(msg)) {
+    return;
+  }
 
   // Respond to regular messages from allowed users (excluding ! commands)
   if (ALLOWED_USER_IDS.length > 0 &&
@@ -627,8 +686,7 @@ export async function sendToChannel(content: string | { embeds: EmbedBuilder[] }
     if (!channel) return;
 
     if (typeof content === 'string' && content.length > DISCORD_MESSAGE_CHUNK) {
-      const chunks = splitForDiscord(content, DISCORD_MESSAGE_CHUNK);
-      for (const chunk of chunks) {
+      for (const chunk of chunkForDiscord(content, DISCORD_MESSAGE_CHUNK)) {
         await channel.send(chunk);
       }
     } else {
@@ -659,6 +717,26 @@ const DISCORD_MESSAGE_CHUNK = 1900;
  * rather than re-stating the number, which is what let the 3900 mismatch sit
  * unnoticed.
  */
+/**
+ * Split a long message for Discord, keeping any answer hint on every chunk.
+ *
+ * The hint is appended last, so plain splitting leaves it on the final chunk
+ * only — and an operator replying to the chunk that actually shows the QUESTION
+ * would be replying to a message carrying no correlation id, which silently
+ * does not answer it. Repeating it costs a line per chunk and makes every piece
+ * of the question a valid thing to reply to. (Caught by the commit-gate review.)
+ *
+ * Messages that carry no hint are split exactly as before.
+ */
+export function chunkForDiscord(content: string, maxLen: number): string[] {
+  const lines = content.split('\n');
+  const hint = correlationIdFromHint(lines[lines.length - 1]) ? lines[lines.length - 1] : undefined;
+  if (hint === undefined) return splitForDiscord(content, maxLen);
+  const body = lines.slice(0, -1).join('\n').trimEnd();
+  const chunks = splitForDiscord(body, Math.max(1, maxLen - hint.length - 2));
+  return chunks.map((chunk) => `${chunk}\n\n${hint}`);
+}
+
 export function splitForDiscordForTest(text: string): string[] {
   return splitForDiscord(text, DISCORD_MESSAGE_CHUNK);
 }

--- a/src/discord/discordDelivery.test.ts
+++ b/src/discord/discordDelivery.test.ts
@@ -6,7 +6,8 @@
 // rejects outright, and two messages in one channel finishing out of order.
 
 import { afterEach, describe, expect, it } from 'vitest';
-import { appendHistoryEntry, channelHistoryMap, splitForDiscordForTest, updateHistoryResponse } from './discordCore.js';
+import { appendHistoryEntry, channelHistoryMap, chunkForDiscord, splitForDiscordForTest, updateHistoryResponse } from './discordCore.js';
+import { answerHint, correlationIdFromHint } from '../coordination/answerHint.js';
 
 /** Discord's hard limit on message content. Embeds are 4096; messages are not. */
 const DISCORD_CONTENT_LIMIT = 2000;
@@ -90,5 +91,32 @@ describe('updateHistoryResponse', () => {
 
   it('is a no-op for an unknown channel', () => {
     expect(() => updateHistoryResponse('nope', 'm1', 'answer')).not.toThrow();
+  });
+});
+
+// AGT-4070: an operator answers a question by replying to it, and the reply is
+// matched back by reading the answer hint out of the message replied to. A long
+// question is split, the hint is appended last — so without this every chunk but
+// the final one is a dead end, including the one that shows the question.
+describe('chunkForDiscord keeps the answer hint replyable', () => {
+  const hint = answerHint('hq-abc123');
+
+  it('repeats the hint on every chunk of a split question', () => {
+    const chunks = chunkForDiscord(`${'x'.repeat(5_000)}\n\n${hint}`, 2_000);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(correlationIdFromHint(chunk)).toBe('hq-abc123');
+      expect(chunk.length).toBeLessThanOrEqual(DISCORD_CONTENT_LIMIT);
+    }
+  });
+
+  it('adds nothing to a message that carries no hint', () => {
+    // The discriminating property: repeating a hint makes the chunks longer
+    // than the input. A message with no hint must gain nothing at all.
+    const plain = 'y'.repeat(5_000);
+    const chunks = chunkForDiscord(plain, 2_000);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join('').length).toBe(plain.length);
+    for (const chunk of chunks) expect(correlationIdFromHint(chunk)).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes AGT-4070. Reported by the operator:

> 디스코드에 답장하기 기능으로 답변 보냈는데 오류: `<urlopen error [Errno 61] Connection refused>` 라고 뜨는데 전달이 안되는거아냐?

The `urlopen` error is **not** OpenSwarm's — this bot is TypeScript, and in six hours it logged exactly one inbound chat message on an unrelated subject. vela also runs a separate Python VEGA stack (`vega-all`, `vega_router` on :18000), which is where that came from.

What *is* ours is that the reply would not have answered anything even had it arrived.

## The dead end

```ts
// src/discord/discordCore.ts — before
if (ALLOWED_USER_IDS.includes(msg.author.id) && !msg.content.startsWith('!')) {
  await handleChat(msg);   // every reply landed here
  return;
}
```

The only path to `answerHumanQuestion` was `!answer <correlation-id> <text>`, with an id copied by hand out of the message. **28 runs are parked** on `[operator-question] asked 2 times with no answer`, against **116 unanswered questions** on the board.

## The link lives in Discord, not in this process

A reply carries `message.reference.messageId`. Rather than keeping a map from message id to correlation id, the correlation id is read back out of the `!answer` hint on the message being replied to. That matters because a parked question routinely outlives the daemon — asked twice, parked, answered hours later, possibly after a restart — and an in-memory map would have lost exactly the ones that matter.

Only our own messages are read for it: otherwise an operator could reply to any message containing that text, including one they wrote themselves, and answer through a route that never passed the allowed-user check on the question.

## Gate — 2 real defects over 3 rounds

| # | Finding |
|---|---|
| 1 | correlation extraction scanned the whole message, and the **agent-authored question body comes first** — a question that merely discusses `!answer <id>` would hand the reply the wrong id |
| 2 | a long question is split across messages and the hint is appended last, so **the chunk that shows the question was a dead end to reply to** |

(1) moved the format into `src/coordination/answerHint.ts`, which both sides import, and anchored the match to a whole line with the last one winning. (2) added `chunkForDiscord`, which repeats the hint on every chunk. Round 3: **APPROVE**.

## Mutation evidence — 8 mutations, each verified to fail

| Mutation | Test that dies |
|---|---|
| drop the bot-author check | "ignores a message somebody else wrote, however it is worded" |
| drop the `!botUserId` guard | "claims nothing when … we do not know who we are" — `undefined !== undefined` is false, so an author-less message would read as ours |
| match anything, not the hint | "reads the correlation id out of a question we posted" + 1 |
| unanchored `!answer` scan | "finds nothing in a message that carries no hint" |
| first hint line wins | "prefers the generated line over an earlier one the body reproduces in full" |
| prefix without the closing anchor | "rejects a line that opens like the hint but does not end like it" |
| hint on the last chunk only | "repeats the hint on every chunk of a split question" |

Two of these tests were rewritten after their first version let the mutation survive: comparing chunkers at different `maxLen`, and cases where line order and the closing anchor happened not to matter.

40 tests across `answerHint`, `discordCore.helpers`, `discordCore.lifecycle`, `discordDelivery`, `humanQuestions`. `tsc` clean.

## Not changed

`!answer <id> <text>` works exactly as before; the posted instruction now offers both. Access control is untouched — only `DISCORD_ALLOWED_USERS` can answer either way.