### PR TITLE
Fix dashboard Linear project mapping

### DIFF
--- a/src/automation/runnerState.coverage.test.ts
+++ b/src/automation/runnerState.coverage.test.ts
@@ -54,6 +54,83 @@ describe('runnerState persistence and helpers', () => {
     expect(mod.isPathEnabled('/repo/application', enabled)).toBe(false);
   });
 
+  it('joins a quiet pinned repository to fetched tasks by Linear project id', () => {
+    const projects = mod.buildProjectsInfo([
+      task('cgf-1', 'CGF-Portal'),
+    ] as any, [], [], new Map(), new Set(['/work/cgf-portal']));
+
+    expect(projects[0]).toMatchObject({
+      path: '',
+      name: 'CGF-Portal',
+      linearProjectId: 'CGF-Portal-id',
+      pending: [expect.objectContaining({ id: 'cgf-1' })],
+    });
+    expect(mod.projectInfoForRepository(projects, {
+      path: '/work/cgf-portal',
+      directoryName: 'cgf-portal',
+      linearProjectId: 'CGF-Portal-id',
+    })).toBe(projects[0]);
+  });
+
+  it('keeps active work attached when a Linear project is renamed', () => {
+    const fetched = task('cgf-1', 'CGF-Portal');
+    const running = task('cgf-2', 'Old CGF name', 1, {
+      linearProject: { id: 'CGF-Portal-id', name: 'Old CGF name' },
+    });
+    const queued = task('cgf-3', 'Another stale name', 1, {
+      linearProject: { id: 'CGF-Portal-id', name: 'Another stale name' },
+    });
+    const projects = mod.buildProjectsInfo(
+      [fetched] as any,
+      [{ task: running, projectPath: '/work/cgf-portal' }] as any,
+      [{ task: queued, projectPath: '/work/cgf-portal' }] as any,
+      new Map(),
+      new Set(['/work/cgf-portal']),
+    );
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0]).toMatchObject({
+      name: 'CGF-Portal',
+      linearProjectId: 'CGF-Portal-id',
+      running: [expect.objectContaining({ id: 'cgf-2' })],
+      queued: [expect.objectContaining({ id: 'cgf-3' })],
+    });
+  });
+
+  it('uses a case-insensitive project-name fallback for legacy repositories', () => {
+    const projects = mod.buildProjectsInfo([
+      task('cgf-1', 'CGF-Portal', 1, { linearProject: { name: 'CGF-Portal' } }),
+    ] as any, [], [], new Map(), new Set());
+
+    expect(mod.projectInfoForRepository(projects, {
+      path: '/work/cgf-portal', directoryName: 'cgf-portal',
+    })).toBe(projects[0]);
+  });
+
+  it('does not let a stale path override configured Linear project identity', () => {
+    const stale = {
+      path: '/work/cgf-portal',
+      name: 'Unrelated',
+      linearProjectId: 'unrelated-id',
+    } as mod.ProjectInfo;
+    const expected = {
+      path: '',
+      name: 'CGF-Portal',
+      linearProjectId: 'cgf-id',
+    } as mod.ProjectInfo;
+
+    expect(mod.projectInfoForRepository([stale, expected], {
+      path: '/work/cgf-portal',
+      directoryName: 'cgf-portal',
+      linearProjectId: 'cgf-id',
+    })).toBe(expected);
+    expect(mod.projectInfoForRepository([stale], {
+      path: '/work/cgf-portal',
+      directoryName: 'cgf-portal',
+      linearProjectId: 'cgf-id',
+    })).toBeUndefined();
+  });
+
   it('records project pace, prunes old entries, and reports daily totals', async () => {
     writeFileSync(mod.DAILY_PACE_FILE, JSON.stringify({
       updatedAt: 'old',

--- a/src/automation/runnerState.ts
+++ b/src/automation/runnerState.ts
@@ -684,6 +684,8 @@ export function getPipelineHistory(limit = 50): PipelineHistoryEntry[] {
 export interface ProjectInfo {
   path: string;
   name: string;
+  /** Stable tracker identity used to join a pinned repo without name guessing. */
+  linearProjectId?: string;
   enabled: boolean;
   running: { id: string; title: string; priority: number }[];
   queued: { id: string; title: string; priority: number }[];
@@ -700,30 +702,38 @@ export function buildProjectsInfo(
   pathCache: Map<string, string>,
   enabledProjects: Set<string>,
 ): ProjectInfo[] {
-  const projectMap = new Map<string, { name: string; path: string | null; tasks: TaskItem[] }>();
+  const projectMap = new Map<string, { id?: string; name: string; path: string | null; tasks: TaskItem[] }>();
 
   for (const task of fetchedTasks) {
     const projName = task.linearProject?.name || '(unknown)';
-    if (!projectMap.has(projName)) {
-      projectMap.set(projName, { name: projName, path: pathCache.get(projName) ?? null, tasks: [] });
+    const projectKey = task.linearProject?.id || projName;
+    if (!projectMap.has(projectKey)) {
+      projectMap.set(projectKey, {
+        id: task.linearProject?.id,
+        name: projName,
+        path: pathCache.get(projName) ?? null,
+        tasks: [],
+      });
     }
-    projectMap.get(projName)!.tasks.push(task);
+    projectMap.get(projectKey)!.tasks.push(task);
   }
 
   for (const r of running) {
     const projName = r.task.linearProject?.name || '(unknown)';
-    if (!projectMap.has(projName)) {
-      projectMap.set(projName, { name: projName, path: r.projectPath, tasks: [] });
-    } else if (!projectMap.get(projName)!.path) {
-      projectMap.get(projName)!.path = r.projectPath;
+    const projectKey = r.task.linearProject?.id || projName;
+    if (!projectMap.has(projectKey)) {
+      projectMap.set(projectKey, { id: r.task.linearProject?.id, name: projName, path: r.projectPath, tasks: [] });
+    } else if (!projectMap.get(projectKey)!.path) {
+      projectMap.get(projectKey)!.path = r.projectPath;
     }
   }
   for (const q of queued) {
     const projName = q.task.linearProject?.name || '(unknown)';
-    if (!projectMap.has(projName)) {
-      projectMap.set(projName, { name: projName, path: q.projectPath, tasks: [] });
-    } else if (!projectMap.get(projName)!.path) {
-      projectMap.get(projName)!.path = q.projectPath;
+    const projectKey = q.task.linearProject?.id || projName;
+    if (!projectMap.has(projectKey)) {
+      projectMap.set(projectKey, { id: q.task.linearProject?.id, name: projName, path: q.projectPath, tasks: [] });
+    } else if (!projectMap.get(projectKey)!.path) {
+      projectMap.get(projectKey)!.path = q.projectPath;
     }
   }
 
@@ -734,18 +744,46 @@ export function buildProjectsInfo(
 
   return Array.from(projectMap.values()).map(proj => {
     const projectPath = proj.path ?? '';
+    const belongsToProject = (task: TaskItem): boolean => proj.id
+      ? task.linearProject?.id === proj.id
+      : (task.linearProject?.name || '(unknown)') === proj.name;
     return {
       path: projectPath,
       name: proj.name,
+      ...(proj.id ? { linearProjectId: proj.id } : {}),
       enabled: Boolean(projectPath) && isPathEnabled(projectPath, enabledProjects),
-      running: running.filter(r => r.task.linearProject?.name === proj.name)
+      running: running.filter(r => belongsToProject(r.task))
         .map(r => ({ id: r.task.id, title: r.task.title, priority: r.task.priority })),
-      queued: queued.filter(q => q.task.linearProject?.name === proj.name)
+      queued: queued.filter(q => belongsToProject(q.task))
         .map(q => ({ id: q.task.id, title: q.task.title, priority: q.task.priority })),
       pending: proj.tasks.filter(t => !activeIds.has(t.issueId || t.id))
         .map(t => ({ id: t.id, title: t.title, priority: t.priority, issueIdentifier: t.issueIdentifier || t.issueId, linearState: t.linearState })),
     };
   });
+}
+
+/**
+ * Join one configured repository to the runner's tracker projection.
+ *
+ * The repository metadata project id is authoritative. Name matching remains
+ * a compatibility fallback for repositories created before openswarm.json,
+ * and is case-insensitive because directory casing is not a tracker identity.
+ */
+export function projectInfoForRepository(
+  projects: readonly ProjectInfo[],
+  input: { path: string; directoryName: string; linearProjectId?: string; linearProjectName?: string },
+): ProjectInfo | undefined {
+  if (input.linearProjectId) {
+    // A configured tracker id is authoritative. Do not fall back to a stale
+    // path/name association and accidentally display another project's tasks.
+    return projects.find((project) => project.linearProjectId === input.linearProjectId);
+  }
+
+  const byPath = projects.find((project) => project.path === input.path);
+  if (byPath) return byPath;
+
+  const expectedName = (input.linearProjectName ?? input.directoryName).toLowerCase();
+  return projects.find((project) => project.name.toLowerCase() === expectedName);
 }
 
 // Exponential Backoff for Failed Task Retries

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -35,6 +35,8 @@ import { runChatCompletion, getDefaultChatModel } from './chatBackend.js';
 import { handleGraphQL, isGraphQLRequest } from '../issues/graphql/server.js';
 import { ISSUE_BOARD_HTML } from '../issues/issueBoardHtml.js';
 import { createSubIssuesWithDependencies, getTaskSource } from '../automation/runnerExecution.js';
+import { projectInfoForRepository } from '../automation/runnerState.js';
+import { loadRepoMetadata } from './repoMetadata.js';
 import type { SubTask } from './planner.js';
 import { buildHealthPayload } from './healthEndpoint.js';
 import { HttpError, readBody } from './httpBody.js';
@@ -555,10 +557,6 @@ export async function startWebServer(port: number = 3847): Promise<void> {
       } else if (url === '/api/projects' && req.method === 'GET') {
         const enabledPaths = new Set(runnerRef?.getEnabledProjects() ?? []);
         const taskInfo = runnerRef?.getProjectsInfo() ?? [];
-        const byPath = new Map(taskInfo.filter(p => p.path).map(p => [p.path, p]));
-        // Fallback: match by project name (for tasks not yet executed → path not cached)
-        const byName = new Map(taskInfo.map(p => [p.name, p]));
-
         // Start with pinned projects
         const allPaths = new Set(pinnedProjects);
         // Auto-include enabled projects and projects with active tasks
@@ -571,7 +569,17 @@ export async function startWebServer(port: number = 3847): Promise<void> {
 
         const result = await Promise.all(Array.from(allPaths).map(async p => {
           const dirName = p.split('/').pop() ?? p;
-          const info = byPath.get(p) ?? byName.get(dirName);
+          // A fetched project has no path until a task runs. Join it to the
+          // pinned repository by the stable project id from openswarm.json so
+          // a quiet repo does not show zero issues merely because its Linear
+          // name differs in case from the directory (CGF-Portal/cgf-portal).
+          const metadata = await loadRepoMetadata(p).catch(() => null);
+          const info = projectInfoForRepository(taskInfo, {
+            path: p,
+            directoryName: dirName,
+            linearProjectId: metadata?.linear?.projectId,
+            linearProjectName: metadata?.linear?.projectName,
+          });
           const gitInfo = await getProjectGitInfo(p);
           return {
             path: p,


### PR DESCRIPTION
## Summary
- expose stable Linear project IDs in the runner dashboard projection
- join pinned repositories to projects by `openswarm.json` project ID
- retain case-insensitive name fallback only for legacy repositories without metadata
- preserve running and queued work across Linear project renames

## Verified
- `npm test -- --run` — 5008 passed, 10 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `openswarm review --path .` — APPROVE

## Live symptom before fix
`/api/work/issues?path=/work/cgf-portal` returned 106 issues while `/api/projects` reported `linearProject: null`, `running: 0`, `pending: 0` for the same repository.