### PR TITLE
fix(ledger): reconcile terminal tracker rows from a durable cache

### DIFF
--- a/src/automation/autonomousRunner.durable.test.ts
+++ b/src/automation/autonomousRunner.durable.test.ts
@@ -510,6 +510,49 @@ esac
     internal.durableRuns.close();
   });
 
+  it('reconciles a stale Done tracker row even when the slim heartbeat fetch is empty', async () => {
+    vi.setSystemTime(new Date('2026-07-21T16:00:00Z')); // 01:00 KST: work window allowed
+    const [{ AutonomousRunner }, execution] = await Promise.all([
+      import('./autonomousRunner.js'),
+      import('./runnerExecution.js'),
+    ]);
+    const source = {
+      kind: 'linear',
+      fetchTasks: vi.fn(async () => []),
+      lookupIssueState: vi.fn(async () => ({
+        ok: true as const,
+        issue: { state: 'Done', stateType: 'completed' },
+      })),
+      updateState: vi.fn(async () => true), addComment: vi.fn(async () => {}),
+      createTask: vi.fn(), createSubIssue: vi.fn(), logPairStart: vi.fn(),
+      logPairComplete: vi.fn(), logBlocked: vi.fn(), logStuck: vi.fn(), unstick: vi.fn(),
+      logHalt: vi.fn(), markAsDecomposed: vi.fn(),
+    } as unknown as ITaskSource;
+    execution.setTaskSource(source);
+    const runner = new AutonomousRunner({
+      linearTeamId: 'team', allowedProjects: ['/repo'], heartbeatSchedule: '0 * * * *',
+      autoExecute: true, maxConsecutiveTasks: 1, cooldownSeconds: 0, dryRun: true,
+      automationLedgerMode: 'primary', automationDbPath: join(root, 'terminal-lookup.db'),
+    });
+    const internal = runner as unknown as InternalRunner;
+    internal.refreshKnowledgeGraphs = vi.fn();
+    const now = Date.now();
+    internal.durableRuns.importLegacyRun({
+      issueId: 'stale-done', source: 'linear', identifier: 'AX-856', title: 'done upstream',
+      projectPath: '/repo', state: 'RETRY_AT', retryAt: now - 2 * 60 * 60_000,
+    }, now - 2 * 60 * 60_000);
+
+    await runner.heartbeat();
+
+    expect(source.fetchTasks).toHaveBeenCalledTimes(1);
+    expect(source.lookupIssueState).toHaveBeenCalledWith('AX-856');
+    expect(internal.durableRuns.listRuns()).toHaveLength(1);
+    expect(internal.durableRuns.getRun('stale-done')).toMatchObject({
+      state: 'DONE', trackerState: 'Done', trackerStateType: 'completed',
+    });
+    internal.durableRuns.close();
+  });
+
   it('returns at the shutdown deadline but defers ledger close until an abort-ignoring executor exits', async () => {
     const { AutonomousRunner } = await import('./autonomousRunner.js');
     const runner = new AutonomousRunner({

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -85,6 +85,7 @@ import {
 } from './durableRunCoordinator.js';
 import type { EffectClaim, ImportRunInput, RunLedgerMode } from './runLedger.js';
 import { buildCancellationEffect, buildCompletionEffect, completionStats, deliverTrackerEffect } from './trackerEffects.js';
+import { reconcileTrackerTerminalRuns } from './trackerTerminalReconciler.js';
 
 // Re-export types and integration setters (used by service.ts)
 export { setNotifier, setTaskSource } from './runnerExecution.js';
@@ -1608,13 +1609,23 @@ export class AutonomousRunner {
 
   private async recoverParkedRunsOnly(): Promise<void> {
     if (!this.durableRuns.isPrimary) return;
-    if (this.durableRuns.listRuns(['NEEDS_RECONCILE']).length === 0) return;
-    const fetchResult = await fetchLinearTasks();
-    if (fetchResult.error) {
-      console.warn(`[AutonomousRunner] Explicit-mode recovery fetch failed: ${fetchResult.error}`);
-      return;
+    const needsArtifactRecovery = this.durableRuns.listRuns(['NEEDS_RECONCILE']).length > 0;
+    let tasks: TaskItem[] = [];
+    if (needsArtifactRecovery) {
+      const fetchResult = await fetchLinearTasks();
+      if (fetchResult.error) {
+        console.warn(`[AutonomousRunner] Explicit-mode recovery fetch failed: ${fetchResult.error}`);
+      } else {
+        tasks = fetchResult.tasks;
+        await this.reconcileDurableArtifacts(tasks);
+      }
     }
-    await this.reconcileDurableArtifacts(fetchResult.tasks);
+    await reconcileTrackerTerminalRuns({
+      durableRuns: this.durableRuns,
+      source: getTaskSource(),
+      inScope: this.getDispatchScopePredicate(),
+      knownTasks: tasks,
+    });
   }
 
   /**
@@ -1970,6 +1981,16 @@ export class AutonomousRunner {
         await reportToDiscord(`⚠️ Linear fetch failed: ${fetchResult.error}`);
         return;
       }
+      const trackerReconcile = await reconcileTrackerTerminalRuns({
+        durableRuns: this.durableRuns,
+        source: getTaskSource(),
+        inScope: this.getDispatchScopePredicate(),
+        knownTasks: fetchResult.tasks,
+      });
+      if (trackerReconcile.lookedUp > 0 || trackerReconcile.fromFetch > 0) {
+        this.syslog(`✓ Tracker cache: ${trackerReconcile.fromFetch} bulk hit(s), ${trackerReconcile.lookedUp} explicit lookup(s), ${trackerReconcile.terminal} terminal ledger row(s) reconciled`);
+      }
+      if (this.stopping) return;
       let tasks = fetchResult.tasks;
       if (tasks.length === 0) {
         this.syslog('— No tasks in backlog');

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -14,7 +14,9 @@ import {
   type RunLedgerMode,
   type RunRecord,
   type RunState,
+  type TrackerStateObservation,
 } from './runLedger.js';
+import type { TrackerTerminalState } from './runLedgerTrackerCache.js';
 import { pickPipelineFailureDetail } from './runnerState.js';
 
 export interface DurableRunCoordinatorConfig {
@@ -226,6 +228,16 @@ export class DurableRunCoordinator {
 
   listRuns(states?: readonly RunState[]): RunRecord[] {
     return this.ledger?.listRuns(states) ?? [];
+  }
+
+  cacheTrackerObservation(
+    expected: Pick<RunRecord, 'issueId' | 'state' | 'stateVersion'>,
+    observation: TrackerStateObservation,
+    terminalState?: TrackerTerminalState,
+    now = Date.now(),
+  ): boolean {
+    if (!this.ledger || this.mode !== 'primary') return false;
+    return this.ledger.cacheTrackerObservation(expected, observation, terminalState, now);
   }
 
   /**

--- a/src/automation/runLedger.test.ts
+++ b/src/automation/runLedger.test.ts
@@ -107,6 +107,62 @@ describe('RunLedger state machine', () => {
   });
 });
 
+describe('RunLedger tracker observation cache (AGT-4127)', () => {
+  it('preserves the row and recovery fields while closing a stale run from tracker truth', () => {
+    const ledger = new RunLedger(createDbPath());
+    ledger.importRun({
+      issueId: 'TRACKER-DONE', source: 'linear', identifier: 'AX-856',
+      title: 'done upstream', projectPath: '/repo', state: 'RETRY_AT',
+      retryAt: 10_000, branchName: 'swarm/AX-856', errorCode: 'failed',
+      errorMessage: 'original failure evidence',
+    }, 1_000);
+    const stale = ledger.getRun('TRACKER-DONE')!;
+
+    expect(ledger.cacheTrackerObservation(
+      stale,
+      { state: 'Done', stateType: 'completed' },
+      'DONE',
+      3_000,
+    )).toBe(true);
+    expect(ledger.listRuns()).toHaveLength(1);
+    expect(ledger.getRun('TRACKER-DONE')).toMatchObject({
+      state: 'DONE',
+      branchName: 'swarm/AX-856',
+      lastErrorCode: 'failed',
+      lastErrorMessage: 'original failure evidence',
+      trackerState: 'Done',
+      trackerStateType: 'completed',
+      trackerCheckedAt: 3_000,
+      completedAt: 3_000,
+    });
+    ledger.close();
+  });
+
+  it('caches an open state without refreshing run age, and loses to a concurrent claim', () => {
+    const ledger = new RunLedger(createDbPath());
+    ledger.importRun({
+      issueId: 'TRACKER-OPEN', source: 'linear', projectPath: '/repo',
+      state: 'RETRY_AT', retryAt: 1_000,
+    }, 1_000);
+    const stale = ledger.getRun('TRACKER-OPEN')!;
+    expect(ledger.cacheTrackerObservation(stale, { state: 'Todo', stateType: 'unstarted' }, undefined, 2_000)).toBe(true);
+    expect(ledger.getRun('TRACKER-OPEN')).toMatchObject({
+      state: 'RETRY_AT', updatedAt: 1_000, trackerState: 'Todo', trackerCheckedAt: 2_000,
+    });
+
+    const observed = ledger.getRun('TRACKER-OPEN')!;
+    expect(claim(ledger, 'TRACKER-OPEN', 'worker', 3_000)).not.toBeNull();
+    expect(ledger.cacheTrackerObservation(
+      observed,
+      { state: 'Done', stateType: 'completed' },
+      'DONE',
+      3_100,
+    )).toBe(false);
+    expect(ledger.getRun('TRACKER-OPEN')?.state).toBe('CLAIMED');
+    ledger.close();
+  });
+});
+
 describe('RunLedger operator re-admission (AGT-4033)', () => {
   it('will not claim a run whose retry time has not come', () => {
     // This is why letting an answered task past the heartbeat filter is not
@@ -772,9 +828,11 @@ describe('RunLedger schema migration', () => {
     ledger.close();
 
     const verify = new Database(path, { readonly: true });
-    const columns = (verify.pragma('table_info(automation_attempts)') as Array<{ name: string }>).map((row) => row.name);
-    expect(columns).toEqual(expect.arrayContaining(['result_status', 'success', 'cost_usd']));
-    expect((verify.prepare("SELECT value FROM automation_meta WHERE key = 'schema_version'").get() as { value: string }).value).toBe('2');
+    const attemptColumns = (verify.pragma('table_info(automation_attempts)') as Array<{ name: string }>).map((row) => row.name);
+    const runColumns = (verify.pragma('table_info(automation_runs)') as Array<{ name: string }>).map((row) => row.name);
+    expect(attemptColumns).toEqual(expect.arrayContaining(['result_status', 'success', 'cost_usd']));
+    expect(runColumns).toEqual(expect.arrayContaining(['tracker_state', 'tracker_state_type', 'tracker_checked_at']));
+    expect((verify.prepare("SELECT value FROM automation_meta WHERE key = 'schema_version'").get() as { value: string }).value).toBe('3');
     verify.close();
   });
 });

--- a/src/automation/runLedger.ts
+++ b/src/automation/runLedger.ts
@@ -10,6 +10,11 @@ import {
 } from './runLedgerTypes.js';
 import { admitsConflictScope } from './runLedgerScope.js';
 import { migrateAutomationSchema } from './runLedgerSchema.js';
+import {
+  cacheTrackerObservation as persistTrackerObservation,
+  readLedgerMetrics,
+  type TrackerTerminalState,
+} from './runLedgerTrackerCache.js';
 import type {
   AttemptResultInput,
   ClaimOptions,
@@ -24,6 +29,7 @@ import type {
   RunLedgerOptions,
   RunRecord,
   RunState,
+  TrackerStateObservation,
   TransitionPatch,
 } from './runLedgerTypes.js';
 
@@ -44,6 +50,7 @@ export type {
   RunLedgerOptions,
   RunRecord,
   RunState,
+  TrackerStateObservation,
   TransitionPatch,
 } from './runLedgerTypes.js';
 
@@ -71,6 +78,9 @@ interface RunRow {
   started_at: number | null;
   updated_at: number;
   completed_at: number | null;
+  tracker_state: string | null;
+  tracker_state_type: string | null;
+  tracker_checked_at: number | null;
   metadata_json: string | null;
 }
 
@@ -260,6 +270,15 @@ export class RunLedger {
       ? this.db.prepare(`SELECT * FROM automation_runs WHERE state IN (${placeholders(states)}) ORDER BY updated_at`).all(...states) as RunRow[]
       : this.db.prepare('SELECT * FROM automation_runs ORDER BY updated_at').all() as RunRow[];
     return rows.map((row) => this.toRun(row));
+  }
+
+  cacheTrackerObservation(
+    expected: Pick<RunRecord, 'issueId' | 'state' | 'stateVersion'>,
+    observation: TrackerStateObservation,
+    terminalState?: TrackerTerminalState,
+    now = Date.now(),
+  ): boolean {
+    return persistTrackerObservation(this.db, expected, observation, terminalState, now);
   }
 
   markReady(issueId: string, now = Date.now()): boolean {
@@ -1282,33 +1301,7 @@ export class RunLedger {
   }
 
   getMetrics(now = Date.now()): LedgerMetrics {
-    const byState: Record<string, number> = {};
-    for (const row of this.db.prepare('SELECT state, COUNT(*) AS count FROM automation_runs GROUP BY state').all() as { state: string; count: number }[]) {
-      byState[row.state] = row.count;
-    }
-    const effectsByStatus: Record<string, number> = {};
-    for (const row of this.db.prepare('SELECT status, COUNT(*) AS count FROM automation_effects GROUP BY status').all() as { status: string; count: number }[]) {
-      effectsByStatus[row.status] = row.count;
-    }
-    const expiredActiveLeases = (this.db.prepare(`
-      SELECT COUNT(*) AS count FROM automation_runs
-      WHERE state IN (${placeholders(ACTIVE_LEASE_STATES)})
-        AND (lease_expires_at IS NULL OR lease_expires_at <= ?)
-    `).get(...ACTIVE_LEASE_STATES, now) as { count: number }).count;
-    const oldest = this.db.prepare(`
-      SELECT MIN(created_at) AS created_at FROM automation_effects
-      WHERE status IN ('pending', 'in_flight')
-    `).get() as { created_at: number | null };
-    const openCircuits = (this.db.prepare(`
-      SELECT COUNT(*) AS count FROM automation_repo_circuits WHERE open_until > ?
-    `).get(now) as { count: number }).count;
-    return {
-      byState,
-      effectsByStatus,
-      expiredActiveLeases,
-      oldestPendingEffectAgeMs: oldest.created_at == null ? 0 : Math.max(0, now - oldest.created_at),
-      openCircuits,
-    };
+    return readLedgerMetrics(this.db, now);
   }
 
   close(): void {
@@ -1472,6 +1465,9 @@ export class RunLedger {
       startedAt: row.started_at ?? undefined,
       updatedAt: row.updated_at,
       completedAt: row.completed_at ?? undefined,
+      trackerState: row.tracker_state ?? undefined,
+      trackerStateType: row.tracker_state_type ?? undefined,
+      trackerCheckedAt: row.tracker_checked_at ?? undefined,
       metadata: parseJson(row.metadata_json),
     };
   }

--- a/src/automation/runLedgerSchema.ts
+++ b/src/automation/runLedgerSchema.ts
@@ -41,6 +41,9 @@ export function migrateAutomationSchema(db: Database.Database): void {
         started_at INTEGER,
         updated_at INTEGER NOT NULL,
         completed_at INTEGER,
+        tracker_state TEXT,
+        tracker_state_type TEXT,
+        tracker_checked_at INTEGER,
         metadata_json TEXT
       );
 
@@ -131,6 +134,18 @@ export function migrateAutomationSchema(db: Database.Database): void {
       if (!attemptColumns.has('repository_infra')) db.exec('ALTER TABLE automation_attempts ADD COLUMN repository_infra INTEGER');
       db.exec(`CREATE INDEX IF NOT EXISTS idx_automation_attempts_budget
         ON automation_attempts(started_at, success, cost_usd)`);
+
+      // v2 -> v3: cache explicit tracker observations beside the run they
+      // reconcile. A still-open issue is then rechecked on a bounded cadence
+      // instead of spending one Linear request on every heartbeat (AGT-4127).
+      const runColumns = new Set(
+        (db.pragma('table_info(automation_runs)') as Array<{ name: string }>).map((column) => column.name),
+      );
+      if (!runColumns.has('tracker_state')) db.exec('ALTER TABLE automation_runs ADD COLUMN tracker_state TEXT');
+      if (!runColumns.has('tracker_state_type')) db.exec('ALTER TABLE automation_runs ADD COLUMN tracker_state_type TEXT');
+      if (!runColumns.has('tracker_checked_at')) db.exec('ALTER TABLE automation_runs ADD COLUMN tracker_checked_at INTEGER');
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_automation_runs_tracker_reconcile
+        ON automation_runs(source, state, tracker_checked_at, updated_at)`);
 
       const current = db.prepare('SELECT value FROM automation_meta WHERE key = ?').get('schema_version') as { value: string } | undefined;
       if (current && Number(current.value) > AUTOMATION_SCHEMA_VERSION) {

--- a/src/automation/runLedgerTrackerCache.ts
+++ b/src/automation/runLedgerTrackerCache.ts
@@ -1,0 +1,113 @@
+import type Database from 'better-sqlite3';
+import { ACTIVE_LEASE_STATES } from './runLedgerTypes.js';
+import type {
+  LedgerMetrics,
+  RunRecord,
+  RunState,
+  TrackerStateObservation,
+} from './runLedgerTypes.js';
+
+export type TrackerTerminalState = 'DONE' | 'CANCELLED';
+
+/** States with neither a live execution lease nor pending tracker side effects. */
+export const TRACKER_RECONCILABLE_STATES: readonly RunState[] = [
+  'DISCOVERED', 'READY', 'RETRY_AT', 'WAITING_EXTERNAL',
+  'NEEDS_SPEC', 'NEEDS_ENV', 'NEEDS_HUMAN',
+];
+
+function placeholders(values: readonly unknown[]): string {
+  return values.map(() => '?').join(', ');
+}
+
+/**
+ * Persist one explicit tracker observation, optionally closing the run.
+ *
+ * Both paths compare the state version and require an unowned row. A worker
+ * that claims the run while the network lookup is in flight therefore wins;
+ * stale tracker data can never close an active execution.
+ */
+export function cacheTrackerObservation(
+  db: Database.Database,
+  expected: Pick<RunRecord, 'issueId' | 'state' | 'stateVersion'>,
+  observation: TrackerStateObservation,
+  terminalState: TrackerTerminalState | undefined,
+  now: number,
+): boolean {
+  if (!TRACKER_RECONCILABLE_STATES.includes(expected.state)) return false;
+  const state = observation.lookupError ? 'lookup_error' : (observation.state ?? 'not_found');
+  const stateType = observation.stateType ?? null;
+  const apply = db.transaction(() => {
+    if (!terminalState) {
+      return db.prepare(`
+        UPDATE automation_runs
+        SET tracker_state = ?, tracker_state_type = ?, tracker_checked_at = ?
+        WHERE issue_id = ? AND state = ? AND state_version = ?
+          AND owner_instance_id IS NULL AND lease_token IS NULL
+      `).run(state, stateType, now, expected.issueId, expected.state, expected.stateVersion).changes === 1;
+    }
+
+    const row = db.prepare(`
+      SELECT attempt_no FROM automation_runs
+      WHERE issue_id = ? AND state = ? AND state_version = ?
+        AND owner_instance_id IS NULL AND lease_token IS NULL
+    `).get(expected.issueId, expected.state, expected.stateVersion) as { attempt_no: number } | undefined;
+    if (!row) return false;
+    const updated = db.prepare(`
+      UPDATE automation_runs
+      SET state = ?, state_version = state_version + 1, retry_at = NULL,
+          lease_expires_at = NULL, completed_at = ?, updated_at = ?,
+          tracker_state = ?, tracker_state_type = ?, tracker_checked_at = ?
+      WHERE issue_id = ? AND state = ? AND state_version = ?
+        AND owner_instance_id IS NULL AND lease_token IS NULL
+    `).run(
+      terminalState, now, now, state, stateType, now,
+      expected.issueId, expected.state, expected.stateVersion,
+    );
+    if (updated.changes !== 1) return false;
+    db.prepare(`
+      INSERT INTO automation_events(
+        issue_id, attempt_no, kind, from_state, to_state, data_json, created_at
+      ) VALUES (?, ?, 'tracker_terminal_reconciled', ?, ?, ?, ?)
+    `).run(
+      expected.issueId,
+      row.attempt_no,
+      expected.state,
+      terminalState,
+      JSON.stringify({ trackerState: state, trackerStateType: stateType }),
+      now,
+    );
+    return true;
+  });
+  return apply.immediate();
+}
+
+/** Kept outside RunLedger so adding tracker caching does not grow its 1500-line gate. */
+export function readLedgerMetrics(db: Database.Database, now: number): LedgerMetrics {
+  const byState: Record<string, number> = {};
+  for (const row of db.prepare('SELECT state, COUNT(*) AS count FROM automation_runs GROUP BY state').all() as { state: string; count: number }[]) {
+    byState[row.state] = row.count;
+  }
+  const effectsByStatus: Record<string, number> = {};
+  for (const row of db.prepare('SELECT status, COUNT(*) AS count FROM automation_effects GROUP BY status').all() as { status: string; count: number }[]) {
+    effectsByStatus[row.status] = row.count;
+  }
+  const expiredActiveLeases = (db.prepare(`
+    SELECT COUNT(*) AS count FROM automation_runs
+    WHERE state IN (${placeholders(ACTIVE_LEASE_STATES)})
+      AND (lease_expires_at IS NULL OR lease_expires_at <= ?)
+  `).get(...ACTIVE_LEASE_STATES, now) as { count: number }).count;
+  const oldest = db.prepare(`
+    SELECT MIN(created_at) AS created_at FROM automation_effects
+    WHERE status IN ('pending', 'in_flight')
+  `).get() as { created_at: number | null };
+  const openCircuits = (db.prepare(`
+    SELECT COUNT(*) AS count FROM automation_repo_circuits WHERE open_until > ?
+  `).get(now) as { count: number }).count;
+  return {
+    byState,
+    effectsByStatus,
+    expiredActiveLeases,
+    oldestPendingEffectAgeMs: oldest.created_at == null ? 0 : Math.max(0, now - oldest.created_at),
+    openCircuits,
+  };
+}

--- a/src/automation/runLedgerTypes.ts
+++ b/src/automation/runLedgerTypes.ts
@@ -1,4 +1,4 @@
-export const AUTOMATION_SCHEMA_VERSION = 2;
+export const AUTOMATION_SCHEMA_VERSION = 3;
 
 export const RUN_STATES = [
   'DISCOVERED',
@@ -96,7 +96,19 @@ export interface RunRecord {
   startedAt?: number;
   updatedAt: number;
   completedAt?: number;
+  /** Last tracker state observed by the terminal reconciler. */
+  trackerState?: string;
+  /** Tracker workflow-state type (`completed`, `canceled`, etc.), when available. */
+  trackerStateType?: string;
+  /** Durable cache timestamp for the explicit tracker lookup. */
+  trackerCheckedAt?: number;
   metadata?: unknown;
+}
+
+export interface TrackerStateObservation {
+  state?: string;
+  stateType?: string;
+  lookupError?: boolean;
 }
 
 export interface RunClaim {

--- a/src/automation/taskSource.test.ts
+++ b/src/automation/taskSource.test.ts
@@ -51,6 +51,18 @@ describe('SqliteTaskSource', () => {
     await expect(src.updateState('missing', 'Done')).resolves.toBe(false);
   });
 
+  it('explicitly looks up terminal local issues that fetchTasks excludes', async () => {
+    store = freshStore();
+    const issue = store.createIssue({ projectId: 'p', title: 'finished', status: 'done' });
+    const src = new SqliteTaskSource(store);
+
+    await expect(src.lookupIssueState(issue.id)).resolves.toEqual({
+      ok: true,
+      issue: { state: 'done', stateType: 'completed' },
+    });
+    await expect(src.lookupIssueState('missing')).resolves.toEqual({ ok: true, issue: null });
+  });
+
   it('addComment records a commented event', async () => {
     store = freshStore();
     const issue = store.createIssue({ projectId: 'p', title: 'x' });

--- a/src/automation/taskSource.ts
+++ b/src/automation/taskSource.ts
@@ -43,6 +43,11 @@ export interface PairCompleteStats {
 
 export type SubIssueResult = { id: string; identifier: string; title: string } | { error: string };
 
+/** Explicit tracker lookup used only for stale durable-run reconciliation. */
+export type TrackerIssueLookup =
+  | { ok: true; issue: { state: string; stateType?: string } | null }
+  | { ok: false; error: string };
+
 /**
  * Everything the autonomous runner needs from its task tracker. LinearTaskSource
  * preserves today's behavior exactly (thin delegation); SqliteTaskSource backs
@@ -51,6 +56,8 @@ export type SubIssueResult = { id: string; identifier: string; title: string } |
 export interface ITaskSource {
   readonly kind: 'linear' | 'local';
   fetchTasks(): Promise<TaskItem[]>;
+  /** Fetch one issue even when terminal states are excluded from fetchTasks(). */
+  lookupIssueState(issueIdOrIdentifier: string): Promise<TrackerIssueLookup>;
   /** Create a top-level task/issue (used by the /plan cockpit to seed a parent). */
   createTask(title: string, description: string, projectId?: string): Promise<SubIssueResult>;
   updateState(issueId: string, state: TaskState): Promise<boolean>;
@@ -86,6 +93,16 @@ export class LinearTaskSource implements ITaskSource {
   constructor(private readonly fetch: () => Promise<TaskItem[]>) {}
 
   fetchTasks(): Promise<TaskItem[]> { return this.fetch(); }
+  async lookupIssueState(issueIdOrIdentifier: string): Promise<TrackerIssueLookup> {
+    const result = await linear.lookupIssue(issueIdOrIdentifier);
+    if (!result.ok) return result;
+    return {
+      ok: true,
+      issue: result.issue
+        ? { state: result.issue.state, stateType: result.issue.stateType }
+        : null,
+    };
+  }
   async createTask(title: string, description: string, projectId?: string): Promise<SubIssueResult> {
     // Pass projectId so createIssue links the issue AND resolves the project's team
     // (multi-team configs would otherwise hit "teamId must be a UUID"). (INT-2210)
@@ -157,6 +174,14 @@ export class SqliteTaskSource implements ITaskSource {
     // Enrich from canonical task state so planner-declared fileScope (plus
     // dependency/topoRank data) reaches the runner — mirrors the Linear path.
     return issues.map((issue) => enrichTaskFromState(issueToTask(issue)));
+  }
+  async lookupIssueState(issueId: string): Promise<TrackerIssueLookup> {
+    const issue = this.store.getIssue(issueId);
+    if (!issue) return { ok: true, issue: null };
+    const stateType = issue.status === 'done'
+      ? 'completed'
+      : issue.status === 'cancelled' ? 'canceled' : undefined;
+    return { ok: true, issue: { state: issue.status, stateType } };
   }
   async createTask(title: string, description: string, projectId?: string): Promise<SubIssueResult> {
     try {

--- a/src/automation/trackerTerminalReconciler.test.ts
+++ b/src/automation/trackerTerminalReconciler.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import { DurableRunCoordinator } from './durableRunCoordinator.js';
+import type { ITaskSource } from './taskSource.js';
+import { reconcileTrackerTerminalRuns } from './trackerTerminalReconciler.js';
+
+const roots: string[] = [];
+
+function coordinator(): DurableRunCoordinator {
+  const root = mkdtempSync(join(tmpdir(), 'openswarm-tracker-reconcile-'));
+  roots.push(root);
+  return new DurableRunCoordinator({
+    mode: 'primary',
+    dbPath: join(root, 'automation.db'),
+    instanceId: 'test-reconciler',
+    leaseMs: 3_000,
+  });
+}
+
+function source(lookupIssueState: ITaskSource['lookupIssueState']): ITaskSource {
+  return {
+    kind: 'linear',
+    lookupIssueState,
+  } as unknown as ITaskSource;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('tracker terminal reconciliation', () => {
+  it('closes a Done issue, caches an open issue, and never looks outside dispatch scope', async () => {
+    const durableRuns = coordinator();
+    const old = 1_000;
+    durableRuns.importLegacyRun({
+      issueId: 'done-id', source: 'linear', identifier: 'AX-DONE', title: 'done',
+      projectPath: '/repo', state: 'RETRY_AT', retryAt: old,
+    }, old);
+    durableRuns.importLegacyRun({
+      issueId: 'open-id', source: 'linear', identifier: 'AX-OPEN', title: 'open',
+      projectPath: '/repo', state: 'RETRY_AT', retryAt: old,
+    }, old);
+    durableRuns.importLegacyRun({
+      issueId: 'outside-id', source: 'linear', identifier: 'AX-OUT', title: 'outside',
+      projectPath: '/disabled', state: 'RETRY_AT', retryAt: old,
+    }, old);
+    const lookup = vi.fn<ITaskSource['lookupIssueState']>(async (key) => ({
+      ok: true,
+      issue: key === 'AX-OPEN'
+        ? { state: 'Todo', stateType: 'unstarted' }
+        : { state: 'Done', stateType: 'completed' },
+    }));
+    const now = old + 8 * 60 * 60_000;
+    const knownOpen: TaskItem = {
+      id: 'open-id', issueId: 'open-id', issueIdentifier: 'AX-OPEN', source: 'linear',
+      title: 'open', priority: 2, createdAt: old, linearState: 'Todo',
+    };
+
+    const first = await reconcileTrackerTerminalRuns({
+      durableRuns,
+      source: source(lookup),
+      inScope: (path) => path === '/repo',
+      knownTasks: [knownOpen],
+      now,
+    });
+    expect(first).toMatchObject({
+      eligible: 2, lookedUp: 1, fromFetch: 1, cached: 2, terminal: 1, failed: 0,
+    });
+    expect(lookup.mock.calls.map(([key]) => key)).toEqual(['AX-DONE']);
+    expect(durableRuns.getRun('done-id')).toMatchObject({
+      state: 'DONE', trackerState: 'Done', trackerStateType: 'completed',
+    });
+    expect(durableRuns.getRun('open-id')).toMatchObject({
+      state: 'RETRY_AT', trackerState: 'Todo', trackerCheckedAt: now,
+    });
+    expect(durableRuns.getRun('outside-id')?.trackerCheckedAt).toBeUndefined();
+
+    const cached = await reconcileTrackerTerminalRuns({
+      durableRuns,
+      source: source(lookup),
+      inScope: (path) => path === '/repo',
+      now: now + 5 * 60 * 60_000,
+    });
+    expect(cached.lookedUp).toBe(0);
+    expect(lookup).toHaveBeenCalledTimes(1);
+    durableRuns.close();
+  });
+
+  it('stores lookup failures in the ledger and retries them on the shorter cache interval', async () => {
+    const durableRuns = coordinator();
+    durableRuns.importLegacyRun({
+      issueId: 'error-id', source: 'linear', identifier: 'AX-ERROR', title: 'error',
+      projectPath: '/repo', state: 'RETRY_AT', retryAt: 1_000,
+    }, 1_000);
+    const lookup = vi.fn<ITaskSource['lookupIssueState']>(async () => ({ ok: false, error: 'offline' }));
+    const now = 2 * 60 * 60_000;
+
+    expect((await reconcileTrackerTerminalRuns({
+      durableRuns, source: source(lookup), now,
+    })).failed).toBe(1);
+    expect(durableRuns.getRun('error-id')).toMatchObject({
+      state: 'RETRY_AT', trackerState: 'lookup_error', trackerCheckedAt: now,
+    });
+    expect((await reconcileTrackerTerminalRuns({
+      durableRuns, source: source(lookup), now: now + 14 * 60_000,
+    })).lookedUp).toBe(0);
+    expect((await reconcileTrackerTerminalRuns({
+      durableRuns, source: source(lookup), now: now + 15 * 60_000,
+    })).lookedUp).toBe(1);
+    expect(lookup).toHaveBeenCalledTimes(2);
+    durableRuns.close();
+  });
+});

--- a/src/automation/trackerTerminalReconciler.ts
+++ b/src/automation/trackerTerminalReconciler.ts
@@ -1,0 +1,129 @@
+import { safeConsole as console } from '../support/safeLog.js';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import type { DurableRunCoordinator } from './durableRunCoordinator.js';
+import type { RunRecord } from './runLedger.js';
+import {
+  TRACKER_RECONCILABLE_STATES,
+  type TrackerTerminalState,
+} from './runLedgerTrackerCache.js';
+import type { ITaskSource, TrackerIssueLookup } from './taskSource.js';
+
+export interface TrackerTerminalReconcileOptions {
+  durableRuns: DurableRunCoordinator;
+  source: ITaskSource | null;
+  /** States already returned by the bulk fetch; these satisfy open-state checks without another API call. */
+  knownTasks?: readonly TaskItem[];
+  inScope?: (projectPath: string) => boolean;
+  now?: number;
+  staleAfterMs?: number;
+  recheckAfterMs?: number;
+  errorRecheckAfterMs?: number;
+  maxLookups?: number;
+}
+
+export interface TrackerTerminalReconcileResult {
+  eligible: number;
+  lookedUp: number;
+  fromFetch: number;
+  cached: number;
+  terminal: number;
+  failed: number;
+}
+
+function terminalState(lookup: TrackerIssueLookup): TrackerTerminalState | undefined {
+  if (!lookup.ok || !lookup.issue) return undefined;
+  const type = lookup.issue.stateType?.trim().toLowerCase();
+  if (type === 'completed') return 'DONE';
+  if (type === 'canceled' || type === 'cancelled') return 'CANCELLED';
+
+  // Local trackers and older Linear responses may not expose workflow-state
+  // type. Keep the fallback deliberately narrow so a custom open state cannot
+  // be closed by a fuzzy name match.
+  const name = lookup.issue.state.trim().toLowerCase();
+  if (name === 'done' || name === 'completed') return 'DONE';
+  if (name === 'canceled' || name === 'cancelled' || name === 'duplicate') return 'CANCELLED';
+  return undefined;
+}
+
+function dueForLookup(
+  run: RunRecord,
+  now: number,
+  staleAfterMs: number,
+  recheckAfterMs: number,
+  errorRecheckAfterMs: number,
+): boolean {
+  if (now - run.updatedAt < staleAfterMs) return false;
+  if (run.trackerCheckedAt == null) return true;
+  const interval = run.trackerState === 'lookup_error' ? errorRecheckAfterMs : recheckAfterMs;
+  return now - run.trackerCheckedAt >= interval;
+}
+
+/**
+ * Reconcile stale ledger rows from a bounded, durable tracker cache.
+ *
+ * Terminal issues disappear from the normal slim fetch, so this is the only
+ * explicit per-issue read. Results are written back to automation_runs before
+ * the next heartbeat; open issues therefore cost at most one lookup per cache
+ * interval, while transient failures retry sooner. No row is deleted.
+ */
+export async function reconcileTrackerTerminalRuns(
+  options: TrackerTerminalReconcileOptions,
+): Promise<TrackerTerminalReconcileResult> {
+  const result: TrackerTerminalReconcileResult = {
+    eligible: 0, lookedUp: 0, fromFetch: 0, cached: 0, terminal: 0, failed: 0,
+  };
+  const { durableRuns, source } = options;
+  if (!durableRuns.isPrimary || !source) return result;
+
+  const now = options.now ?? Date.now();
+  const staleAfterMs = options.staleAfterMs ?? 60 * 60_000;
+  const recheckAfterMs = options.recheckAfterMs ?? 6 * 60 * 60_000;
+  const errorRecheckAfterMs = options.errorRecheckAfterMs ?? 15 * 60_000;
+  const maxLookups = Math.max(1, Math.floor(options.maxLookups ?? 20));
+  const candidates = durableRuns.listRuns(TRACKER_RECONCILABLE_STATES)
+    .filter((run) => run.source === source.kind)
+    .filter((run) => !run.ownerInstanceId && !run.leaseToken)
+    .filter((run) => options.inScope?.(run.projectPath) ?? true)
+    .filter((run) => dueForLookup(run, now, staleAfterMs, recheckAfterMs, errorRecheckAfterMs))
+    .sort((a, b) => a.updatedAt - b.updatedAt);
+  result.eligible = candidates.length;
+  const knownTasks = new Map<string, TaskItem>();
+  for (const task of options.knownTasks ?? []) {
+    knownTasks.set(task.issueId ?? task.id, task);
+    if (task.issueIdentifier) knownTasks.set(task.issueIdentifier, task);
+  }
+
+  for (const run of candidates) {
+    const key = run.source === 'linear' ? (run.identifier ?? run.issueId) : run.issueId;
+    let lookup: TrackerIssueLookup;
+    const known = knownTasks.get(run.issueId) ?? knownTasks.get(key);
+    if (known?.linearState) {
+      lookup = { ok: true, issue: { state: known.linearState } };
+      result.fromFetch++;
+    } else {
+      if (result.lookedUp >= maxLookups) continue;
+      try {
+        lookup = await source.lookupIssueState(key);
+      } catch (error) {
+        lookup = { ok: false, error: error instanceof Error ? error.message : String(error) };
+      }
+      result.lookedUp++;
+    }
+    if (!lookup.ok) {
+      result.failed++;
+      if (durableRuns.cacheTrackerObservation(run, { lookupError: true }, undefined, now)) result.cached++;
+      console.warn(`[TrackerReconciler] Lookup failed for ${run.identifier ?? run.issueId}; cached for bounded retry`);
+      continue;
+    }
+
+    const observation = lookup.issue
+      ? { state: lookup.issue.state, stateType: lookup.issue.stateType }
+      : {};
+    const terminal = terminalState(lookup);
+    if (durableRuns.cacheTrackerObservation(run, observation, terminal, now)) {
+      result.cached++;
+      if (terminal) result.terminal++;
+    }
+  }
+  return result;
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -60,6 +60,8 @@ export type LinearIssueInfo = {
   title: string;
   description?: string;
   state: string;
+  /** Linear workflow-state type, populated by explicit single-issue lookups. */
+  stateType?: string;
   priority: number;
   labels: string[];
   comments: LinearComment[];

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -856,12 +856,14 @@ async function fetchIssue(issueIdOrIdentifier: string): Promise<LinearIssueInfo 
       if (ident.toUpperCase() !== issue.identifier.toUpperCase()) blockedBy.add(ident);
     }
 
+    const issueState = await issue.state;
     return {
       id: issue.id,
       identifier: issue.identifier,
       title: issue.title,
       description: issue.description ?? undefined,
-      state: (await issue.state)?.name ?? 'Unknown',
+      state: issueState?.name ?? 'Unknown',
+      stateType: issueState?.type ?? undefined,
       priority: issue.priority,
       labels: labels.nodes.map((l) => l.name),
       comments: comments.nodes.map((c) => ({


### PR DESCRIPTION
## Summary

- cache explicit tracker observations in automation_runs so stale open issues do not trigger a Linear read every heartbeat
- reuse states from the normal bulk fetch, and limit absent/terminal issue lookups to 20 per heartbeat with 6h open-state and 15m error retry windows
- transition safe unowned stale rows to DONE/CANCELLED with state-version fencing while preserving ledger rows and recovery fields
- run reconciliation before the empty-backlog return and during explicit-mode startup recovery

Closes AGT-4127.

## Safety

- active lease states, SYNC_PENDING, and NEEDS_RECONCILE are excluded
- a concurrent claim wins the compare-and-swap race
- no automation_runs row is deleted
- branch, worktree, PR, and prior error evidence remain intact

## Validation

- npm test -- --run: 4,867 passed, 10 skipped
- targeted tracker/ledger/task-source/heartbeat tests: 85 passed
- npx tsc --noEmit
- npm run build
- oxlint on all 14 changed files: clean
- OpenSwarm working-tree review: APPROVE
- vela online DB backup: schema v3 migration created all tracker cache columns; AX-856 changed RETRY_AT to DONE while row count stayed 289 and branchName was preserved

## Remaining rollout proof

After merge: deploy to vela, verify live migration, run/observe reconciliation, and confirm AX-856 is terminal in the live ledger.