### PR TITLE
fix(automation): reconcile a published run whose tracker card already went terminal (AGT-4094)

### DIFF
--- a/src/automation/autonomousRunner.durable.test.ts
+++ b/src/automation/autonomousRunner.durable.test.ts
@@ -384,6 +384,132 @@ esac
     internal.durableRuns.close();
   });
 
+  // AGT-4094: the heartbeat fetch asks Linear only for Todo / In Progress /
+  // In Review / Backlog, so a run whose card reached Done is structurally
+  // absent from `tasks`. Reconciliation used to skip such a row before it ever
+  // reached the GitHub lookup, leaving it in NEEDS_RECONCILE forever — and
+  // NEEDS_RECONCILE counts toward the per-project admission cap, so the slot
+  // leaked permanently. Production case: AX-876, merged PR, 11.9h stuck.
+  it('reconciles a published run whose tracker card already went terminal, so its admission slot is returned', async () => {
+    const [{ AutonomousRunner }, execution] = await Promise.all([
+      import('./autonomousRunner.js'),
+      import('./runnerExecution.js'),
+    ]);
+    const { updateProjectAfterTask } = await import('../linear/projectUpdater.js');
+    const bin = join(root, 'terminal-bin');
+    const repo = join(root, 'terminal-repo');
+    mkdirSync(bin, { recursive: true });
+    mkdirSync(repo, { recursive: true });
+    writeFileSync(join(bin, 'gh'), `#!/bin/sh
+case "$*" in
+  *"pr list --head"*) echo '[{"url":"https://github.com/acme/repo/pull/171","state":"MERGED","isDraft":false,"headRefOid":"abc171"}]';;
+esac
+`);
+    chmodSync(join(bin, 'gh'), 0o755);
+    const logPairComplete = vi.fn(async () => {});
+    execution.setTaskSource({
+      kind: 'linear',
+      fetchTasks: vi.fn(async () => []),
+      getExecutionComments: vi.fn(async () => []),
+      updateState: vi.fn(async () => true),
+      addComment: vi.fn(async () => {}),
+      createTask: vi.fn(), createSubIssue: vi.fn(), logPairStart: vi.fn(),
+      logPairComplete, logBlocked: vi.fn(), logStuck: vi.fn(), unstick: vi.fn(),
+      logHalt: vi.fn(), markAsDecomposed: vi.fn(),
+    } as unknown as ITaskSource);
+    const runner = new AutonomousRunner({
+      linearTeamId: 'team', allowedProjects: ['/repo'], heartbeatSchedule: '0 * * * *',
+      autoExecute: true, maxConsecutiveTasks: 1, cooldownSeconds: 0, dryRun: true,
+      automationLedgerMode: 'primary', automationDbPath: join(root, 'terminal-card.db'),
+    });
+    const internal = runner as unknown as InternalRunner;
+    internal.durableRuns.importLegacyRun({
+      issueId: 'terminal', source: 'linear', identifier: 'AX-876', title: 'account master',
+      projectPath: repo, state: 'NEEDS_RECONCILE', branchName: 'swarm/AX-876-a2-3',
+      metadata: { projectId: 'cgf', projectName: 'CGF-Portal' },
+    });
+    internal.executePipeline = vi.fn(async () => resultFixture());
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${bin}:${previousPath}`;
+    try {
+      // The decisive argument: an empty task list, exactly what a Done card
+      // produces. Before the fix this left the row untouched and unlogged.
+      await internal.reconcileDurableArtifacts([]);
+    } finally {
+      process.env.PATH = previousPath;
+    }
+
+    expect(internal.executePipeline).not.toHaveBeenCalled();
+    expect(internal.durableRuns.getRun('terminal')).toMatchObject({
+      state: 'DONE', prUrl: 'https://github.com/acme/repo/pull/171', headSha: 'abc171',
+    });
+    // The completion effect carried a task rebuilt from the durable row, not a
+    // live one — identifier, title and project all came back off the record.
+    expect(logPairComplete).toHaveBeenCalledTimes(1);
+    expect(updateProjectAfterTask).toHaveBeenCalledWith('cgf', 'CGF-Portal', expect.objectContaining({
+      title: 'account master',
+      issueIdentifier: 'AX-876',
+      success: true,
+    }));
+    internal.durableRuns.close();
+  });
+
+  // The other half of AGT-4094: absence stays ambiguous wherever it still
+  // matters. With no PR the only exit is to re-run the work, and re-running a
+  // task whose card cannot be seen is exactly what the original guard existed
+  // to prevent — AGT-4056 narrowed its own fix on this assumption, so it has
+  // to keep holding.
+  it('leaves an unpublished run parked when its task is absent, rather than reopening work it cannot see', async () => {
+    const [{ AutonomousRunner }, execution] = await Promise.all([
+      import('./autonomousRunner.js'),
+      import('./runnerExecution.js'),
+    ]);
+    const bin = join(root, 'unpublished-bin');
+    const repo = join(root, 'unpublished-repo');
+    mkdirSync(bin, { recursive: true });
+    mkdirSync(repo, { recursive: true });
+    writeFileSync(join(bin, 'gh'), `#!/bin/sh
+case "$*" in
+  *"pr list --head"*) echo '[]';;
+esac
+`);
+    chmodSync(join(bin, 'gh'), 0o755);
+    const logPairComplete = vi.fn(async () => {});
+    execution.setTaskSource({
+      kind: 'linear',
+      fetchTasks: vi.fn(async () => []),
+      getExecutionComments: vi.fn(async () => []),
+      updateState: vi.fn(async () => true),
+      addComment: vi.fn(async () => {}),
+      createTask: vi.fn(), createSubIssue: vi.fn(), logPairStart: vi.fn(),
+      logPairComplete, logBlocked: vi.fn(), logStuck: vi.fn(), unstick: vi.fn(),
+      logHalt: vi.fn(), markAsDecomposed: vi.fn(),
+    } as unknown as ITaskSource);
+    const runner = new AutonomousRunner({
+      linearTeamId: 'team', allowedProjects: ['/repo'], heartbeatSchedule: '0 * * * *',
+      autoExecute: true, maxConsecutiveTasks: 1, cooldownSeconds: 0, dryRun: true,
+      automationLedgerMode: 'primary', automationDbPath: join(root, 'unpublished.db'),
+    });
+    const internal = runner as unknown as InternalRunner;
+    internal.durableRuns.importLegacyRun({
+      issueId: 'unpublished', source: 'linear', identifier: 'AX-999', title: 'never pushed',
+      projectPath: repo, state: 'NEEDS_RECONCILE', branchName: 'swarm/AX-999',
+    });
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${bin}:${previousPath}`;
+    try {
+      await internal.reconcileDurableArtifacts([]);
+    } finally {
+      process.env.PATH = previousPath;
+    }
+
+    expect(internal.durableRuns.getRun('unpublished')).toMatchObject({ state: 'NEEDS_RECONCILE' });
+    expect(logPairComplete).not.toHaveBeenCalled();
+    internal.durableRuns.close();
+  });
+
   it('returns at the shutdown deadline but defers ledger close until an abort-ignoring executor exits', async () => {
     const { AutonomousRunner } = await import('./autonomousRunner.js');
     const runner = new AutonomousRunner({

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -79,6 +79,7 @@ import {
 } from './backlogGrooming.js';
 import {
   DurableRunCoordinator,
+  runRecordToTask,
   type ExecutionDurabilityHooks,
   type RepositoryAdmissionPolicy,
 } from './durableRunCoordinator.js';
@@ -1237,8 +1238,13 @@ export class AutonomousRunner {
 
     for (const run of this.durableRuns.listRuns(['NEEDS_RECONCILE'])) {
       if (this.stopping) return;
+      // A task may legitimately be absent: the fetch asks only for Todo /
+      // In Progress / In Review / Backlog, so an issue that reached Done is
+      // structurally invisible here. That makes absence ambiguous for the
+      // worktree path below — which re-runs work — but not for the branch
+      // path, where GitHub is the authority. So the guard moved down to the
+      // one place it actually protects something. (AGT-4094)
       const task = taskById.get(run.issueId);
-      if (!task) continue; // absence from an actionable fetch is ambiguous; keep parked
       if (run.ownerInstanceId || run.leaseToken) {
         console.warn(`[Reconciler] Keeping ${run.identifier ?? run.issueId} fenced until its original executor exits`);
         continue;
@@ -1258,6 +1264,7 @@ export class AutonomousRunner {
             this.durableRuns.markNeedsHuman(run.issueId, `Published PR was closed without merge: ${pr.url}`);
             continue;
           }
+          const publishedTask = task ?? runRecordToTask(run);
           const recoveredResult: PipelineResult = {
             success: true,
             sessionId: `recovered-publication-${run.attemptNo}`,
@@ -1267,16 +1274,16 @@ export class AutonomousRunner {
             iterations: Math.max(1, run.attemptNo),
             prUrl: pr.url,
             taskContext: {
-              issueIdentifier: task.issueIdentifier || run.identifier,
-              projectName: task.linearProject?.name,
+              issueIdentifier: publishedTask.issueIdentifier || run.identifier,
+              projectName: publishedTask.linearProject?.name,
               projectPath: run.projectPath,
-              taskTitle: task.title,
+              taskTitle: publishedTask.title,
             },
           };
           if (this.durableRuns.recoverPublishedRun(
             run.issueId,
             { prUrl: pr.url, headSha: pr.headSha },
-            buildCompletionEffect(task, recoveredResult, run.attemptNo),
+            buildCompletionEffect(publishedTask, recoveredResult, run.attemptNo),
           )) {
             console.log(`[Reconciler] Recovered published run ${run.identifier ?? run.issueId}: ${pr.url}`);
           }
@@ -1284,9 +1291,18 @@ export class AutonomousRunner {
         }
       }
 
-      // No PR exists. Never overlap a replacement with an executor that lost
-      // its lease but still owns the filesystem. Missing/ambiguous markers stay
-      // parked; preserved work or a dead owner is safe for createWorktree to resume.
+      // No PR exists, so nothing was published and the only way out of this
+      // state is to run the work again — which needs a live tracker card.
+      // Log it: this branch used to be the loop's one silent exit, which is
+      // exactly why a row stuck here was invisible to log-reading. (AGT-4094)
+      if (!task) {
+        console.warn(`[Reconciler] Keeping ${run.identifier ?? run.issueId} in NEEDS_RECONCILE (no published PR and no actionable task)`);
+        continue;
+      }
+
+      // Never overlap a replacement with an executor that lost its lease but
+      // still owns the filesystem. Missing/ambiguous markers stay parked;
+      // preserved work or a dead owner is safe for createWorktree to resume.
       const recovery = await inspectWorktreeRecovery(run.projectPath, run.issueId, run.worktreePath)
         .catch((error) => {
           console.warn(`[Reconciler] Worktree evidence unreadable for ${run.identifier ?? run.issueId}:`, error);

--- a/src/automation/durableRunCoordinator.test.ts
+++ b/src/automation/durableRunCoordinator.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { PipelineResult } from '../agents/pairPipeline.js';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
-import { DurableRunCoordinator, retryAtFor } from './durableRunCoordinator.js';
+import { DurableRunCoordinator, retryAtFor, runRecordToTask } from './durableRunCoordinator.js';
 import { RunLedger } from './runLedger.js';
 
 const roots: string[] = [];
@@ -993,5 +993,75 @@ describe('DurableRunCoordinator', () => {
 
     coordinator.close();
     ledger.close();
+  });
+});
+
+describe('runRecordToTask', () => {
+  // AGT-4094: reconciliation has to finish a published run whose tracker card
+  // already went Done, and a Done card is never in the fetch — so the run
+  // record itself has to be able to stand in for the task it was registered
+  // from. This is the inverse of observeTask's mapping; round-tripping it is
+  // what keeps the two from drifting apart.
+  function record(overrides: Partial<Parameters<typeof runRecordToTask>[0]> = {}) {
+    return {
+      issueId: 'f8c57098', source: 'linear', identifier: 'AX-876',
+      title: 'account master', projectPath: '/work/cgf-portal',
+      state: 'NEEDS_RECONCILE' as const, stateVersion: 130, attemptNo: 4, leaseEpoch: 4,
+      discoveredAt: 1_787_897_771_595, updatedAt: 1_788_009_300_002,
+      metadata: { projectId: 'cgf', projectName: 'CGF-Portal', fileScope: ['a.ts'] },
+      ...overrides,
+    };
+  }
+
+  it('carries every field the completion effect reads back off the durable row', () => {
+    expect(runRecordToTask(record())).toMatchObject({
+      id: 'f8c57098',
+      issueId: 'f8c57098',
+      issueIdentifier: 'AX-876',
+      source: 'linear',
+      title: 'account master',
+      projectPath: '/work/cgf-portal',
+      linearProject: { id: 'cgf', name: 'CGF-Portal' },
+      fileScope: ['a.ts'],
+      createdAt: 1_787_897_771_595,
+    });
+  });
+
+  it('round-trips what observeTask wrote, so the two mappings cannot drift apart', () => {
+    const ledger = new RunLedger(dbPath());
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', ledger });
+    const original: TaskItem = {
+      id: 'issue-1', issueId: 'issue-1', issueIdentifier: 'AX-1', source: 'linear',
+      title: 'round trip', priority: 2, createdAt: 1_000,
+      linearProject: { id: 'proj', name: 'Proj' }, fileScope: ['x.ts'],
+    };
+    const stored = coordinator.observeTask(original, '/repo');
+    expect(stored).not.toBeNull();
+
+    const rebuilt = runRecordToTask(stored!);
+    expect(rebuilt.issueId).toBe(original.issueId);
+    expect(rebuilt.issueIdentifier).toBe(original.issueIdentifier);
+    expect(rebuilt.title).toBe(original.title);
+    expect(rebuilt.source).toBe(original.source);
+    expect(rebuilt.linearProject).toEqual(original.linearProject);
+    expect(rebuilt.fileScope).toEqual(original.fileScope);
+    coordinator.close();
+    ledger.close();
+  });
+
+  it('names an unrecognized source instead of asserting it into the union', () => {
+    // The column is a free-form string, so a record written by a build that
+    // knew a source this one does not must not be cast into a member it isn't.
+    expect(runRecordToTask(record({ source: 'jira' })).source).toBe('discovered');
+  });
+
+  it('falls back through title -> identifier -> issue id, so a title is never empty', () => {
+    expect(runRecordToTask(record({ title: undefined })).title).toBe('AX-876');
+    expect(runRecordToTask(record({ title: undefined, identifier: undefined })).title).toBe('f8c57098');
+  });
+
+  it('omits linearProject when the row never recorded one', () => {
+    expect(runRecordToTask(record({ metadata: {} })).linearProject).toBeUndefined();
+    expect(runRecordToTask(record({ metadata: undefined })).linearProject).toBeUndefined();
   });
 });

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -123,6 +123,51 @@ function processIsAlive(pid: number): boolean {
   }
 }
 
+const TASK_SOURCES: readonly TaskItem['source'][] = ['linear', 'local', 'discovered', 'github_pr', 'github_pr_review'];
+
+/**
+ * Priority is not durable — the ledger never stored it, because nothing about a
+ * finished run needs one. A rebuilt task is only ever handed to the completion
+ * effect, which reads id/identifier/title/project and nothing else, so this
+ * fills the required field with the lowest rank rather than inventing a rank
+ * that could outrank live work if the value ever did reach a scheduler.
+ */
+const REBUILT_TASK_PRIORITY = 4;
+
+/**
+ * Rebuild the {@link TaskItem} a run was registered from, using only its
+ * durable record — the exact inverse of {@link DurableRunCoordinator.observeTask}'s
+ * mapping.
+ *
+ * Reconciliation needs this because the heartbeat's fetch structurally cannot
+ * see a terminal tracker card: Linear's slim query asks only for Todo /
+ * In Progress / In Review / Backlog. A run whose issue reached Done therefore
+ * has no live task to pair with, while still owning a branch, a merged PR and
+ * an admission slot — so the GitHub-authoritative half of reconciliation would
+ * wait forever on a card it is never going to be handed. (AGT-4094)
+ */
+export function runRecordToTask(run: RunRecord): TaskItem {
+  const metadata = (run.metadata ?? {}) as { projectId?: string; projectName?: string; fileScope?: string[] };
+  const source = TASK_SOURCES.find((candidate) => candidate === run.source);
+  return {
+    id: run.issueId,
+    issueId: run.issueId,
+    issueIdentifier: run.identifier,
+    // The column is a free-form string; anything the union does not cover was
+    // written by a source this build no longer knows, so say so rather than
+    // asserting it into a member it may not be.
+    source: source ?? 'discovered',
+    title: run.title ?? run.identifier ?? run.issueId,
+    priority: REBUILT_TASK_PRIORITY,
+    projectPath: run.projectPath,
+    linearProject: metadata.projectId
+      ? { id: metadata.projectId, name: metadata.projectName ?? run.projectPath }
+      : undefined,
+    fileScope: metadata.fileScope,
+    createdAt: run.discoveredAt,
+  };
+}
+
 /**
  * Connects pipeline execution to the SQLite run state machine. The coordinator
  * owns lease renewal and turns every late callback into a fenced no-op.


### PR DESCRIPTION
## Problem

`reconcileDurableArtifacts()` skipped any `NEEDS_RECONCILE` row whose issue was absent from the heartbeat's task fetch:

```ts
if (!task) continue; // absence from an actionable fetch is ambiguous; keep parked
```

But the fetch **structurally excludes terminal cards** — `getMyIssues({ slim: true })` queries only `Todo`, `In Progress`, `In Review`, `Backlog` (`src/linear/linear.ts:670-680`). A run whose card reached Done therefore could never be seen by the reconciler again: skipped silently on every heartbeat, forever, while `claimRun()`'s admission query counts `NEEDS_RECONCILE` toward the per-project cap (`runLedger.ts:501-510`). The slot leaked permanently.

AGT-4056 deliberately narrowed its own fix to *branchless* orphans and routed a branch-carrying row to "`reconcileDurableArtifacts()`'s GitHub-by-branch lookup instead". That lookup never ran, because this guard short-circuited above it.

## Production evidence

**AX-876** (cgf-portal), run `f8c57098`: `pr_url` = merged PR #171, `owner_instance_id`/`lease_token` both NULL, card **Done at 12:46:21Z**, row entered `NEEDS_RECONCILE` at **13:15Z** — already terminal before it ever needed reconciling, so never once in a fetch. Stuck **11.9 h**, holding 1 of 9 slots. **Zero** occurrences of `AX-876` in the whole container log while `[Reconciler]` emitted 26 lines.

**Natural control — AX-862**: same project, same state, but a non-terminal card, so it stayed in the fetch → 26 `[Reconciler] Keeping AX-862 …` lines → `[Reconciler] Resuming worktree for AX-862`. Same state, opposite outcome, one differing variable.

## Change

Absence is genuinely ambiguous for the **worktree** path, which re-runs the work — that guard stays. It is *not* ambiguous for the **branch** path, where GitHub is the authority:

| PR state | Action | Safe without a live task? |
|---|---|---|
| merged / open | `recoverPublishedRun()` → DONE | yes — GitHub proves publication |
| closed unmerged | `markNeedsHuman()` | yes — a park, not a mutation |
| none | falls through to worktree recovery | **no** — still requires the task |

So the guard moves down to the one place it protects something, and the branch path rebuilds the task it needs from the durable row via a new pure helper `runRecordToTask()` — the exact inverse of `observeTask()`'s mapping. The completion effect reads only `issueId` / `issueIdentifier` / `title` / `linearProject`, all of which the record carries.

`reconcileDurableArtifacts` is only reached after a *successful*, non-empty fetch (`autonomousRunner.ts` returns early on `fetchResult.error` and `tasks.length === 0`), so "absent" here cannot mean "the fetch failed".

The remaining `!task` skip now logs, like every other branch of the loop — that silent exit is why this was invisible to log-reading in the first place.

## Verification

- `npx tsc --noEmit` clean; `npx vitest run src/automation/` — **636/636 pass**.
- **Revert-checked in both directions**, not just asserted:
  - guard restored to the top of the loop (pre-fix) → the new terminal-card test **fails**;
  - guard removed entirely (over-fix) → the parked-regression test **fails**;
  - as implemented → both pass. The AGT-4056 safety property is held by a test, not by a comment.
- `runRecordToTask` covered by a round-trip against `observeTask` (so the two mappings cannot drift), an unrecognized-source case (the column is a free-form string — it maps to `discovered` rather than being cast into the union), title fallbacks, and the no-project case.

## Concurrency

The branch path now runs for rows without a live task, so: the loop still returns early when `ownerInstanceId || leaseToken` is set, and `recoverPublishedRun` re-checks both **inside its transaction** plus `state_version` optimistic concurrency — a claim landing between the read and the write makes the update a no-op rather than a double-publish. The row's destination (`SYNC_PENDING` → `DONE`) is terminal, and `observeTask` reopens `DONE` only on `linearState === 'Todo'` or an explicit dispatch, so this cannot resurrect finished work. Effect delivery is idempotent via `dedupeKey` + marker comment.

Closes AGT-4094.