### PR TITLE
test(setup): give each vitest worker its own coordination store (AGT-4087)

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -2,18 +2,34 @@
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+// Vitest forks a worker per file (measured: distinct pids and VITEST_POOL_IDs),
+// so anything scoped to the run is shared by every worker at once. Every path
+// below is therefore scoped per worker.
+const workerScope = `${process.pid}-${process.env.VITEST_POOL_ID ?? '0'}`;
+
 // Redirect chat-session persistence to a temp dir so ChatPanel renders (which
 // fire a saveSession effect) never write to the real ~/.openswarm/chat. (INT-2014)
-process.env.OPENSWARM_CHAT_DIR = join(tmpdir(), 'openswarm-test-chat');
+// Per worker because listing sessions is a `readdir` of the whole directory, so
+// a shared one lets a worker observe another worker's sessions.
+process.env.OPENSWARM_CHAT_DIR = join(tmpdir(), 'openswarm-test-chat', workerScope);
 
-// Redirect the agent coordination board the same way: several suites exercise
-// the real store (worker routing, the agentic loop's ask_human stop), and
-// without this they append fixture events to the operator's live
+// Redirect the agent coordination board away from the real home dir: several
+// suites exercise the real store (worker routing, the agentic loop's ask_human
+// stop), and without this they append fixture events to the operator's live
 // ~/.openswarm/coordination.json.
-process.env.OPENSWARM_COORDINATION_FILE = join(tmpdir(), 'openswarm-test-coordination', 'events.json');
+//
+// Per worker, not per run: `consume` is a destructive read-modify-write behind
+// a file lock, so one shared board puts every worker in contention. That
+// surfaces as a `coordination_read` which errors — and only a NON-erroring read
+// resets the inbox-nudge clock (agenticLoop.ts), so the nudge fires and the
+// test asserting it must not goes red. It passed in isolation and failed only
+// in the full suite, which is the signature. (AGT-4087)
+process.env.OPENSWARM_COORDINATION_FILE = join(tmpdir(), 'openswarm-test-coordination', workerScope, 'events.json');
 
 // The board mirrors every published event into the automation database, so the
 // same suites that write fixture events would otherwise append them to the
 // operator's live ~/.openswarm/automation.db — and pay a synchronous SQLite
-// write for each one, which is slow enough at suite scale to matter.
-process.env.OPENSWARM_AUTOMATION_DB = join(tmpdir(), 'openswarm-test-automation', 'automation.db');
+// write for each one, which is slow enough at suite scale to matter. Scoped
+// per worker for the same reason as the board: sharing it would reintroduce
+// the contention the line above removes.
+process.env.OPENSWARM_AUTOMATION_DB = join(tmpdir(), 'openswarm-test-automation', workerScope, 'automation.db');


### PR DESCRIPTION
## The failure

`main` went red intermittently on:

```
FAIL src/adapters/agenticLoop.test.ts
  > runAgenticLoop coordination-inbox nudge (AGT-4054)
  > resets the clock when the agent checks its inbox on its own    5017 ms
```

It passed in isolation (24 ms), under `--coverage` (54 ms), with an isolated store
(24 ms), and paired with `autonomousRunner.dispatch.test.ts` (86 ms). **Only the full
suite reproduced it** — which is the signature of shared state across workers, not of
the test's own logic.

## Mechanism

`vitest.setup.ts` pointed every worker at one file:
`${tmpdir()}/openswarm-test-coordination/events.json`. Vitest forks a worker per file
(measured: distinct pids 14967/14968 and distinct `VITEST_POOL_ID`s), so the whole
suite contended on a single board.

`consume` is a **destructive read-modify-write behind a file lock**
(`coordinationStore.ts:175`) with a throwing corrupt-parse path (`:157`). Contention
yields a `coordination_read` that errors — and the nudge clock resets **only on a
non-erroring read**:

```ts
// agenticLoop.ts:536
if (toolCalls.some((tc, i) => tc.function.name === 'coordination_read' && !results[i]?.is_error)) {
  lastCoordinationCheckTurn = turn;
}
```

So the clock stays unreset, the nudge fires at turn 6, and
`expect(...'Coordination-inbox nudge'...).toBe(false)` fails. The nudge is purely
turn-based (`turnsSinceLastCheck >= 6`), so timing pressure alone could not produce
this — only a failed read can.

## Two corrections to the first reading of this

- **"5017 ms is vitest's 5 s default timeout."** Wrong — `vitest.config.ts:120` sets
  `testTimeout: 30000`. The test was never killed; it failed its assertion after
  waiting on a contended board.
- **"#463 caused it."** Wrong — #463 was the only commit in the green→red window, but
  it touches nothing here. The race is pre-existing and parallelism exposes it.

## Change

Scope all three temp paths per worker. The chat dir is included for the same reason:
listing sessions is a `readdir` of the whole directory (`chatSession.ts:136`), so a
shared one lets a worker observe another's sessions.

## Verification

Coordination suites (6 files, 105 tests) and `chatSession.test.ts` (11 tests) pass.
Gate: APPROVE, re-run after the chat-dir addition.

Because the original failure is a **flake**, a single green run does not prove this.
Confirmation is `main` staying green across subsequent runs.

Closes AGT-4087.