### PR TITLE
fix(automation): stop a parked task superseding itself via its own draft PR (AGT-4095)

### DIFF
--- a/src/automation/draftGrooming.ts
+++ b/src/automation/draftGrooming.ts
@@ -47,7 +47,15 @@ export async function applyDraftGates(options: {
   }
 
   if (options.worktreeMode && draft.relevantFiles.length > 0) {
-    const overlaps = await findOpenPRFileOverlaps(options.projectPath, draft.relevantFiles);
+    // Exclude this issue's own PR. `publishOnPark` opens a draft PR for a run
+    // that parks on an operator question, so from the next heartbeat the task
+    // was colliding with itself and superseding forever — measured on
+    // cgf-portal as 15 supersedes and zero real work attempts in 6h. (AGT-4095)
+    const overlaps = await findOpenPRFileOverlaps(
+      options.projectPath,
+      draft.relevantFiles,
+      task.issueIdentifier ?? task.issueId,
+    );
     if (overlaps.length > 0) {
       const lines = overlaps.map(overlap => `- ${overlap.url}: ${overlap.files.map(file => `\`${file}\``).join(', ')}`);
       console.warn(`[AutonomousRunner] Existing open PR owns planned files — skipping duplicate worker: ${lines.join(' ')}`);

--- a/src/automation/runnerExecution.coverage.test.ts
+++ b/src/automation/runnerExecution.coverage.test.ts
@@ -40,7 +40,6 @@ const plannerNeedsDecomposition = vi.fn();
 const plannerEstimateTaskDuration = vi.fn();
 const plannerRunPlanner = vi.fn();
 const plannerFormatPlannerResult = vi.fn();
-const buildBranchName = vi.fn();
 const createWorktree = vi.fn();
 // Stand-in for the real class — the instanceof check under test resolves
 // through this same mock, so identity (not origin) is what matters (AGT-4038).
@@ -99,7 +98,6 @@ vi.mock('../support/planner.js', () => ({
 }));
 
 vi.mock('../support/worktreeManager.js', () => ({
-  buildBranchName,
   createWorktree,
   commitAndCreatePR,
   findOpenPRFileOverlaps,
@@ -306,7 +304,6 @@ describe('runnerExecution.ts coverage extension', () => {
     plannerEstimateTaskDuration.mockReturnValue(45);
     plannerFormatPlannerResult.mockReturnValue('planner result summary');
 
-    buildBranchName.mockReturnValue('swarm/INT-100-fix-the-flaky-retry-logic');
     commitAndCreatePR.mockResolvedValue('https://github.com/org/repo/pull/1');
     findOpenPRFileOverlaps.mockResolvedValue([]);
     hasRecoverableWorktree.mockResolvedValue(false);

--- a/src/automation/runnerExecution.integration.coverage.test.ts
+++ b/src/automation/runnerExecution.integration.coverage.test.ts
@@ -25,7 +25,6 @@ vi.mock('../support/planner.js', () => ({
   formatPlannerResult: vi.fn(),
 }));
 vi.mock('../support/worktreeManager.js', () => ({
-  buildBranchName: vi.fn(),
   createWorktree: vi.fn(),
   commitAndCreatePR: vi.fn(),
   findOpenPRFileOverlaps: vi.fn(),

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -3,6 +3,7 @@
 // Execution/reporting/integration logic extracted from AutonomousRunner
 // ============================================
 
+import { buildBranchName } from '../support/branchNaming.js';
 import { EmbedBuilder } from 'discord.js';
 import { decompositionChildId, reviewerFollowupId } from './decompositionIds.js';
 import { taskEventKey, type TaskItem, type DecisionResult } from '../orchestration/decisionEngine.js';
@@ -26,14 +27,7 @@ import { formatTaskDescription } from '../linear/format.js';
 import { broadcastEvent } from '../core/eventHub.js';
 import type { Notifier } from '../notify/notifier.js';
 import type { ITaskSource } from './taskSource.js';
-import {
-  buildBranchName,
-  createWorktree,
-  hasRecoverableWorktree,
-  preserveWorktree,
-  removeWorktree,
-  WorktreeCoordinationError,
-} from '../support/worktreeManager.js';
+import {createWorktree, hasRecoverableWorktree, preserveWorktree, removeWorktree, WorktreeCoordinationError,  } from '../support/worktreeManager.js';
 import type { WorktreeInfo } from '../support/worktreeManager.js';
 import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
 import { publishApprovedWork, publishParkedWork, shouldPublishParkedWork } from './publishOnPark.js';

--- a/src/cli/workCommand.ts
+++ b/src/cli/workCommand.ts
@@ -14,6 +14,7 @@
 // 2 = nothing was deployed at all (validation failed / nothing selected),
 // 130 = interrupted.
 
+import { buildBranchName } from '../support/branchNaming.js';
 import { join, resolve } from 'node:path';
 import { existsSync } from 'node:fs';
 import { loadConfig } from '../core/config.js';
@@ -38,7 +39,7 @@ import {
 import type { EffectClaim } from '../automation/runLedger.js';
 import { setAutomationDbPath } from '../automation/automationDbPath.js';
 import { loadRepoMetadata, type RepoMetadata } from '../support/repoMetadata.js';
-import { buildBranchName, hasRecoverableWorktree } from '../support/worktreeManager.js';
+import {hasRecoverableWorktree } from '../support/worktreeManager.js';
 import { runPool } from '../support/concurrencyPool.js';
 import { ensureTaskSource } from './reviewCommand.js';
 import { filterRepoIssues, selectIssuesInteractive, WORK_SKIP_STATES } from './workSelect.js';

--- a/src/support/branchNaming.ts
+++ b/src/support/branchNaming.ts
@@ -1,0 +1,35 @@
+// ============================================
+// OpenSwarm - Task branch naming convention
+// The one place that knows what a `swarm/<issue>-<slug>` branch looks like
+// ============================================
+
+/** The namespace every task branch this daemon creates lives under. */
+const BRANCH_NAMESPACE = 'swarm';
+
+/** Generate branch name: swarm/INT-512-llm-tool-interface */
+export function buildBranchName(issueIdentifier: string, title: string): string {
+  const slug = title.toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 40);
+  return `${BRANCH_NAMESPACE}/${issueIdentifier}-${slug}`;
+}
+
+/**
+ * Does `branch` belong to `issueIdentifier`, whatever slug it was cut with?
+ *
+ * Deliberately not `branch === buildBranchName(id, title)`: the slug is derived
+ * from the issue title, and a title edited after the branch was cut makes the
+ * two disagree. Measured against live branches — AX-858 and AX-863 reproduce
+ * exactly, but AX-864's branch is `swarm/AX-864-a2-slack` while today's title
+ * yields `swarm/AX-864-a2-6-slack`. An equality test would silently miss a
+ * third of real cases. (AGT-4095)
+ *
+ * The trailing delimiter is what keeps the prefix unambiguous: `swarm/AX-86-`
+ * cannot match `swarm/AX-863-...`.
+ */
+export function isBranchForIssue(branch: string, issueIdentifier: string): boolean {
+  if (!issueIdentifier) return false;
+  const prefix = `${BRANCH_NAMESPACE}/${issueIdentifier}`;
+  return branch === prefix || branch.startsWith(`${prefix}-`);
+}

--- a/src/support/worktreeManager.coverage.test.ts
+++ b/src/support/worktreeManager.coverage.test.ts
@@ -7,22 +7,13 @@
 // reach: pure-function edges, retry/resume error paths, the file-overlap
 // report's real gh+git integration, and defensive fs-permission fallbacks.
 
+import { buildBranchName } from './branchNaming.js';
 import { execFileSync } from 'node:child_process';
 import { chmodSync, existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { hostname, tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  buildBranchName,
-  commitAndCreatePR,
-  createWorktree,
-  inspectWorktreeRecovery,
-  preserveWorktree,
-  pruneWorktrees,
-  removePreservedWorktreeAt,
-  resolveBaseRef,
-  resolveSharedPaths,
-} from './worktreeManager.js';
+import {commitAndCreatePR, createWorktree, inspectWorktreeRecovery, preserveWorktree, pruneWorktrees, removePreservedWorktreeAt, resolveBaseRef, resolveSharedPaths,  } from './worktreeManager.js';
 
 // registerOwnedPR persists to a REAL file under the user's home directory
 // (~/.openswarm/pr-ownership.json) — its target path is resolved once at

--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -1,3 +1,4 @@
+import { isBranchForIssue } from './branchNaming.js';
 import { execFileSync } from 'node:child_process';
 import { chmodSync, existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -5,7 +6,7 @@ import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import Database from 'better-sqlite3';
 import { isProofCapableSpace, processNamespaceId } from './processLiveness.js';
-import { createWorktree, preserveWorktree, removePreservedWorktreeAt, removeWorktree, resolveSharedPaths, computeFileOverlaps, formatOverlapReport, findOpenPRFileOverlaps, resolveBaseRef, commitAndCreatePR, type WorktreeInfo } from './worktreeManager.js';
+import {createWorktree, preserveWorktree, removePreservedWorktreeAt, removeWorktree, resolveSharedPaths, computeFileOverlaps, formatOverlapReport, findOpenPRFileOverlaps, resolveBaseRef, commitAndCreatePR, type WorktreeInfo } from './worktreeManager.js';
 
 // The fast-path proof needs a REAL pid space, which only Linux can give (boot
 // id + pid-namespace inode). Elsewhere the recorded id is a machine hint, good
@@ -35,6 +36,61 @@ esac
       process.env.PATH = previous;
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  // AGT-4095: publishOnPark opens a draft PR for a run that parked on an
+  // operator question, so from the next heartbeat the task was colliding with
+  // its own branch and superseding itself forever.
+  it('does not report the dispatched issue own PR, but still reports another issue', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'openswarm-pr-self-'));
+    const bin = join(root, 'bin');
+    mkdirSync(bin, { recursive: true });
+    writeFileSync(join(bin, 'gh'), `#!/bin/sh
+case "$*" in
+  *"pr list --state open"*) echo '[{"number":180,"url":"https://example.test/180","headRefName":"swarm/AX-858-a3-4-sheet-lead-id","files":[{"path":"src/jobs.py"}]},{"number":179,"url":"https://example.test/179","headRefName":"swarm/AX-863-a2-4","files":[{"path":"src/jobs.py"}]}]';;
+esac
+`);
+    chmodSync(join(bin, 'gh'), 0o755);
+    const previous = process.env.PATH;
+    process.env.PATH = `${bin}:${previous}`;
+    try {
+      // Only the sibling survives...
+      await expect(findOpenPRFileOverlaps(root, ['src/jobs.py'], 'AX-858')).resolves.toEqual([
+        expect.objectContaining({ number: 179 }),
+      ]);
+      // ...and without a self identifier nothing is excluded, so the gate keeps
+      // its pre-AGT-4095 behavior rather than silently switching off.
+      await expect(findOpenPRFileOverlaps(root, ['src/jobs.py'])).resolves.toHaveLength(2);
+    } finally {
+      process.env.PATH = previous;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('isBranchForIssue', () => {
+  it('matches a branch whose slug no longer matches the current title', () => {
+    // Live case: the stored branch is `swarm/AX-864-a2-slack` while the current
+    // title now derives `swarm/AX-864-a2-6-slack`. An equality test would miss it.
+    expect(isBranchForIssue('swarm/AX-864-a2-slack', 'AX-864')).toBe(true);
+    expect(isBranchForIssue('swarm/AX-864-a2-6-slack', 'AX-864')).toBe(true);
+  });
+
+  it('does not let a shorter identifier match a longer sibling', () => {
+    // The trailing delimiter is the whole point: without it `AX-86` would claim
+    // AX-863's branch and silently suppress a real overlap.
+    expect(isBranchForIssue('swarm/AX-863-a2-4', 'AX-86')).toBe(false);
+    expect(isBranchForIssue('swarm/AX-863-a2-4', 'AX-863')).toBe(true);
+  });
+
+  it('accepts a bare branch with no slug', () => {
+    expect(isBranchForIssue('swarm/AX-864', 'AX-864')).toBe(true);
+  });
+
+  it('rejects foreign branches and an empty identifier', () => {
+    expect(isBranchForIssue('audit/a', 'AX-864')).toBe(false);
+    expect(isBranchForIssue('heewonoh/cgf-answers-20260828', 'AX-864')).toBe(false);
+    expect(isBranchForIssue('swarm/AX-864-a2', '')).toBe(false);
   });
 });
 

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -118,14 +118,9 @@ async function stripRuntimeMarkerFromGit(worktreePath: string): Promise<void> {
 
 // Branch & Path Utilities
 
-/** Generate branch name: swarm/INT-512-llm-tool-interface */
-export function buildBranchName(issueIdentifier: string, title: string): string {
-  const slug = title.toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-    .slice(0, 40);
-  return `swarm/${issueIdentifier}-${slug}`;
-}
+// The naming convention lives in its own module (branchNaming.ts) so the one
+// rule that decides "is this branch mine?" is not buried in lifecycle code.
+import { isBranchForIssue } from './branchNaming.js';
 
 function isPathInside(parent: string, child: string): boolean {
   const rel = relative(parent, child);
@@ -916,6 +911,13 @@ export async function findPullRequestForBranch(
 export async function findOpenPRFileOverlaps(
   repoPath: string,
   plannedFiles: string[],
+  /**
+   * The issue being dispatched. Its own open PR is not competing work — it is
+   * this task's parked or in-flight branch — so it must not supersede the
+   * task that owns it. Omitted means "no self to exclude", which is the
+   * pre-AGT-4095 behavior rather than a disabled gate.
+   */
+  selfIssueIdentifier?: string,
 ): Promise<OpenPRFileOverlap[]> {
   if (plannedFiles.length === 0) return [];
   const planned = new Set(plannedFiles.map((f) => f.replace(/^\.\//, '')));
@@ -929,6 +931,7 @@ export async function findOpenPRFileOverlaps(
     const prs: { number: number; url: string; headRefName: string; files?: { path: string }[] }[] = JSON.parse(raw || '[]');
     const overlaps: OpenPRFileOverlap[] = [];
     for (const pr of prs) {
+      if (selfIssueIdentifier && isBranchForIssue(pr.headRefName, selfIssueIdentifier)) continue;
       const shared = (pr.files ?? []).map((f) => f.path).filter((f) => planned.has(f.replace(/^\.\//, '')));
       if (shared.length > 0) overlaps.push({ number: pr.number, url: pr.url, label: `PR #${pr.number} (${pr.headRefName})`, files: shared });
     }


