### PR TITLE
fix(automation): reserve a PR's files only while a worker holds its run (AGT-4097)

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -2523,6 +2523,7 @@ export class AutonomousRunner {
       maxReflections: this.config.maxReflections,
       durability,
       peerIssues: this.lastFetchedTasks,
+      getActiveWorkerIssues: (p) => this.durableRuns.activeWorkerIdentifiers(p),
       mcpPolicies: this.config.mcpPolicies,
       adapterRouting: this.config.adapterRouting,
     };

--- a/src/automation/draftGrooming.ts
+++ b/src/automation/draftGrooming.ts
@@ -30,6 +30,8 @@ export async function applyDraftGates(options: {
   peers?: TaskItem[];
   source: ITaskSource | null;
   worktreeMode?: boolean;
+  /** Issues a worker currently holds; only their PRs reserve files. (AGT-4097) */
+  activeWorkerIssues?: readonly string[];
 }): Promise<PipelineResult | null> {
   const { task, draft, peers, source } = options;
   const duplicateTarget = peers?.find(peer => (peer.issueId || peer.id) === draft.duplicateOfIssueId);
@@ -47,14 +49,21 @@ export async function applyDraftGates(options: {
   }
 
   if (options.worktreeMode && draft.relevantFiles.length > 0) {
-    // Exclude this issue's own PR. `publishOnPark` opens a draft PR for a run
-    // that parks on an operator question, so from the next heartbeat the task
-    // was colliding with itself and superseding forever — measured on
-    // cgf-portal as 15 supersedes and zero real work attempts in 6h. (AGT-4095)
+    // An open PR reserves its files only while a worker is editing them.
+    // `publishOnPark` publishes a run that stops for an operator, so its PR
+    // outlives the worker by hours or days: the task first collided with its
+    // own PR (AGT-4095) and then with every sibling's — seven such PRs held
+    // cgf-portal's hot files for 7-12h, and each blocked attempt doubled the
+    // backoff again. (AGT-4097)
     const overlaps = await findOpenPRFileOverlaps(
       options.projectPath,
       draft.relevantFiles,
-      task.issueIdentifier ?? task.issueId,
+      {
+        selfIssueIdentifier: task.issueIdentifier ?? task.issueId,
+        // Passed through as-is: undefined means the caller could not ask the
+        // ledger, and every swarm PR keeps reserving. See findOpenPRFileOverlaps.
+        activeIssueIdentifiers: options.activeWorkerIssues,
+      },
     );
     if (overlaps.length > 0) {
       const lines = overlaps.map(overlap => `- ${overlap.url}: ${overlap.files.map(file => `\`${file}\``).join(', ')}`);

--- a/src/automation/durableRunCoordinator.test.ts
+++ b/src/automation/durableRunCoordinator.test.ts
@@ -1065,3 +1065,82 @@ describe('runRecordToTask', () => {
     expect(runRecordToTask(record({ metadata: undefined })).linearProject).toBeUndefined();
   });
 });
+
+describe('activeWorkerIdentifiers', () => {
+  // AGT-4097: an open PR reserves its files only while a worker holds the run.
+  // The first attempt keyed on WHY a run stopped (lastErrorCode) and did not
+  // survive production: every blocking PR's run had parked on an operator
+  // question, but later dispatches overwrote that code, so only 2 of 10 still
+  // said so. A lease is not overwritten by the next attempt.
+  it('reports runs a worker holds and nothing else', () => {
+    const ledger = new RunLedger(dbPath());
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', ledger });
+    ledger.importRun({
+      issueId: 'ready', source: 'linear', identifier: 'AX-1', title: 'claimable',
+      projectPath: '/repo', state: 'READY',
+    });
+    ledger.importRun({
+      issueId: 'parked', source: 'linear', identifier: 'AX-2', title: 'operator park',
+      projectPath: '/repo', state: 'RETRY_AT', errorCode: 'waiting_on_operator',
+    });
+    ledger.importRun({
+      issueId: 'superseded', source: 'linear', identifier: 'AX-3', title: 'gate park',
+      projectPath: '/repo', state: 'RETRY_AT', errorCode: 'superseded',
+    });
+    ledger.importRun({
+      issueId: 'escalated', source: 'linear', identifier: 'AX-4', title: 'needs human',
+      projectPath: '/repo', state: 'NEEDS_HUMAN',
+    });
+    expect(coordinator.activeWorkerIdentifiers('/repo')).toEqual([]);
+
+    // Claiming one is what makes it reserve: the lease, not the error code.
+    expect(ledger.claimRun('ready', { ownerInstanceId: 'owner', leaseMs: 60_000 })).not.toBeNull();
+    expect(coordinator.activeWorkerIdentifiers('/repo')).toEqual(['AX-1']);
+
+    // Another project's held run must not leak into this project's answer.
+    ledger.importRun({
+      issueId: 'other', source: 'linear', identifier: 'KT-1', title: 'elsewhere',
+      projectPath: '/other', state: 'READY',
+    });
+    expect(ledger.claimRun('other', { ownerInstanceId: 'owner', leaseMs: 60_000 })).not.toBeNull();
+    expect(coordinator.activeWorkerIdentifiers('/repo')).toEqual(['AX-1']);
+    coordinator.close();
+    ledger.close();
+  });
+
+  it('drops a run whose lease has lapsed, since no worker is left holding it', () => {
+    const ledger = new RunLedger(dbPath());
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', ledger });
+    ledger.importRun({
+      issueId: 'held', source: 'linear', identifier: 'AX-5', title: 'held',
+      projectPath: '/repo', state: 'READY',
+    });
+    expect(ledger.claimRun('held', { ownerInstanceId: 'owner', leaseMs: 1_000, now: 1_000 })).not.toBeNull();
+
+    // Inside the lease the PR still reserves; past it the row is only waiting
+    // for a reconciliation sweep, and its files are nobody's.
+    expect(coordinator.activeWorkerIdentifiers('/repo', 1_500)).toEqual(['AX-5']);
+    expect(coordinator.activeWorkerIdentifiers('/repo', 2_001)).toEqual([]);
+    coordinator.close();
+    ledger.close();
+  });
+
+  // A coordinator that never claims cannot say the set is empty — it can only
+  // say it does not know. Returning [] here would assert "nothing is held" and
+  // the overlap gate, which fails closed on undefined, would stop reserving.
+  it('answers undefined rather than empty when it does not claim', () => {
+    const off = new DurableRunCoordinator({ mode: 'off' });
+    expect(off.activeWorkerIdentifiers('/repo')).toBeUndefined();
+    off.close();
+
+    const shadowLedger = new RunLedger(dbPath());
+    const shadow = new DurableRunCoordinator({ mode: 'shadow', ledger: shadowLedger });
+    shadowLedger.importRun({
+      issueId: 'observed', source: 'linear', identifier: 'AX-9', title: 'observed only',
+      projectPath: '/repo', state: 'READY',
+    });
+    expect(shadow.activeWorkerIdentifiers('/repo')).toBeUndefined();
+    shadow.close();
+    shadowLedger.close();
+  });
+});

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -3,6 +3,7 @@ import type { PipelineResult } from '../agents/pairPipeline.js';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
 import { normalizeProjectPath } from '../orchestration/taskScheduler.js';
 import type { WorktreeInfo } from '../support/worktreeManager.js';
+import { ACTIVE_LEASE_STATES } from './runLedgerTypes.js';
 import {
   RunLedger,
   type EffectClaim,
@@ -146,6 +147,18 @@ const REBUILT_TASK_PRIORITY = 4;
  * an admission slot — so the GitHub-authoritative half of reconciliation would
  * wait forever on a card it is never going to be handed. (AGT-4094)
  */
+/**
+ * Is a worker still holding this run, or has its lease lapsed?
+ *
+ * An active state alone is not enough: a process that died leaves its row in
+ * EXECUTING until reconciliation sweeps it, which can be a full lease period
+ * later. Same test the ledger applies when it reclaims those rows, including
+ * treating a missing expiry as lapsed rather than eternal. (AGT-4097)
+ */
+function holdsLiveLease(run: Pick<RunRecord, 'leaseExpiresAt'>, now: number): boolean {
+  return run.leaseExpiresAt != null && run.leaseExpiresAt > now;
+}
+
 export function runRecordToTask(run: RunRecord): TaskItem {
   const metadata = (run.metadata ?? {}) as { projectId?: string; projectName?: string; fileScope?: string[] };
   const source = TASK_SOURCES.find((candidate) => candidate === run.source);
@@ -212,6 +225,31 @@ export class DurableRunCoordinator {
 
   listRuns(states?: readonly RunState[]): RunRecord[] {
     return this.ledger?.listRuns(states) ?? [];
+  }
+
+  /**
+   * Identifiers of this project's runs a worker currently holds.
+   *
+   * This is what decides whether an open PR reserves its files. Not *why* a run
+   * stopped — that was the first attempt and it did not survive contact with
+   * production: the runs whose PRs were blocking siblings had all parked on an
+   * operator question, but each later dispatch overwrote `lastErrorCode`, so
+   * only 2 of 10 still said so. A lease is not overwritten by the next attempt;
+   * it is held or it is not. (AGT-4097)
+   *
+   * `undefined` when this coordinator does not claim: `off` has no ledger at
+   * all, and `shadow` observes without ever transitioning a run into an active
+   * state. Both would otherwise return an empty array, which asserts "nothing
+   * is held" — and a caller that fails closed on the difference (the draft
+   * overlap gate does) would silently stop reserving anything.
+   */
+  activeWorkerIdentifiers(projectPath: string, now = Date.now()): string[] | undefined {
+    if (!this.isPrimary || !this.ledger) return undefined;
+    const normalized = normalizeProjectPath(projectPath);
+    return this.listRuns(ACTIVE_LEASE_STATES)
+      .filter((run) => run.projectPath === normalized && holdsLiveLease(run, now))
+      .map((run) => run.identifier)
+      .filter((identifier): identifier is string => !!identifier);
   }
 
   markReady(issueId: string, now = Date.now()): boolean {

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -199,6 +199,12 @@ export interface ExecutionContext {
   durability?: ExecutionDurabilityHooks;
   /** Current open issue snapshot for same-project duplicate grooming in draft. */
   peerIssues?: TaskItem[];
+  /**
+   * Issues in this project a worker currently holds. Resolved per project (like
+   * getRolesForProject) because the draft gate needs it after the project is
+   * known, while the context itself is built without one. (AGT-4097)
+   */
+  getActiveWorkerIssues?: (projectPath: string) => string[] | undefined;
   mcpPolicies?: import('../automation/runnerTypes.js').AutonomousConfig['mcpPolicies'];
   adapterRouting?: import('../automation/runnerTypes.js').AutonomousConfig['adapterRouting'];
 }
@@ -759,7 +765,8 @@ export async function executePipeline(
       console.log(`[AutonomousRunner] Draft: type=${draftResult.taskType}, files=${draftResult.relevantFiles.length}, ${draftResult.durationMs}ms`);
 
       const draftGate = await applyDraftGates({ task, projectPath, draft: draftResult,
-        peers: ctx.peerIssues, source: taskSource, worktreeMode: ctx.worktreeMode });
+        peers: ctx.peerIssues, source: taskSource, worktreeMode: ctx.worktreeMode,
+        activeWorkerIssues: ctx.getActiveWorkerIssues?.(projectPath) });
       if (draftGate) return draftGate;
     } catch (err) {
       if (err instanceof RateLimitError) throw err; // → outer catch → rate_limited (INT-2521)

--- a/src/support/branchNaming.ts
+++ b/src/support/branchNaming.ts
@@ -33,3 +33,15 @@ export function isBranchForIssue(branch: string, issueIdentifier: string): boole
   const prefix = `${BRANCH_NAMESPACE}/${issueIdentifier}`;
   return branch === prefix || branch.startsWith(`${prefix}-`);
 }
+
+/**
+ * Is this branch one the daemon cut for a task?
+ *
+ * Used to decide how much a PR's silence means. A `swarm/*` branch has a run
+ * in the ledger, so "no active worker" is knowable and trustworthy. Any other
+ * branch — a human's, another tool's — has no run to consult, so it keeps
+ * reserving its files. (AGT-4097)
+ */
+export function isSwarmBranch(branch: string): boolean {
+  return branch.startsWith(`${BRANCH_NAMESPACE}/`);
+}

--- a/src/support/fileOverlap.ts
+++ b/src/support/fileOverlap.ts
@@ -1,0 +1,44 @@
+// ============================================
+// OpenSwarm - Branch/PR file-overlap reporting
+// Pure set arithmetic and rendering, no git or gh
+// ============================================
+
+export interface BranchScope {
+  /** Human label, e.g. "PR #206 (feat/int-2389-…)". */
+  label: string;
+  /** Files this scope changes relative to main. */
+  files: string[];
+}
+
+export interface FileOverlap {
+  label: string;
+  files: string[];
+}
+
+/** Pure: intersect this branch's changed files with each other scope's files. */
+export function computeFileOverlaps(selfFiles: string[], others: BranchScope[]): FileOverlap[] {
+  const selfSet = new Set(selfFiles);
+  const out: FileOverlap[] = [];
+  for (const o of others) {
+    const shared = o.files.filter(f => selfSet.has(f));
+    if (shared.length > 0) out.push({ label: o.label, files: shared });
+  }
+  return out;
+}
+
+/** Pure: render overlaps as a PR-body markdown section (empty string if none). */
+export function formatOverlapReport(overlaps: FileOverlap[]): string {
+  if (overlaps.length === 0) return '';
+  const lines = [
+    '## ⚠️ File overlap with in-flight work',
+    '',
+    'This branch changes files that other open PRs / active branches also touch. Coordinate before merging to avoid divergent parallel edits (INT-2388 #3):',
+    '',
+  ];
+  for (const o of overlaps) {
+    const shown = o.files.slice(0, 8).map(f => `\`${f}\``).join(', ');
+    const more = o.files.length > 8 ? ` (+${o.files.length - 8} more)` : '';
+    lines.push(`- **${o.label}** — ${o.files.length} file(s): ${shown}${more}`);
+  }
+  return lines.join('\n');
+}

--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -1,4 +1,4 @@
-import { isBranchForIssue } from './branchNaming.js';
+import { isBranchForIssue, isSwarmBranch } from './branchNaming.js';
 import { execFileSync } from 'node:child_process';
 import { chmodSync, existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -54,13 +54,30 @@ esac
     const previous = process.env.PATH;
     process.env.PATH = `${bin}:${previous}`;
     try {
-      // Only the sibling survives...
-      await expect(findOpenPRFileOverlaps(root, ['src/jobs.py'], 'AX-858')).resolves.toEqual([
-        expect.objectContaining({ number: 179 }),
-      ]);
-      // ...and without a self identifier nothing is excluded, so the gate keeps
-      // its pre-AGT-4095 behavior rather than silently switching off.
+      // Only the sibling survives — its run still holds a lease, so its PR
+      // still reserves.
+      await expect(findOpenPRFileOverlaps(root, ['src/jobs.py'], {
+        selfIssueIdentifier: 'AX-858', activeIssueIdentifiers: ['AX-863'],
+      })).resolves.toEqual([expect.objectContaining({ number: 179 })]);
+
+      // With no ledger to ask, every swarm PR keeps reserving — omitting the
+      // accessor must not empty the gate.
       await expect(findOpenPRFileOverlaps(root, ['src/jobs.py'])).resolves.toHaveLength(2);
+
+      // AGT-4097: an empty array is an assertion, not a missing value — it says
+      // nothing is held, so no swarm PR reserves.
+      await expect(findOpenPRFileOverlaps(root, ['src/jobs.py'], {
+        selfIssueIdentifier: 'AX-858', activeIssueIdentifiers: [],
+      })).resolves.toHaveLength(0);
+
+      // Self-exclusion (AGT-4095) still holds on its own: with AX-858 unnamed
+      // but its run held, its own PR would otherwise block it.
+      await expect(findOpenPRFileOverlaps(root, ['src/jobs.py'], {
+        activeIssueIdentifiers: ['AX-858', 'AX-863'],
+      })).resolves.toHaveLength(2);
+      await expect(findOpenPRFileOverlaps(root, ['src/jobs.py'], {
+        selfIssueIdentifier: 'AX-858', activeIssueIdentifiers: ['AX-858', 'AX-863'],
+      })).resolves.toEqual([expect.objectContaining({ number: 179 })]);
     } finally {
       process.env.PATH = previous;
       rmSync(root, { recursive: true, force: true });
@@ -91,6 +108,19 @@ describe('isBranchForIssue', () => {
     expect(isBranchForIssue('audit/a', 'AX-864')).toBe(false);
     expect(isBranchForIssue('heewonoh/cgf-answers-20260828', 'AX-864')).toBe(false);
     expect(isBranchForIssue('swarm/AX-864-a2', '')).toBe(false);
+  });
+});
+
+describe('isSwarmBranch', () => {
+  // AGT-4097: this decides whether "no active worker" is knowable at all. A
+  // branch the daemon did not cut has no run to consult, so it keeps reserving.
+  it('recognizes the daemon own namespace and nothing else', () => {
+    expect(isSwarmBranch('swarm/AX-864-a2-slack')).toBe(true);
+    expect(isSwarmBranch('swarm/')).toBe(true);
+    expect(isSwarmBranch('heewonoh/cgf-answers-20260828')).toBe(false);
+    expect(isSwarmBranch('swarming/AX-1')).toBe(false);
+    expect(isSwarmBranch('feature/swarm/AX-1')).toBe(false);
+    expect(isSwarmBranch('')).toBe(false);
   });
 });
 

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -120,7 +120,11 @@ async function stripRuntimeMarkerFromGit(worktreePath: string): Promise<void> {
 
 // The naming convention lives in its own module (branchNaming.ts) so the one
 // rule that decides "is this branch mine?" is not buried in lifecycle code.
-import { isBranchForIssue } from './branchNaming.js';
+import { isBranchForIssue, isSwarmBranch } from './branchNaming.js';
+// Overlap set arithmetic and rendering live in fileOverlap.ts — pure, and this
+// file is at the pre-commit LOC cap. Re-exported so callers keep one import.
+export { computeFileOverlaps, formatOverlapReport, type BranchScope, type FileOverlap } from './fileOverlap.js';
+import { computeFileOverlaps, formatOverlapReport, type BranchScope, type FileOverlap } from './fileOverlap.js';
 
 function isPathInside(parent: string, child: string): boolean {
   const rel = relative(parent, child);
@@ -852,18 +856,6 @@ async function ensureLfsSmudged(worktreePath: string): Promise<void> {
 // created, surface which open PRs / active swarm/* branches touch the same
 // files — advisory only, never blocks PR creation.
 
-export interface BranchScope {
-  /** Human label, e.g. "PR #206 (feat/int-2389-…)". */
-  label: string;
-  /** Files this scope changes relative to main. */
-  files: string[];
-}
-
-export interface FileOverlap {
-  label: string;
-  files: string[];
-}
-
 export interface OpenPRFileOverlap extends FileOverlap {
   number: number;
   url: string;
@@ -912,12 +904,28 @@ export async function findOpenPRFileOverlaps(
   repoPath: string,
   plannedFiles: string[],
   /**
-   * The issue being dispatched. Its own open PR is not competing work — it is
-   * this task's parked or in-flight branch — so it must not supersede the
-   * task that owns it. Omitted means "no self to exclude", which is the
-   * pre-AGT-4095 behavior rather than a disabled gate.
+   * Which open PRs count as competing work.
+   *
+   * A PR reserves its files while a worker is editing them, and `publishOnPark`
+   * leaves a PR behind long after its worker exits — so an open PR alone is not
+   * evidence of anyone editing. Two exclusions follow: the dispatched issue's
+   * own PR (AGT-4095), and a `swarm/*` PR whose run no longer holds a lease
+   * (AGT-4097).
+   *
+   * A branch outside the `swarm/` namespace — a human's, another tool's — has
+   * no run to consult, so it always reserves.
+   *
+   * `activeIssueIdentifiers` distinguishes "none are active" from "I cannot
+   * tell": an array, **including an empty one**, asserts it is the complete set
+   * of held leases; `undefined` means the caller has no ledger to ask, and
+   * every `swarm/*` PR keeps reserving. Getting those two confused would empty
+   * the gate on any caller that simply never wired the accessor.
    */
-  selfIssueIdentifier?: string,
+  competing: {
+    selfIssueIdentifier?: string;
+    /** Issues whose runs a worker currently holds; undefined when unknowable. */
+    activeIssueIdentifiers?: readonly string[];
+  } = {},
 ): Promise<OpenPRFileOverlap[]> {
   if (plannedFiles.length === 0) return [];
   const planned = new Set(plannedFiles.map((f) => f.replace(/^\.\//, '')));
@@ -931,7 +939,11 @@ export async function findOpenPRFileOverlaps(
     const prs: { number: number; url: string; headRefName: string; files?: { path: string }[] }[] = JSON.parse(raw || '[]');
     const overlaps: OpenPRFileOverlap[] = [];
     for (const pr of prs) {
-      if (selfIssueIdentifier && isBranchForIssue(pr.headRefName, selfIssueIdentifier)) continue;
+      if (competing.selfIssueIdentifier && isBranchForIssue(pr.headRefName, competing.selfIssueIdentifier)) continue;
+      const active = competing.activeIssueIdentifiers;
+      const heldByAWorker = active === undefined
+        || active.some((id) => isBranchForIssue(pr.headRefName, id));
+      if (isSwarmBranch(pr.headRefName) && !heldByAWorker) continue;
       const shared = (pr.files ?? []).map((f) => f.path).filter((f) => planned.has(f.replace(/^\.\//, '')));
       if (shared.length > 0) overlaps.push({ number: pr.number, url: pr.url, label: `PR #${pr.number} (${pr.headRefName})`, files: shared });
     }
@@ -940,34 +952,6 @@ export async function findOpenPRFileOverlaps(
     console.warn('[Worktree] Preflight open-PR overlap check skipped:', err);
     return [];
   }
-}
-
-/** Pure: intersect this branch's changed files with each other scope's files. */
-export function computeFileOverlaps(selfFiles: string[], others: BranchScope[]): FileOverlap[] {
-  const selfSet = new Set(selfFiles);
-  const out: FileOverlap[] = [];
-  for (const o of others) {
-    const shared = o.files.filter(f => selfSet.has(f));
-    if (shared.length > 0) out.push({ label: o.label, files: shared });
-  }
-  return out;
-}
-
-/** Pure: render overlaps as a PR-body markdown section (empty string if none). */
-export function formatOverlapReport(overlaps: FileOverlap[]): string {
-  if (overlaps.length === 0) return '';
-  const lines = [
-    '## ⚠️ File overlap with in-flight work',
-    '',
-    'This branch changes files that other open PRs / active branches also touch. Coordinate before merging to avoid divergent parallel edits (INT-2388 #3):',
-    '',
-  ];
-  for (const o of overlaps) {
-    const shown = o.files.slice(0, 8).map(f => `\`${f}\``).join(', ');
-    const more = o.files.length > 8 ? ` (+${o.files.length - 8} more)` : '';
-    lines.push(`- **${o.label}** — ${o.files.length} file(s): ${shown}${more}`);
-  }
-  return lines.join('\n');
 }
 
 /** Split git/gh newline output into a trimmed, non-empty list. */


### PR DESCRIPTION
## Problem

`applyDraftGates` supersedes a task when an open PR already owns the files it plans to touch. That is right while someone is editing them — but `publishOnPark` leaves a PR behind long after its worker exits, so **an open PR alone is not evidence of anyone editing**. AGT-4095 removed the collision with the task's *own* PR; this removes it with every sibling's.

## Production evidence

Right after the AGT-4095 deploy, AX-864 drafted successfully (22 files) and the gate ran for real:

```
Existing open PR owns planned files — skipping duplicate worker:
  - .../pull/180: apps/pipelines/src/cgf_pipelines/jobs.py
  - .../pull/179: apps/pipelines/src/cgf_pipelines/a2_inputs.py
```

Its own #178 is correctly gone (AGT-4095 works), but #180 and #179 are PRs left behind by parked runs, untouched for 7–12 h. **Seven of the repo's eight open PRs are such leftovers**, and they have **zero pairwise file overlap** with each other — verified by computing the matrix from live `gh pr list --json files` — so this was never a deadlock between them. A broad plan simply sweeps in files that PRs going nowhere happen to own. AX-858/863/864 sat at attempts 14–16, 294–360 min out, each blocked attempt doubling the backoff again.

## The signal is the lease, not the reason a run stopped

My first implementation keyed on `lastErrorCode` (`NEEDS_HUMAN`, or `RETRY_AT` under `waiting_on_operator`). **It would not have fixed anything.** Checked against the live ledger before shipping:

```
AX-1028  RETRY_AT     superseded            176
AX-1029  RETRY_AT     superseded            174
AX-1030  NEEDS_HUMAN  needs_human           172
AX-1039  RETRY_AT     superseded            173
AX-854   RETRY_AT     superseded            170
AX-858   RETRY_AT     superseded            180
AX-859   RETRY_AT     waiting_on_operator   181
AX-863   RETRY_AT     superseded            179
AX-864   RETRY_AT     superseded            178
AX-879   RETRY_AT     superseded            177
→ predicate matched 2 of 10
```

Every one of those runs *had* parked on an operator question — that is why `publishOnPark` opened its PR — but each later dispatch overwrote `lastErrorCode`. A lease is not overwritten by the next attempt: it is held or it is not.

`isDraft` is not the signal either, checked rather than assumed: `worktreeManager.ts:1267` opens a PR as a draft for duplicates too, and says so in its own comment.

## Three distinctions the gate has to keep, each held by a test

| Case | Behaviour | Why |
|---|---|---|
| Branch outside `swarm/` | always reserves | no run to consult (a human's PR, another tool's) |
| `activeIssueIdentifiers: []` | nothing reserves | an assertion: the set of held leases is empty |
| `activeIssueIdentifiers: undefined` | every swarm PR reserves | the caller has no ledger to ask — `off` and `shadow` never claim, so they answer `undefined` rather than `[]` |
| Active row, lapsed lease | does not reserve | the process died; the row is waiting for a reconciliation sweep. Same expiry test the ledger itself uses |

Conflating the middle two would empty the gate on any caller that simply never wired the accessor — the mutation test for that line fails when the `??  []` shortcut is restored.

## Verification

- `npx tsc --noEmit` clean; `npx vitest run src/automation/ src/support/` — **1228 passed, 3 skipped** (Linux-only pid-space cases).
- Every new behaviour revert-checked: removing the lease guard, the `undefined`/`[]` distinction, or the self-exclusion each fails its own test.
- Commit gate ran **four rounds**. Rounds 1–3 each produced a real finding — the `lastErrorCode` predicate not reaching production state, `off`/`shadow` asserting an empty set, and lapsed leases still counted as held. Round 4: `Decision: APPROVE`.

## Note on scope

`worktreeManager.ts` tripped the 1500-line pre-commit cap again, one commit after being shaved to 1498. The pure overlap arithmetic (`computeFileOverlaps`, `formatOverlapReport`) moves to `fileOverlap.ts` — real headroom (now 1476) instead of another trimmed line. Re-exported, so no import path changes.

## Accepted tradeoff

Two branches may now edit one file. That is safe while they run (worktree isolation) and surfaces at integration, where `formatOverlapReport` already annotates the PR and AGT-4078 tracks merge conflicts on their own terms. The operator chose this explicitly over leaving siblings blocked indefinitely by one unanswered question.

Closes AGT-4097.