### PR TITLE
fix(adapters): let the worker's report reach the reviewer (AGT-4073)

### DIFF
--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -19,6 +19,7 @@ import type { ReviewDecision } from '../agents/agentPair.js';
 import { extractCostFromStreamJson, formatCost } from '../support/costTracker.js';
 import { extractResultFromStreamJson } from '../agents/cliStreamParser.js';
 import { t } from '../locale/index.js';
+import { extractSummary } from './resultParsing.js';
 import { writeClaudeMcpConfig } from './memoryMcp.js';
 
 const execFileAsync = promisify(execFile);
@@ -267,12 +268,6 @@ function extractWorkerFromText(text: string): WorkerResult {
   };
 }
 
-function extractSummary(text: string): string {
-  const lines = text.split('\n').filter((l) => l.trim().length > 10);
-  if (lines.length === 0) return t('common.fallback.noSummary');
-  const summary = lines[0].trim();
-  return summary.length > 200 ? summary.slice(0, 200) + '...' : summary;
-}
 
 function extractErrorMessage(text: string): string {
   const errorMatch = text.match(/(?:error|exception|failed?):\s*(.+)/i);

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -20,7 +20,7 @@ import { AuthProfileStore, ensureValidToken } from '../auth/index.js';
 import { getCodexModelIds } from './codexModels.js';
 import { codexMcpConfigArgs } from './memoryMcp.js';
 import { codexUserMcpDisableArgs } from './codexUserMcp.js';
-import { parseReviewerResult } from './resultParsing.js';
+import { extractSummary, parseReviewerResult } from './resultParsing.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -484,12 +484,6 @@ function isExplicitFailure(text: string): boolean {
   return /\b(failed to|unable to|could not|couldn['’]t|cannot (?:complete|finish|proceed|continue)|giving up|abort(?:ed|ing))\b/i.test(text);
 }
 
-function extractSummary(text: string): string {
-  const lines = text.split('\n').filter((l) => l.trim().length > 10);
-  if (lines.length === 0) return t('common.fallback.noSummary');
-  const summary = lines[0].trim();
-  return summary.length > 200 ? `${summary.slice(0, 200)}...` : summary;
-}
 
 function extractErrorMessage(text: string): string {
   const errorMatch = text.match(/(?:error|exception|failed?):\s*(.+)/i);

--- a/src/adapters/resultParsing.test.ts
+++ b/src/adapters/resultParsing.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseReviewerResult, parseWorkerResult } from './resultParsing.js';
+import { t } from '../locale/index.js';
 
 const wrap = (obj: unknown) => '```json\n' + JSON.stringify(obj) + '\n```';
 
@@ -192,5 +193,62 @@ describe('agent codename passthrough (AGT-4019)', () => {
   it('leaves codename unset when the agent did not introduce itself', () => {
     const parsed = parseWorkerResult('```json\n{"success":true,"summary":"did it","noChangesReason":"n/a"}\n```');
     expect(parsed.codename).toBeUndefined();
+  });
+});
+
+describe("the worker's report survives extraction (AGT-4073)", () => {
+  // The worker prompt asks for a plain-text report whose FIRST line is the
+  // agent's `Codename:` introduction, and for no JSON on the success path — so
+  // this is the shape the text fallback actually receives in production.
+  const promptShapedReport = [
+    'Codename: Atlas',
+    'Wired a low-confidence filter into renderA2() so it is excluded from the daily figure.',
+    'Verified with 32 targeted Node tests; the two-week backfill is still unverified.',
+    'Reviewer: start at src/a2/render.ts:118.',
+  ].join('\n');
+
+  it('summarises the report body, not the codename line', () => {
+    const parsed = parseWorkerResult(promptShapedReport);
+    expect(parsed.summary).not.toMatch(/Codename/i);
+    expect(parsed.summary).toContain('Wired a low-confidence filter');
+  });
+
+  it('carries later lines a single-line summary would have dropped', () => {
+    // What the worker could not verify sits on the SECOND line; taking only the
+    // first line lost it. The third line ("start at …") does not fit under the
+    // 200-character cap, which is unchanged by this fix and bounds how much of
+    // any report reaches the reviewer.
+    const parsed = parseWorkerResult(promptShapedReport);
+    expect(parsed.summary).toContain('still unverified');
+  });
+
+  it('leaves a report with no codename line exactly as before', () => {
+    const parsed = parseWorkerResult('Rewrote the retry policy so a 429 backs off.');
+    expect(parsed.summary).toBe('Rewrote the retry policy so a 429 backs off.');
+  });
+
+  it('stops at a whole line rather than joining past the cap and cutting mid-word', () => {
+    // Joining everything and truncating afterwards would also respect the cap,
+    // so length alone does not discriminate. The property that does: a report
+    // whose individual lines fit is never cut mid-word, so it carries no
+    // ellipsis — the summary ends where a line ended.
+    const long = ['Codename: Atlas', ...Array.from({ length: 12 }, (_, i) => `Sentence number ${i} about the change.`)].join('\n');
+    const parsed = parseWorkerResult(long);
+    expect(parsed.summary.length).toBeLessThanOrEqual(200);
+    expect(parsed.summary.endsWith('...')).toBe(false);
+    expect(parsed.summary.endsWith('.')).toBe(true);
+  });
+
+  it('truncates a single over-long line rather than returning it whole', () => {
+    const parsed = parseWorkerResult('x'.repeat(400));
+    expect(parsed.summary).toHaveLength(203);
+    expect(parsed.summary.endsWith('...')).toBe(true);
+  });
+
+  it('falls back to the no-summary placeholder when only a codename was said', () => {
+    // Nothing but the introduction: there is genuinely no report to carry, and
+    // the board's own normaliser turns this into the timing line.
+    const parsed = parseWorkerResult('Codename: Atlas');
+    expect(parsed.summary).toBe(t('common.fallback.noSummary'));
   });
 });

--- a/src/adapters/resultParsing.ts
+++ b/src/adapters/resultParsing.ts
@@ -190,11 +190,37 @@ function isExplicitFailure(text: string): boolean {
   return /\b(failed to|unable to|could not|couldn['’]t|cannot (?:complete|finish|proceed|continue)|giving up|abort(?:ed|ing))\b/i.test(text);
 }
 
-function extractSummary(text: string): string {
-  const lines = text.split('\n').filter((l) => l.trim().length > 10);
+/** The self-introduction line the worker prompt mandates, not part of the report. */
+const CODENAME_LINE = /^\s*Codename:/i;
+const SUMMARY_MAX_CHARS = 200;
+
+/**
+ * The agent's own words, recovered from a plain-text answer.
+ *
+ * Two rules, both learned from what the worker prompt actually asks for
+ * (`locale/prompts/*.ts`: report in short plain text, first line
+ * `Codename: <name>`, no JSON on the success path):
+ *
+ * - **Codename lines are skipped.** Taking the literal first line handed the
+ *   reviewer `- **Summary:** Codename: Atlas` and threw the report away, so the
+ *   worker had no channel to the reviewer at all (AGT-4073).
+ * - **Content is joined up to the cap**, not cut at the first line. A report
+ *   states what was done, what could not be verified, and where to look; one
+ *   line keeps only the first of those. The 200-character bound is unchanged,
+ *   so this carries more of the answer without carrying more text.
+ */
+export function extractSummary(text: string): string {
+  const lines = text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 10 && !CODENAME_LINE.test(line));
   if (lines.length === 0) return t('common.fallback.noSummary');
-  const summary = lines[0].trim();
-  return summary.length > 200 ? `${summary.slice(0, 200)}...` : summary;
+  let summary = lines[0];
+  for (const line of lines.slice(1)) {
+    if (summary.length + 1 + line.length > SUMMARY_MAX_CHARS) break;
+    summary = `${summary} ${line}`;
+  }
+  return summary.length > SUMMARY_MAX_CHARS ? `${summary.slice(0, SUMMARY_MAX_CHARS)}...` : summary;
 }
 
 function extractErrorMessage(text: string): string {
@@ -290,9 +316,9 @@ const DECISION_PHRASE =
  *
  * The two parse paths need different evidence. A JSON verdict carries its findings
  * in dedicated fields, so those are authoritative. The text fallback does not: its
- * `feedback` comes from extractSummary, which quotes the first substantial line —
- * usually the "Decision: revise" line itself — so a populated feedback field there
- * proves nothing. For that path the question is whether the message holds anything
+ * `feedback` comes from extractSummary, which quotes the substantial lines up to a
+ * length cap — usually starting with the "Decision: revise" line itself — so a
+ * populated feedback field there proves nothing. For that path the question is whether the message holds anything
  * once the control tokens and the verdict declaration are removed.
  *
  * Residual prose only counts when the reviewer actually DECLARED a verdict. Without


### PR DESCRIPTION
## The defect

The worker prompt (`src/locale/prompts/{ko,en}.ts:230-233`) asks for a plain-text
report whose **first line** is the agent's `Codename:` introduction, and says no
JSON is needed on the success path. `extractSummary()` kept only `lines[0]`, so:

- `src/agents/reviewer.ts:215-219` built the reviewer prompt's
  `- **Summary:** Codename: Atlas` — the worker's words never reached the reviewer.
- `src/agents/pipelineCoordination.ts:158-162` stripped the codename, got an empty
  string, and the coordination board fell back to `Finished in 148.8s`.

## Measured on the deployed daemon (6 h of `coordination_trace`)

| role | timing fallback | real speech |
|---|---|---|
| reviewer | 2/9 (22 %) | **78 %** |
| worker | 38/61 (62 %) | 38 % |

Reviewers post substantive `[revise]` critiques; workers answered with a duration.
That asymmetry was a missing channel, not a difference in model output.

## Proven by running the parser, not by reading it

Feeding `parseWorkerResult()` exactly the shape the prompt asks for:

```
before: summary = "Codename: Atlas"          → board: timing fallback
after:  summary = "Wired a low-confidence filter into renderA2() … still unverified."
```

## The change

- Skip `Codename:` lines before choosing the summary.
- Join whole lines up to the **existing** 200-character bound, so a report's later
  sentences (what could not be verified, where to look) survive. The bound is
  unchanged — this is not a widening.
- `extractSummary` existed byte-for-byte in `resultParsing.ts`, `codex.ts` and
  `claude.ts`; it now lives once and the other two import it.

## Verification

- 31 tests in `resultParsing.test.ts` pass; 6 are new.
- Three mutations verified to fail a test: removing the codename filter, removing
  the line join, and removing the cap boundary. The cap test was rewritten after
  the first version failed to discriminate — length alone passes either way, so it
  now asserts the summary ends at a whole line rather than mid-word.
- Downstream consumers re-run green: `worker.test.ts`, `reviewer.test.ts`,
  `linear/format.test.ts`, `documenter.test.ts`, `codex.test.ts`, `claude.test.ts`
  (183 tests).

## Known limit, deliberately not changed here

An English three-line report needs ~240 characters, so the 200-character cap still
drops its last line. The cap is pre-existing and applied equally before this fix;
sizing a new one needs evidence about real report lengths, which is not collected
anywhere today. Recorded on AGT-4073 rather than widened unreviewed.

Closes AGT-4073.