### PR TITLE
fix(coordination): page the operator with the issue, not a worktree id (AGT-4074)

### DIFF
--- a/src/coordination/coordinationTools.ts
+++ b/src/coordination/coordinationTools.ts
@@ -227,6 +227,7 @@ export async function executeCoordinationTool(
     const posted = await postHumanQuestion({
       repository: context.repository,
       taskId: context.taskId,
+      taskLabel: context.taskLabel,
       actor: context.actor,
       actorName: context.actorName,
       actorRole: context.actorRole,

--- a/src/coordination/humanQuestions.test.ts
+++ b/src/coordination/humanQuestions.test.ts
@@ -296,3 +296,66 @@ describe('human questions', () => {
       .filter((event) => event.kind === 'human-question')).toHaveLength(1);
   });
 });
+
+describe('the operator is told which issue is asking (AGT-4074)', () => {
+  it('names the issue identifier in the page, not the worktree id', async () => {
+    const h = await modules();
+    const notify = vi.fn(async () => true);
+    await h.postHumanQuestion({
+      repository: '/repo',
+      taskId: 'f8c57098-cbf6-4beb-9e0f-20595d60c7c7',
+      taskLabel: 'AX-867',
+      actor: 'pylon-dev', actorName: 'pylon_dev', actorRole: 'worker',
+      question: 'Which DSN?', notify,
+    });
+    const page = notify.mock.calls[0][0] as string;
+    expect(page).toContain('AX-867');
+    expect(page).not.toContain('f8c57098');
+  });
+
+  it('falls back to the task id when no label is known', async () => {
+    const h = await modules();
+    const notify = vi.fn(async () => true);
+    await h.postHumanQuestion({
+      repository: '/repo', taskId: 'unlabelled-task',
+      actor: 'pylon-dev', question: 'Which DSN?', notify,
+    });
+    expect(notify.mock.calls[0][0]).toContain('unlabelled-task');
+  });
+
+  it('labels the question, the page marker and the answer', async () => {
+    const h = await modules();
+    const store = await import('./coordinationStore.js');
+    const posted = await h.postHumanQuestion({
+      repository: '/repo', taskId: 'wt-uuid', taskLabel: 'AX-867',
+      actor: 'pylon-dev', actorName: 'pylon_dev', actorRole: 'worker',
+      question: 'Which DSN?', notify: async () => true,
+    });
+    await h.answerHumanQuestion(posted.correlationId, 'Use the staging DSN', 'discord:user');
+    const events = store.getCoordinationStore().exchange(posted.correlationId);
+    expect(events.length).toBeGreaterThanOrEqual(3);
+    for (const event of events) expect(event.taskLabel).toBe('AX-867');
+  });
+
+  it('attributes the page marker to the asking agent, not the daemon', async () => {
+    // The board's pending set is the latest event per correlation id, and this
+    // marker lands after the question — so publishing it as the daemon made
+    // every "who is waiting on the operator" readout name the daemon.
+    const h = await modules();
+    const store = await import('./coordinationStore.js');
+    const posted = await h.postHumanQuestion({
+      repository: '/repo', taskId: 'wt-uuid', taskLabel: 'AX-867',
+      actor: 'pylon-dev', actorName: 'pylon_dev', actorRole: 'worker',
+      question: 'Which DSN?', notify: async () => true,
+    });
+    const events = store.getCoordinationStore().exchange(posted.correlationId);
+    const latest = events.reduce((a, b) => (b.seq > a.seq ? b : a));
+    expect(latest.summary).toBe('Operator paged on Discord');
+    expect(latest.actor).toBe('pylon-dev');
+    expect(latest.actorName).toBe('pylon_dev');
+    // It must stay a pending human-question: another kind drops the exchange out
+    // of pendingQuestions, and a terminal status drops it out of pending entirely.
+    expect(latest.kind).toBe('human-question');
+    expect(latest.status).toBe('running');
+  });
+});