### PR DESCRIPTION
## Problem

`findOpenPRFileOverlaps()` has **no notion of which issue is being dispatched** — its signature is `(repoPath, plannedFiles)`. So when `applyDraftGates()` asks "does an open PR already own the files I plan to touch?", the answer includes **the task's own draft PR**, opened moments earlier by `publishOnPark` (AGT-4076) when the very same task parked on an operator question.

The task supersedes itself, on every heartbeat, forever.

## Production evidence (cgf-portal — the daemon's only enabled project)

Every supersede in the log matches the dispatched issue to a PR on **its own branch**:

| Superseded task | Blocking PR | PR branch |
|---|---|---|
| AX-858 | #180 | `swarm/`**`AX-858`**`-a3-4-sheet-lead-id` |
| AX-863 | #179 | `swarm/`**`AX-863`**`-a2-4` |
| AX-864 | #178 | `swarm/`**`AX-864`**`-a2-slack` |
| AX-1039 | #173 | `swarm/`**`AX-1039`**`-b1` |

4 of 4. Of the 8 open PRs on the repo, **7 are the daemon's own `swarm/*` drafts**.

**Throughput:** `automation_attempts` for `/work/cgf-portal` over the last 6 h holds `superseded` ×15 and `waiting_on_operator` ×4 — **zero real work attempts** — while each pointless dispatch still pays for a full Draft pre-analysis first (measured `[AX-874] [Draft] Complete in 56204ms`, one model call each).

