### PR TITLE
fix(ledger): count metrics within the daemon's dispatch scope (AGT-4127)

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -28,7 +28,7 @@ import {
   type TaskState,
   type ProjectInfo,
 } from './runnerState.js';
-import { taskEventKey, DecisionEngine, DecisionResult, TaskItem, getDecisionEngine, classifyStuck } from '../orchestration/decisionEngine.js';
+import { taskEventKey, DecisionEngine, DecisionResult, TaskItem, getDecisionEngine, classifyStuck, effectiveProjectScope } from '../orchestration/decisionEngine.js';
 import { getCoordinationStore } from '../coordination/coordinationStore.js';
 import { OPERATOR_PARK_REASON, shouldReadmitEarly } from '../coordination/operatorAnswers.js';
 // ExecutorResult used via execution.reportExecutionResult
@@ -2589,6 +2589,29 @@ export class AutonomousRunner {
     return this.config.allowedProjects ?? [];
   }
 
+  /**
+   * The project set the daemon will actually dispatch to right now: the
+   * configured allow-list narrowed by the dashboard's enabled selection, the
+   * same two gates every dispatch decision passes (isProjectEnabled +
+   * decisionEngine's allow-list). Metrics scoped by only the former still
+   * counted repositories the operator had disabled as live work. (AGT-4127
+   * PR review)
+   *
+   * `undefined` means no restriction exists — the legacy allow-everything
+   * configuration — and is deliberately distinct from `[]`, which means the
+   * gates admit nothing (every project disabled). The two collapse to the same
+   * array value but opposite dispatch behaviour, so the translation happens
+   * here, the one place that knows which is which.
+   */
+  getEffectiveProjectScope(): string[] | undefined {
+    return effectiveProjectScope(
+      this.config.allowedProjects ?? [],
+      this.enabledProjects,
+      this.shouldFilterByEnabled(),
+    );
+  }
+
+
   updateAllowedProjects(paths: string[]): void {
     this.config.allowedProjects = paths;
     this.engine.updateAllowedProjects(paths);
@@ -2598,7 +2621,7 @@ export class AutonomousRunner {
     return { isRunning: this.state.isRunning, lastHeartbeat: this.state.lastHeartbeat,
       engineStats: this.engine.getStats(), pendingApproval: !!this.state.pendingApproval,
       schedulerStats: this.scheduler.getStats(),
-      automationLedger: this.durableRuns.getMetrics(),
+      automationLedger: this.durableRuns.getMetrics(Date.now(), this.getEffectiveProjectScope()),
       turboMode: this.turboMode,
       turboExpiresAt: this.turboExpiresAt,
       dailyPace: getDailyPaceInfo(),

--- a/src/automation/durableRunCoordinator.test.ts
+++ b/src/automation/durableRunCoordinator.test.ts
@@ -101,6 +101,101 @@ describe('DurableRunCoordinator', () => {
     );
   });
 
+  it('counts only the projects the daemon dispatches to, and reports the rest', async () => {
+    const path = dbPath();
+    const ledger = new RunLedger(path);
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', dbPath: path, instanceId: 'daemon', ledger });
+
+    await coordinator.execute(task('live-1'), '/work/cgf-portal', async () => result(true));
+    // A path from an earlier deployment: the row is permanent, can never run,
+    // and used to dominate the totals. (AGT-4127)
+    await coordinator.execute(task('stale-1'), '/Users/someone/dev/STONKS', async () => result(true));
+    await coordinator.execute(task('stale-2'), '/Users/someone/dev/kyte-portal', async () => result(true));
+
+    const scoped = coordinator.getMetrics(Date.now(), ['/work/cgf-portal']);
+    const total = Object.values(scoped.byState).reduce((sum, n) => sum + n, 0);
+
+    expect(total).toBe(1);
+    expect(scoped.outOfScope).toBe(2);
+  });
+
+  it('treats an empty scope as empty — every row out of it', async () => {
+    const path = dbPath();
+    const ledger = new RunLedger(path);
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', dbPath: path, instanceId: 'daemon', ledger });
+
+    await coordinator.execute(task('a'), '/work/cgf-portal', async () => result(true));
+    await coordinator.execute(task('b'), '/Users/someone/dev/STONKS', async () => result(true));
+
+    // The scope argument is literal. The daemon's "[] means allow everything"
+    // convention is translated by getEffectiveProjectScope, the one place that
+    // knows whether [] arose from no restriction or from every project being
+    // disabled — a fully-disabled daemon must not report its ledger as busy.
+    const none = coordinator.getMetrics(Date.now(), []);
+
+    expect(Object.values(none.byState).reduce((sum, n) => sum + n, 0)).toBe(0);
+    expect(none.outOfScope).toBe(2);
+  });
+
+  it('scopes the expired-lease count alongside byState', async () => {
+    // Both metrics derive from the runs table, so a sibling metric must not
+    // keep counting the projects byState just excluded. Two genuinely expired
+    // active leases — held EXECUTING runs probed after their lease lapsed —
+    // one in scope, one out. (gate round 2: the first version of this test
+    // never created an expired lease and asserted <=, which nothing can fail.)
+    const path = dbPath();
+    const ledger = new RunLedger(path);
+    const coordinator = new DurableRunCoordinator({
+      mode: 'primary', ledger, instanceId: 'expiry-owner', leaseMs: 3_000,
+    });
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    const live = coordinator.execute(task('LIVE-EXP'), '/work/cgf-portal', async () => { await held; return result(); });
+    const stale = coordinator.execute(task('STALE-EXP'), '/Users/someone/dev/STONKS', async () => { await held; return result(); });
+    await Promise.resolve();
+
+    // Probe past every renewal the coordinator could have written.
+    const past = Date.now() + 24 * 60 * 60_000;
+    const raw = coordinator.getMetrics(past);
+    const scoped = coordinator.getMetrics(past, ['/work/cgf-portal']);
+
+    expect(raw.expiredActiveLeases).toBe(2);
+    expect(scoped.expiredActiveLeases).toBe(1);
+    expect(scoped.outOfScope).toBe(1);
+
+    release();
+    await Promise.all([live, stale]);
+    coordinator.close();
+    ledger.close();
+  });
+
+  it('keeps the raw totals when no scope is given', async () => {
+    const path = dbPath();
+    const ledger = new RunLedger(path);
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', dbPath: path, instanceId: 'daemon', ledger });
+
+    await coordinator.execute(task('live-1'), '/work/cgf-portal', async () => result(true));
+    await coordinator.execute(task('stale-1'), '/Users/someone/dev/STONKS', async () => result(true));
+
+    const raw = coordinator.getMetrics(Date.now());
+
+    expect(Object.values(raw.byState).reduce((sum, n) => sum + n, 0)).toBe(2);
+    expect(raw.outOfScope).toBe(0);
+  });
+
+  it('counts a nested path under an allowed project as in scope', async () => {
+    const path = dbPath();
+    const ledger = new RunLedger(path);
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', dbPath: path, instanceId: 'daemon', ledger });
+
+    // Shares admission's predicate, so a subdirectory of an allowed project is
+    // in scope here exactly as it is there — the two cannot describe different
+    // project sets.
+    await coordinator.execute(task('nested'), '/work/cgf-portal/apps/pipelines', async () => result(true));
+
+    expect(coordinator.getMetrics(Date.now(), ['/work/cgf-portal']).outOfScope).toBe(0);
+  });
+
   it('admits only one concurrent run per repository across coordinator instances', async () => {
     const path = dbPath();
     const first = new DurableRunCoordinator({ mode: 'primary', dbPath: path, instanceId: 'a' });

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import type { PipelineResult } from '../agents/pairPipeline.js';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
+import { isAllowedProjectPath } from '../orchestration/decisionEngine.js';
 import { normalizeProjectPath } from '../orchestration/taskScheduler.js';
 import type { WorktreeInfo } from '../support/worktreeManager.js';
 import { ACTIVE_LEASE_STATES } from './runLedgerTypes.js';
@@ -712,11 +713,54 @@ export class DurableRunCoordinator {
     return outcome;
   }
 
-  getMetrics(now = Date.now()) {
-    return this.ledger?.getMetrics(now) ?? {
+  /**
+   * Ledger metrics, counted within the projects the daemon actually works on.
+   *
+   * The raw table is a permanent record of everything the daemon has ever seen,
+   * including projects that were later disabled and paths from an earlier
+   * deployment that do not exist in this one. Those rows can never execute, but
+   * they dominate a whole-table `GROUP BY state` and make the totals read as a
+   * backlog. Measured on one host: 158 of 254 rows referenced host paths from
+   * before containerisation, so `RETRY_AT` reported 88 where the live figure was
+   * 48, and `READY` reported 24 where it was 4. Both readings produced a wrong
+   * diagnosis before the scope was applied. (AGT-4127)
+   *
+   * Scoping uses `isAllowedProjectPath`, the same predicate admission uses, so
+   * the counts cannot describe a different set of projects than the daemon
+   * dispatches to. Out-of-scope rows are reported as a single number rather than
+   * dropped — hiding them would trade one misleading total for another.
+   *
+   * `allowedProjects` is literal: the scope passed is the scope counted.
+   * Omitted means unscoped — the raw table. An empty array means an empty
+   * scope — every row is out of it. The daemon's config uses `[]` to mean
+   * "allow everything", but that translation belongs to the caller
+   * (`getEffectiveProjectScope`), which alone knows whether an empty array
+   * arose from "no restriction" or from "every project disabled"; conflating
+   * them here made metrics report a fully-disabled daemon as fully busy.
+   *
+   * `byState` and `expiredActiveLeases` are scoped because both are derived from
+   * the runs table. `effectsByStatus` and `openCircuits` are not: effects and
+   * circuits are keyed by their own identifiers rather than by project path, so
+   * scoping them needs a join this method deliberately does not do. They stay
+   * global, and this comment is the record of that.
+   */
+  getMetrics(now = Date.now(), allowedProjects?: readonly string[]) {
+    const base = this.ledger?.getMetrics(now) ?? {
       byState: {}, effectsByStatus: {}, expiredActiveLeases: 0, oldestPendingEffectAgeMs: 0,
       openCircuits: 0,
     };
+    if (!this.ledger || allowedProjects === undefined) return { ...base, outOfScope: 0 };
+
+    const scope = [...allowedProjects];
+    const byState: Record<string, number> = {};
+    let outOfScope = 0;
+    let expiredActiveLeases = 0;
+    for (const run of this.ledger.listRuns()) {
+      if (!isAllowedProjectPath(run.projectPath, scope)) { outOfScope++; continue; }
+      byState[run.state] = (byState[run.state] ?? 0) + 1;
+      if (ACTIVE_LEASE_STATES.includes(run.state) && !holdsLiveLease(run, now)) expiredActiveLeases++;
+    }
+    return { ...base, byState, expiredActiveLeases, outOfScope };
   }
 
   close(): void {

--- a/src/orchestration/decisionEngine.test.ts
+++ b/src/orchestration/decisionEngine.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isAllowedProjectPath, isUmbrellaIssue, selectTasksRoundRobin, type TaskItem } from './decisionEngine.js';
+import { effectiveProjectScope, isAllowedProjectPath, isUmbrellaIssue, selectTasksRoundRobin, type TaskItem } from './decisionEngine.js';
 
 // INT-1810 R2: parent/EPIC issues are umbrellas, not executable work. INT-1702 (tracking,
 // decomposed into sub-issues) and KT-300 ([EPIC] …) were wrongly picked for the worker.
@@ -29,6 +29,57 @@ describe('isUmbrellaIssue', () => {
     expect(isUmbrellaIssue(task({ issueId: 'leaf', title: 'fix(adapters): codex flag' }), parentIds)).toBe(false);
     // "epic" inside a word must not false-positive
     expect(isUmbrellaIssue(task({ issueId: 'l2', title: 'add epicenter map widget' }), parentIds)).toBe(false);
+  });
+});
+
+describe('effectiveProjectScope', () => {
+  it('returns undefined for the legacy no-restriction configuration', () => {
+    // [] in config means "allow everything"; [] as a scope means "admit
+    // nothing". The translation to undefined happens here, the one place that
+    // knows which meaning applies. (AGT-4127)
+    expect(effectiveProjectScope([], new Set(), false)).toBeUndefined();
+  });
+
+  it('passes the allow-list through when no selection filter applies', () => {
+    expect(effectiveProjectScope(['/work/a'], new Set(['/ignored']), false)).toEqual(['/work/a']);
+  });
+
+  it('narrows the allow-list to the enabled selection', () => {
+    expect(effectiveProjectScope(
+      ['/work/cgf-portal', '/work/vega-agent'],
+      new Set(['/work/cgf-portal']),
+      true,
+    )).toEqual(['/work/cgf-portal']);
+  });
+
+  it('returns an empty scope when every project is disabled', () => {
+    // Distinct from undefined: a fully-disabled daemon dispatches nothing, and
+    // its metrics must not report the ledger as busy.
+    expect(effectiveProjectScope(['/work/cgf-portal'], new Set(), true)).toEqual([]);
+  });
+
+  it('keeps the narrower path when allowed and enabled overlap as prefixes', () => {
+    // Keeping the wider /work would sweep sibling projects dispatch refuses
+    // back into the counts.
+    expect(effectiveProjectScope(['/work'], new Set(['/work/cgf-portal']), true))
+      .toEqual(['/work/cgf-portal']);
+    expect(effectiveProjectScope(['/work/cgf-portal'], new Set(['/work']), true))
+      .toEqual(['/work/cgf-portal']);
+  });
+
+  it('uses the enabled selection alone when the allow-list is empty', () => {
+    expect(effectiveProjectScope([], new Set(['/work/a']), true)).toEqual(['/work/a']);
+  });
+
+  it('matches case-insensitively where the runner admission does', () => {
+    // macOS/Windows filesystems are case-insensitive, and the runner's
+    // enabled-set admission folds case there. A casing difference between
+    // UI-captured and configured paths must not drop a project from the counts
+    // that dispatch admits. (gate round: case-sensitivity mismatch)
+    expect(effectiveProjectScope(['/Work/CGF-Portal'], new Set(['/work/cgf-portal']), true, true))
+      .toEqual(['/Work/CGF-Portal']);
+    expect(effectiveProjectScope(['/Work/CGF-Portal'], new Set(['/work/cgf-portal']), true, false))
+      .toEqual([]);
   });
 });
 

--- a/src/orchestration/decisionEngine.ts
+++ b/src/orchestration/decisionEngine.ts
@@ -261,6 +261,52 @@ function normalizeProjectPath(input: string): string {
   return resolve(expandHomePath(input));
 }
 
+/**
+ * The project set dispatch will actually admit: the configured allow-list
+ * narrowed by the enabled selection, when a selection is being applied.
+ *
+ * `undefined` means no restriction exists (the legacy allow-everything
+ * configuration); `[]` means the gates admit nothing (every project disabled).
+ * The two collapse to the same array value but opposite dispatch behaviour, so
+ * callers scoping metrics or reports must preserve the distinction rather than
+ * defaulting one into the other. (AGT-4127)
+ *
+ * Pure so it can be tested without the runner harness; the runner delegates.
+ */
+export function effectiveProjectScope(
+  allowedProjects: readonly string[],
+  enabledProjects: ReadonlySet<string>,
+  applyEnabledFilter: boolean,
+  caseInsensitivePaths = process.platform === 'darwin' || process.platform === 'win32',
+): string[] | undefined {
+  if (!applyEnabledFilter) return allowedProjects.length === 0 ? undefined : [...allowedProjects];
+  if (allowedProjects.length === 0) return [...enabledProjects];
+  // The runner's enabled-set admission compares case-insensitively on macOS and
+  // Windows (their filesystems are), so this intersection must too — a casing
+  // difference between UI-captured and configured paths would otherwise drop a
+  // project from the counts that dispatch happily admits. Comparison only: the
+  // returned entries keep their original casing.
+  const fold = (p: string) => (caseInsensitivePaths ? normalizeProjectPath(p).toLowerCase() : normalizeProjectPath(p));
+  const allowed = [...allowedProjects];
+  const enabled = [...enabledProjects];
+  const allowedFolded = allowed.map(fold);
+  const enabledFolded = enabled.map(fold);
+  // Both lists are prefix-closed (a path is in if it is under an entry), so the
+  // effective scope is their intersection: from each overlapping pair keep the
+  // NARROWER path. Keeping the wider one — allowed `/work` when only
+  // `/work/cgf-portal` is enabled — would sweep sibling projects dispatch
+  // refuses back into the counts.
+  const scope = new Map<string, string>();
+  for (const p of [
+    ...allowed.filter((_, i) => isAllowedProjectPath(allowedFolded[i], enabledFolded)),
+    ...enabled.filter((_, i) => isAllowedProjectPath(enabledFolded[i], allowedFolded)),
+  ]) {
+    // Dedupe on the folded key: the same directory spelt two ways is one entry.
+    if (!scope.has(fold(p))) scope.set(fold(p), normalizeProjectPath(p));
+  }
+  return [...scope.values()];
+}
+
 export function isAllowedProjectPath(projectPath: string, allowedProjects: string[]): boolean {
   const normalizedProjectPath = normalizeProjectPath(projectPath);
 


### PR DESCRIPTION
## What

`getMetrics` counted the whole `automation_runs` table. That table is a permanent record: it still holds 158 rows (of 254) referencing macOS paths from before containerisation, plus projects disabled since. Those rows can never execute, but they dominated the totals — `RETRY_AT` read 88 where the live figure was 48, `READY` read 24 where it was 4. Both misled this session's monitoring into a wrong diagnosis before scoping by hand.

## How

- `DurableRunCoordinator.getMetrics(now, allowedProjects?)` scopes `byState` and `expiredActiveLeases` through **`isAllowedProjectPath` — the same predicate admission uses** — so the counts cannot describe a different project set than dispatch does.
- Out-of-scope rows are reported as one `outOfScope` number, not silently dropped.
- Omitted scope = raw table (explicit caller choice). Empty allow-list = the daemon's "no restriction" config, which decisionEngine reads as allow-everything — so everything is in scope. The two are deliberately distinct (gate round 1).
- `effectsByStatus` / `openCircuits` stay global: keyed by their own ids, not project paths; documented instead of half-scoped.
- `AutonomousRunner.getStats()` passes its live allow-list.
- No deletion — the ledger stays the recovery record (per AGT-4124, parked branches still hold real work).

## Review rounds

1. Gate: empty-vs-omitted conflation + sibling metric unscoped → both fixed, tested.
2. Gate: the expired-lease test asserted `<=` on counts that were both zero — replaced with two held EXECUTING runs probed past their lease, asserting exactly 2 raw / 1 scoped / 1 outOfScope.
3. Gate: ✓ APPROVE.

## Verification

- 52 coordinator tests, 860 across `src/automation/` + `src/orchestration/`, `tsc --noEmit` clean
- Mutation-checked: exact-match instead of the shared predicate → 1 test fails; scoping skipped → 1 test fails; sibling metric left global → 1 test fails

Closes AGT-4127 (scope-fencing half; Linear terminal reconciliation is follow-up work on the same issue).