### PR TITLE
perf(docker): bump pinned uv to 0.12.7 so worktree venvs share their files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,8 +104,20 @@ RUN npm install -g @intrect/cxt@0.3.0 && npm cache clean --force
 # uv, for repositories that are uv projects. Copied from the official image
 # rather than piped from an installer, and pinned by digest rather than tag —
 # a tag can be repointed, so only the digest makes this build reproducible.
-# The digest is the multi-arch index for v0.5.11; bump both together.
-COPY --from=ghcr.io/astral-sh/uv@sha256:0ac957607303916420297a4c9c213bb33fbd3c888f9cd7f4f7273596ebf42b85 /uv /uvx /usr/local/bin/
+# The digest is the multi-arch index for v0.12.7; bump both together.
+#
+# Held at 0.5.11 until 2026-08-29, where it cost the daemon its event loop.
+# 0.5.11 caches wheels as archives and re-extracts them into every venv: of 129
+# files sampled in a fresh venv, 0 were hardlinks, and `UV_LINK_MODE=hardlink`
+# made no difference. 0.12.7 keeps an extracted `archive-v0` store and links
+# from it — 349 of 400 files in a real `uv sync` of apps/pipelines, whose venv
+# is 392MB. With 23 worktrees each building their own (the venv is deliberately
+# never shared: a linked one makes a worktree import the main checkout's src/),
+# rebuilding three or four at once wrote ~1.49GB and blocked the loop for 28-33s,
+# observed seven times. Verified against the real lockfile before bumping:
+# `uv.lock` is version 1, 0.12.7 reads it unmigrated and `sync --frozen`
+# completed in 1.7s.
+COPY --from=ghcr.io/astral-sh/uv@sha256:95f2aa1fe59274951cfe9b0cbc7972e879ff1004bc8945d130a32eb0dbd85945 /uv /uvx /usr/local/bin/
 
 RUN groupadd --gid 1001 openswarm && \
     useradd --uid 1001 --gid openswarm --shell /bin/bash --create-home openswarm


### PR DESCRIPTION
## What this fixes

The event-loop monitor shipped in #463 recorded **seven stalls of 28-33 s**, each writing **~1.49 GB** — 2,901,640 to 2,913,064 blocks of 512 B, within 0.4% of each other. An identical write volume repeating that many times is one deterministic operation, and it is per-worktree Python venv rebuilds.

`/work/cgf-portal` is 11 GB: `.git` is 24 MB, `worktree/` is 10.4 GB. **23 of 27 worktrees carry a ~414 MB `apps/pipelines/.venv`, 9,526 MB in total.** Three or four rebuilding at once is ~1.49 GB.

## Why the venvs are not simply shared

`scripts/dev/link-local-assets.sh` refuses to link `.venv` **on purpose**, and records the measurement behind it: `cgf_pipelines` is installed editable pointing at the main checkout's `src/`, so a worktree that links the venv imports the *main repo's* code — "a guard test kept passing while its guard was deleted, because the deletion was in the worktree and the import came from the main tree" (2026-08-28).

That isolation is load-bearing. The fix has to share the **files**, not the environment.

## Measured, not read from release notes

I was already wrong once here by assuming uv's linking behaviour, so everything below is from probes run inside the daemon container.

**uv 0.5.11 — cannot share:**

| probe | result |
|---|---|
| fresh venv, files with `nlink > 1` | **0 / 129** |
| `UV_LINK_MODE=copy` vs `hardlink` | byte-identical venvs, 2,408 KB each |
| cache layout | `wheels-v3/` — archives, nothing to link *from* |

**uv 0.12.7 — shares:**

| probe | result |
|---|---|
| fresh venv, files with `nlink > 1` | **112 / 129** |
| cache layout | gains `archive-v0/` — an extracted store |
| **real `uv sync --frozen` of `apps/pipelines`** | **349 / 400 hardlinked**, 392 MB venv, **1.7 s** |
| `uv.lock` compatibility | version 1, read unmigrated, no rewrite |

So a worktree venv build goes from writing ~392 MB to roughly an eighth of it, and the ~1.49 GB burst should fall proportionally.

## Scope

One line — the pinned digest — plus the comment recording why. The pin stays a digest, since a tag can be repointed.

Lockfile compatibility was the real risk and it was tested against the actual `uv.lock` before bumping, not assumed.

## Deploy-side companion (not in this PR)

`docker-compose.yml` on vela now mounts a persistent `UV_CACHE_DIR` on the same filesystem as `/work` — without it, uv cannot hardlink across devices and the cache was being wiped by every `docker compose up -d` anyway. A shared `npm_config_cache` went in on the same pass; note that npm 10.9.8 **copies** from its cache (0 of 300 files hardlinked), so the 820 MB of duplicated `node_modules` across OpenSwarm's worktrees needs a content-addressed installer to collapse — a lockfile and CI change, deliberately not done here.

Review gate: `openswarm review` — `Decision: APPROVE`, reviewer independently pulled the digest and confirmed it resolves to 0.12.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)