### PR TITLE
fix(agents): keep OpenSwarm's own generated files out of the sibling advisory (AGT-4088)

### DIFF
--- a/src/agents/siblingWork.test.ts
+++ b/src/agents/siblingWork.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import {
   MAX_FILES_PER_SIBLING, MAX_SIBLINGS, STATUS_CONCURRENCY, TOTAL_BUDGET_MS, collectSiblingWork,
   commandTimeoutMs, formatSiblingWork, identifierFromBranch, parseChangedFiles, parseWorktreeList,
-  selectSiblingWorktrees,
+  selectSiblingWorktrees, withoutBookkeeping, isBookkeepingPath,
 } from './siblingWork.js';
 
 // `git worktree list --porcelain -z`: each attribute is its own NUL-terminated
@@ -158,6 +158,46 @@ describe('parseChangedFiles', () => {
   });
 });
 
+describe('withoutBookkeeping', () => {
+  it('drops the preserve marker every managed worktree carries', () => {
+    // Measured live the moment this shipped: 16 of 23 reported entries were
+    // this one file, and 15 of 19 siblings had nothing else — the advisory was
+    // 79% housekeeping, pushing the siblings doing real work past the cap.
+    expect(withoutBookkeeping(['.openswarm-preserved', 'src/a.ts'])).toEqual(['src/a.ts']);
+  });
+
+  it('drops the generated repo snapshot and graph', () => {
+    expect(withoutBookkeeping(['.openswarm/repo-snapshot.json', '.openswarm/repo.graphql'])).toEqual([]);
+  });
+
+  it('drops generated audit reports', () => {
+    expect(withoutBookkeeping(['.openswarm/audit/audit-123.md'])).toEqual([]);
+  });
+
+  it('KEEPS .openswarm/verify.yaml — a sibling editing it is real conflicting work', () => {
+    // Repository-owned configuration (README; deterministicTester's
+    // VERIFY_INPUTS). Filtering the whole directory would suppress exactly the
+    // overlap this advisory exists to report.
+    expect(isBookkeepingPath('.openswarm/verify.yaml')).toBe(false);
+    expect(withoutBookkeeping(['.openswarm/verify.yaml'])).toEqual(['.openswarm/verify.yaml']);
+  });
+
+  it('shows an unrecognised .openswarm path rather than guessing it is noise', () => {
+    // Between over- and under-filtering, over-filtering is the worse failure.
+    expect(withoutBookkeeping(['.openswarm/something-new.json'])).toEqual(['.openswarm/something-new.json']);
+  });
+
+  it('keeps openswarm.json, which is the repository\'s own config', () => {
+    // Without the dot it is a real file a task may legitimately edit.
+    expect(isBookkeepingPath('openswarm.json')).toBe(false);
+    expect(withoutBookkeeping(['openswarm.json'])).toEqual(['openswarm.json']);
+  });
+
+  it('keeps a file that merely starts with the same letters', () => {
+    expect(withoutBookkeeping(['.openswarm-preserved-notes.md'])).toEqual(['.openswarm-preserved-notes.md']);
+  });
+});
+
 describe('formatSiblingWork', () => {
   it('says nothing at all when no sibling has changes', () => {
     expect(formatSiblingWork([])).toBe('');
@@ -239,6 +279,16 @@ describe('collectSiblingWork', () => {
       readStatus: async (cwd) => { seen.push(cwd); return ''; },
     });
     expect(seen).toHaveLength(20);
+  });
+
+  it('drops a sibling whose only change is bookkeeping', async () => {
+    // 15 of 19 live siblings looked like this. Reporting them as peers doing
+    // work is worse than saying nothing: it fills the cap with noise.
+    const result = await collectSiblingWork('/repo/worktree/self', {
+      listWorktrees: async () => worktreeList(3),
+      readStatus: async (cwd) => (cwd === '/repo/worktree/w1' ? 'M  src/real.ts\0' : 'M  .openswarm-preserved\0'),
+    });
+    expect(result).toEqual([{ identifier: 'AX-1001', files: ['src/real.ts'] }]);
   });
 
   it('loses only the failing worktree when git errors', async () => {

--- a/src/agents/siblingWork.ts
+++ b/src/agents/siblingWork.ts
@@ -3,7 +3,7 @@ import { promisify } from 'node:util';
 import { realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 import {
-  parseChangedFiles, parseWorktreeList, identifierFromBranch, selectSiblingWorktrees,
+  parseChangedFiles, parseWorktreeList, identifierFromBranch, selectSiblingWorktrees, withoutBookkeeping,
   type SiblingWork, type WorktreeEntry,
 } from './siblingWorkFormat.js';
 
@@ -130,7 +130,7 @@ export async function collectSiblingWork(
     // begun, so the scan overruns by at most one in-flight command.
     if (now() >= deadline) return { identifier, files: [] };
     try {
-      return { identifier, files: parseChangedFiles(await readStatus(entry.path)) };
+      return { identifier, files: withoutBookkeeping(parseChangedFiles(await readStatus(entry.path))) };
     } catch {
       return { identifier, files: [] };
     }

--- a/src/agents/siblingWorkFormat.ts
+++ b/src/agents/siblingWorkFormat.ts
@@ -96,6 +96,40 @@ export function selectSiblingWorktrees(
 }
 
 /**
+ * Paths OpenSwarm generates inside a repository, which every managed worktree
+ * carries and which tell a worker nothing about what a peer is building.
+ *
+ * Measured on the live host the moment this shipped: 16 of 23 reported file
+ * entries were `.openswarm-preserved`, and 15 of 19 siblings had nothing else
+ * at all — so the advisory was 79% noise, and the four siblings doing real work
+ * were being pushed past the display cap by housekeeping. The synthetic
+ * fixtures could not show this; only the production distribution did.
+ *
+ * An explicit list, not a `.openswarm/` prefix. That directory also holds
+ * `verify.yaml`, which is repository-owned configuration a task may genuinely
+ * change (README, and `deterministicTester`'s VERIFY_INPUTS) — hiding a sibling's
+ * edit to it would suppress exactly the conflict this advisory exists to report.
+ * Between over- and under-filtering, an unrecognised path is therefore shown.
+ * (Caught by the commit-gate review.)
+ */
+const GENERATED_PATHS: ReadonlySet<string> = new Set([
+  '.openswarm-preserved',
+  '.openswarm/repo-snapshot.json',
+  '.openswarm/repo.graphql',
+]);
+
+export function isBookkeepingPath(path: string): boolean {
+  // `openswarm.json` without the dot is the repository's own config — a task may
+  // legitimately edit it, so it is deliberately not matched here.
+  return GENERATED_PATHS.has(path) || path.startsWith('.openswarm/audit/');
+}
+
+/** Drop OpenSwarm's bookkeeping from a worktree's changed-file list. */
+export function withoutBookkeeping(files: readonly string[]): string[] {
+  return files.filter((file) => !isBookkeepingPath(file));
+}
+
+/**
  * Render the advisory block, or an empty string when there is nothing to say.
  *
  * Empty rather than a "no siblings" sentence: a worker running alone is the


### PR DESCRIPTION
## Found by deploying it

AGT-4088 (#467) shipped and its own DoD check — run the collector against the live
repository — showed the advisory was mostly noise:

```
파일 항목 23개 중 16개가 .openswarm-preserved     (70%)
형제 19개 중 15개가 그 파일만 가짐                (79%)
```

Rendered, 6 of the 8 displayed lines were `AX-#### — .openswarm-preserved`, and the
four siblings doing real work were being pushed past the display cap by housekeeping.

Every synthetic fixture passed. Only the production distribution showed it.

## Fix

Filter the paths OpenSwarm generates inside a repository, and drop a sibling left with
nothing to report.

**An explicit list, not a `.openswarm/` prefix.** That directory also holds
`verify.yaml`, which is repository-owned configuration a task may genuinely change
(README:228; `deterministicTester.ts:13` `VERIFY_INPUTS`). Hiding a sibling's edit to it
would suppress exactly the overlap this advisory exists to report. Between over- and
under-filtering, over-filtering is the worse failure, so an unrecognised path is shown.

My first attempt *did* filter the whole directory; the commit gate caught it, and the
narrowing is covered by a test that fails if the prefix form comes back.

## Tests

46 on the module. Mutation-tested: disabling the filter, widening it to a prefix match,
and dropping it from the collector wiring each fail.