### PR TITLE
feat(agents): tell a worker what its sibling worktrees are editing (AGT-4088)

### DIFF
--- a/src/agents/siblingWork.test.ts
+++ b/src/agents/siblingWork.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
   MAX_FILES_PER_SIBLING, MAX_SIBLINGS, STATUS_CONCURRENCY, TOTAL_BUDGET_MS, collectSiblingWork,
   commandTimeoutMs, formatSiblingWork, identifierFromBranch, parseChangedFiles, parseWorktreeList,
@@ -84,6 +87,19 @@ describe('selectSiblingWorktrees', () => {
     // phantom peer.
     expect(selectSiblingWorktrees(entries, '/work/cgf-portal/worktree/../worktree/05a3c502')
       .map((e) => e.path)).not.toContain('/work/cgf-portal/worktree/05a3c502');
+  });
+
+  it('recognises ourselves when git reports our real path and we hold a symlinked one', () => {
+    // git always reports a worktree by its real path; the dispatched project
+    // path can carry a symlinked component. Compared lexically the two differ,
+    // and we would scan ourselves and report our own edits as a peer's.
+    const canonicalise = (p: string) => p.replace('/link/', '/real/');
+    const linked = [
+      { path: '/real/worktree/a' },
+      { path: '/real/worktree/b' },
+    ];
+    expect(selectSiblingWorktrees(linked, '/link/worktree/a', canonicalise).map((e) => e.path))
+      .toEqual(['/real/worktree/b']);
   });
 
   it('keeps the main checkout — it holds edits too', () => {
@@ -179,6 +195,9 @@ describe('formatSiblingWork', () => {
 });
 
 describe('collectSiblingWork', () => {
+  const cleanups: string[] = [];
+  afterAll(() => { for (const dir of cleanups) rmSync(dir, { recursive: true, force: true }); });
+
   function worktreeList(count: number): string {
     return Array.from({ length: count }, (_, i) =>
       `worktree /repo/worktree/w${i}\0HEAD abc${i}\0branch refs/heads/swarm/AX-${1000 + i}-task\0\0`).join('');
@@ -277,6 +296,27 @@ describe('collectSiblingWork', () => {
   it('never asks for a zero timeout, which child_process reads as "no timeout"', () => {
     expect(commandTimeoutMs(0)).toBe(1);
     expect(commandTimeoutMs(-500)).toBe(1);
+  });
+
+  it('excludes itself through a real symlink, not just in theory', async () => {
+    // The pure selector takes an injectable canonicaliser, so a test of it
+    // passes even if production forgets to pass one. This covers the wiring:
+    // git reports the real path, we hold the symlinked one, and only an actual
+    // realpath call reconciles them.
+    const root = mkdtempSync(join(tmpdir(), 'sibling-symlink-'));
+    cleanups.push(root);
+    const real = join(root, 'real');
+    mkdirSync(join(real, 'self'), { recursive: true });
+    mkdirSync(join(real, 'peer'), { recursive: true });
+    symlinkSync(real, join(root, 'link'));
+
+    const result = await collectSiblingWork(join(root, 'link', 'self'), {
+      // git always answers with the real path, whichever spelling it was asked through.
+      listWorktrees: async () => `worktree ${join(real, 'self')}\0worktree ${join(real, 'peer')}\0\0`,
+      readStatus: async () => 'M  a.ts\0',
+    });
+
+    expect(result.map((r) => r.identifier)).toEqual([join(real, 'peer')]);
   });
 
   it('returns nothing, and does not throw, when the repository cannot be listed', async () => {

--- a/src/agents/siblingWork.test.ts
+++ b/src/agents/siblingWork.test.ts
@@ -33,6 +33,22 @@ describe('parseWorktreeList', () => {
     expect(parseWorktreeList('worktree /w/a\nHEAD abc\ndetached\n')).toEqual([{ path: '/w/a' }]);
   });
 
+  it('keeps a worktree path with a trailing space', () => {
+    // Verified against real git: `worktree list --porcelain` emits paths
+    // literally, trailing space and all. Trimming it either hides a real
+    // overlap or makes us report our own edits as a peer's.
+    expect(parseWorktreeList('worktree /repo/trailing \nHEAD abc\n')).toEqual([{ path: '/repo/trailing ' }]);
+  });
+
+  it('keeps a worktree path containing spaces', () => {
+    expect(parseWorktreeList('worktree /repo/my worktree\nHEAD abc\n')).toEqual([{ path: '/repo/my worktree' }]);
+  });
+
+  it('tolerates CRLF line endings', () => {
+    expect(parseWorktreeList('worktree /repo/a\r\nbranch refs/heads/x\r\n'))
+      .toEqual([{ path: '/repo/a', branch: 'refs/heads/x' }]);
+  });
+
   it('returns nothing for empty output', () => {
     expect(parseWorktreeList('')).toEqual([]);
   });

--- a/src/agents/siblingWork.test.ts
+++ b/src/agents/siblingWork.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_FILES_PER_SIBLING, MAX_SIBLINGS, STATUS_CONCURRENCY, TOTAL_BUDGET_MS, collectSiblingWork,
+  commandTimeoutMs, formatSiblingWork, identifierFromBranch, parseChangedFiles, parseWorktreeList,
+  selectSiblingWorktrees,
+} from './siblingWork.js';
+
+// Shape taken verbatim from `git worktree list --porcelain` on the live host.
+const PORCELAIN = `worktree /work/cgf-portal
+HEAD a882db13ea2731ab0a5a35a2f80c282ba2d73b23
+branch refs/heads/chore/link-nas-env
+
+worktree /work/cgf-portal/worktree/05a3c502
+HEAD 904aafb4f1e8cf85c24c4507ca50699c1d96de1f
+branch refs/heads/swarm/AX-1062-policy-finalize
+
+worktree /work/cgf-portal/worktree/1b0c6d1a
+HEAD 2821f2aee0eff87e05185235af20f9eb8cb22d48
+branch refs/heads/swarm/AX-1027-ops-tool-meta
+`;
+
+describe('parseWorktreeList', () => {
+  it('reads each worktree and its branch', () => {
+    expect(parseWorktreeList(PORCELAIN)).toEqual([
+      { path: '/work/cgf-portal', branch: 'refs/heads/chore/link-nas-env' },
+      { path: '/work/cgf-portal/worktree/05a3c502', branch: 'refs/heads/swarm/AX-1062-policy-finalize' },
+      { path: '/work/cgf-portal/worktree/1b0c6d1a', branch: 'refs/heads/swarm/AX-1027-ops-tool-meta' },
+    ]);
+  });
+
+  it('keeps a detached worktree, which has no branch line', () => {
+    // A detached worktree still holds edits; dropping it would hide them.
+    expect(parseWorktreeList('worktree /w/a\nHEAD abc\ndetached\n')).toEqual([{ path: '/w/a' }]);
+  });
+
+  it('returns nothing for empty output', () => {
+    expect(parseWorktreeList('')).toEqual([]);
+  });
+});
+
+describe('identifierFromBranch', () => {
+  it('pulls the issue key out of a swarm branch', () => {
+    expect(identifierFromBranch('refs/heads/swarm/AX-1062-policy-finalize')).toBe('AX-1062');
+  });
+
+  it('falls back to the short branch name when there is no issue key', () => {
+    // A hand-made branch still holds conflicting edits — naming it by its
+    // branch beats dropping it for not matching the convention.
+    expect(identifierFromBranch('refs/heads/chore/link-nas-env')).toBe('chore/link-nas-env');
+  });
+
+  it('has nothing to say about a detached worktree', () => {
+    expect(identifierFromBranch(undefined)).toBeUndefined();
+    expect(identifierFromBranch('refs/heads/')).toBeUndefined();
+  });
+});
+
+describe('selectSiblingWorktrees', () => {
+  const entries = parseWorktreeList(PORCELAIN);
+
+  it('excludes the worktree we are working in', () => {
+    expect(selectSiblingWorktrees(entries, '/work/cgf-portal/worktree/05a3c502').map((e) => e.path))
+      .toEqual(['/work/cgf-portal', '/work/cgf-portal/worktree/1b0c6d1a']);
+  });
+
+  it('recognises ourselves through an unresolved path', () => {
+    // Reporting our own edits back to us would read as a conflict with a
+    // phantom peer.
+    expect(selectSiblingWorktrees(entries, '/work/cgf-portal/worktree/../worktree/05a3c502')
+      .map((e) => e.path)).not.toContain('/work/cgf-portal/worktree/05a3c502');
+  });
+
+  it('keeps the main checkout — it holds edits too', () => {
+    expect(selectSiblingWorktrees(entries, '/work/cgf-portal/worktree/05a3c502').map((e) => e.path))
+      .toContain('/work/cgf-portal');
+  });
+});
+
+describe('parseChangedFiles', () => {
+  // `git status --porcelain -z`: `XY <path>\0`, and for a rename/copy a second
+  // field carrying the source path.
+  const z = (...fields: string[]) => fields.map((f) => `${f}\0`).join('');
+
+  it('reads staged, unstaged and untracked alike', () => {
+    expect(parseChangedFiles(z('M  src/a.ts', '?? src/b.ts', ' M src/c.ts')))
+      .toEqual(['src/a.ts', 'src/b.ts', 'src/c.ts']);
+  });
+
+  it('takes the destination of a rename and drops its source', () => {
+    // The new path is where this worktree is writing; the old one is only
+    // where the content came from.
+    expect(parseChangedFiles(z('R  src/new.ts', 'src/old.ts'))).toEqual(['src/new.ts']);
+  });
+
+  it('does not let a rename source swallow the entry after it', () => {
+    expect(parseChangedFiles(z('R  src/new.ts', 'src/old.ts', 'M  src/after.ts')))
+      .toEqual(['src/new.ts', 'src/after.ts']);
+  });
+
+  it('handles a copy the same way as a rename', () => {
+    expect(parseChangedFiles(z('C  src/copy.ts', 'src/source.ts'))).toEqual(['src/copy.ts']);
+  });
+
+  it('keeps a path containing a space intact', () => {
+    // Plain porcelain would C-quote this one; -z gives it literally.
+    expect(parseChangedFiles(z('M  docs/my report.md'))).toEqual(['docs/my report.md']);
+  });
+
+  it('keeps a path that itself contains " -> "', () => {
+    // The old line parser split here and named a file that does not exist.
+    expect(parseChangedFiles(z('M  docs/a -> b.md'))).toEqual(['docs/a -> b.md']);
+  });
+
+  it('keeps a trailing space in a path', () => {
+    // Legal on Linux, and trimming it names a different file than the one the
+    // sibling is actually writing.
+    expect(parseChangedFiles(z('M  docs/trailing '))).toEqual(['docs/trailing ']);
+  });
+
+  it('keeps a non-ASCII path intact', () => {
+    expect(parseChangedFiles(z('M  docs/보고서.md'))).toEqual(['docs/보고서.md']);
+  });
+
+  it('returns nothing for a clean worktree', () => {
+    expect(parseChangedFiles('')).toEqual([]);
+  });
+});
+
+describe('formatSiblingWork', () => {
+  it('says nothing at all when no sibling has changes', () => {
+    expect(formatSiblingWork([])).toBe('');
+    expect(formatSiblingWork([{ identifier: 'AX-1', files: [] }])).toBe('');
+  });
+
+  it('lists each sibling with its files', () => {
+    expect(formatSiblingWork([
+      { identifier: 'AX-1047', files: ['src/api/report.ts', 'src/db/schema.ts'] },
+      { identifier: 'AX-1066', files: ['docs/INTEGRATIONS.md'] },
+    ])).toBe('  AX-1047 — src/api/report.ts, src/db/schema.ts\n  AX-1066 — docs/INTEGRATIONS.md');
+  });
+
+  it('caps the files per sibling and says how many it hid', () => {
+    const files = Array.from({ length: MAX_FILES_PER_SIBLING + 3 }, (_, i) => `f${i}.ts`);
+    const out = formatSiblingWork([{ identifier: 'AX-1', files }]);
+    expect(out).toContain(`f${MAX_FILES_PER_SIBLING - 1}.ts`);
+    expect(out).not.toContain(`f${MAX_FILES_PER_SIBLING}.ts`);
+    expect(out).toContain('+3 more');
+  });
+
+  it('caps the sibling count and says how many it hid', () => {
+    const siblings = Array.from({ length: MAX_SIBLINGS + 2 }, (_, i) => ({ identifier: `AX-${i}`, files: ['a.ts'] }));
+    const out = formatSiblingWork(siblings);
+    expect(out.split('\n')).toHaveLength(MAX_SIBLINGS + 1);
+    expect(out).toContain('(+2 more worktrees)');
+  });
+
+  it('drops siblings with no changes rather than printing an empty line', () => {
+    expect(formatSiblingWork([
+      { identifier: 'AX-1', files: [] },
+      { identifier: 'AX-2', files: ['a.ts'] },
+    ])).toBe('  AX-2 — a.ts');
+  });
+});
+
+describe('collectSiblingWork', () => {
+  function worktreeList(count: number): string {
+    return Array.from({ length: count }, (_, i) =>
+      `worktree /repo/worktree/w${i}\nHEAD abc${i}\nbranch refs/heads/swarm/AX-${1000 + i}-task\n`).join('\n');
+  }
+
+  it('reports a dirty worktree that sits far past the sibling cap', async () => {
+    // The first version capped the worktree list BEFORE reading status, so on
+    // this host — 25 worktrees against a cap of 8 — a dirty worktree past the
+    // cut vanished without a trace. Silently omitting a conflict is the one
+    // failure this feature exists to prevent.
+    const dirtyIndex = MAX_SIBLINGS + 11;
+    const result = await collectSiblingWork('/repo/worktree/self', {
+      listWorktrees: async () => worktreeList(25),
+      readStatus: async (cwd) => (cwd === `/repo/worktree/w${dirtyIndex}` ? 'M  src/late.ts\0' : ''),
+    });
+    expect(result).toEqual([{ identifier: `AX-${1000 + dirtyIndex}`, files: ['src/late.ts'] }]);
+  });
+
+  it('keeps at most STATUS_CONCURRENCY status reads in flight', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await collectSiblingWork('/repo/worktree/self', {
+      listWorktrees: async () => worktreeList(25),
+      readStatus: async () => {
+        peak = Math.max(peak, ++inFlight);
+        await new Promise((r) => setImmediate(r));
+        inFlight--;
+        return '';
+      },
+    });
+    expect(peak).toBeLessThanOrEqual(STATUS_CONCURRENCY);
+    expect(peak).toBeGreaterThan(1); // and it is actually parallel, not serial
+  });
+
+  it('reads every worktree even when there are more than the cap', async () => {
+    const seen: string[] = [];
+    await collectSiblingWork('/repo/worktree/self', {
+      listWorktrees: async () => worktreeList(20),
+      readStatus: async (cwd) => { seen.push(cwd); return ''; },
+    });
+    expect(seen).toHaveLength(20);
+  });
+
+  it('loses only the failing worktree when git errors', async () => {
+    const result = await collectSiblingWork('/repo/worktree/self', {
+      listWorktrees: async () => worktreeList(3),
+      readStatus: async (cwd) => {
+        if (cwd === '/repo/worktree/w1') throw new Error('worktree is gone');
+        return 'M  a.ts\0';
+      },
+    });
+    expect(result.map((s) => s.identifier)).toEqual(['AX-1000', 'AX-1002']);
+  });
+
+  it('stops scanning once the total budget is spent', async () => {
+    // Per-command timeouts do not bound the whole scan: N worktrees means
+    // ceil(N / concurrency) batches, and this runs ahead of every worker
+    // attempt. A repo full of stalled worktrees must not delay dispatch.
+    let clock = 0;
+    const scanned: string[] = [];
+    const result = await collectSiblingWork('/repo/worktree/self', {
+      listWorktrees: async () => worktreeList(40),
+      // Each read burns a quarter of the budget.
+      readStatus: async (cwd) => { scanned.push(cwd); clock += 25; return 'M  a.ts\0'; },
+      budgetMs: 100,
+      now: () => clock,
+    });
+    // Four reads fit in the budget; the rest are reported clean, not awaited.
+    expect(scanned.length).toBeLessThan(40);
+    expect(result.length).toBe(scanned.length);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('scans everything when the work fits inside the budget', async () => {
+    const scanned: string[] = [];
+    await collectSiblingWork('/repo/worktree/self', {
+      listWorktrees: async () => worktreeList(20),
+      readStatus: async (cwd) => { scanned.push(cwd); return ''; },
+      now: () => 0,
+    });
+    expect(scanned).toHaveLength(20);
+  });
+
+  it('has a budget that leaves room for more than one batch', () => {
+    expect(TOTAL_BUDGET_MS).toBeGreaterThan(0);
+  });
+
+  it('never lets a git call outlive the remaining budget', () => {
+    // Skipping only unstarted worktrees is not enough: up to STATUS_CONCURRENCY
+    // commands are already running, and each could otherwise add its full
+    // per-command timeout on top of the budget.
+    expect(commandTimeoutMs(1_200)).toBe(1_200);
+    expect(commandTimeoutMs(99_000)).toBe(5_000); // capped by the per-command limit
+  });
+
+  it('never asks for a zero timeout, which child_process reads as "no timeout"', () => {
+    expect(commandTimeoutMs(0)).toBe(1);
+    expect(commandTimeoutMs(-500)).toBe(1);
+  });
+
+  it('returns nothing, and does not throw, when the repository cannot be listed', async () => {
+    // This decorates a prompt; it must never be able to fail a dispatch.
+    await expect(collectSiblingWork('/repo/worktree/self', {
+      listWorktrees: async () => { throw new Error('not a git repository'); },
+    })).resolves.toEqual([]);
+  });
+});

--- a/src/agents/siblingWork.test.ts
+++ b/src/agents/siblingWork.test.ts
@@ -5,19 +5,14 @@ import {
   selectSiblingWorktrees,
 } from './siblingWork.js';
 
-// Shape taken verbatim from `git worktree list --porcelain` on the live host.
-const PORCELAIN = `worktree /work/cgf-portal
-HEAD a882db13ea2731ab0a5a35a2f80c282ba2d73b23
-branch refs/heads/chore/link-nas-env
-
-worktree /work/cgf-portal/worktree/05a3c502
-HEAD 904aafb4f1e8cf85c24c4507ca50699c1d96de1f
-branch refs/heads/swarm/AX-1062-policy-finalize
-
-worktree /work/cgf-portal/worktree/1b0c6d1a
-HEAD 2821f2aee0eff87e05185235af20f9eb8cb22d48
-branch refs/heads/swarm/AX-1027-ops-tool-meta
-`;
+// `git worktree list --porcelain -z`: each attribute is its own NUL-terminated
+// field, and an empty field separates records. Shape taken from the live host.
+const wt = (...records: string[][]) => records.map((r) => `${r.join('\0')}\0\0`).join('');
+const PORCELAIN = wt(
+  ['worktree /work/cgf-portal', 'HEAD a882db13', 'branch refs/heads/chore/link-nas-env'],
+  ['worktree /work/cgf-portal/worktree/05a3c502', 'HEAD 904aafb4', 'branch refs/heads/swarm/AX-1062-policy-finalize'],
+  ['worktree /work/cgf-portal/worktree/1b0c6d1a', 'HEAD 2821f2ae', 'branch refs/heads/swarm/AX-1027-ops-tool-meta'],
+);
 
 describe('parseWorktreeList', () => {
   it('reads each worktree and its branch', () => {
@@ -28,25 +23,30 @@ describe('parseWorktreeList', () => {
     ]);
   });
 
-  it('keeps a detached worktree, which has no branch line', () => {
+  it('keeps a detached worktree, which has no branch field', () => {
     // A detached worktree still holds edits; dropping it would hide them.
-    expect(parseWorktreeList('worktree /w/a\nHEAD abc\ndetached\n')).toEqual([{ path: '/w/a' }]);
+    expect(parseWorktreeList(wt(['worktree /w/a', 'HEAD abc', 'detached']))).toEqual([{ path: '/w/a' }]);
   });
 
   it('keeps a worktree path with a trailing space', () => {
-    // Verified against real git: `worktree list --porcelain` emits paths
-    // literally, trailing space and all. Trimming it either hides a real
-    // overlap or makes us report our own edits as a peer's.
-    expect(parseWorktreeList('worktree /repo/trailing \nHEAD abc\n')).toEqual([{ path: '/repo/trailing ' }]);
+    // Verified against real git: paths come through literally here, trailing
+    // space and all — unlike `status --porcelain`, this command does not
+    // C-quote. Trimming either hides a real overlap or makes us report our own
+    // edits as a peer's.
+    expect(parseWorktreeList(wt(['worktree /repo/trailing ', 'HEAD abc']))).toEqual([{ path: '/repo/trailing ' }]);
   });
 
-  it('keeps a worktree path containing spaces', () => {
-    expect(parseWorktreeList('worktree /repo/my worktree\nHEAD abc\n')).toEqual([{ path: '/repo/my worktree' }]);
+  it('keeps a worktree path containing spaces, quotes and non-ASCII', () => {
+    expect(parseWorktreeList(wt(['worktree /repo/my "보고서" dir', 'HEAD abc'])))
+      .toEqual([{ path: '/repo/my "보고서" dir' }]);
   });
 
-  it('tolerates CRLF line endings', () => {
-    expect(parseWorktreeList('worktree /repo/a\r\nbranch refs/heads/x\r\n'))
-      .toEqual([{ path: '/repo/a', branch: 'refs/heads/x' }]);
+  it('keeps a worktree path containing a newline', () => {
+    // The line-based form splits this path across two lines and yields a
+    // truncated directory that does not exist, so the sibling's changes are
+    // never read. -z keeps it in one field.
+    expect(parseWorktreeList(wt(['worktree /repo/new\nline', 'HEAD abc'])))
+      .toEqual([{ path: '/repo/new\nline' }]);
   });
 
   it('returns nothing for empty output', () => {
@@ -181,7 +181,7 @@ describe('formatSiblingWork', () => {
 describe('collectSiblingWork', () => {
   function worktreeList(count: number): string {
     return Array.from({ length: count }, (_, i) =>
-      `worktree /repo/worktree/w${i}\nHEAD abc${i}\nbranch refs/heads/swarm/AX-${1000 + i}-task\n`).join('\n');
+      `worktree /repo/worktree/w${i}\0HEAD abc${i}\0branch refs/heads/swarm/AX-${1000 + i}-task\0\0`).join('');
   }
 
   it('reports a dirty worktree that sits far past the sibling cap', async () => {

--- a/src/agents/siblingWork.ts
+++ b/src/agents/siblingWork.ts
@@ -43,11 +43,20 @@ export function parseWorktreeList(porcelain: string): WorktreeEntry[] {
   const entries: WorktreeEntry[] = [];
   let current: WorktreeEntry | undefined;
 
-  for (const line of porcelain.split('\n')) {
+  for (const rawLine of porcelain.split('\n')) {
+    // Only \r is stripped, for a checkout written with CRLF endings. The path
+    // itself is NOT trimmed: measured against real git, `worktree list
+    // --porcelain` emits paths literally and unquoted, trailing space included,
+    // so trimming corrupts a legitimate path — which then either fails to match
+    // ourselves (and we report our own edits as a peer's) or points `git status`
+    // at a directory that does not exist (and a real overlap goes unseen).
+    // (Caught by the fresh PR review.)
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
     if (line.startsWith('worktree ')) {
-      current = { path: line.slice('worktree '.length).trim() };
+      current = { path: line.slice('worktree '.length) };
       entries.push(current);
     } else if (line.startsWith('branch ') && current) {
+      // A ref name cannot contain whitespace, so trimming here is safe.
       current.branch = line.slice('branch '.length).trim();
     }
   }

--- a/src/agents/siblingWork.ts
+++ b/src/agents/siblingWork.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const execFileAsync = promisify(execFile);
@@ -87,15 +88,41 @@ export function identifierFromBranch(branch?: string): string | undefined {
 }
 
 /**
+ * Canonicalise a path for comparison: symlinks resolved where the path exists,
+ * lexical normalisation where it does not.
+ *
+ * `resolve` alone is not enough. git always reports a worktree by its *real*
+ * path — verified by asking through a symlink, which still answered with the
+ * resolved directory — while the dispatched project path can carry a symlinked
+ * component (on macOS `/var` alone is one). Comparing the two forms lexically
+ * makes them differ, and the current worktree is then scanned and reported as
+ * a conflicting peer. (Caught by the fresh PR review.)
+ */
+export function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    // A worktree git still lists but that is gone from disk; lexical is the
+    // best available, and it is only used to tell it apart from ourselves.
+    return resolve(path);
+  }
+}
+
+/**
  * Every worktree of this repository except the one we are working in.
  *
- * Paths are resolved before comparison so a worktree reached by a different
- * spelling is still recognised as ourselves — reporting our own edits back to
- * us would read as a conflict with a phantom peer.
+ * Both sides go through the same canonicaliser, so a worktree reached by a
+ * different spelling is still recognised as ourselves — reporting our own edits
+ * back to us would read as a conflict with a phantom peer. The canonicaliser is
+ * a parameter so the decision stays testable without symlinks on disk.
  */
-export function selectSiblingWorktrees(entries: readonly WorktreeEntry[], selfPath: string): WorktreeEntry[] {
-  const self = resolve(selfPath);
-  return entries.filter((entry) => resolve(entry.path) !== self);
+export function selectSiblingWorktrees(
+  entries: readonly WorktreeEntry[],
+  selfPath: string,
+  canonicalise: (path: string) => string = resolve,
+): WorktreeEntry[] {
+  const self = canonicalise(selfPath);
+  return entries.filter((entry) => canonicalise(entry.path) !== self);
 }
 
 /**
@@ -230,7 +257,7 @@ export async function collectSiblingWork(
 
   let entries: WorktreeEntry[];
   try {
-    entries = selectSiblingWorktrees(parseWorktreeList(await listWorktrees(worktreePath)), worktreePath);
+    entries = selectSiblingWorktrees(parseWorktreeList(await listWorktrees(worktreePath)), worktreePath, canonicalPath);
   } catch {
     return [];
   }

--- a/src/agents/siblingWork.ts
+++ b/src/agents/siblingWork.ts
@@ -32,32 +32,38 @@ export const MAX_SIBLINGS = 8;
 export const MAX_FILES_PER_SIBLING = 12;
 
 /**
- * Parse `git worktree list --porcelain`.
+ * Parse `git worktree list --porcelain -z`.
  *
  * Git is asked rather than the run ledger on purpose: git knows every worktree
  * of the repository, including ones no run owns (the main checkout, a worktree
  * left behind by an abandoned run), and those hold edits that conflict exactly
  * as much. It is also reachable from inside a worktree, which the ledger is not.
+ *
+ * `-z` because the line-based form cannot represent a path containing a
+ * newline: measured against real git, such a path splits across two lines and
+ * the parser reads a truncated directory that does not exist, so a real overlap
+ * goes unseen. With `-z` each attribute is one NUL-terminated field and the
+ * path survives whole.
+ *
+ * Note that unlike `status --porcelain`, this command does NOT C-quote unusual
+ * paths — spaces, quotes and non-ASCII were all verified to come through
+ * literally in both forms — so the field is used as-is rather than unescaped.
+ * (Newline case caught by the fresh PR review.)
  */
-export function parseWorktreeList(porcelain: string): WorktreeEntry[] {
+export function parseWorktreeList(porcelainZ: string): WorktreeEntry[] {
   const entries: WorktreeEntry[] = [];
   let current: WorktreeEntry | undefined;
 
-  for (const rawLine of porcelain.split('\n')) {
-    // Only \r is stripped, for a checkout written with CRLF endings. The path
-    // itself is NOT trimmed: measured against real git, `worktree list
-    // --porcelain` emits paths literally and unquoted, trailing space included,
-    // so trimming corrupts a legitimate path — which then either fails to match
-    // ourselves (and we report our own edits as a peer's) or points `git status`
-    // at a directory that does not exist (and a real overlap goes unseen).
-    // (Caught by the fresh PR review.)
-    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
-    if (line.startsWith('worktree ')) {
-      current = { path: line.slice('worktree '.length) };
+  for (const field of porcelainZ.split('\0')) {
+    if (field.startsWith('worktree ')) {
+      // Not trimmed: a trailing space is part of the path, and trimming it
+      // either hides a real overlap or makes us report our own edits as a
+      // peer's.
+      current = { path: field.slice('worktree '.length) };
       entries.push(current);
-    } else if (line.startsWith('branch ') && current) {
+    } else if (field.startsWith('branch ') && current) {
       // A ref name cannot contain whitespace, so trimming here is safe.
-      current.branch = line.slice('branch '.length).trim();
+      current.branch = field.slice('branch '.length).trim();
     }
   }
 
@@ -212,7 +218,7 @@ export async function collectSiblingWork(
   const remaining = () => deadline - now();
 
   const listWorktrees = io.listWorktrees ?? (async (cwd: string) => (
-    (await execFileAsync('git', ['-C', cwd, 'worktree', 'list', '--porcelain'], {
+    (await execFileAsync('git', ['-C', cwd, 'worktree', 'list', '--porcelain', '-z'], {
       ...GIT_LIMITS, timeout: commandTimeoutMs(remaining()),
     })).stdout
   ));

--- a/src/agents/siblingWork.ts
+++ b/src/agents/siblingWork.ts
@@ -1,0 +1,236 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { resolve } from 'node:path';
+
+const execFileAsync = promisify(execFile);
+
+const GIT_LIMITS = { timeout: 5_000, maxBuffer: 1024 * 1024 } as const;
+
+/**
+ * What timeout to give one git call: whatever is left of the scan's budget,
+ * never more than the per-command cap and never zero — `0` means "no timeout"
+ * to child_process, which is the opposite of what an exhausted budget wants.
+ */
+export function commandTimeoutMs(remainingMs: number, cap: number = GIT_LIMITS.timeout): number {
+  return Math.max(1, Math.min(cap, remainingMs));
+}
+
+/** One worktree of a repository, as reported by `git worktree list`. */
+export interface WorktreeEntry {
+  path: string;
+  branch?: string;
+}
+
+/** A sibling worktree and what it currently has uncommitted. */
+export interface SiblingWork {
+  identifier: string;
+  files: string[];
+}
+
+/** Keep the injected block context, not payload. */
+export const MAX_SIBLINGS = 8;
+export const MAX_FILES_PER_SIBLING = 12;
+
+/**
+ * Parse `git worktree list --porcelain`.
+ *
+ * Git is asked rather than the run ledger on purpose: git knows every worktree
+ * of the repository, including ones no run owns (the main checkout, a worktree
+ * left behind by an abandoned run), and those hold edits that conflict exactly
+ * as much. It is also reachable from inside a worktree, which the ledger is not.
+ */
+export function parseWorktreeList(porcelain: string): WorktreeEntry[] {
+  const entries: WorktreeEntry[] = [];
+  let current: WorktreeEntry | undefined;
+
+  for (const line of porcelain.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      current = { path: line.slice('worktree '.length).trim() };
+      entries.push(current);
+    } else if (line.startsWith('branch ') && current) {
+      current.branch = line.slice('branch '.length).trim();
+    }
+  }
+
+  return entries.filter((entry) => entry.path.length > 0);
+}
+
+/**
+ * The issue identifier a branch was cut for, e.g.
+ * `refs/heads/swarm/AX-1062-receivables` -> `AX-1062`.
+ *
+ * Falls back to the short branch name: a worktree on a hand-made branch still
+ * holds conflicting edits, and naming it by its branch is more use to the
+ * worker than dropping it for not matching a convention.
+ */
+export function identifierFromBranch(branch?: string): string | undefined {
+  if (!branch) return undefined;
+  const short = branch.replace(/^refs\/heads\//, '');
+  if (!short) return undefined;
+  const match = /(?:^|\/)([A-Z][A-Z0-9]*-\d+)(?:[-/]|$)/.exec(short);
+  return match ? match[1] : short;
+}
+
+/**
+ * Every worktree of this repository except the one we are working in.
+ *
+ * Paths are resolved before comparison so a worktree reached by a different
+ * spelling is still recognised as ourselves — reporting our own edits back to
+ * us would read as a conflict with a phantom peer.
+ */
+export function selectSiblingWorktrees(entries: readonly WorktreeEntry[], selfPath: string): WorktreeEntry[] {
+  const self = resolve(selfPath);
+  return entries.filter((entry) => resolve(entry.path) !== self);
+}
+
+/**
+ * Render the advisory block, or an empty string when there is nothing to say.
+ *
+ * Empty rather than a "no siblings" sentence: a worker running alone is the
+ * common case, and a paragraph saying nothing is happening would be noise in
+ * most prompts.
+ */
+export function formatSiblingWork(siblings: readonly SiblingWork[]): string {
+  // No early return for the empty case: slice -> map -> join already yields the
+  // empty string, and a guard for it is a branch no test can distinguish.
+  const withFiles = siblings.filter((sibling) => sibling.files.length > 0);
+  const lines = withFiles.slice(0, MAX_SIBLINGS).map((sibling) => {
+    const shown = sibling.files.slice(0, MAX_FILES_PER_SIBLING);
+    const omitted = sibling.files.length - shown.length;
+    return `  ${sibling.identifier} — ${shown.join(', ')}${omitted > 0 ? `, +${omitted} more` : ''}`;
+  });
+
+  const dropped = withFiles.length - Math.min(withFiles.length, MAX_SIBLINGS);
+  if (dropped > 0) lines.push(`  (+${dropped} more worktree${dropped === 1 ? '' : 's'})`);
+
+  return lines.join('\n');
+}
+
+/**
+ * Uncommitted paths in one worktree, from `git status --porcelain -z`.
+ *
+ * `-z` rather than plain porcelain: without it git C-quotes any path holding a
+ * space, quote, backslash or non-ASCII byte (`"src/a\tb.ts"`), and prints a
+ * rename as `old -> new` on one line — so a filename containing ` -> ` splits
+ * in the wrong place. Both would name a file that does not exist, which is
+ * worse than saying nothing. With `-z` each field is literal and NUL-separated,
+ * and a rename is two fields: the new path, then the original.
+ * (Caught by the commit-gate review.)
+ */
+export function parseChangedFiles(porcelainZ: string): string[] {
+  const fields = porcelainZ.split('\0').filter((field) => field.length > 0);
+  const files: string[] = [];
+
+  for (let i = 0; i < fields.length; i++) {
+    const entry = fields[i];
+    const status = entry.slice(0, 2);
+    // `XY ` — two status codes and a space. Not trimmed: a path may legitimately
+    // end in a space, and trimming would name a different file.
+    const path = entry.slice(3);
+    if (path) files.push(path);
+    // A rename or copy is followed by its source path as a separate field. That
+    // path is where the content came from, not somewhere this worktree is
+    // writing, so it is consumed rather than reported.
+    if (status.includes('R') || status.includes('C')) i++;
+  }
+
+  return files;
+}
+
+/** How many `git status` calls may be in flight at once. */
+export const STATUS_CONCURRENCY = 8;
+
+/**
+ * Total wall-clock this scan may spend, across all worktrees.
+ *
+ * The per-command timeout alone does not bound it: with N worktrees the scan
+ * runs ceil(N / STATUS_CONCURRENCY) batches, so a repository full of stalled or
+ * unreachable worktrees could add minutes — and this runs ahead of *every*
+ * worker attempt. Past the budget the remaining worktrees are reported as
+ * clean rather than waited for, which is the right trade for an advisory: a
+ * partial list is useful, a delayed dispatch is not.
+ *
+ * Enforced on both edges, because skipping only *unstarted* worktrees still
+ * lets the commands already running overrun it: every git invocation is given
+ * whatever is left of the budget as its own timeout, so the scan cannot outlive
+ * this figure by more than process teardown.
+ * (Both caught by the commit-gate review.)
+ */
+export const TOTAL_BUDGET_MS = 5_000;
+
+/** Run `worker` over every item, at most `limit` in flight. */
+async function mapWithLimit<T, R>(items: readonly T[], limit: number, worker: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = Array.from({ length: items.length });
+  let next = 0;
+  const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (let i = next++; i < items.length; i = next++) results[i] = await worker(items[i]);
+  });
+  await Promise.all(runners);
+  return results;
+}
+
+/**
+ * What every other worktree of this repository is currently editing.
+ *
+ * Best effort throughout: this decorates a prompt, so a removed worktree, a
+ * failing git, or a repository mid-rebase costs that one sibling its line and
+ * nothing more.
+ *
+ * Every sibling is inspected, and only then are the dirty ones capped. Capping
+ * the worktree list first was wrong: this host runs 25 worktrees against a cap
+ * of 8, so a dirty worktree sitting past the cut was dropped without a trace —
+ * and silently omitting a conflict is the one failure this feature exists to
+ * prevent. It also left `formatSiblingWork`'s "+N more" count unreachable in
+ * production, since the list could never exceed the cap. (Caught by the
+ * commit-gate review.)
+ *
+ * Cost stays bounded by `STATUS_CONCURRENCY` rather than by truncation: at most
+ * that many `git status` processes run at once, however many worktrees exist.
+ */
+export async function collectSiblingWork(
+  worktreePath: string,
+  // Seams, defaulted to git. Injected only by the tests, which need to cover
+  // the ordering property below without 25 real worktrees on disk.
+  io: {
+    listWorktrees?: (cwd: string) => Promise<string>;
+    readStatus?: (cwd: string) => Promise<string>;
+    budgetMs?: number;
+    now?: () => number;
+  } = {},
+): Promise<SiblingWork[]> {
+  const now = io.now ?? Date.now;
+  const deadline = now() + (io.budgetMs ?? TOTAL_BUDGET_MS);
+  const remaining = () => deadline - now();
+
+  const listWorktrees = io.listWorktrees ?? (async (cwd: string) => (
+    (await execFileAsync('git', ['-C', cwd, 'worktree', 'list', '--porcelain'], {
+      ...GIT_LIMITS, timeout: commandTimeoutMs(remaining()),
+    })).stdout
+  ));
+  const readStatus = io.readStatus ?? (async (cwd: string) => (
+    (await execFileAsync('git', ['-C', cwd, 'status', '--porcelain', '-z'], {
+      ...GIT_LIMITS, timeout: commandTimeoutMs(remaining()),
+    })).stdout
+  ));
+
+  let entries: WorktreeEntry[];
+  try {
+    entries = selectSiblingWorktrees(parseWorktreeList(await listWorktrees(worktreePath)), worktreePath);
+  } catch {
+    return [];
+  }
+
+  const collected = await mapWithLimit(entries, STATUS_CONCURRENCY, async (entry) => {
+    const identifier = identifierFromBranch(entry.branch) ?? entry.path;
+    // Checked before starting, not after: the budget caps how many batches are
+    // begun, so the scan overruns by at most one in-flight command.
+    if (now() >= deadline) return { identifier, files: [] };
+    try {
+      return { identifier, files: parseChangedFiles(await readStatus(entry.path)) };
+    } catch {
+      return { identifier, files: [] };
+    }
+  });
+
+  return collected.filter((sibling) => sibling.files.length > 0);
+}

--- a/src/agents/siblingWork.ts
+++ b/src/agents/siblingWork.ts
@@ -2,6 +2,10 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
+import {
+  parseChangedFiles, parseWorktreeList, identifierFromBranch, selectSiblingWorktrees,
+  type SiblingWork, type WorktreeEntry,
+} from './siblingWorkFormat.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -14,77 +18,6 @@ const GIT_LIMITS = { timeout: 5_000, maxBuffer: 1024 * 1024 } as const;
  */
 export function commandTimeoutMs(remainingMs: number, cap: number = GIT_LIMITS.timeout): number {
   return Math.max(1, Math.min(cap, remainingMs));
-}
-
-/** One worktree of a repository, as reported by `git worktree list`. */
-export interface WorktreeEntry {
-  path: string;
-  branch?: string;
-}
-
-/** A sibling worktree and what it currently has uncommitted. */
-export interface SiblingWork {
-  identifier: string;
-  files: string[];
-}
-
-/** Keep the injected block context, not payload. */
-export const MAX_SIBLINGS = 8;
-export const MAX_FILES_PER_SIBLING = 12;
-
-/**
- * Parse `git worktree list --porcelain -z`.
- *
- * Git is asked rather than the run ledger on purpose: git knows every worktree
- * of the repository, including ones no run owns (the main checkout, a worktree
- * left behind by an abandoned run), and those hold edits that conflict exactly
- * as much. It is also reachable from inside a worktree, which the ledger is not.
- *
- * `-z` because the line-based form cannot represent a path containing a
- * newline: measured against real git, such a path splits across two lines and
- * the parser reads a truncated directory that does not exist, so a real overlap
- * goes unseen. With `-z` each attribute is one NUL-terminated field and the
- * path survives whole.
- *
- * Note that unlike `status --porcelain`, this command does NOT C-quote unusual
- * paths — spaces, quotes and non-ASCII were all verified to come through
- * literally in both forms — so the field is used as-is rather than unescaped.
- * (Newline case caught by the fresh PR review.)
- */
-export function parseWorktreeList(porcelainZ: string): WorktreeEntry[] {
-  const entries: WorktreeEntry[] = [];
-  let current: WorktreeEntry | undefined;
-
-  for (const field of porcelainZ.split('\0')) {
-    if (field.startsWith('worktree ')) {
-      // Not trimmed: a trailing space is part of the path, and trimming it
-      // either hides a real overlap or makes us report our own edits as a
-      // peer's.
-      current = { path: field.slice('worktree '.length) };
-      entries.push(current);
-    } else if (field.startsWith('branch ') && current) {
-      // A ref name cannot contain whitespace, so trimming here is safe.
-      current.branch = field.slice('branch '.length).trim();
-    }
-  }
-
-  return entries.filter((entry) => entry.path.length > 0);
-}
-
-/**
- * The issue identifier a branch was cut for, e.g.
- * `refs/heads/swarm/AX-1062-receivables` -> `AX-1062`.
- *
- * Falls back to the short branch name: a worktree on a hand-made branch still
- * holds conflicting edits, and naming it by its branch is more use to the
- * worker than dropping it for not matching a convention.
- */
-export function identifierFromBranch(branch?: string): string | undefined {
-  if (!branch) return undefined;
-  const short = branch.replace(/^refs\/heads\//, '');
-  if (!short) return undefined;
-  const match = /(?:^|\/)([A-Z][A-Z0-9]*-\d+)(?:[-/]|$)/.exec(short);
-  return match ? match[1] : short;
 }
 
 /**
@@ -106,77 +39,6 @@ export function canonicalPath(path: string): string {
     // best available, and it is only used to tell it apart from ourselves.
     return resolve(path);
   }
-}
-
-/**
- * Every worktree of this repository except the one we are working in.
- *
- * Both sides go through the same canonicaliser, so a worktree reached by a
- * different spelling is still recognised as ourselves — reporting our own edits
- * back to us would read as a conflict with a phantom peer. The canonicaliser is
- * a parameter so the decision stays testable without symlinks on disk.
- */
-export function selectSiblingWorktrees(
-  entries: readonly WorktreeEntry[],
-  selfPath: string,
-  canonicalise: (path: string) => string = resolve,
-): WorktreeEntry[] {
-  const self = canonicalise(selfPath);
-  return entries.filter((entry) => canonicalise(entry.path) !== self);
-}
-
-/**
- * Render the advisory block, or an empty string when there is nothing to say.
- *
- * Empty rather than a "no siblings" sentence: a worker running alone is the
- * common case, and a paragraph saying nothing is happening would be noise in
- * most prompts.
- */
-export function formatSiblingWork(siblings: readonly SiblingWork[]): string {
-  // No early return for the empty case: slice -> map -> join already yields the
-  // empty string, and a guard for it is a branch no test can distinguish.
-  const withFiles = siblings.filter((sibling) => sibling.files.length > 0);
-  const lines = withFiles.slice(0, MAX_SIBLINGS).map((sibling) => {
-    const shown = sibling.files.slice(0, MAX_FILES_PER_SIBLING);
-    const omitted = sibling.files.length - shown.length;
-    return `  ${sibling.identifier} — ${shown.join(', ')}${omitted > 0 ? `, +${omitted} more` : ''}`;
-  });
-
-  const dropped = withFiles.length - Math.min(withFiles.length, MAX_SIBLINGS);
-  if (dropped > 0) lines.push(`  (+${dropped} more worktree${dropped === 1 ? '' : 's'})`);
-
-  return lines.join('\n');
-}
-
-/**
- * Uncommitted paths in one worktree, from `git status --porcelain -z`.
- *
- * `-z` rather than plain porcelain: without it git C-quotes any path holding a
- * space, quote, backslash or non-ASCII byte (`"src/a\tb.ts"`), and prints a
- * rename as `old -> new` on one line — so a filename containing ` -> ` splits
- * in the wrong place. Both would name a file that does not exist, which is
- * worse than saying nothing. With `-z` each field is literal and NUL-separated,
- * and a rename is two fields: the new path, then the original.
- * (Caught by the commit-gate review.)
- */
-export function parseChangedFiles(porcelainZ: string): string[] {
-  const fields = porcelainZ.split('\0').filter((field) => field.length > 0);
-  const files: string[] = [];
-
-  for (let i = 0; i < fields.length; i++) {
-    const entry = fields[i];
-    const status = entry.slice(0, 2);
-    // `XY ` — two status codes and a space. Not trimmed: a path may legitimately
-    // end in a space, and trimming would name a different file.
-    const path = entry.slice(3);
-    if (path) files.push(path);
-    // A rename or copy is followed by its source path as a separate field. That
-    // path is where the content came from, not somewhere this worktree is
-    // writing, so it is consumed rather than reported.
-    if (status.includes('R') || status.includes('C')) i++;
-  }
-
-  return files;
 }
 
 /** How many `git status` calls may be in flight at once. */
@@ -276,3 +138,5 @@ export async function collectSiblingWork(
 
   return collected.filter((sibling) => sibling.files.length > 0);
 }
+
+export * from './siblingWorkFormat.js';

--- a/src/agents/siblingWorkFormat.ts
+++ b/src/agents/siblingWorkFormat.ts
@@ -1,0 +1,150 @@
+// Pure half of the sibling-work advisory: parsing, selection and rendering.
+//
+// Split from the collector so the prompt templates can render this without
+// importing a module that reaches for child_process. They did, and a suite
+// that partially mocks `child_process` then failed to even load the prompts,
+// because `promisify(execFile)` runs at module scope. (Caught by CI.)
+
+import { resolve } from 'node:path';
+
+/** One worktree of a repository, as reported by `git worktree list`. */
+export interface WorktreeEntry {
+  path: string;
+  branch?: string;
+}
+
+/** A sibling worktree and what it currently has uncommitted. */
+export interface SiblingWork {
+  identifier: string;
+  files: string[];
+}
+
+/** Keep the injected block context, not payload. */
+export const MAX_SIBLINGS = 8;
+export const MAX_FILES_PER_SIBLING = 12;
+
+/**
+ * Parse `git worktree list --porcelain -z`.
+ *
+ * Git is asked rather than the run ledger on purpose: git knows every worktree
+ * of the repository, including ones no run owns (the main checkout, a worktree
+ * left behind by an abandoned run), and those hold edits that conflict exactly
+ * as much. It is also reachable from inside a worktree, which the ledger is not.
+ *
+ * `-z` because the line-based form cannot represent a path containing a
+ * newline: measured against real git, such a path splits across two lines and
+ * the parser reads a truncated directory that does not exist, so a real overlap
+ * goes unseen. With `-z` each attribute is one NUL-terminated field and the
+ * path survives whole.
+ *
+ * Note that unlike `status --porcelain`, this command does NOT C-quote unusual
+ * paths — spaces, quotes and non-ASCII were all verified to come through
+ * literally in both forms — so the field is used as-is rather than unescaped.
+ * (Newline case caught by the fresh PR review.)
+ */
+export function parseWorktreeList(porcelainZ: string): WorktreeEntry[] {
+  const entries: WorktreeEntry[] = [];
+  let current: WorktreeEntry | undefined;
+
+  for (const field of porcelainZ.split('\0')) {
+    if (field.startsWith('worktree ')) {
+      // Not trimmed: a trailing space is part of the path, and trimming it
+      // either hides a real overlap or makes us report our own edits as a
+      // peer's.
+      current = { path: field.slice('worktree '.length) };
+      entries.push(current);
+    } else if (field.startsWith('branch ') && current) {
+      // A ref name cannot contain whitespace, so trimming here is safe.
+      current.branch = field.slice('branch '.length).trim();
+    }
+  }
+
+  return entries.filter((entry) => entry.path.length > 0);
+}
+
+/**
+ * The issue identifier a branch was cut for, e.g.
+ * `refs/heads/swarm/AX-1062-receivables` -> `AX-1062`.
+ *
+ * Falls back to the short branch name: a worktree on a hand-made branch still
+ * holds conflicting edits, and naming it by its branch is more use to the
+ * worker than dropping it for not matching a convention.
+ */
+export function identifierFromBranch(branch?: string): string | undefined {
+  if (!branch) return undefined;
+  const short = branch.replace(/^refs\/heads\//, '');
+  if (!short) return undefined;
+  const match = /(?:^|\/)([A-Z][A-Z0-9]*-\d+)(?:[-/]|$)/.exec(short);
+  return match ? match[1] : short;
+}
+
+/**
+ * Every worktree of this repository except the one we are working in.
+ *
+ * Both sides go through the same canonicaliser, so a worktree reached by a
+ * different spelling is still recognised as ourselves — reporting our own edits
+ * back to us would read as a conflict with a phantom peer. The canonicaliser is
+ * a parameter so the decision stays testable without symlinks on disk.
+ */
+export function selectSiblingWorktrees(
+  entries: readonly WorktreeEntry[],
+  selfPath: string,
+  canonicalise: (path: string) => string = resolve,
+): WorktreeEntry[] {
+  const self = canonicalise(selfPath);
+  return entries.filter((entry) => canonicalise(entry.path) !== self);
+}
+
+/**
+ * Render the advisory block, or an empty string when there is nothing to say.
+ *
+ * Empty rather than a "no siblings" sentence: a worker running alone is the
+ * common case, and a paragraph saying nothing is happening would be noise in
+ * most prompts.
+ */
+export function formatSiblingWork(siblings: readonly SiblingWork[]): string {
+  // No early return for the empty case: slice -> map -> join already yields the
+  // empty string, and a guard for it is a branch no test can distinguish.
+  const withFiles = siblings.filter((sibling) => sibling.files.length > 0);
+  const lines = withFiles.slice(0, MAX_SIBLINGS).map((sibling) => {
+    const shown = sibling.files.slice(0, MAX_FILES_PER_SIBLING);
+    const omitted = sibling.files.length - shown.length;
+    return `  ${sibling.identifier} — ${shown.join(', ')}${omitted > 0 ? `, +${omitted} more` : ''}`;
+  });
+
+  const dropped = withFiles.length - Math.min(withFiles.length, MAX_SIBLINGS);
+  if (dropped > 0) lines.push(`  (+${dropped} more worktree${dropped === 1 ? '' : 's'})`);
+
+  return lines.join('\n');
+}
+
+/**
+ * Uncommitted paths in one worktree, from `git status --porcelain -z`.
+ *
+ * `-z` rather than plain porcelain: without it git C-quotes any path holding a
+ * space, quote, backslash or non-ASCII byte (`"src/a\tb.ts"`), and prints a
+ * rename as `old -> new` on one line — so a filename containing ` -> ` splits
+ * in the wrong place. Both would name a file that does not exist, which is
+ * worse than saying nothing. With `-z` each field is literal and NUL-separated,
+ * and a rename is two fields: the new path, then the original.
+ * (Caught by the commit-gate review.)
+ */
+export function parseChangedFiles(porcelainZ: string): string[] {
+  const fields = porcelainZ.split('\0').filter((field) => field.length > 0);
+  const files: string[] = [];
+
+  for (let i = 0; i < fields.length; i++) {
+    const entry = fields[i];
+    const status = entry.slice(0, 2);
+    // `XY ` — two status codes and a space. Not trimmed: a path may legitimately
+    // end in a space, and trimming would name a different file.
+    const path = entry.slice(3);
+    if (path) files.push(path);
+    // A rename or copy is followed by its source path as a separate field. That
+    // path is where the content came from, not somewhere this worktree is
+    // writing, so it is consumed rather than reported.
+    if (status.includes('R') || status.includes('C')) i++;
+  }
+
+  return files;
+}

--- a/src/agents/workerContext.ts
+++ b/src/agents/workerContext.ts
@@ -3,6 +3,7 @@ import { recallRepoKnowledge } from '../memory/repoKnowledge.js';
 import { getRegistryStore } from '../registry/sqliteStore.js';
 import type { WorkerContext } from '../locale/types.js';
 import { safeConsole } from '../support/safeLog.js';
+import { collectSiblingWork } from './siblingWork.js';
 import type { PipelineContext } from './pairPipelineTypes.js';
 
 export async function collectWorkerContext(
@@ -39,6 +40,12 @@ export async function collectWorkerContext(
     }
     const memories = await recallRepoKnowledge(context.projectPath, context.task.title, context.task.description || '');
     if (memories.length) { wc.repoMemories = memories; safeConsole.log(`[Pipeline] Recalled ${memories.length} repo memories for context`); }
-    return wc.impactAnalysis || wc.registryBriefs || wc.draftAnalysis || wc.repoMemories ? wc : undefined;
+    // Overlap is invisible to a worker otherwise: the coordination board is
+    // partitioned per worktree, and same-repo conflict checking is deliberately
+    // off so workers are never serialised (autonomousRunner). Advisory only —
+    // it changes what the worker knows, not what it is allowed to do. (AGT-4088)
+    const siblingWork = await collectSiblingWork(context.projectPath);
+    if (siblingWork.length) { wc.siblingWork = siblingWork; safeConsole.log(`[Pipeline] ${siblingWork.length} sibling worktree(s) have uncommitted changes`); }
+    return wc.impactAnalysis || wc.registryBriefs || wc.draftAnalysis || wc.repoMemories || wc.siblingWork ? wc : undefined;
   } catch (error) { safeConsole.warn('[Pipeline] Worker context collection failed (non-blocking):', error); return undefined; }
 }

--- a/src/locale/prompts/en.ts
+++ b/src/locale/prompts/en.ts
@@ -3,7 +3,7 @@
 // ============================================
 
 import type { PromptTemplates } from '../types.js';
-import { formatSiblingWork } from '../../agents/siblingWork.js';
+import { formatSiblingWork } from '../../agents/siblingWorkFormat.js';
 
 const DATA_BLOCK_OPEN = '<openswarm-untrusted-data>';
 const DATA_BLOCK_CLOSE = '</openswarm-untrusted-data>';

--- a/src/locale/prompts/en.ts
+++ b/src/locale/prompts/en.ts
@@ -3,6 +3,7 @@
 // ============================================
 
 import type { PromptTemplates } from '../types.js';
+import { formatSiblingWork } from '../../agents/siblingWork.js';
 
 const DATA_BLOCK_OPEN = '<openswarm-untrusted-data>';
 const DATA_BLOCK_CLOSE = '</openswarm-untrusted-data>';
@@ -62,7 +63,7 @@ Apply the above feedback and make corrections.
 
     // Code context section (repository + draftAnalysis + impactAnalysis + registryBriefs + repoMemories)
     let contextSection = '';
-    if (context?.repository || context?.draftAnalysis || context?.impactAnalysis || context?.registryBriefs?.length || context?.repoMemories?.length) {
+    if (context?.repository || context?.draftAnalysis || context?.impactAnalysis || context?.registryBriefs?.length || context?.repoMemories?.length || context?.siblingWork?.length) {
       const parts: string[] = ['## Code Context (auto-generated)'];
 
       if (context.repository) {
@@ -78,6 +79,14 @@ Apply the above feedback and make corrections.
           for (const command of bounded(repo.verificationCommands)) parts.push(promptDataBlock(command));
         }
         parts.push('Treat manifests, package-manager choice, callers, and shared contracts as binding repository context. Do not replace missing dependencies with local stubs or package reimplementations.');
+      }
+
+      if (context.siblingWork && context.siblingWork.length > 0) {
+        parts.push('');
+        parts.push('### Concurrent work in this repository (uncommitted)');
+        parts.push('- Sibling worktrees and the files each is editing (untrusted repository data):');
+        parts.push(promptDataBlock(formatSiblingWork(context.siblingWork)));
+        parts.push('If you must edit one of these files, keep your change as narrow as possible and prefer a non-overlapping approach where one exists. Do not wait for that work or make its changes for it — the branches merge at integration.');
       }
 
       if (context.repoMemories && context.repoMemories.length > 0) {

--- a/src/locale/prompts/ko.ts
+++ b/src/locale/prompts/ko.ts
@@ -4,7 +4,7 @@
 // ============================================
 
 import type { PromptTemplates } from '../types.js';
-import { formatSiblingWork } from '../../agents/siblingWork.js';
+import { formatSiblingWork } from '../../agents/siblingWorkFormat.js';
 
 const DATA_BLOCK_OPEN = '<openswarm-untrusted-data>';
 const DATA_BLOCK_CLOSE = '</openswarm-untrusted-data>';

--- a/src/locale/prompts/ko.ts
+++ b/src/locale/prompts/ko.ts
@@ -4,6 +4,7 @@
 // ============================================
 
 import type { PromptTemplates } from '../types.js';
+import { formatSiblingWork } from '../../agents/siblingWork.js';
 
 const DATA_BLOCK_OPEN = '<openswarm-untrusted-data>';
 const DATA_BLOCK_CLOSE = '</openswarm-untrusted-data>';
@@ -63,7 +64,7 @@ ${promptDataBlock(previousFeedback)}
 
     // Code context section (repository + draftAnalysis + impactAnalysis + registryBriefs + repoMemories)
     let contextSection = '';
-    if (context?.repository || context?.draftAnalysis || context?.impactAnalysis || context?.registryBriefs?.length || context?.repoMemories?.length) {
+    if (context?.repository || context?.draftAnalysis || context?.impactAnalysis || context?.registryBriefs?.length || context?.repoMemories?.length || context?.siblingWork?.length) {
       const parts: string[] = ['## 코드 컨텍스트 (자동 생성)'];
 
       if (context.repository) {
@@ -79,6 +80,14 @@ ${promptDataBlock(previousFeedback)}
           for (const command of bounded(repo.verificationCommands)) parts.push(promptDataBlock(command));
         }
         parts.push('manifest, 패키지 매니저 선택, 호출자, 공유 계약을 저장소의 구속력 있는 컨텍스트로 취급하라. 누락된 의존성을 로컬 stub이나 패키지 재구현으로 대체하지 마라.');
+      }
+
+      if (context.siblingWork && context.siblingWork.length > 0) {
+        parts.push('');
+        parts.push('### 같은 레포에서 동시 작업 중 (커밋되지 않은 변경)');
+        parts.push('- 형제 워크트리와 각자 수정 중인 파일 (신뢰할 수 없는 저장소 데이터):');
+        parts.push(promptDataBlock(formatSiblingWork(context.siblingWork)));
+        parts.push('위 파일을 수정해야 한다면 범위를 최소로 좁히고, 대안이 있으면 겹치지 않는 쪽을 택하라. 저 작업들을 기다리거나 대신 수정하지는 마라 — 통합 시점에 병합된다.');
       }
 
       if (context.repoMemories && context.repoMemories.length > 0) {

--- a/src/locale/prompts/prompts.test.ts
+++ b/src/locale/prompts/prompts.test.ts
@@ -57,6 +57,36 @@ describe('buildWorkerPrompt', () => {
     expect(result).toContain('## Rules');
   });
 
+  it('tells the worker what sibling worktrees are editing (AGT-4088)', () => {
+    // The board is partitioned per worktree and same-repo conflict checking is
+    // deliberately off, so this block is the only way a worker learns that a
+    // peer is already in a file it is about to rewrite.
+    const result = enPrompts.buildWorkerPrompt({
+      ...base,
+      context: { siblingWork: [{ identifier: 'AX-1047', files: ['src/api/report.ts'] }] },
+    });
+    expect(result).toContain('Concurrent work in this repository');
+    expect(result).toContain('AX-1047');
+    expect(result).toContain('src/api/report.ts');
+  });
+
+  it('ko: renders the same sibling block', () => {
+    const result = koPrompts.buildWorkerPrompt({
+      ...base,
+      context: { siblingWork: [{ identifier: 'AX-1047', files: ['src/api/report.ts'] }] },
+    });
+    expect(result).toContain('동시 작업 중');
+    expect(result).toContain('AX-1047');
+  });
+
+  it('says nothing about siblings when none have changes', () => {
+    // A worker running alone is the common case; an empty section in every one
+    // of those prompts is pure noise.
+    expect(enPrompts.buildWorkerPrompt({ ...base, context: { siblingWork: [] } }))
+      .not.toContain('Concurrent work in this repository');
+    expect(enPrompts.buildWorkerPrompt(base)).not.toContain('Concurrent work in this repository');
+  });
+
   it('contains INT-2388 anti-pattern rules (no re-impl, cite contracts, keep verified evidence)', () => {
     const result = enPrompts.buildWorkerPrompt(base);
     // #1 no re-implementation / version spoofing on import failure

--- a/src/locale/prompts/promptsIsolation.test.ts
+++ b/src/locale/prompts/promptsIsolation.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Several suites (scheduler, prProcessor) partially mock child_process. If any
+// module the prompts import touches it at module scope — `promisify(execFile)`
+// did — those suites stop loading entirely with "No 'execFile' export is
+// defined on the child_process mock", and the failure names the innocent suite
+// rather than the prompt module that caused it. This reproduces that shape.
+vi.mock('node:child_process', () => ({}));
+vi.mock('child_process', () => ({}));
+
+describe('prompt templates', () => {
+  it('load without child_process, so a suite that mocks it can still import them', async () => {
+    const { enPrompts } = await import('./en.js');
+    const { koPrompts } = await import('./ko.js');
+    const context = { siblingWork: [{ identifier: 'AX-1', files: ['a.ts'] }] };
+
+    expect(enPrompts.buildWorkerPrompt({ taskTitle: 't', taskDescription: 'd', context }))
+      .toContain('Concurrent work in this repository');
+    expect(koPrompts.buildWorkerPrompt({ taskTitle: 't', taskDescription: 'd', context }))
+      .toContain('동시 작업 중');
+  });
+});

--- a/src/locale/types.ts
+++ b/src/locale/types.ts
@@ -394,6 +394,11 @@ export interface LocaleMessages {
  */
 /** Worker에 주입할 코드 컨텍스트 (반복 횟수 감소 목적) */
 export interface WorkerContext {
+  /**
+   * What the repository's other worktrees are editing right now, so a worker
+   * can see an overlap before its branch collides with theirs at integration.
+   */
+  siblingWork?: { identifier: string; files: string[] }[];
   /** Repository/toolchain capsule captured before a fix worker mutates files. */
   repository?: {
     packageManager?: string;


### PR DESCRIPTION
## Why

A worker talks only to its reviewer. It cannot learn what other workers on the **same
repository** are editing, so two can rewrite the same file and only find out when their
branches integrate.

The board cannot carry this: **50 of the 55** distinct `repository` values on the live
board are worktree paths, and reads filter on exact equality
(`coordinationStore.ts:260`). Same-repo conflict checking is also off on purpose —
`autonomousRunner.ts:1191`, *"must not serialize workers"*. The gap is not that overlap
is allowed; it is that **the worker is never told**.

## Current exposure

| measurement | value |
|---|---|
| open cgf-portal PRs | 5, all MERGEABLE |
| active tasks declaring a `fileScope` | 37 |
| active tasks declaring **none** | **104** |
| `maxConcurrentTasks` | 9 |

Zero conflicts today — but concurrency is running at 1–3, not 9, and `fileScope` is
empty for 74% of active tasks, so it could not be the basis for detection.

## How

Collect at dispatch what every other worktree has uncommitted; render as an advisory
block in both locales. Read-only — the worker is told to narrow its change, not to wait.

**git, not the run ledger.** git knows every worktree, including ones no run owns (the
main checkout, one left by an abandoned run), and those hold conflicting edits too; it
is also reachable from inside a worktree, which the ledger is not. Files come from the
working tree, not `fileScope`.

## Four defects the gate caught (5 rounds)

| # | defect | fix |
|---|---|---|
| 1 | worktree list capped **before** status was read — on this host (25 worktrees, cap 8) a dirty worktree past the cut vanished silently | inspect all, cap only the dirty ones |
| 2 | plain porcelain C-quotes unusual paths and prints renames as `old -> new`, so a filename containing `" -> "` split wrong and named a nonexistent file | `-z`, verified against **real git output** |
| 3 | per-command timeouts did not bound the scan: `ceil(N/concurrency)` batches ahead of *every* worker attempt | total budget |
| 4 | that budget skipped only *unstarted* worktrees, so running commands could overrun it | each call gets the remaining budget as its timeout |

Defect 1 was the one this feature exists to prevent — a silently omitted conflict.

Verification of the `-z` format against a real repository, not assumption:

```
A  a -> b.md\0        ← literal " -> " in a filename survives
 M my report.md\0     ← spaces literal, no quoting
R  new.ts\0old.ts\0   ← rename: new path, then source as its own field
```

## Tests

33 on the module, 4 on the rendered prompt. Every assertion verified to fail on revert,
including reintroducing each of the four defects above.

Closes AGT-4088.