**It ratchets.** `retryAtFor()` doubles the backoff on `superseded`. AX-863's own history: att5 (08-28 15:39Z) → att6 (19:12Z) → att13 → att15 → att16 (08-30 00:50Z), widening to the 6-hour ceiling. Six issues now sit 4.6–5.9 h out at attempt 10–16 without one genuine work failure among them.

Before AGT-4076 a parked run had no PR, so the gate had nothing to collide with. Neither change is wrong alone; the interaction is.

## Change

`findOpenPRFileOverlaps` takes an optional `selfIssueIdentifier` and drops PRs whose `headRefName` belongs to that issue; `applyDraftGates` passes `task.issueIdentifier ?? task.issueId`.

**Matched on the identifier, not the built branch name** — and this was computed against the live branches rather than reasoned about:

```
MATCH swarm/AX-858-a3-4-sheet-lead-id | PR: swarm/AX-858-a3-4-sheet-lead-id
MATCH swarm/AX-863-a2-4               | PR: swarm/AX-863-a2-4
DIFF  swarm/AX-864-a2-6-slack         | PR: swarm/AX-864-a2-slack
```

AX-864's title changed after its branch was cut, so an equality test against `buildBranchName` would have silently missed a third of real cases. The trailing delimiter keeps the prefix unambiguous: `swarm/AX-86-` cannot match `swarm/AX-863-…`.

Omitting the identifier keeps the pre-fix behaviour rather than disabling the gate.

## Refactor note

`worktreeManager.ts` sat one line under the 1500-line pre-commit cap, so the naming convention moved to its own `branchNaming.ts` — it is self-contained and now lives in one place. Consumers import it directly, which means two coverage suites that mocked `buildBranchName` *through* `worktreeManager` no longer intercept it. Those mock declarations are **removed rather than left inert**: the function is pure and deterministic, so the suites now exercise the real convention, and a stale mock would mislead the next reader.

## Verification

- `npx tsc --noEmit` clean; `npx vitest run src/automation/ src/support/ src/cli/workCommand` — **1271 passed, 3 skipped** (the skips are Linux-only pid-space cases).
- **Revert-checked:** deleting the self-exclusion line makes the new test fail; restored, it passes. The gate's actual purpose is held by an assertion in the same test — a *sibling* issue's overlapping PR still supersedes.
- `isBranchForIssue` covered for title drift (the AX-864 case), sibling-identifier ambiguity (`AX-86` must not claim `AX-863`), a bare slug-less branch, foreign branches, and an empty identifier.

Closes AGT-4095.