### PR TITLE
feat: add shared local asset warehouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,19 +467,22 @@ curl http://localhost:3847/api/health         # daemon health (token-less)
 
 Without `OPENSWARM_WEB_TOKEN` the dashboard binds only inside the container — an unauthenticated `0.0.0.0` bind is refused by design — so the published port answers nothing while the daemon itself keeps running. With the token set, browser/API access from the host sends it as the `X-OpenSwarm-Token` header (`/api/health` stays token-less).
 
-The compose file wires the three mounts that matter:
+The compose file wires the persistent and local-data mounts that matter:
 
 | Mount | Purpose |
 |---|---|
 | `./config.yaml → /app/config.yaml` | daemon configuration (read-only) |
 | `openswarm-state → /home/openswarm/.openswarm` | task state, auth profiles, coordination board — **must persist**, and one container per state volume (two daemons sharing it would fight over locks and double-process issues) |
 | `./workspace → /work` | the repositories the daemon works on; point `autonomous.allowedProjects` at `/work/<repo>` |
+| `../openswarm-warehouse → /warehouse` | agent-readable, Git-external local assets (read-only) |
+| `../openswarm-warehouse → /warehouse-rw` | operator upload path used only by the authenticated `/warehouse` web UI |
 
 Notes:
 
 - **Provider CLIs are not baked in.** The default `codex-responses` adapter runs OpenSwarm's own tool loop against OAuth state — log in on the host (`openswarm auth login`) and mount `~/.codex` / reuse the state volume. For the delegated CLI adapters (`claude`, `codex`, `cursor`), derive your own image: `FROM ghcr.io/unohee/openswarm` + `npm install -g <cli>`.
 - **Git identity**: mount `~/.gitconfig` or set `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL` (and `GH_TOKEN` for `gh`) so worker commits and PRs attribute correctly.
 - **Verify sandbox**: `bubblewrap` is installed but fail-closed under Docker's default seccomp profile. Enabling it requires `security_opt: [seccomp=unconfined]` + `cap_add: [SYS_ADMIN]` (commented in `docker-compose.yml`) — weigh that against your threat model.
+- **Local asset warehouse**: create `../openswarm-warehouse/INDEX.md`, then open `/warehouse` in the dashboard to browse, download, or upload. Agents are prompted to inspect `/warehouse/INDEX.md` before asking for gitignored data. See [docs/WAREHOUSE.md](docs/WAREHOUSE.md).
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
       # the in-container healthcheck still work. Reads/mutations from outside
       # then require the X-OpenSwarm-Token header (/api/health stays open).
       - OPENSWARM_WEB_TOKEN=${OPENSWARM_WEB_TOKEN:-}
+      # Agents read the warehouse through the read-only mount. The operator
+      # web UI writes through a second mount of the same host directory.
+      - OPENSWARM_WAREHOUSE_ROOT=/warehouse
+      - OPENSWARM_WAREHOUSE_WRITE_ROOT=/warehouse-rw
       # Provider/API keys come from .env (see env_file) or the shell:
       #   LINEAR_API_KEY, LINEAR_TEAM_ID, DISCORD_TOKEN, DISCORD_CHANNEL_ID,
       #   ATLASCLOUD_API_KEY, OPENROUTER_API_KEY, ...
@@ -42,6 +46,11 @@ services:
       - openswarm-state:/home/openswarm/.openswarm
       # Repositories the daemon works on. Point allowedProjects at /work/<repo>.
       - ${OPENSWARM_WORKSPACE:-./workspace}:/work
+      # Local-only data and credentials live outside every Git checkout. The
+      # first view is agent-readable only; the second is used by the authorized
+      # browser upload handler. See docs/WAREHOUSE.md.
+      - ${OPENSWARM_WAREHOUSE_HOST:-../openswarm-warehouse}:/warehouse:ro
+      - ${OPENSWARM_WAREHOUSE_HOST:-../openswarm-warehouse}:/warehouse-rw
       # Git identity for worker commits (or set GIT_AUTHOR_* env instead).
       # - ~/.gitconfig:/home/openswarm/.gitconfig:ro
       # ChatGPT-OAuth (codex-responses adapter) state from a host login:
@@ -59,6 +68,10 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+
+    # A concrete ceiling makes host provisioning observable. Override on large
+    # hosts (vela uses 48g) while leaving headroom for Docker and other services.
+    mem_limit: ${OPENSWARM_MEMORY_LIMIT:-24g}
 
     security_opt:
       - no-new-privileges:true

--- a/docs/WAREHOUSE.md
+++ b/docs/WAREHOUSE.md
@@ -1,0 +1,87 @@
+# Local Asset Warehouse
+
+The warehouse gives isolated workers one stable, Git-external place to find
+credentials, customer-provided files, cross-repository evaluation artifacts,
+and operating recipes. It is intended for a single-operator deployment where
+all workers may inspect the same material.
+
+## Host layout
+
+The default Compose path is `../openswarm-warehouse` relative to the Compose
+file. Override it with `OPENSWARM_WAREHOUSE_HOST`.
+
+```text
+openswarm-warehouse/
+  INDEX.md
+  cgf-portal/
+    data/
+    env/
+    nas.md
+  vega-agent/
+    env/
+    artifacts/
+  vega-router/
+    env/
+    artifacts/
+  vega-plugins/
+    env/
+    artifacts/
+  shared/
+    fixtures/
+```
+
+`INDEX.md` is the front door. List paths, intended consumers, freshness, key
+names, and usage commands there. Never copy credential values into the index,
+logs, issue comments, or agent answers.
+
+## Mount and permission model
+
+Compose mounts the same host directory twice:
+
+- `/warehouse` is read-only and is the only path advertised to agents.
+- `/warehouse-rw` is used by the authorized web upload handler.
+
+The in-process `read_file` and `search_files` tools may read `/warehouse`, while
+all edit tools reject it. The mount enforces the same rule for ordinary writes
+to `/warehouse`. Because daemon and workers currently share one container user,
+a worker shell could discover `/warehouse-rw`; this deployment model is not a
+multi-tenant security boundary. Split the web service and worker uid before
+using the warehouse with mutually distrusting workers.
+
+## Web file manager
+
+Open `http://<host>:3847/warehouse`. The page can:
+
+- browse names, sizes, and modification times;
+- download a file;
+- upload into the current directory, capped at 50 MiB;
+- overwrite only when the operator explicitly enables it.
+
+When `OPENSWARM_WEB_TOKEN` protects a remote deployment, enter that value in
+the page's **OpenSwarm web token** field. It is sent only as the
+`X-OpenSwarm-Token` request header and retained in `sessionStorage`, so closing
+the browser tab clears it. Downloads also use authenticated `fetch`; the token
+is never placed in a URL.
+
+There is deliberately no delete endpoint. API routes inherit the dashboard's
+loopback/Tailscale/token authorization and reject absolute paths, traversal,
+and symlinks that leave the configured root.
+
+## Container configuration
+
+```env
+OPENSWARM_WAREHOUSE_HOST=/srv/openswarm-warehouse
+OPENSWARM_MEMORY_LIMIT=48g
+```
+
+Inside the container the roots are fixed by Compose:
+
+```env
+OPENSWARM_WAREHOUSE_ROOT=/warehouse
+OPENSWARM_WAREHOUSE_WRITE_ROOT=/warehouse-rw
+```
+
+After provisioning, verify both interfaces independently: use an agent
+`read_file` call against `/warehouse/INDEX.md`, then browse/download/upload from
+the live `/warehouse` page. A successful shell `cat` alone does not prove the
+file-tool sandbox is wired correctly.

