### PR TITLE
fix(docker): give workers venv and pip so Python repositories can run their tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,12 @@ FROM node:22-slim AS production
 # Python extractor shells out to an interpreter. Without it a single tracked
 # .py file makes `codeql database create --build-mode=none` fail, which the
 # pipeline reports as an infra error and parks the task.
+# python3-venv + python3-pip: workers on Python repositories (vega-agent) must
+# create a project venv and install its requirements to run tests; the slim
+# distribution python3 ships without ensurepip, so `python3 -m venv` fails and
+# every such task parks asking an operator for a "usable Python dependency
+# environment". The venvs themselves live under /work (a bind mount), so they
+# survive redeploys — only the interpreter machinery belongs to the image.
 #
 # postgresql-client / sqlite3 / openssh-client / jq / netcat-openbsd are the
 # agent's toolchain, not the daemon's. Repository credentials already reach an
@@ -69,6 +75,7 @@ FROM node:22-slim AS production
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         dumb-init ca-certificates curl git bubblewrap gnupg python3 \
+        python3-venv python3-pip \
         postgresql-client sqlite3 openssh-client jq netcat-openbsd && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \


### PR DESCRIPTION
## What

Workers on vega-agent park with *"cannot run tests: the worktree has no usable Python dependency environment"* (live example: AGT-4113's operator question). Root cause measured in the running container: the slim `python3` (added for CodeQL's Python extractor, AGT-4011) has **no ensurepip and no pip**, so `python3 -m venv` fails at bootstrap and no requirements can ever be installed by an agent.

Adds `python3-venv` + `python3-pip` to the runtime apt list, with the rationale extended in the existing python3 comment block.

The venvs themselves deliberately live under `/work` (bind mount) — they survive redeploys; only the interpreter machinery belongs to the image. `/work/vega-agent/.venv` has already been provisioned live (same packages installed via apt in the running container), so this PR is the durable half: the next image build keeps the capability.

## Verification

- Commit gate: ✓ APPROVE
- Live container after the equivalent apt install: `python3 -m venv` succeeds, `.venv/bin/pip install -r requirements-dev.txt` runs (in progress at PR time)

Related: AGT-4011 (python3 for CodeQL), operator-question triage during 24h loop monitoring.