### PR TITLE
fix(docker): install sqlite3 so agents can run a repo's SQLite-backed tests (AGT-4096)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,12 +49,19 @@ FROM node:22-slim AS production
 # .py file makes `codeql database create --build-mode=none` fail, which the
 # pipeline reports as an infra error and parks the task.
 #
-# postgresql-client / openssh-client / jq / netcat-openbsd are the agent's
-# toolchain, not the daemon's. Repository credentials already reach an isolated
-# worktree — cgf-portal links .env, apps/pipelines/.env and friends in via its
-# post-checkout hook, and AGT-4061 lets the sandbox read through those links —
-# so an agent holding a working DSN and no `psql`, or reachable NAS credentials
-# and no `ssh`, can do nothing but ask the operator to verify for it.
+# postgresql-client / sqlite3 / openssh-client / jq / netcat-openbsd are the
+# agent's toolchain, not the daemon's. Repository credentials already reach an
+# isolated worktree — cgf-portal links .env, apps/pipelines/.env and friends in
+# via its post-checkout hook, and AGT-4061 lets the sandbox read through those
+# links — so an agent holding a working DSN and no `psql`, or reachable NAS
+# credentials and no `ssh`, can do nothing but ask the operator to verify for it.
+#
+# sqlite3 is the same argument for a file rather than a service: a repository
+# whose tests `execFileSync("sqlite3", ...)` fails on the missing binary, and the
+# worker cannot tell that from a real regression. Measured on cgf-portal:
+# 42 of 940 `npm run verify` failures were this, and it cost an operator
+# question (AGT-4096). The daemon's own better-sqlite3 is a Node addon and puts
+# nothing on PATH, so it does not cover this.
 #
 # These grant no new access: they are clients for services the container can
 # already reach with credentials it already has. Evidence and the measured
@@ -62,7 +69,7 @@ FROM node:22-slim AS production
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         dumb-init ca-certificates curl git bubblewrap gnupg python3 \
-        postgresql-client openssh-client jq netcat-openbsd && \
+        postgresql-client sqlite3 openssh-client jq netcat-openbsd && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \


### PR DESCRIPTION
## Problem

The runtime image ships `postgresql-client` but not `sqlite3`. A repository whose tests shell out to the `sqlite3` CLI therefore fails inside the daemon for a reason unrelated to the change under test — and the worker, correctly unable to distinguish a missing tool from a real regression, spends an **operator question** on it.

## Evidence

A cgf-portal worker parked with: *"AX-864 검증이 시스템 `sqlite3` CLI 부재로 차단됐습니다. `npm run verify`는 940개 중 898 pass / 42 fail"*.

Both halves checked independently rather than taken on the worker's word:

```
$ docker exec openswarm sh -c "command -v sqlite3 || echo MISSING"
MISSING
$ docker exec openswarm sh -c "command -v psql >/dev/null && echo psql-present"
psql-present

$ docker exec openswarm grep -n sqlite3 /work/cgf-portal/apps/portal/test/collection-decisions.test.js
61:    execFileSync("sqlite3", [file], {
```

So 42 of 940 failures are the missing binary. The daemon's own `better-sqlite3` is a Node addon and puts no executable on `PATH`, so it does not cover this.

## Change

`sqlite3` added to the runtime stage's apt list, beside `postgresql-client`. The comment block above that `RUN` already argues exactly this case — *"an agent holding a working DSN and no `psql` … can do nothing but ask the operator to verify for it"* — so the new comment extends it rather than restating it, and notes the one way sqlite3 differs: it is a client for a **file** rather than a service.

Same class as AGT-4039 (no docker CLI) and the `python3` install for CodeQL's Python extractor. No new access is granted.

## Verification

- Commit-gate `openswarm review` — `Decision: APPROVE`.
- Post-merge, the image will be rebuilt and redeployed to vela; the DoD item is `docker exec openswarm sqlite3 --version` returning a version **and** the blocked test file's `execFileSync` call no longer throwing ENOENT (pass or fail then being on its own merits). That result will be posted to AGT-4096 — it is not claimed here.

## Note

Found while triaging the 74 open operator questions for any answerable without external input. This one was never a question for the operator: it was an infrastructure gap reported as one. A missing tool surfacing as a *human* question is the most expensive possible way to report it.

Closes AGT-4096.