--- a/src/coordination/humanQuestions.ts
+++ b/src/coordination/humanQuestions.ts
@@ -16,6 +16,12 @@ import { answerHint } from './answerHint.js';
 export interface HumanQuestionInput {
   repository: string;
   taskId: string;
+  /**
+   * The issue identifier this question belongs to (AX-867), used to address the
+   * operator and to attribute the board event. `taskId` is a worktree UUID, so
+   * without this the page reads "a decision for f8c57098-cbf6-…" (AGT-4074).
+   */
+  taskLabel?: string;
   /** Board address of the agent asking, so the answer can be routed back. */
   actor: string;
   actorName?: string;
@@ -96,6 +102,7 @@ export async function postHumanQuestion(input: HumanQuestionInput): Promise<Huma
     await store.publish({
       repository: input.repository,
       taskId: input.taskId,
+      taskLabel: input.taskLabel,
       actor: input.actor,
       actorName: input.actorName,
       actorRole: input.actorRole,
@@ -145,16 +152,29 @@ export async function postHumanQuestion(input: HumanQuestionInput): Promise<Huma
 
   const notify = input.notify ?? notifyOperatorViaDiscord;
   const delivered = await notify(
-    `OpenSwarm needs a decision for ${input.taskId}` +
+    `OpenSwarm needs a decision for ${input.taskLabel ?? input.taskId}` +
       `${input.actorName ? ` (asked by ${input.actorName})` : ''}.\n${input.question}\n\n` +
       answerHint(correlationId),
   );
   if (delivered) {
+    // Published under the ASKING agent, not the daemon. The board's pending set
+    // is the latest event per correlation id
+    // (`web/static/js/orchestrationModel.mjs:129-133`), and this marker shares
+    // the question's id and lands after it — so it was the latest event for 48
+    // of 69 pending exchanges on the live board, and every "who is waiting on
+    // the operator" readout named the daemon instead of the parked worker.
+    //
+    // It stays a pending `human-question` on purpose: moving it to another kind
+    // would drop those exchanges out of `pendingQuestions`, and marking it
+    // terminal would drop them out of the pending set altogether. The note is
+    // about this agent's question, so the agent is the right speaker (AGT-4074).
     await store.publish({
       repository: input.repository,
       taskId: input.taskId,
-      actor: 'openswarm-daemon',
-      actorName: 'OpenSwarm daemon',
+      taskLabel: input.taskLabel,
+      actor: input.actor,
+      actorName: input.actorName,
+      actorRole: input.actorRole,
       recipient: 'human',
       kind: 'human-question',
       status: 'running',
@@ -186,6 +206,7 @@ export async function answerHumanQuestion(
   const event = await store.publish({
     repository: question.repository,
     taskId: question.taskId,
+    taskLabel: question.taskLabel,
     actor,
     actorRole: 'human',
     recipient: question.actor,
@@ -218,6 +239,7 @@ export async function answerHumanQuestion(
     await store.publish({
       repository: question.repository,
       taskId: question.taskId,
+      taskLabel: sibling.taskLabel,
       actor,
       actorRole: 'human',
       recipient: sibling.actor,


### PR DESCRIPTION
## The defect

`src/coordination/coordinationTools.ts:209` already forwards `context.taskLabel` for
`coordination_publish`. The `ask_human` branch below it did not.

## Measured on the deployed daemon (24 h of `coordination_trace`)

```
task_label null rate by kind
  delegation-request     0/281
  delegation-result      0/280
  instruction-snapshot   0/179
  human-question     131/131     <-- 100 %
  human-answer         23/23     <-- 100 %
```

So the page the operator actually received was built from the worktree UUID:

```
OpenSwarm needs a decision for f8c57098-cbf6-4beb-9e0f-20595d60c7c7
```

## Second defect in the same path: the page marker spoke as the daemon

`web/static/js/orchestrationModel.mjs:129-133` derives the pending set from the
**latest event per correlation id**. The `Operator paged on Discord` marker shares the
question's correlation id and is published after it, so it wins. On the live board:

```
pending human-question exchanges whose latest event is the marker: 48
pending human-question exchanges whose latest event is the question: 21

seq=225 human-question waiting  Archmagos Ultor-Tertius  NAS Docker·운영 PostgreSQL…
seq=226 human-question running  OpenSwarm daemon         Operator paged on Discord
```

`agentsAwaitingOperator`, `owner.pendingCount` and `conversationModel`'s `replyTo`
therefore named the daemon for 48 of 69 open questions, and the actually-parked
workers were invisible.

## The change

- `HumanQuestionInput` carries `taskLabel`; `ask_human` forwards it; the question, the
  page marker and both answer paths stamp it.
- The operator is addressed by `taskLabel ?? taskId`, so a caller with no label is
  unchanged.
- The page marker is published under the **asking agent's** identity.

### Why the marker stays a `human-question`

My own issue text first proposed giving it a distinct kind. Measuring the UI model
showed that is wrong: another kind drops those exchanges out of `pendingQuestions`
(69 → 21), and a terminal status drops them out of the pending set entirely, showing
no open questions at all. AGT-4074's approach and DoD were amended rather than left
implying the original plan.

## Verification

- 16 tests in `humanQuestions.test.ts` pass; 4 are new.
- Three mutations each fail exactly one test: reverting the page to `taskId`,
  reverting the marker's speaker to the daemon, and dropping the label stamp.
- The existing once-per-question paging tests still pass — `alreadyPaged` matches on
  kind and status, which are unchanged.
- `coordinationTools`, `coordinationStore`, `coordinationRoutes`, `orchestratorAgent`
  re-run green (51 tests).

Closes AGT-4074.