### PR TITLE
fix(liveness): decide a prior generation by owner id, not by clock (AGT-4071)

### DIFF
--- a/src/support/processLiveness.test.ts
+++ b/src/support/processLiveness.test.ts
@@ -72,6 +72,45 @@ describe('writerProvablyGone', () => {
   it('claims nothing when the timestamp is unreadable', () => {
     expect(writerProvablyGone({ pid: process.pid, writtenAtMs: Number.NaN })).toBe(false);
   });
+
+  // AGT-4071: the timestamp path could not decide the case it was written for.
+  // A container recreate takes about half a second — measured on vela at 0.561 s
+  // — which is INSIDE any margin big enough to absorb a coarse mtime. The owner
+  // id settles it without consulting a clock at all.
+  it('proves death from the owner id even when the record is newer than the clock margin', () => {
+    expect(writerProvablyGone({
+      pid: process.pid,
+      ownerId: 'a-previous-boot',
+      ourOwnerId: 'this-boot',
+      writtenAtMs: PROCESS_STARTED_AT_MS - 500, // the real gap; the margin is 1000
+    })).toBe(true);
+  });
+
+  it('never reclaims our own record, however far back its timestamp reads', () => {
+    // The margin existed for this: a lock file's mtime can round down below our
+    // own start on a coarse filesystem. With an owner id the timestamp is not
+    // consulted, so it cannot go wrong.
+    expect(writerProvablyGone({
+      pid: process.pid,
+      ownerId: 'this-boot',
+      ourOwnerId: 'this-boot',
+      writtenAtMs: 0,
+    })).toBe(false);
+  });
+
+  it('still claims nothing about another live process, whatever its owner id', () => {
+    expect(writerProvablyGone({
+      pid: process.pid + 1,
+      ownerId: 'somebody-else',
+      ourOwnerId: 'this-boot',
+      writtenAtMs: 0,
+    })).toBe(false);
+  });
+
+  it('falls back to the timestamp when the record carries no owner id', () => {
+    expect(writerProvablyGone({ pid: process.pid, writtenAtMs: PROCESS_STARTED_AT_MS - 60_000 })).toBe(true);
+    expect(writerProvablyGone({ pid: process.pid, writtenAtMs: PROCESS_STARTED_AT_MS - 500 })).toBe(false);
+  });
 });
 
 describe('processNamespaceId / sameProcessNamespace', () => {

--- a/src/support/processLiveness.ts
+++ b/src/support/processLiveness.ts
@@ -172,19 +172,42 @@ export function processAppearsAlive(pid: number): boolean {
  * Whether the process that wrote a record is *provably* gone.
  *
  * A pid is unique among live processes, so a record carrying this process's own
- * pid was written either by this process or by one that has since exited. If it
- * predates our start it cannot be ours, which settles it however alive the pid
- * table claims that pid to be. That is exactly the container-restart shape, and
- * it needs nothing written into the record beyond a pid and a timestamp — so it
- * also reaches records already on disk.
+ * pid was written either by this process or by one that has since exited.
+ * Deciding which is what the two signals below are for, and either suffices:
  *
- * Deliberately narrow: it returns false for any pid that is not ours, because a
- * *different* live process legitimately owns its own records. Concurrent
+ *  - **`ownerId`** — an id minted per process. Ours means the record is ours and
+ *    live; anything else, *given that the pid is ours*, means a process that has
+ *    exited. Note the pid conjunct is doing the work: a differing id alone
+ *    proves nothing, because a live sibling process also differs (AGT-4067).
+ *    Clock-free, so nothing below can undermine it.
+ *  - **`writtenAtMs`** — the fallback for records carrying no owner id. A record
+ *    older than our own start cannot be ours.
+ *
+ * The timestamp path needs a margin and the margin is the reason `ownerId`
+ * exists. It has to absorb an imprecise timestamp — for a lock file that is the
+ * **mtime**, and on a filesystem with one-second granularity a lock we wrote at
+ * `…13.900` reports `…13.000`, before our own start of `…13.231`, so without a
+ * margin we would reclaim our own live lock. But a container recreate takes
+ * about half a second, which is *inside* any margin large enough for that, so
+ * the timestamp path cannot decide the very case this exists for. Measured on
+ * vela: lock written 17:12:12.670, successor started 17:12:13.231, gap 0.561 s
+ * against a 1 s margin. (AGT-4071)
+ *
+ * Deliberately narrow in both paths: false for any pid that is not ours, because
+ * a *different* live process legitimately owns its own records. Concurrent
  * OpenSwarm processes — `openswarm attach`, a manual `openswarm run`, a second
  * daemon — must keep their locks and worktrees.
  */
-export function writerProvablyGone(record: { pid: number; writtenAtMs: number }): boolean {
+export function writerProvablyGone(record: {
+  pid: number;
+  writtenAtMs?: number;
+  ownerId?: string;
+  ourOwnerId?: string;
+}): boolean {
   if (record.pid !== process.pid) return false;
-  if (!Number.isFinite(record.writtenAtMs)) return false; // unreadable — never claim proof
+  if (record.ownerId !== undefined && record.ourOwnerId !== undefined) {
+    return record.ownerId !== record.ourOwnerId;
+  }
+  if (record.writtenAtMs === undefined || !Number.isFinite(record.writtenAtMs)) return false;
   return record.writtenAtMs < PROCESS_STARTED_AT_MS - PROCESS_START_JITTER_MS;
 }

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -484,7 +484,7 @@ function activeMarkerAbandonMs(): number {
  * exited. Needs no field on the marker, so it also releases the markers a
  * crashed daemon left behind before `ownerInstanceId` existed. (AGT-4067)
  */
-function markerPredatesThisProcess(marker: ActiveWorktreeMarker): boolean {
+function markerWriterIsGone(marker: ActiveWorktreeMarker): boolean {
   // Gated on the recorded pid space, because that is the scope in which a pid
   // is unique. This checkout can be mounted into more than one container, each
   // with its own pid 1, and taking a worktree from a live owner in another one
@@ -496,7 +496,12 @@ function markerPredatesThisProcess(marker: ActiveWorktreeMarker): boolean {
   // space establishes.
   if (!isProofCapableSpace(marker.ownerNamespace ?? undefined)) return false;
   if (!sameProcessNamespace(marker.ownerNamespace ?? undefined)) return false;
-  return writerProvablyGone({ pid: marker.ownerPid, writtenAtMs: Date.parse(marker.createdAt) });
+  return writerProvablyGone({
+    pid: marker.ownerPid,
+    ownerId: marker.ownerInstanceId,
+    ourOwnerId: getInstanceId(),
+    writtenAtMs: Date.parse(marker.createdAt),
+  });
 }
 
 /**
@@ -519,7 +524,7 @@ function markerPredatesThisProcess(marker: ActiveWorktreeMarker): boolean {
  */
 function markerWriterProvablyGone(marker: ActiveWorktreeMarker): boolean {
   if (marker.ownerInstanceId === getInstanceId()) return false;
-  return markerPredatesThisProcess(marker);
+  return markerWriterIsGone(marker);
 }
 
 /**

--- a/src/taskState/store.test.ts
+++ b/src/taskState/store.test.ts
@@ -18,9 +18,11 @@ import {
   hydrateTaskStateFromComments,
   markTaskBacklog,
   resetTaskStateStoreForTests,
+  buildLockPayload,
   type OpenSwarmTaskState,
 } from './store.js';
 import { PROCESS_STARTED_AT_MS, isProofCapableSpace, processNamespaceId } from '../support/processLiveness.js';
+import { getInstanceId } from '../support/healthEndpoint.js';
 
 // The fast-path proof needs a REAL pid space, which only Linux can give (boot
 // id + pid-namespace inode). Elsewhere the recorded id is a machine hint, good
@@ -519,6 +521,52 @@ describe('task state store', () => {
 
       expect(() => upsertTaskState('ISSUE-LOCK-11', { execution: { status: 'todo', retryCount: 0 } }))
         .toThrow(/Timed out waiting for task state lock/);
+    });
+
+    itWithPidSpace('reclaims a prior-generation lock written half a second before we started (AGT-4071)', () => {
+      // The production case, at production timing: the outgoing container wrote
+      // this at 17:12:12.670 and its successor started at 17:12:13.231. The
+      // timestamp path cannot see 0.561 s past a 1 s margin; the owner id can.
+      writeFileSync(lockFile(), JSON.stringify({
+        pid: process.pid,
+        token: 'prior-generation',
+        ns: processNamespaceId(),
+        instance: 'a-previous-boot',
+      }), 'utf8');
+      const justBeforeWeStarted = new Date(PROCESS_STARTED_AT_MS - 500);
+      utimesSync(lockFile(), justBeforeWeStarted, justBeforeWeStarted);
+
+      upsertTaskState('ISSUE-LOCK-12', { execution: { status: 'todo', retryCount: 0 } });
+
+      expect(getTaskState('ISSUE-LOCK-12')?.execution.status).toBe('todo');
+      expect(existsSync(lockFile())).toBe(false);
+    });
+
+    itWithPidSpace('does not reclaim a lock this very process holds, however its mtime reads (AGT-4071)', () => {
+      // A coarse-granularity filesystem can report our own fresh lock as older
+      // than our start. The owner id keeps that from mattering.
+      writeFileSync(lockFile(), JSON.stringify({
+        pid: process.pid,
+        token: 'ours-right-now',
+        ns: processNamespaceId(),
+        instance: getInstanceId(),
+      }), 'utf8');
+      const impossiblyOld = new Date(PROCESS_STARTED_AT_MS - 500);
+      utimesSync(lockFile(), impossiblyOld, impossiblyOld);
+
+      expect(() => upsertTaskState('ISSUE-LOCK-13', { execution: { status: 'todo', retryCount: 0 } }))
+        .toThrow(/Timed out waiting for task state lock/);
+    });
+
+    it('records who holds it, so a successor can decide ownership without a clock (AGT-4071)', () => {
+      const payload = buildLockPayload('tok-1');
+      expect(payload.pid).toBe(process.pid);
+      expect(payload.token).toBe('tok-1');
+      expect(payload.instance).toBe(getInstanceId());
+      // `null`, not absent: an omitted key reads as "written before the field
+      // existed", which is entitled to a local pid probe.
+      expect('ns' in payload).toBe(true);
+      expect(payload.ns).toBe(processNamespaceId() ?? null);
     });
 
     it('still ages out a lock with no readable owner on the shorter clock', () => {

--- a/src/taskState/store.ts
+++ b/src/taskState/store.ts
@@ -21,6 +21,7 @@ import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
 import { isProofCapableSpace, processAppearsAlive, processNamespaceId, sameProcessNamespace, writerProvablyGone } from '../support/processLiveness.js';
+import { getInstanceId } from '../support/healthEndpoint.js';
 
 const TASK_STATE_MARKER = '<!-- openswarm:task-state:v1 -->';
 
@@ -116,12 +117,26 @@ const lockWaitBuffer = new Int32Array(new SharedArrayBuffer(4));
  * /proc/self/ns/pid); absent means the lock predates the field entirely. The
  * three are distinct — collapsing "unknown" into "absent" would let a
  * fail-closed writer be probed as if it had opted into the legacy rule. */
-type StoreLockOwner = { pid: number; token: string; ns?: string | null };
+type StoreLockOwner = { pid: number; token: string; ns?: string | null; instance?: string };
 
 /** Preserves the string / null / absent distinction described on StoreLockOwner. */
 function lockNamespaceOf(raw: unknown): string | null | undefined {
   if (raw === null) return null;
   return typeof raw === 'string' ? raw : undefined;
+}
+
+/**
+ * What a held lock records about its holder. Exported because the writer is the
+ * only place these fields originate and `withStoreLock` removes the file in its
+ * `finally`, so there is no way to observe the real thing after the fact — a
+ * mutation dropping `instance` passed the whole suite until this existed.
+ *
+ * `instance` is what lets a successor decide ownership without a clock;
+ * `ns` scopes the pid; `?? null` on the namespace is deliberate — an omitted
+ * key would be indistinguishable from a lock written before the field existed.
+ */
+export function buildLockPayload(token: string): StoreLockOwner {
+  return { pid: process.pid, token, ns: processNamespaceId() ?? null, instance: getInstanceId() };
 }
 
 /** Whether this lock's pid can be probed from here at all. */
@@ -138,7 +153,12 @@ function readStoreLockOwner(lockPath: string): StoreLockOwner | null {
   try {
     const value = JSON.parse(readFileSync(lockPath, 'utf8')) as Partial<StoreLockOwner>;
     return Number.isInteger(value.pid) && (value.pid ?? 0) > 0 && typeof value.token === 'string'
-      ? { pid: value.pid!, token: value.token, ns: lockNamespaceOf(value.ns) }
+      ? {
+        pid: value.pid!,
+        token: value.token,
+        ns: lockNamespaceOf(value.ns),
+        instance: typeof value.instance === 'string' ? value.instance : undefined,
+      }
       : null;
   } catch {
     return null;
@@ -203,7 +223,7 @@ function withStoreLock<T>(operation: () => T): T {
       lockFd = openSync(lockPath, 'wx', 0o600);
       // `?? null` deliberately: an omitted key would be indistinguishable from
       // a pre-field lock, which readers are entitled to probe locally.
-      writeFileSync(lockFd, JSON.stringify({ pid: process.pid, token: lockToken, ns: processNamespaceId() ?? null }), 'utf8');
+      writeFileSync(lockFd, JSON.stringify(buildLockPayload(lockToken)), 'utf8');
       fsyncSync(lockFd);
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
@@ -236,7 +256,12 @@ function withStoreLock<T>(operation: () => T): T {
         // which is exactly what the AGT-4023 policy test pins.
         const priorGenerationLock = owner !== null
           && isProofCapableSpace(owner.ns ?? undefined) && sameProcessNamespace(owner.ns ?? undefined)
-          && writerProvablyGone({ pid: owner.pid, writtenAtMs: judgedMtimeMs });
+          && writerProvablyGone({
+            pid: owner.pid,
+            ownerId: owner.instance,
+            ourOwnerId: getInstanceId(),
+            writtenAtMs: judgedMtimeMs,
+          });
         // A pid probe cannot see past its own namespace, and a container
         // assigns the daemon the same pid every start — so a lock left behind
         // by a killed container reads as "alive" against the new daemon


### PR DESCRIPTION
Closes AGT-4071.

## AGT-4068 shipped and did not fire

Deployed 17:12 KST. First heartbeat after the restart:

```
[HB] ✗ Linear fetch error: Timed out waiting for task state lock
```

— the exact symptom AGT-4068 closed. The measurement:

```
lock mtime         17:12:12.670   ← written by the OUTGOING container at shutdown
container started  17:12:13.231
gap                0.561 s        vs PROCESS_START_JITTER_MS = 1.000 s
```

Everything else was working: the pid space matched and was proof-capable on both sides (`pidns:1c3bda3d-…:pid:[4026533598]` — the namespace inode is stable across recreates, which is worth knowing). Only the margin was wrong, and it was wrong in the one case that exists.

**Why the AGT-4068 verification missed it.** The synthetic lock planted to isolate the fast path was backdated *five minutes*, which sails past a 1s margin. The parameter did not represent the real distribution.

## Shrinking the margin makes it worse

The margin absorbs an imprecise timestamp, and for the lock that timestamp is the file's **mtime**. On a filesystem with one-second granularity a lock this process wrote at `…13.900` reports `…13.000`, before our own start of `…13.231` — and we would reclaim our own live lock. The margin has to be larger than the gap it must resolve, so the timestamp path cannot decide this case at all.

## Decide by identity

A pid is unique among live processes. A record carrying **our pid** whose **owner id is not ours** was written by a process that has exited. No clock, no granularity, no NTP step.

This is not the "a differing id means dead" rule AGT-4068 rejected — that failed because a *live sibling* process also differs. The pid conjunct is what excludes it, and it is load-bearing: dropping it kills two tests.

The worktree marker already recorded `ownerInstanceId` and only needed reading. The task-state lock now records one too. The timestamp comparison remains the fallback for records carrying no owner id — which is every record written before this.

## Mutation evidence — 5 mutations, each verified to fail

| Mutation | Test that dies |
|---|---|
| remove the owner-id path | "proves death from the owner id even when the record is newer than the clock margin" + 1 |
| a matching owner id also counts as gone | "never reclaims our own record, however far back its timestamp reads" |
| drop the pid conjunct | "claims nothing about a pid that is not ours" + "still claims nothing about another live process" |
| lock stops recording `instance` | "records who holds it, so a successor can decide ownership without a clock" |
| (earlier) namespace and fail-closed gates | unchanged from AGT-4068, still covered |

That fourth one initially **survived**: `withStoreLock` removes the lock file in its `finally`, so the writer's output cannot be observed after the fact. Extracted `buildLockPayload` so the tests can see it.

The lock integration tests now use the **production timing** — a record 0.5 s before our start, inside the margin — rather than a comfortably backdated one.

139 tests pass, 6 skipped (the Linux-only pid-space cases, which run in CI). `tsc` clean.

## Gate

Commit gate: **APPROVE** on the first round. Its own vitest run was terminated at the time limit (exit 143); the 139/6 figure above is from running the same suites directly.

## DoD not yet met

The last item needs the next deploy: verified against a **real container recreate**, not a backdated synthetic record — the first heartbeat must fetch with no lock timeout. That is precisely the check AGT-4068 did not do.