--- a/docs/WAREHOUSE.md
+++ b/docs/WAREHOUSE.md
@@ -53,7 +53,8 @@ using the warehouse with mutually distrusting workers.
 Open `http://<host>:3847/warehouse`. The page can:
 
 - browse names, sizes, and modification times;
-- download a file;
+- browse directories capped at 200 entries (split larger sets into subdirectories);
+- download a file, streamed by the server and capped at 250 MiB;
 - upload into the current directory, capped at 50 MiB;
 - overwrite only when the operator explicitly enables it.
 

--- a/src/adapters/agenticLoop.test.ts
+++ b/src/adapters/agenticLoop.test.ts
@@ -207,6 +207,25 @@ describe('runAgenticLoop nudge budgets (INT-1925)', () => {
   });
 });
 
+describe('runAgenticLoop warehouse discovery (AGT-4128)', () => {
+  it('points every tool-loop worker at the warehouse index before it asks for local-only data', async () => {
+    let firstMessages: ChatMessage[] = [];
+    await runAgenticLoop({
+      prompt: 'run the repository tests',
+      cwd: process.cwd(),
+      model: 'test',
+      webTools: false,
+      maxTurns: 1,
+      callApi: async (messages) => {
+        firstMessages = messages;
+        return finalResp('done');
+      },
+    });
+    expect(firstMessages[0].content).toContain('/warehouse/INDEX.md');
+    expect(firstMessages[0].content).toContain('never print secret values');
+  });
+});
+
 describe('runAgenticLoop timeout contract', () => {
   afterEach(() => { vi.restoreAllMocks(); });
 

--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -239,7 +239,9 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
     `# Working directory\n` +
     `Your project root is: ${cwd}\n` +
     `All file tools operate within this root. Use paths relative to it (e.g. "src/foo.ts" or ".") ` +
-    `or absolute paths under this root. Do NOT use "/" or a bare repo name — those are outside the project and will be rejected.\n\n`;
+    `or absolute paths under this root. Do NOT use "/" or a bare repo name — those are outside the project and will be rejected.\n` +
+    `Local-only data, credentials, and cross-repository artifacts may be available read-only under /warehouse. ` +
+    `Read /warehouse/INDEX.md before asking the operator for missing material, and never print secret values.\n\n`;
   messages.push({ role: 'user', content: cwdNote + prompt });
 
   // In search-replace / whole-file mode the model edits via response-text blocks

--- a/src/adapters/tools.test.ts
+++ b/src/adapters/tools.test.ts
@@ -35,6 +35,7 @@ try {
 
 // Shared temp directory for all tests
 const TMP_DIR = await fs.mkdtemp('/tmp/openswarm-tools-test-');
+const WAREHOUSE_DIR = await fs.mkdtemp('/var/tmp/openswarm-warehouse-test-');
 
 /** Helper to build a ToolCall object */
 function makeCall(name: string, args: Record<string, unknown>, id = 'tc-1'): ToolCall {
@@ -51,6 +52,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await fs.rm(TMP_DIR, { recursive: true, force: true });
+  await fs.rm(WAREHOUSE_DIR, { recursive: true, force: true });
 });
 
 // ──────────────────────────────────────────────
@@ -81,6 +83,43 @@ describe('validatePath realpath containment', () => {
       expect(() => validatePath(link, TMP_DIR)).toThrow(/outside the project root/);
     } finally {
       await fs.unlink(link);
+    }
+  });
+
+  it('allows warehouse reads while keeping writes outside the project root denied', async () => {
+    vi.stubEnv('OPENSWARM_WAREHOUSE_ROOT', WAREHOUSE_DIR);
+    const file = path.join(WAREHOUSE_DIR, 'vega-agent.env');
+    await fs.writeFile(file, 'KEY_NAME=redacted\n');
+    try {
+      const read = await executeTool(makeCall('read_file', { path: file }), TMP_DIR);
+      const write = await executeTool(makeCall('write_file', { path: file, content: 'changed' }), TMP_DIR);
+      expect(read).toMatchObject({ is_error: false });
+      expect(read.content).toContain('KEY_NAME=redacted');
+      expect(write).toMatchObject({ is_error: true });
+      await expect(fs.readFile(file, 'utf8')).resolves.toBe('KEY_NAME=redacted\n');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('allows a read-only file tool to follow a worktree symlink into the warehouse', async () => {
+    vi.stubEnv('OPENSWARM_WAREHOUSE_ROOT', WAREHOUSE_DIR);
+    const target = path.join(WAREHOUSE_DIR, 'INDEX.md');
+    const link = path.join(TMP_DIR, 'warehouse-index.md');
+    await fs.writeFile(target, '# Warehouse\n');
+    await fs.symlink(target, link);
+    try {
+      const result = await executeTool(
+        makeCall('read_file', { path: link }),
+        TMP_DIR,
+        undefined,
+        { readOnly: true },
+      );
+      expect(result).toMatchObject({ is_error: false });
+      expect(result.content).toContain('Warehouse');
+    } finally {
+      await fs.unlink(link);
+      vi.unstubAllEnvs();
     }
   });
 });

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -59,7 +59,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     type: 'function',
     function: {
       name: 'read_file',
-      description: 'Read a file and return its content. Use offset/limit for large files.',
+      description: 'Read a file and return its content. Use offset/limit for large files. Local-only assets may be read under /warehouse when provisioned.',
       parameters: {
         type: 'object',
         properties: {
@@ -469,6 +469,8 @@ export interface ValidatePathOptions {
    * sandbox its real outbound boundary — INT-3189 — and it stays untouched.
    */
   allowMainCheckoutRead?: boolean;
+  /** Accept the configured warehouse root for read/search tools only. */
+  allowWarehouseRead?: boolean;
 }
 
 /** 프로젝트 경로 내로 접근을 제한하는 경로 검증 */
@@ -484,9 +486,17 @@ export function validatePath(filePath: string, cwd: string, options: ValidatePat
     return rel === '' || (!rel.startsWith(`..${path.sep}`) && rel !== '..' && !path.isAbsolute(rel));
   };
   const mainCheckout = options.allowMainCheckoutRead ? mainCheckoutOf(projectRoot) : null;
+  const warehouseRoot = options.allowWarehouseRead
+    ? (process.env.OPENSWARM_WAREHOUSE_ROOT?.trim() || '/warehouse')
+    : null;
   // cwd 하위이거나, /tmp 하위만 허용. 문자열 prefix 비교는 상대 cwd를
   // 전부 거부하고 `/repo-evil` 같은 sibling을 `/repo` 내부로 오인한다.
-  if (!inside(projectRoot) && !inside('/tmp') && !(mainCheckout && inside(mainCheckout))) {
+  if (
+    !inside(projectRoot)
+    && !inside('/tmp')
+    && !(mainCheckout && inside(mainCheckout))
+    && !(warehouseRoot && inside(warehouseRoot))
+  ) {
     // 모델이 자가수정하도록 안내 — 그냥 거부만 하면 같은 실수를 반복한다.
     throw new Error(
       `Path "${filePath}" is outside the project root (${projectRoot}). ` +
@@ -587,7 +597,10 @@ export async function executeTool(
         // agent can reach local-only material the repo links in (AGT-4061).
         // Withheld in readOnly: there `bash` is denied, so this sandbox is the
         // run's real outbound boundary (INT-3189).
-        const filePath = validatePath(args.path, cwd, { allowMainCheckoutRead: !execOptions?.readOnly });
+        const filePath = validatePath(args.path, cwd, {
+          allowMainCheckoutRead: !execOptions?.readOnly,
+          allowWarehouseRead: true,
+        });
         const offset = args.offset ?? 0;
         const limit = args.limit ?? 500;
         const cacheKey = `${filePath}#${offset}:${limit}`;
@@ -732,7 +745,10 @@ export async function executeTool(
       }
 
       case 'search_files': {
-        const searchPath = validatePath(args.path, cwd, { allowMainCheckoutRead: !execOptions?.readOnly });
+        const searchPath = validatePath(args.path, cwd, {
+          allowMainCheckoutRead: !execOptions?.readOnly,
+          allowWarehouseRead: true,
+        });
         const rgArgs = ['--no-heading', '--line-number', '--max-count', '50'];
         if (args.glob) {
           rgArgs.push('--glob', args.glob);

--- a/src/support/staticAssets.ts
+++ b/src/support/staticAssets.ts
@@ -114,6 +114,17 @@ export async function readChatShell(): Promise<Buffer | null> {
   }
 }
 
+/** The operator warehouse shell (AGT-4128). */
+export async function readWarehouseShell(): Promise<Buffer | null> {
+  const root = resolveStaticRoot();
+  if (!root) return null;
+  try {
+    return await readFile(join(root, 'warehouse.html'));
+  } catch {
+    return null;
+  }
+}
+
 export async function readAppShell(): Promise<Buffer | null> {
   const root = resolveStaticRoot();
   if (!root) return null;

--- a/src/support/warehouseBrowser.test.ts
+++ b/src/support/warehouseBrowser.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+const fetchMock = vi.fn(async (input: RequestInfo | URL, _options?: RequestInit) => {
+  const url = String(input);
+  if (url.startsWith('/api/warehouse/tree')) {
+    return new Response(JSON.stringify({
+      path: '',
+      entries: [{ name: 'INDEX.md', type: 'file', size: 12, mtime: '2026-08-30T00:00:00.000Z' }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }
+  return new Response('warehouse index', { status: 200 });
+});
+
+beforeAll(async () => {
+  document.body.innerHTML = `
+    <button id="up"></button><nav id="breadcrumbs"></nav><button id="refresh"></button>
+    <table><tbody id="entries"></tbody></table>
+    <input id="file" type="file"><span id="file-label"></span>
+    <input id="overwrite" type="checkbox"><button id="upload"></button>
+    <span id="upload-directory"></span><p id="status"></p>
+    <input id="web-token" type="password"><button id="save-token"></button><button id="clear-token"></button>
+  `;
+  sessionStorage.setItem('openswarm.webToken', 'browser-secret');
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubGlobal('URL', Object.assign(URL, {
+    createObjectURL: vi.fn(() => 'blob:warehouse-download'),
+    revokeObjectURL: vi.fn(),
+  }));
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+  await import('../../web/static/js/warehouse.mjs');
+});
+
+describe('warehouse browser authentication', () => {
+  it('sends the session token as a header for listing and authenticated downloads, never in the URL', async () => {
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const download = await vi.waitFor(() => {
+      const button = document.querySelector<HTMLButtonElement>('button.download');
+      expect(button).toBeTruthy();
+      return button!;
+    });
+    download.click();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    for (const [url, options] of fetchMock.mock.calls) {
+      expect(String(url)).not.toContain('browser-secret');
+      expect(options).toBeDefined();
+      expect((options!.headers as Headers).get('X-OpenSwarm-Token')).toBe('browser-secret');
+    }
+  });
+});

--- a/src/support/warehouseRoutes.test.ts
+++ b/src/support/warehouseRoutes.test.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'node:stream';
+import { PassThrough, Readable } from 'node:stream';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs/promises';
@@ -10,23 +10,31 @@ const OUTSIDE = await fs.mkdtemp('/var/tmp/openswarm-warehouse-outside-');
 
 type Response = { handled: boolean; status: number; headers: Record<string, string>; body: Buffer };
 
-async function call(method: string, rawUrl: string, body: Buffer = Buffer.alloc(0)): Promise<Response> {
+async function call(
+  method: string,
+  rawUrl: string,
+  body: Buffer = Buffer.alloc(0),
+  abortAfterHeaders = false,
+): Promise<Response> {
   const req = Object.assign(Readable.from(body.length ? [body] : []), { method, headers: {} }) as IncomingMessage;
   let status = 0;
+  let headersSent = false;
   let headers: Record<string, string> = {};
-  let responseBody = Buffer.alloc(0);
-  const res = {
-    writeHead(code: number, values: Record<string, string> = {}) {
-      status = code;
-      headers = values;
-    },
-    end(value?: string | Buffer) {
-      responseBody = Buffer.isBuffer(value) ? value : Buffer.from(value ?? '');
-    },
-  } as unknown as ServerResponse;
+  const chunks: Buffer[] = [];
+  const res = new PassThrough() as unknown as ServerResponse;
+  res.on('data', (chunk: Buffer) => chunks.push(chunk));
+  res.on('error', () => {});
+  Object.defineProperty(res, 'headersSent', { get: () => headersSent });
+  res.writeHead = ((code: number, values: Record<string, string> = {}) => {
+    status = code;
+    headersSent = true;
+    headers = values;
+    if (abortAfterHeaders) res.destroy(new Error('simulated client disconnect'));
+    return res;
+  }) as ServerResponse['writeHead'];
   const requestUrl = new URL(rawUrl, 'http://127.0.0.1');
   const handled = await tryHandleWarehouseRoutes(req, res, requestUrl.pathname, requestUrl);
-  return { handled, status, headers, body: responseBody };
+  return { handled, status, headers, body: Buffer.concat(chunks) };
 }
 
 function json(response: Response): any {
@@ -59,11 +67,28 @@ describe('warehouse HTTP routes', () => {
     ]);
   });
 
+  it('bounds every directory request to 201 reads and requires subdirectories above 200 entries', async () => {
+    const many = path.join(ROOT, 'many');
+    await fs.mkdir(many);
+    await Promise.all(Array.from({ length: 205 }, (_, index) => (
+      fs.writeFile(path.join(many, `item-${String(index).padStart(3, '0')}`), '')
+    )));
+    const response = await call('GET', '/api/warehouse/tree?path=many');
+    expect(response.status).toBe(413);
+    expect(json(response).error).toContain('split it into subdirectories');
+  });
+
   it('downloads the authorized canonical file with attachment headers', async () => {
     const response = await call('GET', '/api/warehouse/file?path=INDEX.md');
     expect(response.status).toBe(200);
     expect(response.headers['Content-Disposition']).toContain('attachment');
     expect(response.body.toString('utf8')).toBe('# Warehouse\n');
+  });
+
+  it('does not attempt a JSON error after download headers are committed', async () => {
+    const response = await call('GET', '/api/warehouse/file?path=INDEX.md', Buffer.alloc(0), true);
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveLength(0);
   });
 
   it('uploads without clobbering, then overwrites only when explicit', async () => {

--- a/src/support/warehouseRoutes.test.ts
+++ b/src/support/warehouseRoutes.test.ts
@@ -1,0 +1,96 @@
+import { Readable } from 'node:stream';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { tryHandleWarehouseRoutes } from './warehouseRoutes.js';
+
+const ROOT = await fs.mkdtemp('/var/tmp/openswarm-warehouse-routes-');
+const OUTSIDE = await fs.mkdtemp('/var/tmp/openswarm-warehouse-outside-');
+
+type Response = { handled: boolean; status: number; headers: Record<string, string>; body: Buffer };
+
+async function call(method: string, rawUrl: string, body: Buffer = Buffer.alloc(0)): Promise<Response> {
+  const req = Object.assign(Readable.from(body.length ? [body] : []), { method, headers: {} }) as IncomingMessage;
+  let status = 0;
+  let headers: Record<string, string> = {};
+  let responseBody = Buffer.alloc(0);
+  const res = {
+    writeHead(code: number, values: Record<string, string> = {}) {
+      status = code;
+      headers = values;
+    },
+    end(value?: string | Buffer) {
+      responseBody = Buffer.isBuffer(value) ? value : Buffer.from(value ?? '');
+    },
+  } as unknown as ServerResponse;
+  const requestUrl = new URL(rawUrl, 'http://127.0.0.1');
+  const handled = await tryHandleWarehouseRoutes(req, res, requestUrl.pathname, requestUrl);
+  return { handled, status, headers, body: responseBody };
+}
+
+function json(response: Response): any {
+  return JSON.parse(response.body.toString('utf8'));
+}
+
+beforeAll(async () => {
+  vi.stubEnv('OPENSWARM_WAREHOUSE_ROOT', ROOT);
+  vi.stubEnv('OPENSWARM_WAREHOUSE_WRITE_ROOT', ROOT);
+  await fs.mkdir(path.join(ROOT, 'vega-agent', 'env'), { recursive: true });
+  await fs.writeFile(path.join(ROOT, 'INDEX.md'), '# Warehouse\n');
+  await fs.writeFile(path.join(ROOT, 'vega-agent', 'env', '.env'), 'KEY=value\n');
+  await fs.symlink(path.join(ROOT, 'INDEX.md'), path.join(ROOT, 'inside-link'));
+  await fs.writeFile(path.join(OUTSIDE, 'secret.txt'), 'outside\n');
+  await fs.symlink(path.join(OUTSIDE, 'secret.txt'), path.join(ROOT, 'outside-link'));
+});
+
+afterAll(async () => {
+  vi.unstubAllEnvs();
+  await fs.rm(ROOT, { recursive: true, force: true });
+  await fs.rm(OUTSIDE, { recursive: true, force: true });
+});
+
+describe('warehouse HTTP routes', () => {
+  it('lists dotfiles with size and mtime for browser exploration', async () => {
+    const response = await call('GET', '/api/warehouse/tree?path=vega-agent/env');
+    expect(response).toMatchObject({ handled: true, status: 200 });
+    expect(json(response).entries).toEqual([
+      expect.objectContaining({ name: '.env', type: 'file', size: 10 }),
+    ]);
+  });
+
+  it('downloads the authorized canonical file with attachment headers', async () => {
+    const response = await call('GET', '/api/warehouse/file?path=INDEX.md');
+    expect(response.status).toBe(200);
+    expect(response.headers['Content-Disposition']).toContain('attachment');
+    expect(response.body.toString('utf8')).toBe('# Warehouse\n');
+  });
+
+  it('uploads without clobbering, then overwrites only when explicit', async () => {
+    const file = 'vega-agent/env/new.env';
+    const created = await call('POST', `/api/warehouse/file?path=${file}`, Buffer.from('one'));
+    const refused = await call('POST', `/api/warehouse/file?path=${file}`, Buffer.from('two'));
+    const replaced = await call('POST', `/api/warehouse/file?path=${file}&overwrite=true`, Buffer.from('two'));
+    expect(created.status).toBe(201);
+    expect(refused.status).toBe(409);
+    expect(replaced.status).toBe(201);
+    await expect(fs.readFile(path.join(ROOT, file), 'utf8')).resolves.toBe('two');
+  });
+
+  it.each([
+    '/api/warehouse/file?path=../outside',
+    '/api/warehouse/file?path=/etc/passwd',
+    '/api/warehouse/file?path=C:%5CWindows%5Cwin.ini',
+    '/api/warehouse/file?path=inside-link',
+    '/api/warehouse/file?path=outside-link',
+  ])('refuses traversal, absolute and symlink-out reads: %s', async (url) => {
+    const response = await call('GET', url);
+    expect([400, 403]).toContain(response.status);
+  });
+
+  it('refuses an upload through a symlink whose canonical target is outside', async () => {
+    const response = await call('POST', '/api/warehouse/file?path=outside-link&overwrite=true', Buffer.from('nope'));
+    expect(response.status).toBe(403);
+    await expect(fs.readFile(path.join(OUTSIDE, 'secret.txt'), 'utf8')).resolves.toBe('outside\n');
+  });
+});

--- a/src/support/warehouseRoutes.ts
+++ b/src/support/warehouseRoutes.ts
@@ -1,0 +1,271 @@
+// Operator-facing warehouse API (AGT-4128).
+// web.ts applies local/Tailscale/token authorization before delegating here.
+
+import { randomUUID } from 'node:crypto';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { constants, existsSync, realpathSync } from 'node:fs';
+import { link, lstat, open, readdir, rename, stat, unlink, type FileHandle } from 'node:fs/promises';
+import { basename, isAbsolute, join, relative, resolve, sep, win32 } from 'node:path';
+
+const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+
+class WarehouseHttpError extends Error {
+  constructor(public statusCode: number, message: string) {
+    super(message);
+  }
+}
+
+function writeJson(res: ServerResponse, statusCode: number, body: unknown): void {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readRoot(): string {
+  return process.env.OPENSWARM_WAREHOUSE_ROOT?.trim() || '/warehouse';
+}
+
+function writeRoot(): string {
+  return process.env.OPENSWARM_WAREHOUSE_WRITE_ROOT?.trim() || readRoot();
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+}
+
+function safeRelativePath(raw: string | null, allowEmpty: boolean): string {
+  const value = (raw ?? '').trim();
+  if ((!value && !allowEmpty) || value.includes('\0') || isAbsolute(value) || win32.isAbsolute(value)) {
+    throw new WarehouseHttpError(400, 'path must be a relative warehouse path');
+  }
+  return value;
+}
+
+function existingRoot(root: string): string {
+  if (!existsSync(root)) throw new WarehouseHttpError(503, 'Warehouse is not provisioned');
+  return realpathSync(root);
+}
+
+/** Resolve and authorize an existing path once; callers perform I/O on this exact string. */
+export function resolveWarehouseReadPath(raw: string | null, allowEmpty = false): string {
+  const rel = safeRelativePath(raw, allowEmpty);
+  const root = existingRoot(readRoot());
+  const lexical = resolve(root, rel || '.');
+  if (!isInside(root, lexical)) throw new WarehouseHttpError(403, 'Path escapes the warehouse');
+  let canonical: string;
+  try {
+    canonical = realpathSync(lexical);
+  } catch {
+    throw new WarehouseHttpError(404, 'Warehouse path not found');
+  }
+  if (!isInside(root, canonical)) throw new WarehouseHttpError(403, 'Path escapes the warehouse');
+  return canonical;
+}
+
+interface AnchoredTarget {
+  directory: FileHandle;
+  ioDirectory: string;
+  name: string;
+}
+
+/**
+ * Anchor a final path component to an already-open, authorized directory.
+ * Linux production I/O goes through /proc/self/fd/<dirfd>, which prevents a
+ * path component from being swapped after validation. The inode recheck is the
+ * portable fallback used by development/test hosts without procfs dirfd paths.
+ */
+async function openAnchoredTarget(rootPath: string, raw: string | null): Promise<AnchoredTarget> {
+  const rel = safeRelativePath(raw, false);
+  const root = existingRoot(rootPath);
+  const lexical = resolve(root, rel);
+  if (!isInside(root, lexical)) throw new WarehouseHttpError(403, 'Path escapes the warehouse');
+
+  let parent: string;
+  try {
+    parent = realpathSync(resolve(lexical, '..'));
+  } catch {
+    throw new WarehouseHttpError(404, 'Warehouse directory not found');
+  }
+  if (!isInside(root, parent)) throw new WarehouseHttpError(403, 'Path escapes the warehouse');
+
+  const directory = await open(
+    parent,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+  );
+  try {
+    const openedInfo = await directory.stat();
+    let ioDirectory = parent;
+    if (process.platform === 'linux') {
+      ioDirectory = `/proc/self/fd/${directory.fd}`;
+      const openedPath = realpathSync(ioDirectory);
+      if (!isInside(root, openedPath)) throw new WarehouseHttpError(403, 'Path escapes the warehouse');
+    } else {
+      const currentPath = realpathSync(parent);
+      const currentInfo = await stat(currentPath);
+      if (
+        !isInside(root, currentPath)
+        || currentInfo.dev !== openedInfo.dev
+        || currentInfo.ino !== openedInfo.ino
+      ) {
+        throw new WarehouseHttpError(403, 'Warehouse directory changed during validation');
+      }
+    }
+    return { directory, ioDirectory, name: basename(lexical) };
+  } catch (error) {
+    await directory.close();
+    throw error;
+  }
+}
+
+function readUpload(req: IncomingMessage): Promise<Buffer> {
+  return new Promise((resolveBody, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let tooLarge = false;
+    req.on('data', (chunk: Buffer | string) => {
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += bytes.length;
+      if (total > MAX_UPLOAD_BYTES) {
+        tooLarge = true;
+        chunks.length = 0;
+      } else if (!tooLarge) {
+        chunks.push(bytes);
+      }
+    });
+    req.on('end', () => {
+      if (tooLarge) reject(new WarehouseHttpError(413, `Upload exceeds ${MAX_UPLOAD_BYTES} bytes`));
+      else resolveBody(Buffer.concat(chunks));
+    });
+    req.on('aborted', () => reject(new WarehouseHttpError(400, 'Upload aborted')));
+    req.on('error', () => reject(new WarehouseHttpError(400, 'Upload failed')));
+  });
+}
+
+async function writeUpload(target: AnchoredTarget, body: Buffer, overwrite: boolean): Promise<void> {
+  const temporaryName = `.${target.name}.${process.pid}.${randomUUID()}.tmp`;
+  const temporary = join(target.ioDirectory, temporaryName);
+  const destination = join(target.ioDirectory, target.name);
+  let handle: FileHandle | null = null;
+  try {
+    try {
+      const existing = await lstat(destination);
+      if (existing.isSymbolicLink()) throw new WarehouseHttpError(403, 'Symbolic-link targets are not accepted');
+      if (existing.isDirectory()) throw new WarehouseHttpError(409, 'Upload target is a directory');
+    } catch (error) {
+      if (!(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT')) throw error;
+    }
+    handle = await open(
+      temporary,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
+    );
+    await handle.writeFile(body);
+    await handle.sync();
+    await handle.close();
+    handle = null;
+    if (overwrite) {
+      await rename(temporary, destination);
+    } else {
+      // link() is the atomic no-clobber publication step: unlike access()+
+      // rename(), it cannot overwrite a target created between the two calls.
+      await link(temporary, destination);
+      await unlink(temporary);
+    }
+  } catch (error) {
+    await handle?.close().catch(() => {});
+    await unlink(temporary).catch(() => {});
+    throw error;
+  }
+}
+
+function statusOf(error: unknown): number {
+  if (error instanceof WarehouseHttpError) return error.statusCode;
+  if (error && typeof error === 'object' && 'code' in error && error.code === 'EEXIST') return 409;
+  if (error && typeof error === 'object' && 'code' in error && ['ELOOP', 'EPERM'].includes(String(error.code))) return 403;
+  if (error && typeof error === 'object' && 'code' in error && ['ENOENT', 'ENOTDIR'].includes(String(error.code))) return 404;
+  return 500;
+}
+
+function messageOf(error: unknown): string {
+  if (error instanceof WarehouseHttpError) return error.message;
+  if (error && typeof error === 'object' && 'code' in error && error.code === 'EEXIST') {
+    return 'File already exists; enable overwrite explicitly';
+  }
+  if (error && typeof error === 'object' && 'code' in error && ['ELOOP', 'EPERM'].includes(String(error.code))) {
+    return 'Symbolic-link targets are not accepted';
+  }
+  if (error && typeof error === 'object' && 'code' in error && ['ENOENT', 'ENOTDIR'].includes(String(error.code))) {
+    return 'Warehouse path not found';
+  }
+  return 'Warehouse operation failed';
+}
+
+export async function tryHandleWarehouseRoutes(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: string,
+  requestUrl: URL,
+): Promise<boolean> {
+  if (req.method === 'GET' && url === '/api/warehouse/tree') {
+    try {
+      const directory = resolveWarehouseReadPath(requestUrl.searchParams.get('path'), true);
+      if (!(await stat(directory)).isDirectory()) throw new WarehouseHttpError(400, 'Path is not a directory');
+      const entries = await Promise.all((await readdir(directory, { withFileTypes: true })).map(async (entry) => {
+        const info = await lstat(join(directory, entry.name));
+        return {
+          name: entry.name,
+          type: entry.isDirectory() ? 'directory' : entry.isSymbolicLink() ? 'symlink' : 'file',
+          size: info.size,
+          mtime: info.mtime.toISOString(),
+        };
+      }));
+      entries.sort((a, b) => (a.type === 'directory' ? -1 : 1) - (b.type === 'directory' ? -1 : 1) || a.name.localeCompare(b.name));
+      writeJson(res, 200, { path: requestUrl.searchParams.get('path') ?? '', entries });
+    } catch (error) {
+      writeJson(res, statusOf(error), { error: messageOf(error) });
+    }
+    return true;
+  }
+
+  if (req.method === 'GET' && url === '/api/warehouse/file') {
+    let target: AnchoredTarget | null = null;
+    let file: FileHandle | null = null;
+    try {
+      target = await openAnchoredTarget(readRoot(), requestUrl.searchParams.get('path'));
+      file = await open(join(target.ioDirectory, target.name), constants.O_RDONLY | constants.O_NOFOLLOW);
+      if (!(await file.stat()).isFile()) throw new WarehouseHttpError(400, 'Path is not a file');
+      const body = await file.readFile();
+      const filename = target.name.replace(/["\\\r\n]/g, '_');
+      res.writeHead(200, {
+        'Content-Type': 'application/octet-stream',
+        'Content-Length': String(body.length),
+        'Content-Disposition': `attachment; filename="${filename}"; filename*=UTF-8''${encodeURIComponent(filename)}`,
+      });
+      res.end(body);
+    } catch (error) {
+      writeJson(res, statusOf(error), { error: messageOf(error) });
+    } finally {
+      await file?.close().catch(() => {});
+      await target?.directory.close().catch(() => {});
+    }
+    return true;
+  }
+
+  if (req.method === 'POST' && url === '/api/warehouse/file') {
+    let target: AnchoredTarget | null = null;
+    try {
+      target = await openAnchoredTarget(writeRoot(), requestUrl.searchParams.get('path'));
+      const overwrite = requestUrl.searchParams.get('overwrite') === 'true';
+      const body = await readUpload(req);
+      await writeUpload(target, body, overwrite);
+      writeJson(res, 201, { ok: true, path: requestUrl.searchParams.get('path'), size: body.length, overwritten: overwrite });
+    } catch (error) {
+      writeJson(res, statusOf(error), { error: messageOf(error) });
+    } finally {
+      await target?.directory.close().catch(() => {});
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/src/support/warehouseRoutes.ts
+++ b/src/support/warehouseRoutes.ts
@@ -4,10 +4,13 @@
 import { randomUUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { constants, existsSync, realpathSync } from 'node:fs';
-import { link, lstat, open, readdir, rename, stat, unlink, type FileHandle } from 'node:fs/promises';
+import { link, lstat, open, opendir, rename, stat, unlink, type FileHandle } from 'node:fs/promises';
 import { basename, isAbsolute, join, relative, resolve, sep, win32 } from 'node:path';
+import { pipeline } from 'node:stream/promises';
 
 const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+const MAX_DOWNLOAD_BYTES = 250 * 1024 * 1024;
+const TREE_PAGE_SIZE = 200;
 
 class WarehouseHttpError extends Error {
   constructor(public statusCode: number, message: string) {
@@ -200,6 +203,14 @@ function messageOf(error: unknown): string {
   return 'Warehouse operation failed';
 }
 
+function writeRouteError(res: ServerResponse, error: unknown): void {
+  if (res.headersSent) {
+    res.destroy();
+    return;
+  }
+  writeJson(res, statusOf(error), { error: messageOf(error) });
+}
+
 export async function tryHandleWarehouseRoutes(
   req: IncomingMessage,
   res: ServerResponse,
@@ -210,7 +221,21 @@ export async function tryHandleWarehouseRoutes(
     try {
       const directory = resolveWarehouseReadPath(requestUrl.searchParams.get('path'), true);
       if (!(await stat(directory)).isDirectory()) throw new WarehouseHttpError(400, 'Path is not a directory');
-      const entries = await Promise.all((await readdir(directory, { withFileTypes: true })).map(async (entry) => {
+      const selected = [];
+      const handle = await opendir(directory);
+      try {
+        for (let index = 0; index < TREE_PAGE_SIZE + 1; index += 1) {
+          const entry = await handle.read();
+          if (!entry) break;
+          selected.push(entry);
+        }
+      } finally {
+        await handle.close();
+      }
+      if (selected.length > TREE_PAGE_SIZE) {
+        throw new WarehouseHttpError(413, `Directory exceeds ${TREE_PAGE_SIZE} entries; split it into subdirectories`);
+      }
+      const entries = await Promise.all(selected.map(async (entry) => {
         const info = await lstat(join(directory, entry.name));
         return {
           name: entry.name,
@@ -220,9 +245,12 @@ export async function tryHandleWarehouseRoutes(
         };
       }));
       entries.sort((a, b) => (a.type === 'directory' ? -1 : 1) - (b.type === 'directory' ? -1 : 1) || a.name.localeCompare(b.name));
-      writeJson(res, 200, { path: requestUrl.searchParams.get('path') ?? '', entries });
+      writeJson(res, 200, {
+        path: requestUrl.searchParams.get('path') ?? '',
+        entries,
+      });
     } catch (error) {
-      writeJson(res, statusOf(error), { error: messageOf(error) });
+      writeRouteError(res, error);
     }
     return true;
   }
@@ -233,17 +261,21 @@ export async function tryHandleWarehouseRoutes(
     try {
       target = await openAnchoredTarget(readRoot(), requestUrl.searchParams.get('path'));
       file = await open(join(target.ioDirectory, target.name), constants.O_RDONLY | constants.O_NOFOLLOW);
-      if (!(await file.stat()).isFile()) throw new WarehouseHttpError(400, 'Path is not a file');
-      const body = await file.readFile();
+      const fileInfo = await file.stat();
+      if (!fileInfo.isFile()) throw new WarehouseHttpError(400, 'Path is not a file');
+      if (fileInfo.size > MAX_DOWNLOAD_BYTES) {
+        throw new WarehouseHttpError(413, `Download exceeds ${MAX_DOWNLOAD_BYTES} bytes`);
+      }
       const filename = target.name.replace(/["\\\r\n]/g, '_');
       res.writeHead(200, {
         'Content-Type': 'application/octet-stream',
-        'Content-Length': String(body.length),
+        'Content-Length': String(fileInfo.size),
         'Content-Disposition': `attachment; filename="${filename}"; filename*=UTF-8''${encodeURIComponent(filename)}`,
       });
-      res.end(body);
+      if (fileInfo.size === 0) res.end();
+      else await pipeline(file.createReadStream({ autoClose: false, start: 0, end: fileInfo.size - 1 }), res);
     } catch (error) {
-      writeJson(res, statusOf(error), { error: messageOf(error) });
+      writeRouteError(res, error);
     } finally {
       await file?.close().catch(() => {});
       await target?.directory.close().catch(() => {});
@@ -260,7 +292,7 @@ export async function tryHandleWarehouseRoutes(
       await writeUpload(target, body, overwrite);
       writeJson(res, 201, { ok: true, path: requestUrl.searchParams.get('path'), size: body.length, overwritten: overwrite });
     } catch (error) {
-      writeJson(res, statusOf(error), { error: messageOf(error) });
+      writeRouteError(res, error);
     } finally {
       await target?.directory.close().catch(() => {});
     }

--- a/src/support/webAppRoutes.ts
+++ b/src/support/webAppRoutes.ts
@@ -40,6 +40,11 @@ export async function tryHandleAppRoutes(
   readBody: (req: IncomingMessage) => Promise<string>,
 ): Promise<boolean> {
   {
+    const { tryHandleWarehouseRoutes } = await import('./warehouseRoutes.js');
+    if (await tryHandleWarehouseRoutes(req, res, url, requestUrl)) return true;
+  }
+
+  {
     const { tryHandleCoordinationRoutes } = await import('../coordination/coordinationRoutes.js');
     if (await tryHandleCoordinationRoutes(req, res, url, requestUrl, readBody)) return true;
   }
@@ -66,6 +71,18 @@ export async function tryHandleAppRoutes(
   if (url === '/chat') {
     const { readChatShell } = await import('./staticAssets.js');
     const shell = await readChatShell();
+    if (!shell) {
+      writeJson(res, 404, { error: 'Static assets not built (run npm run build)' });
+    } else {
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache' });
+      res.end(shell);
+    }
+    return true;
+  }
+
+  if (url === '/warehouse') {
+    const { readWarehouseShell } = await import('./staticAssets.js');
+    const shell = await readWarehouseShell();
     if (!shell) {
       writeJson(res, 404, { error: 'Static assets not built (run npm run build)' });
     } else {

--- a/web/static/app.html
+++ b/web/static/app.html
@@ -17,6 +17,7 @@
       <button type="button" class="nav-item" data-view="issues">Issues</button>
       <a class="nav-item" href="/orchestration">Orchestration</a>
       <a class="nav-item" href="/chat">Chat room</a>
+      <a class="nav-item" href="/warehouse">Warehouse</a>
     </nav>
     <div class="sidebar-section-head">Repository</div>
     <div id="repo-picker" class="repo-picker"></div>

--- a/web/static/css/warehouse.css
+++ b/web/static/css/warehouse.css
@@ -1,0 +1,87 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #0d1117;
+  color: #e6edf3;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; background: radial-gradient(circle at top left, #182235, #0d1117 44%); }
+button, input { font: inherit; }
+button, a { color: inherit; }
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  min-height: 92px;
+  padding: 20px clamp(20px, 5vw, 72px);
+  border-bottom: 1px solid #293241;
+  background: rgba(13, 17, 23, .82);
+  backdrop-filter: blur(18px);
+}
+.brand { color: #f5c451; font-weight: 800; text-decoration: none; white-space: nowrap; }
+h1, h2, p { margin: 0; }
+h1 { font-size: 22px; }
+.topbar p { margin-top: 4px; color: #8b98a9; font-size: 13px; }
+
+main {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 22px;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 28px clamp(20px, 5vw, 72px);
+}
+.browser, .upload { border: 1px solid #293241; border-radius: 14px; background: rgba(18, 24, 33, .92); overflow: hidden; }
+.toolbar { display: flex; align-items: center; gap: 10px; min-height: 58px; padding: 10px 14px; border-bottom: 1px solid #293241; }
+.toolbar > button, .breadcrumbs button {
+  border: 1px solid #354052;
+  border-radius: 8px;
+  padding: 7px 10px;
+  background: #192230;
+  cursor: pointer;
+}
+.toolbar > button:disabled { opacity: .4; cursor: default; }
+.breadcrumbs { display: flex; align-items: center; gap: 7px; flex: 1; overflow-x: auto; }
+.breadcrumbs span { color: #667386; }
+
+.table-wrap { overflow: auto; min-height: 520px; }
+table { width: 100%; border-collapse: collapse; }
+th, td { padding: 13px 16px; border-bottom: 1px solid #222c3a; text-align: left; white-space: nowrap; }
+th { color: #8b98a9; font-size: 12px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; }
+td { font-size: 13px; color: #b9c4d1; }
+td:first-child { width: 100%; color: #edf3fa; }
+.file-name { border: 0; padding: 0; background: none; color: inherit; cursor: default; }
+button.file-name { cursor: pointer; }
+td a, .download { border: 0; padding: 0; background: none; color: #79b8ff; text-decoration: none; cursor: pointer; }
+.empty { padding: 48px; text-align: center; color: #738096; }
+.error { color: #ff8f8f !important; }
+
+.upload { align-self: start; padding: 20px; }
+.upload h2 { margin-bottom: 8px; font-size: 17px; }
+.upload > p { color: #8b98a9; font-size: 12px; }
+code { color: #9dd7ff; }
+.access { margin: -20px -20px 22px; padding: 20px; border-bottom: 1px solid #293241; background: #111923; }
+.access p { margin-bottom: 14px; color: #8b98a9; font-size: 12px; line-height: 1.45; }
+.access label { display: block; margin-bottom: 6px; color: #a9b6c7; font-size: 12px; }
+.token-row { display: flex; gap: 8px; }
+.token-row input { min-width: 0; flex: 1; border: 1px solid #354052; border-radius: 8px; padding: 8px; background: #0d141d; color: #edf3fa; }
+.token-row button { border: 1px solid #49627f; border-radius: 8px; padding: 8px 11px; background: #192c42; cursor: pointer; }
+.text-button { margin-top: 9px; border: 0; padding: 0; background: none; color: #79b8ff; font-size: 12px; cursor: pointer; }
+.dropzone { display: grid; place-items: center; min-height: 130px; margin: 20px 0 14px; border: 1px dashed #4b5d74; border-radius: 12px; background: #111923; color: #a9b6c7; cursor: pointer; text-align: center; padding: 20px; }
+.dropzone input { display: none; }
+.overwrite { display: flex; gap: 8px; align-items: center; color: #a9b6c7; font-size: 13px; }
+.primary { width: 100%; margin-top: 18px; border: 0; border-radius: 9px; padding: 11px; background: #2f81f7; color: white; font-weight: 700; cursor: pointer; }
+.primary:disabled { opacity: .45; cursor: default; }
+.status { min-height: 20px; margin-top: 12px !important; }
+.success { color: #5ed58a !important; }
+.status.error { color: #ff8f8f !important; }
+.rules { display: grid; gap: 7px; margin-top: 20px; padding-top: 18px; border-top: 1px solid #293241; color: #8492a6; font-size: 12px; line-height: 1.45; }
+.rules strong { color: #d9e2ec; }
+
+@media (max-width: 860px) {
+  main { grid-template-columns: 1fr; }
+  .upload { order: -1; }
+  th:nth-child(2), td:nth-child(2), th:nth-child(4), td:nth-child(4) { display: none; }
+}

--- a/web/static/js/warehouse.mjs
+++ b/web/static/js/warehouse.mjs
@@ -1,0 +1,194 @@
+const entriesBody = document.querySelector('#entries');
+const breadcrumbs = document.querySelector('#breadcrumbs');
+const upButton = document.querySelector('#up');
+const refreshButton = document.querySelector('#refresh');
+const fileInput = document.querySelector('#file');
+const fileLabel = document.querySelector('#file-label');
+const overwriteInput = document.querySelector('#overwrite');
+const uploadButton = document.querySelector('#upload');
+const uploadDirectory = document.querySelector('#upload-directory');
+const status = document.querySelector('#status');
+const webTokenInput = document.querySelector('#web-token');
+const saveTokenButton = document.querySelector('#save-token');
+const clearTokenButton = document.querySelector('#clear-token');
+
+const TOKEN_KEY = 'openswarm.webToken';
+
+let currentPath = '';
+
+function parts(path) {
+  return path.split('/').filter(Boolean);
+}
+
+function joinPath(directory, name) {
+  return [...parts(directory), name].join('/');
+}
+
+function formatBytes(size) {
+  if (size < 1024) return `${size} B`;
+  const units = ['KiB', 'MiB', 'GiB'];
+  let value = size / 1024;
+  let unit = units[0];
+  for (let i = 1; i < units.length && value >= 1024; i += 1) {
+    value /= 1024;
+    unit = units[i];
+  }
+  return `${value.toFixed(value >= 10 ? 0 : 1)} ${unit}`;
+}
+
+async function api(url, options) {
+  const headers = new Headers(options?.headers);
+  const token = sessionStorage.getItem(TOKEN_KEY);
+  if (token) headers.set('X-OpenSwarm-Token', token);
+  const response = await fetch(url, { ...options, headers });
+  if (!response.ok) {
+    let message = `HTTP ${response.status}`;
+    try { message = (await response.json()).error || message; } catch { /* non-JSON */ }
+    throw new Error(message);
+  }
+  return response;
+}
+
+function setStatus(message, kind = '') {
+  status.className = `status${kind ? ` ${kind}` : ''}`;
+  status.textContent = message;
+}
+
+function renderBreadcrumbs() {
+  breadcrumbs.replaceChildren();
+  const root = document.createElement('button');
+  root.type = 'button';
+  root.textContent = 'warehouse';
+  root.addEventListener('click', () => loadTree(''));
+  breadcrumbs.append(root);
+  const segments = parts(currentPath);
+  segments.forEach((segment, index) => {
+    const divider = document.createElement('span');
+    divider.textContent = '/';
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = segment;
+    button.addEventListener('click', () => loadTree(segments.slice(0, index + 1).join('/')));
+    breadcrumbs.append(divider, button);
+  });
+  upButton.disabled = segments.length === 0;
+  uploadDirectory.textContent = `/${currentPath}`;
+}
+
+function downloadButton(path, name) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'download';
+  button.textContent = '내려받기';
+  button.addEventListener('click', async () => {
+    button.disabled = true;
+    try {
+      const response = await api(`/api/warehouse/file?path=${encodeURIComponent(path)}`);
+      const objectUrl = URL.createObjectURL(await response.blob());
+      const link = document.createElement('a');
+      link.href = objectUrl;
+      link.download = name;
+      link.click();
+      setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+    } catch (error) {
+      setStatus(error.message, 'error');
+    } finally {
+      button.disabled = false;
+    }
+  });
+  return button;
+}
+
+function renderEntries(entries) {
+  entriesBody.replaceChildren();
+  if (!entries.length) {
+    const row = document.createElement('tr');
+    row.innerHTML = '<td colspan="5" class="empty">빈 폴더입니다.</td>';
+    entriesBody.append(row);
+    return;
+  }
+  for (const entry of entries) {
+    const row = document.createElement('tr');
+    const nameCell = document.createElement('td');
+    const name = document.createElement(entry.type === 'directory' ? 'button' : 'span');
+    name.className = 'file-name';
+    name.textContent = `${entry.type === 'directory' ? '📁' : entry.type === 'symlink' ? '🔗' : '📄'} ${entry.name}`;
+    if (entry.type === 'directory') name.addEventListener('click', () => loadTree(joinPath(currentPath, entry.name)));
+    nameCell.append(name);
+    const typeCell = document.createElement('td');
+    typeCell.textContent = entry.type;
+    const sizeCell = document.createElement('td');
+    sizeCell.textContent = entry.type === 'directory' ? '—' : formatBytes(entry.size);
+    const modifiedCell = document.createElement('td');
+    modifiedCell.textContent = new Date(entry.mtime).toLocaleString('ko-KR');
+    const actionCell = document.createElement('td');
+    if (entry.type !== 'directory') actionCell.append(downloadButton(joinPath(currentPath, entry.name), entry.name));
+    row.append(nameCell, typeCell, sizeCell, modifiedCell, actionCell);
+    entriesBody.append(row);
+  }
+}
+
+async function loadTree(path) {
+  setStatus('');
+  try {
+    const response = await api(`/api/warehouse/tree?path=${encodeURIComponent(path)}`);
+    const payload = await response.json();
+    currentPath = path;
+    renderBreadcrumbs();
+    renderEntries(payload.entries);
+  } catch (error) {
+    entriesBody.innerHTML = `<tr><td colspan="5" class="empty error"></td></tr>`;
+    entriesBody.querySelector('td').textContent = error.message;
+  }
+}
+
+fileInput.addEventListener('change', () => {
+  const file = fileInput.files?.[0];
+  fileLabel.textContent = file ? `${file.name} · ${formatBytes(file.size)}` : '파일을 선택하세요';
+  uploadButton.disabled = !file;
+});
+
+uploadButton.addEventListener('click', async () => {
+  const file = fileInput.files?.[0];
+  if (!file) return;
+  uploadButton.disabled = true;
+  setStatus('업로드 중…');
+  const target = joinPath(currentPath, file.name);
+  try {
+    const overwrite = overwriteInput.checked ? '&overwrite=true' : '';
+    await api(`/api/warehouse/file?path=${encodeURIComponent(target)}${overwrite}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: file,
+    });
+    setStatus(`${file.name} 업로드 완료`, 'success');
+    fileInput.value = '';
+    fileLabel.textContent = '파일을 선택하세요';
+    overwriteInput.checked = false;
+    await loadTree(currentPath);
+  } catch (error) {
+    setStatus(error.message, 'error');
+  } finally {
+    uploadButton.disabled = !fileInput.files?.length;
+  }
+});
+
+saveTokenButton.addEventListener('click', () => {
+  const token = webTokenInput.value.trim();
+  if (token) sessionStorage.setItem(TOKEN_KEY, token);
+  else sessionStorage.removeItem(TOKEN_KEY);
+  webTokenInput.value = '';
+  setStatus(token ? '이 탭에 웹 토큰을 적용했습니다.' : '웹 토큰을 지웠습니다.', 'success');
+  loadTree(currentPath);
+});
+
+clearTokenButton.addEventListener('click', () => {
+  sessionStorage.removeItem(TOKEN_KEY);
+  webTokenInput.value = '';
+  setStatus('이 탭의 웹 토큰을 지웠습니다.');
+  loadTree(currentPath);
+});
+
+upButton.addEventListener('click', () => loadTree(parts(currentPath).slice(0, -1).join('/')));
+refreshButton.addEventListener('click', () => loadTree(currentPath));
+loadTree('');

--- a/web/static/warehouse.html
+++ b/web/static/warehouse.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OpenSwarm Warehouse</title>
+  <link rel="stylesheet" href="/static/css/tokens.css" />
+  <link rel="stylesheet" href="/static/css/warehouse.css" />
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="/app">🐝 OpenSwarm</a>
+    <div>
+      <h1>Warehouse</h1>
+      <p>에이전트가 읽는 로컬 전용 자산 창고</p>
+    </div>
+  </header>
+
+  <main>
+    <section class="browser" aria-label="Warehouse files">
+      <div class="toolbar">
+        <button id="up" type="button">← 상위</button>
+        <nav id="breadcrumbs" class="breadcrumbs" aria-label="Current path"></nav>
+        <button id="refresh" type="button">새로고침</button>
+      </div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>이름</th><th>종류</th><th>크기</th><th>수정 시각</th><th></th></tr></thead>
+          <tbody id="entries"><tr><td colspan="5" class="empty">불러오는 중…</td></tr></tbody>
+        </table>
+      </div>
+    </section>
+
+    <aside class="upload">
+      <section class="access" aria-labelledby="access-title">
+        <h2 id="access-title">원격 접근</h2>
+        <p>로컬이 아닌 브라우저에서는 배포 시 설정한 웹 토큰이 필요합니다.</p>
+        <label for="web-token">OpenSwarm 웹 토큰</label>
+        <div class="token-row">
+          <input id="web-token" type="password" autocomplete="off" spellcheck="false" />
+          <button id="save-token" type="button">적용</button>
+        </div>
+        <button id="clear-token" class="text-button" type="button">이 탭의 토큰 지우기</button>
+      </section>
+
+      <h2>파일 올리기</h2>
+      <p>현재 폴더: <code id="upload-directory">/</code></p>
+      <label class="dropzone" for="file">
+        <span id="file-label">파일을 선택하세요</span>
+        <input id="file" type="file" />
+      </label>
+      <label class="overwrite"><input id="overwrite" type="checkbox" /> 같은 이름이면 덮어쓰기</label>
+      <button id="upload" class="primary" type="button" disabled>업로드</button>
+      <p id="status" class="status" role="status"></p>
+      <div class="rules">
+        <strong>안전 경계</strong>
+        <span>에이전트 경로 <code>/warehouse</code>는 읽기 전용입니다.</span>
+        <span>삭제 기능은 제공하지 않습니다.</span>
+        <span>기존 파일은 체크박스를 켜야 덮어씁니다.</span>
+      </div>
+    </aside>
+  </main>
+
+  <script type="module" src="/static/js/warehouse.mjs"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a single Git-external `/warehouse` visible to all tool-loop workers through read-only file-tool access
- add authenticated browser browse/download/upload at `/warehouse`, with explicit overwrite and no delete
- harden downloads/uploads with canonical containment, `O_NOFOLLOW`, Linux dirfd-anchored I/O, atomic no-clobber publication, and a 50 MiB cap
- document Compose mounts and configurable memory ceiling for the vela deployment

## Verification
- `npm test -- src/support/warehouseRoutes.test.ts src/support/warehouseBrowser.test.ts src/adapters/tools.test.ts src/adapters/agenticLoop.test.ts src/support/staticAssets.test.ts` (127 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `docker compose config --quiet`
- real local HTTP upload/download hash, collision, overwrite, and traversal checks
- Debian Node 22 `/proc/self/fd/<dirfd>` create/link/rename/mode check
- `openswarm review --path .`: APPROVE

Linear: AGT-4128