### PR TITLE
fix(runner): publish a parked run's committed work as a draft PR (AGT-4076)

### DIFF
--- a/src/automation/durableRunCoordinator.test.ts
+++ b/src/automation/durableRunCoordinator.test.ts
@@ -303,6 +303,31 @@ describe('DurableRunCoordinator', () => {
     coordinator.close();
   });
 
+  it('a parked result carrying a prUrl stops being a park (AGT-4076 guard)', async () => {
+    // Why the parked-publish path in runnerExecution attaches the PR to the
+    // LEDGER but never writes `result.prUrl`. `publishedNeedsReconcile` treats
+    // any prUrl on a non-approved result as publication debt, so setting it
+    // would turn an operator park — which frees the repository admission slot
+    // and resumes on the answer — into a NEEDS_RECONCILE row that holds one.
+    // If this classification ever changes, the comment in runnerExecution.ts
+    // is stale and this test is where that shows up.
+    const coordinator = new DurableRunCoordinator({
+      mode: 'primary', dbPath: dbPath(), instanceId: 'park-with-pr',
+    });
+
+    await coordinator.execute(task('AGT-PARK-PR'), '/repo', async () => ({
+      ...result(false),
+      finalStatus: 'waiting_on_operator',
+      prUrl: 'https://github.com/o/r/pull/1',
+    }));
+
+    expect(coordinator.getRun('AGT-PARK-PR')).toMatchObject({
+      state: 'NEEDS_RECONCILE',
+      lastErrorCode: 'publication_reconcile',
+    });
+    coordinator.close();
+  });
+
   it('reconciles a published PR before any retry when publication attachment throws', async () => {
     const path = dbPath();
     const ledger = new RunLedger(path);

--- a/src/automation/publishOnPark.test.ts
+++ b/src/automation/publishOnPark.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { shouldPublishParkedWork } from './publishOnPark.js';
+
+describe('shouldPublishParkedWork (AGT-4076)', () => {
+  it('publishes when a run parks for the operator with a worktree', () => {
+    expect(shouldPublishParkedWork(true, { finalStatus: 'waiting_on_operator' })).toBe(true);
+  });
+
+  it('does not publish an approved run — the normal path already does', () => {
+    // Publishing here too would open a second PR for the same branch.
+    expect(shouldPublishParkedWork(true, { finalStatus: 'approved' })).toBe(false);
+  });
+
+  it('does not publish a failed run', () => {
+    expect(shouldPublishParkedWork(true, { finalStatus: 'failed' })).toBe(false);
+  });
+
+  it('does not publish a superseded run — admission was refused, so nothing ran', () => {
+    expect(shouldPublishParkedWork(true, { finalStatus: 'superseded' })).toBe(false);
+  });
+
+  it('does not publish twice when a PR already exists', () => {
+    expect(shouldPublishParkedWork(true, {
+      finalStatus: 'waiting_on_operator', prUrl: 'https://github.com/o/r/pull/1',
+    })).toBe(false);
+  });
+
+  it('does not publish without a worktree — there is nothing to publish from', () => {
+    expect(shouldPublishParkedWork(false, { finalStatus: 'waiting_on_operator' })).toBe(false);
+  });
+});

--- a/src/automation/publishOnPark.ts
+++ b/src/automation/publishOnPark.ts
@@ -1,0 +1,182 @@
+// ============================================
+// OpenSwarm — publishing a finished run's branch (AGT-4076)
+// ============================================
+//
+// Both publication paths a worktree-mode run can take, kept together because
+// they share `commitAndCreatePR` and differ only in what the run earned:
+//
+// - `publishApprovedWork` — the reviewed path. A publication failure is fatal:
+//   a run is not deliverable until its branch is reviewable.
+// - `publishParkedWork` — a run that stopped for an operator decision. Draft,
+//   committed work only, and a failure never changes the park.
+//
+// Split out of runnerExecution.ts, which sits on the 1500-line pre-commit cap.
+
+import { broadcastEvent } from '../core/eventHub.js';
+import { commitAndCreatePR, type WorktreeInfo } from '../support/worktreeManager.js';
+import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
+
+/** The fields these paths read; narrower than the full pipeline result. */
+interface PublishableResult {
+  success?: boolean;
+  finalStatus?: string;
+  prUrl?: string;
+}
+
+/** The fields these paths read off the task. */
+interface PublishableTask {
+  /** Required: the broadcast events key on `issueId || id`. */
+  id: string;
+  issueId?: string;
+  title: string;
+  description?: string;
+  issueIdentifier?: string;
+}
+
+/**
+ * Should a finished run publish the work it already committed?
+ *
+ * True only when it parked for the operator with a worktree and nothing
+ * published yet. Pure so the decision is testable without the runner's
+ * singletons and timers.
+ */
+export function shouldPublishParkedWork(
+  hasWorktree: boolean,
+  result: PublishableResult,
+): boolean {
+  return hasWorktree && result.finalStatus === 'waiting_on_operator' && !result.prUrl;
+}
+
+/**
+ * Publish the branch of a run that stopped for an operator decision.
+ *
+ * Otherwise the commits sit on a branch that was never pushed: measured on the
+ * deployed daemon, 23 commits across six branches with no PR, while the
+ * operator was being asked 70 questions about work they could not see. (The
+ * operator's own framing: "supersded할거면 PR은 올리고 가라".)
+ *
+ * Called from the runner rather than from a later sweep. Three commit-gate
+ * rounds rejected a sweep for the same reason: a parked run can be resumed and
+ * claimed while an out-of-band publish is in flight, and if that publish opened
+ * a PR first, the eventual reviewed publication would silently reuse it and
+ * ship approved work as a draft. Here the executor still owns the claim, the
+ * lease and the worktree, so there is nothing to race.
+ */
+export async function publishParkedWork(
+  worktreeInfo: WorktreeInfo,
+  task: PublishableTask,
+  durability: ExecutionDurabilityHooks | undefined,
+): Promise<void> {
+  // The same lease fence the approved path uses. Without it an executor that
+  // already lost its claim — expired lease, a newer generation now owning the
+  // run — could still push the branch and open a PR for work it no longer
+  // speaks for. A refused fence is not an error: the run parks either way.
+  const publishAllowed = await durability?.beforePublish() ?? true;
+  if (!publishAllowed) {
+    console.warn(`[Runner] Parked publication fenced for ${task.issueIdentifier}; leaving the branch unpublished`);
+    return;
+  }
+  try {
+    const prUrl = await commitAndCreatePR(
+      worktreeInfo,
+      task.title,
+      task.issueIdentifier || '',
+      'Published because this run parked for an operator decision, so the work is'
+        + ' visible instead of sitting on an unpushed branch. It has not been'
+        + ' reviewed — this PR is a draft on purpose.',
+      // Draft, and committed work only: nothing reviewed this, and the tree
+      // must stay exactly as the worker left it so the resume continues.
+      { draft: true, committedOnly: true },
+    );
+    // The ledger records the PR; the pipeline result deliberately does NOT.
+    //
+    // `durableRunCoordinator.execute()` classifies any result carrying a prUrl
+    // that is not an approved success as `publication_reconcile` and parks it
+    // in NEEDS_RECONCILE. Setting it here would convert an operator park —
+    // which frees the repository admission slot and resumes on the answer —
+    // into a reconcile row that holds a slot until a sweep releases it. That is
+    // the phantom-row shape that idled the whole loop on 2026-08-29.
+    const attached = await durability?.onPublication(prUrl) ?? true;
+    if (attached) {
+      console.log(`[Runner] Parked run published as draft for ${task.issueIdentifier}: ${prUrl}`);
+    } else {
+      console.warn(`[Runner] Parked publication for ${task.issueIdentifier} was not durably attached (lease fence); the PR exists at ${prUrl} and will be reused by branch name`);
+    }
+  } catch (err) {
+    // "No commits to create PR from" is the common, correct outcome — the run
+    // parked before committing anything. Nothing here may change the park: the
+    // operator still has to answer either way.
+    const detail = err instanceof Error ? err.message : String(err);
+    if (!/No commits to create PR from/.test(detail)) {
+      console.warn(`[Runner] Could not publish parked work for ${task.issueIdentifier}: ${detail}`);
+    }
+  }
+}
+
+/**
+ * Publish the branch of a run that passed review.
+ *
+ * A publication failure is fatal here, unlike the parked path: a worktree-mode
+ * run is not deliverable until its branch is remotely reviewable, so the result
+ * is turned back into a retryable `infra_error` with the worktree preserved.
+ */
+export async function publishApprovedWork(
+  worktreeInfo: WorktreeInfo | null | undefined,
+  task: PublishableTask,
+  result: PublishableResult & { success?: boolean; finalStatus?: string; prUrl?: string },
+  durability: ExecutionDurabilityHooks | undefined,
+): Promise<void> {
+  // Create PR (worktree mode + pipeline success = finalStatus 'approved')
+  if (worktreeInfo && result.success && result.finalStatus === 'approved') {
+    const publishAllowed = await durability?.beforePublish() ?? true;
+    if (!publishAllowed) {
+      result.success = false;
+      result.finalStatus = 'infra_error';
+      console.warn(`[Worktree] Publication fenced for ${task.issueIdentifier}; preserving worktree`);
+    } else {
+      try {
+        const prUrl = await commitAndCreatePR(
+          worktreeInfo,
+          task.title,
+          task.issueIdentifier || '',
+          task.description || '',
+        );
+        result.prUrl = prUrl;
+        const publicationRecorded = await durability?.onPublication(prUrl) ?? true;
+        if (!publicationRecorded) {
+          throw new Error('Durable lease fence rejected publication attachment');
+        }
+        broadcastEvent({
+          type: 'log',
+          data: {
+            taskId: task.issueId || task.id,
+            stage: 'pr',
+            line: `PR created: ${prUrl}`,
+          },
+        });
+        console.log(`[Runner] PR created for ${task.issueIdentifier}: ${prUrl}`);
+      } catch (err) {
+        console.error('[Worktree] PR creation failed:', err);
+        // A worktree-mode run is not deliverable until the branch is published.
+        // Keep it retryable and preserved instead of marking the issue Done with
+        // no remotely reviewable artifact.
+        result.success = false;
+        result.finalStatus = 'infra_error';
+        broadcastEvent({
+          type: 'log',
+          data: {
+            taskId: task.issueId || task.id,
+            stage: 'pr',
+            line: `PR creation failed: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        });
+      }
+    }
+  } else if (worktreeInfo) {
+    // Log why PR was not created
+    const reason = !result.success
+      ? `Pipeline failed (${result.finalStatus})`
+      : `Unexpected state (success=${result.success}, finalStatus=${result.finalStatus})`;
+    console.log(`[Runner] PR not created for ${task.issueIdentifier}: ${reason}`);
+  }
+}

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -29,7 +29,6 @@ import type { ITaskSource } from './taskSource.js';
 import {
   buildBranchName,
   createWorktree,
-  commitAndCreatePR,
   hasRecoverableWorktree,
   preserveWorktree,
   removeWorktree,
@@ -37,6 +36,7 @@ import {
 } from '../support/worktreeManager.js';
 import type { WorktreeInfo } from '../support/worktreeManager.js';
 import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
+import { publishApprovedWork, publishParkedWork, shouldPublishParkedWork } from './publishOnPark.js';
 import { loadRepoMetadata } from '../support/repoMetadata.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
 import { applyDraftGates, projectDraftPeers } from './draftGrooming.js';
@@ -1154,59 +1154,11 @@ export async function executePipeline(
       result.finalStatus = 'infra_error';
     }
 
-    // Create PR (worktree mode + pipeline success = finalStatus 'approved')
-    if (worktreeInfo && result.success && result.finalStatus === 'approved') {
-      const publishAllowed = await ctx.durability?.beforePublish() ?? true;
-      if (!publishAllowed) {
-        result.success = false;
-        result.finalStatus = 'infra_error';
-        console.warn(`[Worktree] Publication fenced for ${task.issueIdentifier}; preserving worktree`);
-      } else {
-        try {
-          const prUrl = await commitAndCreatePR(
-            worktreeInfo,
-            task.title,
-            task.issueIdentifier || '',
-            task.description || '',
-          );
-          result.prUrl = prUrl;
-          const publicationRecorded = await ctx.durability?.onPublication(prUrl) ?? true;
-          if (!publicationRecorded) {
-            throw new Error('Durable lease fence rejected publication attachment');
-          }
-          broadcastEvent({
-            type: 'log',
-            data: {
-              taskId: task.issueId || task.id,
-              stage: 'pr',
-              line: `PR created: ${prUrl}`,
-            },
-          });
-          console.log(`[Runner] PR created for ${task.issueIdentifier}: ${prUrl}`);
-        } catch (err) {
-          console.error('[Worktree] PR creation failed:', err);
-          // A worktree-mode run is not deliverable until the branch is published.
-          // Keep it retryable and preserved instead of marking the issue Done with
-          // no remotely reviewable artifact.
-          result.success = false;
-          result.finalStatus = 'infra_error';
-          broadcastEvent({
-            type: 'log',
-            data: {
-              taskId: task.issueId || task.id,
-              stage: 'pr',
-              line: `PR creation failed: ${err instanceof Error ? err.message : String(err)}`,
-            },
-          });
-        }
-      }
-    } else if (worktreeInfo) {
-      // Log why PR was not created
-      const reason = !result.success
-        ? `Pipeline failed (${result.finalStatus})`
-        : `Unexpected state (success=${result.success}, finalStatus=${result.finalStatus})`;
-      console.log(`[Runner] PR not created for ${task.issueIdentifier}: ${reason}`);
+    if (shouldPublishParkedWork(Boolean(worktreeInfo), result) && worktreeInfo) {
+      await publishParkedWork(worktreeInfo, task, ctx.durability);
     }
+
+    await publishApprovedWork(worktreeInfo, task, result, ctx.durability);
 
     keepWorktree = !(result.success && result.finalStatus === 'approved');
     return result;

--- a/src/support/pullRequestReady.ts
+++ b/src/support/pullRequestReady.ts
@@ -1,0 +1,67 @@
+// ============================================
+// OpenSwarm — taking a reused PR out of draft (AGT-4076)
+// ============================================
+//
+// Split out of worktreeManager.ts, which sits on the 1500-line pre-commit cap.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const GH_TIMEOUT_MS = 60_000;
+
+/** `gh` always runs with an explicit cwd — see the note on worktreeManager's own
+ * helper: a `gh` call without one dies with "fatal: not a git repository" and
+ * strands finished work on a pushed branch with no PR. (INT-2321) */
+async function gh(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('gh', args, { cwd, timeout: GH_TIMEOUT_MS });
+  return stdout;
+}
+
+/**
+ * Take a PR out of draft.
+ *
+ * A run that parks for the operator opens its PR as a draft, because nothing
+ * has reviewed it. When that same branch later passes review,
+ * `commitAndCreatePR` finds the existing PR and returns it instead of opening a
+ * second one — so without this the approved work would ship still marked draft,
+ * and nobody would be asked to review it.
+ *
+ * Throws on failure rather than warning: the approved caller treats a
+ * publication failure as retryable `infra_error`, which is the right outcome
+ * for "the PR exists but is not actually open for review".
+ */
+async function markPullRequestReady(worktreePath: string, prUrl: string): Promise<void> {
+  const raw = await gh(worktreePath, 'pr', 'view', prUrl, '--json', 'isDraft', '--jq', '.isDraft');
+  // `gh pr ready` fails on a PR that is already open for review, and that
+  // failure would mark a run that actually succeeded as broken.
+  if (raw.trim() !== 'true') return;
+  await gh(worktreePath, 'pr', 'ready', prUrl);
+  console.log(`[Worktree] Promoted draft PR to ready for review: ${prUrl}`);
+}
+
+/**
+ * Take a reused PR out of draft when nothing else justifies the draft.
+ *
+ * Two paths reuse an existing PR instead of creating one — the early return
+ * when `pr list` already finds it, and the create-race fallback — and both must
+ * apply the same rule, or reviewed work stays hidden as a draft on whichever
+ * one was missed.
+ *
+ * `draft` is not the only reason a PR is one: a PR is also opened draft when
+ * another branch already closes the same issue (INT-2544), deliberately, so a
+ * duplicate implementation cannot masquerade as the sole one. The caller passes
+ * that count so the safeguard survives.
+ */
+export async function readyReusedPullRequest(
+  worktreePath: string,
+  prUrl: string,
+  issueIdentifier: string,
+  duplicateCount: number,
+): Promise<void> {
+  if (duplicateCount > 0) {
+    console.log(`[Worktree] Leaving ${prUrl} as a draft: ${duplicateCount} other PR(s) also close ${issueIdentifier}`);
+    return;
+  }
+  await markPullRequestReady(worktreePath, prUrl);
+}

--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -554,6 +554,210 @@ describe('resolveBaseRef / createWorktree on non-main-default repos (INT-2545)',
     git(repo, 'worktree', 'remove', '--force', info.worktreePath);
   });
 
+  it('committedOnly publishes committed work and leaves the working tree untouched (AGT-4076)', async () => {
+    // The shape a parked run is in: one commit made, and dirty files the worker
+    // was still holding when it stopped for the operator. The commit must ship;
+    // the dirty files must stay dirty so the resume continues from the same place.
+    const repo = makeRepo('parkrepo', 'main', 'origin');
+    const bare = join(root, 'parkrepo.git');
+    const info = await createWorktree(repo, 'INT-76', 'swarm/INT-76-park');
+    writeFileSync(join(info.worktreePath, 'done.py'), 'finished work\n');
+    git(info.worktreePath, 'add', 'done.py');
+    git(info.worktreePath, 'commit', '-m', 'feat: finished part');
+    writeFileSync(join(info.worktreePath, 'wip.py'), 'half-written\n');
+
+    const bin = join(root, 'bin-park');
+    mkdirSync(bin, { recursive: true });
+    const ghLog = join(root, 'gh-park.log');
+    writeFileSync(join(bin, 'gh'),
+      `#!/bin/sh\nprintf '%s\\n' "$*" >> "${ghLog}"\ncase "$*" in *"pr create"*) echo "https://example.test/park";; esac\n`);
+    chmodSync(join(bin, 'gh'), 0o755);
+
+    const prevPath = process.env.PATH;
+    process.env.PATH = `${bin}:${prevPath}`;
+    try {
+      const url = await commitAndCreatePR(info, 'parked', 'INT-76', 'desc', { draft: true, committedOnly: true });
+      expect(url).toBe('https://example.test/park');
+    } finally {
+      process.env.PATH = prevPath;
+    }
+
+    // The committed work reached the remote.
+    expect(execFileSync('git', ['-C', bare, 'branch', '--list', 'swarm/INT-76-park'], { encoding: 'utf8' }))
+      .toContain('swarm/INT-76-park');
+    // The dirty file was NOT committed — it is still an untracked change.
+    expect(String(git(info.worktreePath, 'status', '--porcelain'))).toContain('wip.py');
+    expect(String(git(info.worktreePath, 'log', '--oneline', '-1'))).toContain('finished part');
+    // Draft, because nothing reviewed this.
+    expect(readFileSync(ghLog, 'utf8')).toContain('--draft');
+  });
+
+  it('promotes a reused draft PR to ready when the reviewed path republishes (AGT-4076)', async () => {
+    // The exact sequence the fifth gate round flagged: a parked run opens a
+    // draft, the branch later passes review, and commitAndCreatePR reuses the
+    // existing PR. Without promotion the approved work ships as a draft.
+    const repo = makeRepo('promoterepo', 'main', 'origin');
+    const info = await createWorktree(repo, 'INT-77', 'swarm/INT-77-promote');
+    writeFileSync(join(info.worktreePath, 'done.py'), 'work\n');
+    git(info.worktreePath, 'add', 'done.py');
+    git(info.worktreePath, 'commit', '-m', 'feat: done');
+
+    const bin = join(root, 'bin-promote');
+    mkdirSync(bin, { recursive: true });
+    const ghLog = join(root, 'gh-promote.log');
+    // `pr list` reports an existing PR; `pr view --json isDraft` says it is one.
+    writeFileSync(join(bin, 'gh'),
+      `#!/bin/sh\nprintf '%s\\n' "$*" >> "${ghLog}"\n`
+      + `case "$*" in\n`
+      + `  *"pr list"*) echo "https://example.test/pull/5";;\n`
+      + `  *"isDraft"*) echo "true";;\n`
+      + `esac\n`);
+    chmodSync(join(bin, 'gh'), 0o755);
+
+    const prevPath = process.env.PATH;
+    process.env.PATH = `${bin}:${prevPath}`;
+    try {
+      const url = await commitAndCreatePR(info, 'reviewed', 'INT-77', 'desc');
+      expect(url).toBe('https://example.test/pull/5');
+    } finally {
+      process.env.PATH = prevPath;
+    }
+    expect(readFileSync(ghLog, 'utf8')).toContain('pr ready https://example.test/pull/5');
+  });
+
+  it('promotes the PR it loses a create race to, when the losing publish is reviewed (AGT-4076)', async () => {
+    // `gh pr create` fails (the winner already made one), the fallback finds
+    // that PR, and it is a draft because the winner was a parked run. A reviewed
+    // publication must still end up open for review.
+    const repo = makeRepo('racerepo', 'main', 'origin');
+    const info = await createWorktree(repo, 'INT-81', 'swarm/INT-81-race');
+    writeFileSync(join(info.worktreePath, 'done.py'), 'work\n');
+    git(info.worktreePath, 'add', 'done.py');
+    git(info.worktreePath, 'commit', '-m', 'feat: done');
+
+    const bin = join(root, 'bin-race');
+    mkdirSync(bin, { recursive: true });
+    const ghLog = join(root, 'gh-race.log');
+    // First `pr list` (the pre-create check) finds nothing, so creation is tried;
+    // creation fails; the fallback `pr list` then finds the winner's draft.
+    const stateFile = join(root, 'race-state');
+    writeFileSync(join(bin, 'gh'),
+      `#!/bin/sh\nprintf '%s\\n' "$*" >> "${ghLog}"\n`
+      + `case "$*" in\n`
+      + `  *"--search"*) echo '[]';;\n`
+      + `  *"pr create"*) echo "already exists" >&2; exit 1;;\n`
+      + `  *"isDraft"*) echo "true";;\n`
+      + `  *"pr list"*) if [ -f "${stateFile}" ]; then echo "https://example.test/pull/9"; else touch "${stateFile}"; fi;;\n`
+      + `esac\n`);
+    chmodSync(join(bin, 'gh'), 0o755);
+
+    const prevPath = process.env.PATH;
+    process.env.PATH = `${bin}:${prevPath}`;
+    try {
+      const url = await commitAndCreatePR(info, 'reviewed', 'INT-81', 'desc');
+      expect(url).toBe('https://example.test/pull/9');
+    } finally {
+      process.env.PATH = prevPath;
+    }
+    expect(readFileSync(ghLog, 'utf8')).toContain('pr ready https://example.test/pull/9');
+  });
+
+  it('keeps a reused PR draft while another branch also closes the issue (AGT-4076)', async () => {
+    // A PR is opened draft when a duplicate implementation exists (INT-2544).
+    // Promoting on the caller's `draft` option alone would defeat that guard.
+    const repo = makeRepo('duprepo', 'main', 'origin');
+    const info = await createWorktree(repo, 'INT-80', 'swarm/INT-80-dup');
+    writeFileSync(join(info.worktreePath, 'done.py'), 'work\n');
+    git(info.worktreePath, 'add', 'done.py');
+    git(info.worktreePath, 'commit', '-m', 'feat: done');
+
+    const bin = join(root, 'bin-dup');
+    mkdirSync(bin, { recursive: true });
+    const ghLog = join(root, 'gh-dup.log');
+    // `pr list --search` (the duplicate probe) reports a sibling PR on another branch.
+    writeFileSync(join(bin, 'gh'),
+      `#!/bin/sh\nprintf '%s\\n' "$*" >> "${ghLog}"\n`
+      + `case "$*" in\n`
+      + `  *"--search"*) echo '[{"number":3,"url":"https://example.test/pull/3","headRefName":"swarm/other"}]';;\n`
+      + `  *"pr list"*) echo "https://example.test/pull/8";;\n`
+      + `  *"isDraft"*) echo "true";;\n`
+      + `esac\n`);
+    chmodSync(join(bin, 'gh'), 0o755);
+
+    const prevPath = process.env.PATH;
+    process.env.PATH = `${bin}:${prevPath}`;
+    try {
+      const url = await commitAndCreatePR(info, 'reviewed', 'INT-80', 'desc');
+      expect(url).toBe('https://example.test/pull/8');
+    } finally {
+      process.env.PATH = prevPath;
+    }
+    expect(readFileSync(ghLog, 'utf8')).not.toContain('pr ready');
+  });
+
+  it('does not re-ready a PR that is already open for review (AGT-4076)', async () => {
+    // `gh pr ready` on a non-draft PR fails, and the reviewed path treats a
+    // publication failure as retryable infra_error — so a run that actually
+    // succeeded would be marked broken. The isDraft check is what prevents that.
+    const repo = makeRepo('readyrepo', 'main', 'origin');
+    const info = await createWorktree(repo, 'INT-79', 'swarm/INT-79-ready');
+    writeFileSync(join(info.worktreePath, 'done.py'), 'work\n');
+    git(info.worktreePath, 'add', 'done.py');
+    git(info.worktreePath, 'commit', '-m', 'feat: done');
+
+    const bin = join(root, 'bin-ready');
+    mkdirSync(bin, { recursive: true });
+    const ghLog = join(root, 'gh-ready.log');
+    // Existing PR is NOT a draft, and `pr ready` fails the way real gh does.
+    writeFileSync(join(bin, 'gh'),
+      `#!/bin/sh\nprintf '%s\\n' "$*" >> "${ghLog}"\n`
+      + `case "$*" in\n`
+      + `  *"pr list"*) echo "https://example.test/pull/7";;\n`
+      + `  *"isDraft"*) echo "false";;\n`
+      + `  *"pr ready"*) echo "not a draft" >&2; exit 1;;\n`
+      + `esac\n`);
+    chmodSync(join(bin, 'gh'), 0o755);
+
+    const prevPath = process.env.PATH;
+    process.env.PATH = `${bin}:${prevPath}`;
+    try {
+      const url = await commitAndCreatePR(info, 'reviewed', 'INT-79', 'desc');
+      expect(url).toBe('https://example.test/pull/7');
+    } finally {
+      process.env.PATH = prevPath;
+    }
+    expect(readFileSync(ghLog, 'utf8')).not.toContain('pr ready');
+  });
+
+  it('leaves a reused PR alone when publishing as a draft (AGT-4076)', async () => {
+    // The parked path must not promote: nothing has reviewed this work.
+    const repo = makeRepo('nopromoterepo', 'main', 'origin');
+    const info = await createWorktree(repo, 'INT-78', 'swarm/INT-78-nopromote');
+    writeFileSync(join(info.worktreePath, 'done.py'), 'work\n');
+    git(info.worktreePath, 'add', 'done.py');
+    git(info.worktreePath, 'commit', '-m', 'feat: done');
+
+    const bin = join(root, 'bin-nopromote');
+    mkdirSync(bin, { recursive: true });
+    const ghLog = join(root, 'gh-nopromote.log');
+    writeFileSync(join(bin, 'gh'),
+      `#!/bin/sh\nprintf '%s\\n' "$*" >> "${ghLog}"\n`
+      + `case "$*" in\n`
+      + `  *"pr list"*) echo "https://example.test/pull/6";;\n`
+      + `  *"isDraft"*) echo "true";;\n`
+      + `esac\n`);
+    chmodSync(join(bin, 'gh'), 0o755);
+
+    const prevPath = process.env.PATH;
+    process.env.PATH = `${bin}:${prevPath}`;
+    try {
+      await commitAndCreatePR(info, 'parked', 'INT-78', 'desc', { draft: true, committedOnly: true });
+    } finally {
+      process.env.PATH = prevPath;
+    }
+    expect(readFileSync(ghLog, 'utf8')).not.toContain('pr ready');
+  });
+
   it('commitAndCreatePR pushes to the RESOLVED remote and PRs against the resolved base (non-origin)', async () => {
     const repo = makeRepo('forkrepo', 'main', 'unohee');
     const bare = join(root, 'forkrepo.git');

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -8,6 +8,7 @@ import { promisify } from 'node:util';
 import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { getInstanceId } from './healthEndpoint.js';
+import { readyReusedPullRequest } from './pullRequestReady.js';
 import { isProofCapableSpace, processAppearsAlive, processNamespaceId, sameProcessNamespace, writerProvablyGone } from './processLiveness.js';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import Database from 'better-sqlite3';
@@ -1141,39 +1142,49 @@ async function findOpenPullRequestUrl(worktreePath: string, branchName: string):
   )).trim();
 }
 
+
 /** Commit changes + push + gh pr create */
 export async function commitAndCreatePR(
   info: WorktreeInfo,
   title: string,
   issueIdentifier: string,
   description: string,
+  options: { draft?: boolean; committedOnly?: boolean } = {},
 ): Promise<string> {
   const { worktreePath, branchName } = info;
 
-  // Check for uncommitted changes and commit them
-  await stripRuntimeMarkerFromGit(worktreePath);
-  const status = await git(worktreePath, 'status', '--porcelain');
+  // Check for uncommitted changes and commit them.
+  //
+  // `committedOnly` skips this whole phase, and with it every write into the
+  // working tree. A run parked for the operator publishes what it has already
+  // committed and leaves the tree exactly as the worker left it, so the resume
+  // continues from the same place instead of inheriting a commit it never made.
+  // (AGT-4076)
+  if (!options.committedOnly) {
+    await stripRuntimeMarkerFromGit(worktreePath);
+    const status = await git(worktreePath, 'status', '--porcelain');
 
-  if (status.trim()) {
-    await git(worktreePath, 'add', '-A');
-    await guardUnsafeBinaryStaging(worktreePath); // INT-2430
+    if (status.trim()) {
+      await git(worktreePath, 'add', '-A');
+      await guardUnsafeBinaryStaging(worktreePath); // INT-2430
 
-    const stillStaged = await git(worktreePath, 'diff', '--cached', '--name-only');
-    if (stillStaged.trim()) {
-      const commitMsg = [
-        `feat(${issueIdentifier}): ${title.slice(0, 72)}`,
-      ].join('\n');
+      const stillStaged = await git(worktreePath, 'diff', '--cached', '--name-only');
+      if (stillStaged.trim()) {
+        const commitMsg = [
+          `feat(${issueIdentifier}): ${title.slice(0, 72)}`,
+        ].join('\n');
 
-      // Validate conventional commit format (warning only)
-      const commitCheck = runConventionalCommitGuard(commitMsg);
-      if (!commitCheck.passed) {
-        console.warn(`[Worktree] Commit format warning: ${commitCheck.issues.join('; ')}`);
+        // Validate conventional commit format (warning only)
+        const commitCheck = runConventionalCommitGuard(commitMsg);
+        if (!commitCheck.passed) {
+          console.warn(`[Worktree] Commit format warning: ${commitCheck.issues.join('; ')}`);
+        }
+
+        await git(worktreePath, 'commit', '-m', commitMsg);
+        console.log(`[Worktree] Committed uncommitted changes (${branchName})`);
+      } else {
+        console.log(`[Worktree] Nothing left to commit after unsafe-binary-staging guard stripped all staged changes (${branchName})`);
       }
-
-      await git(worktreePath, 'commit', '-m', commitMsg);
-      console.log(`[Worktree] Committed uncommitted changes (${branchName})`);
-    } else {
-      console.log(`[Worktree] Nothing left to commit after unsafe-binary-staging guard stripped all staged changes (${branchName})`);
     }
   }
 
@@ -1201,6 +1212,19 @@ export async function commitAndCreatePR(
 
   if (existing) {
     console.log(`[Worktree] PR already exists: ${existing}`);
+    // Reusing a PR opened while the run was parked must not leave reviewed work
+    // sitting as a draft. Only the reviewed caller promotes; a parked publish
+    // (`draft: true`) is meant to stay a draft.
+    //
+    // But `draft` is not the only reason a PR is one. A PR is also opened draft
+    // when another branch already closes this issue (INT-2544), deliberately, so
+    // a duplicate implementation cannot masquerade as the sole one. Promoting on
+    // the caller's option alone would defeat that, so the duplicate condition is
+    // re-checked here. (Caught by the commit gate, not self-caught.)
+    if (!options.draft) {
+      const stillDuplicated = await findDuplicateIssuePRs(worktreePath, issueIdentifier, branchName);
+      await readyReusedPullRequest(worktreePath, existing, issueIdentifier, stillDuplicated.length);
+    }
     return existing;
   }
 
@@ -1234,7 +1258,10 @@ export async function commitAndCreatePR(
   ].join('\n');
 
   const createArgs = ['pr', 'create', '--head', branchName, '--base', base.branch, '--title', title, '--body', prBody];
-  if (duplicates.length > 0) createArgs.push('--draft');
+  // Draft when the work never earned a review: a duplicate implementation must
+  // not masquerade as the sole one, and work published because a run parked
+  // (AGT-4076) never reached a reviewer at all.
+  if (options.draft || duplicates.length > 0) createArgs.push('--draft');
   let url: string;
   try {
     url = (await gh(worktreePath, ...createArgs)).trim();
@@ -1249,6 +1276,10 @@ export async function commitAndCreatePR(
     if (!racedUrl) throw createError;
     url = racedUrl;
     console.warn(`[Worktree] PR create raced with another publisher; using existing PR: ${url}`);
+    // The winner may have opened it as a draft (a parked run does). Losing the
+    // race must not turn a reviewed publication into a hidden draft. Reuses the
+    // duplicate set already computed above rather than re-querying.
+    if (!options.draft) await readyReusedPullRequest(worktreePath, url, issueIdentifier, duplicates.length);
   }
 
   // Register PR ownership for conflict auto-resolution


### PR DESCRIPTION
> supersded할거면 PR은 올리고 가라그래.

## The defect

A run that stops for an operator decision leaves its commits on a branch that was
**never pushed**. Measured on the deployed daemon:

```
swarm/AX-1030-ops-tool-solapi   9 commits ahead   remote: absent
swarm/AX-885-a1-3               6                 absent
swarm/AX-863-a2-4               3                 absent
swarm/AX-1066-backend-…-fix     2                 absent
swarm/AX-871-ext-a2-slack       2                 absent
swarm/AX-879-a2-9-2             1                 absent
```

23 commits, no PR, while the operator was being asked **70 questions** about work
they could not see.

## Where it publishes, and why not anywhere else

At the moment the run parks, in the runner, right beside the approved path. There the
executor still owns the claim, the lease and the worktree, so there is nothing to race.

An earlier attempt swept parked rows from the reconciler. The commit gate rejected it
three times for the same reason: a parked run can be resumed and claimed while an
out-of-band publish is in flight, and if that publish opened a PR first, the eventual
reviewed publication would silently reuse it and ship approved work as a draft.

## The rules this had to learn (each one a gate finding)

- **Lease fence.** Uses the same `beforePublish()` the approved path does, so an
  executor that already lost its claim cannot publish for work it no longer speaks for.
- **`committedOnly`.** Skips every write into the working tree — no marker strip, no
  `add -A`, no commit — so the resume continues from exactly where the worker stopped.
- **Draft.** Nothing reviewed this.
- **Promotion on reuse.** When the branch later passes review, both reuse paths (the
  pre-create lookup and the create-race fallback) take the PR out of draft, or reviewed
  work ships hidden.
- **…except when duplicates justify the draft.** A PR opened draft because another
  branch also closes the issue (INT-2544) stays draft. The duplicate set is re-checked
  rather than assumed.
- **Never re-ready an already-open PR.** `gh pr ready` fails on one, and that failure
  would mark a successful run as `infra_error`.
- **No `result.prUrl`.** Any prUrl on a non-approved result is classified as
  `publication_reconcile` and parked in NEEDS_RECONCILE — which would convert an
  operator park into a row holding a repository admission slot. That is the exact
  phantom-row shape that idled the whole loop earlier the same day. The PR is attached
  to the ledger instead.

## Verification

- 154 tests across `worktreeManager`, `publishOnPark`, `durableRunCoordinator` and
  `runnerExecution.coverage` pass.
- New tests use real git fixtures with a fake `gh` on PATH: committed work is pushed
  while a dirty file stays dirty; a reused draft is promoted; a reused non-draft is not
  touched; a duplicate keeps it draft; the create-race loser promotes.
- Seven mutations each fail a test: dropping `committedOnly`, dropping `draft`, dropping
  the promotion, promoting on the draft path, dropping the `isDraft` check, dropping the
  duplicate re-check, dropping the race-path promotion.
- A guard test in `durableRunCoordinator.test.ts` pins the classification that makes
  `result.prUrl` unsafe here, so the reasoning goes stale loudly rather than silently.

## Two extractions

Both forced by the 1500-line pre-commit cap, both coherent on their own:
`publishOnPark.ts` holds the two publication paths (same helper, differing only in what
the run earned) and `pullRequestReady.ts` holds the promotion rule shared by the two
PR-reuse paths.

Closes AGT-4076.