### PR TITLE
fix(reconciler): report when a fenced run actually frees (AGT-4126)

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -1246,7 +1246,11 @@ export class AutonomousRunner {
       // one place it actually protects something. (AGT-4094)
       const task = taskById.get(run.issueId);
       if (run.ownerInstanceId || run.leaseToken) {
-        console.warn(`[Reconciler] Keeping ${run.identifier ?? run.issueId} fenced until its original executor exits`);
+        // Not "until its executor exits": a container restart replaces the
+        // process holding the claim, so that exit is never observed and the
+        // line reads as a permanent wedge. What actually frees the row is the
+        // age sweep in durableRunCoordinator, so report its deadline. (AGT-4126)
+        console.warn(this.durableRuns.fenceWaitMessage(run));
         continue;
       }
 

--- a/src/automation/durableRunCoordinator.test.ts
+++ b/src/automation/durableRunCoordinator.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { PipelineResult } from '../agents/pairPipeline.js';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
-import { DurableRunCoordinator, retryAtFor, runRecordToTask } from './durableRunCoordinator.js';
+import { DurableRunCoordinator, formatFenceWait, retryAtFor, runRecordToTask } from './durableRunCoordinator.js';
 import { RunLedger } from './runLedger.js';
 
 const roots: string[] = [];
@@ -53,6 +53,52 @@ describe('DurableRunCoordinator', () => {
     expect(retryAtFor(superseded, 1_000, 2)).toBe(1_000 + 10 * 60_000);
     expect(retryAtFor(superseded, 1_000, 3)).toBe(1_000 + 20 * 60_000);
     expect(retryAtFor(superseded, 1_000, 20)).toBe(1_000 + 6 * 60 * 60_000);
+  });
+
+  it('reports the deadline the age sweep will actually act on', () => {
+    const coordinator = new DurableRunCoordinator({
+      mode: 'primary', dbPath: dbPath(), instanceId: 'daemon', reconcileAbandonMs: 10 * 60_000,
+    });
+
+    // Read off updatedAt — the same field the sweep compares — so the reported
+    // wait and the actual free cannot drift. (AGT-4126)
+    expect(coordinator.reconcileAbandonDeadline({ updatedAt: 1_000 })).toBe(1_000 + 10 * 60_000);
+  });
+
+  it('names a checkable condition and a time in the fence message', () => {
+    const coordinator = new DurableRunCoordinator({
+      mode: 'primary', dbPath: dbPath(), instanceId: 'daemon', reconcileAbandonMs: 10 * 60_000,
+    });
+
+    const message = coordinator.fenceWaitMessage({ updatedAt: 0, identifier: 'AX-879', issueId: 'uuid-1' });
+
+    expect(message).toContain('AX-879');
+    expect(message).toContain('1970-01-01T00:10:00.000Z');
+    // Both exits the sweep has, and only those: nothing renews a row that has
+    // already sat through a full lease of silence.
+    expect(message).toContain('by age');
+    expect(message).toContain('exited');
+    expect(message).not.toContain('renew');
+    // The old wording pointed at an event no one can observe once the container
+    // holding that executor has been replaced, so a self-healing wait read as a
+    // permanent wedge.
+    expect(message).not.toContain('original executor');
+  });
+
+  it('falls back to the issue id when a run has no identifier', () => {
+    const coordinator = new DurableRunCoordinator({
+      mode: 'primary', dbPath: dbPath(), instanceId: 'daemon', reconcileAbandonMs: 60_000,
+    });
+
+    expect(coordinator.fenceWaitMessage({ updatedAt: 0, issueId: 'uuid-1' })).toContain('uuid-1');
+  });
+
+  it('formats the wait without needing a coordinator', () => {
+    expect(formatFenceWait('AX-1', 0)).toBe(
+      '[Reconciler] Keeping AX-1 fenced — its claim is still held;'
+      + ' frees at 1970-01-01T00:00:00.000Z by age,'
+      + ' or sooner if its owner process is seen to have exited',
+    );
   });
 
   it('admits only one concurrent run per repository across coordinator instances', async () => {

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -243,6 +243,30 @@ export class DurableRunCoordinator {
    * is held" — and a caller that fails closed on the difference (the draft
    * overlap gate does) would silently stop reserving anything.
    */
+  /**
+   * When the age sweeper will free `run` if its owner stays silent.
+   *
+   * Read from the same field the sweep compares against, so a caller reporting
+   * the deadline and the sweep acting on it cannot drift apart. Exposed because
+   * the reconciler in autonomousRunner logs the wait but lives in another file,
+   * and named the executor's exit — a condition no one can observe once the
+   * container holding it has been replaced. (AGT-4126)
+   */
+  reconcileAbandonDeadline(run: { updatedAt: number }): number {
+    return run.updatedAt + this.reconcileAbandonMs;
+  }
+
+  /**
+   * The sentence the reconciler prints while a claim is still held.
+   *
+   * Owned here because this class owns the policy it describes: the wait ends
+   * when the age sweep fires, not when a process exits, and the two must not be
+   * described by different files that can drift. (AGT-4126)
+   */
+  fenceWaitMessage(run: { updatedAt: number; identifier?: string | null; issueId: string }): string {
+    return formatFenceWait(run.identifier ?? run.issueId, this.reconcileAbandonDeadline(run));
+  }
+
   activeWorkerIdentifiers(projectPath: string, now = Date.now()): string[] | undefined {
     if (!this.isPrimary || !this.ledger) return undefined;
     const normalized = normalizeProjectPath(projectPath);
@@ -727,4 +751,23 @@ export class DurableRunCoordinator {
       onPublication: async () => true,
     };
   }
+}
+
+/**
+ * Why a `NEEDS_RECONCILE` row is still fenced, and when that ends.
+ *
+ * Names both exits the sweep actually has — age, or a pid probe that shows the
+ * owner gone — and pins the first to a clock time. There is deliberately no
+ * "unless the owner renews": reaching `NEEDS_RECONCILE` already required a full
+ * lease of silence, and nothing renews a row in that state, so offering renewal
+ * as an alternative would describe a transition the state machine does not have.
+ *
+ * The previous wording — "until its original executor exits" — named an event
+ * that is never observed when a container restart replaced the process holding
+ * the claim, so a self-healing wait read as a permanent wedge. (AGT-4126)
+ */
+export function formatFenceWait(identifier: string, freesAtMs: number): string {
+  return `[Reconciler] Keeping ${identifier} fenced — its claim is still held;`
+    + ` frees at ${new Date(freesAtMs).toISOString()} by age,`
+    + ' or sooner if its owner process is seen to have exited';
 }


### PR DESCRIPTION
## What

`[Reconciler] Keeping <id> fenced until its original executor exits` named a condition that **cannot be observed** once a container restart replaced the process holding the claim. The line described an endless wait and pointed away from the mechanism that actually resolves it.

It does resolve: `reconcileAbandonMs` (default = `leaseMs` = 10 min) frees the row by age — the container pid-reuse fallback from AGT-4053. Measured on vela today: 7 rows orphaned by a redeploy, and AX-1074 / AX-1076 crossed the threshold and returned to `EXECUTING` on their own.

## Why it matters

The wording misled a reader **with full source access** into diagnosing a healthy, self-healing system as permanently wedged. Every supporting observation was true — `lease_expires_at` NULL on all fenced rows, the fence keyed on claim *presence* rather than liveness, the owner instance `7-e68cb63e…` holding no live row anywhere in the ledger — and the conclusion was still wrong, because the age sweeper lives in a different file.

An operator who reaches that conclusion redeploys, resetting a recovery that would have finished in under ten minutes.

## What changed

- `DurableRunCoordinator.reconcileAbandonDeadline()` reads the deadline off the **same `updatedAt`** the sweep compares, so the reported wait and the actual free cannot drift.
- `formatFenceWait()` / `fenceWaitMessage()` live next to the policy they describe.
- The message names **both** exits the sweep has — age, and a pid probe showing the owner gone — and deliberately offers no renewal alternative: reaching `NEEDS_RECONCILE` already required a full lease of silence, and nothing renews a row in that state. (Caught by commit-gate round 1, which flagged the first draft's "unless the owner renews" as a transition the state machine does not have.)

**Fencing behaviour is unchanged** — only the message.

## Verification

- 47 coordinator tests + 664 across `src/automation/`, `tsc --noEmit` clean
- Mutation-checked: drifting the deadline off `leaseMs*2` fails 2 tests; restoring the old wording fails 2 tests
- Commit gate: `✓ APPROVE` — *"the reported deadline is derived from `updatedAt`, matching the age-sweep predicate in `reconcile()`"*
- Message asserted through a pure formatter rather than the `AutonomousRunner` harness, which is flaky by global-singleton and timer contamination

Closes AGT-4126.