### PR TITLE
feat: highlight chat mentions

### DIFF
--- a/tests/web/chatView.test.ts
+++ b/tests/web/chatView.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 // @ts-expect-error — browser ESM asset without type declarations
-import { startChatView, isNearBottom, renderLine } from '../../web/static/js/chatView.mjs';
+import { startChatView, isNearBottom, renderLine, renderMentionText } from '../../web/static/js/chatView.mjs';
 
 function shell(): Document {
   document.body.innerHTML = `
@@ -24,6 +24,7 @@ function shell(): Document {
 function boardEvent(over: Record<string, unknown> = {}) {
   return {
     id: `id-${Math.random()}`,
+    fingerprint: 'fingerprint-1',
     seq: 1,
     timestamp: Date.now(),
     correlationId: 'c1',
@@ -75,7 +76,7 @@ describe('startChatView', () => {
     expect(lines[0].querySelector('.text')!.textContent).toBe('Landed the retry change.');
     // The reply prefers its long form and names its addressee.
     expect(lines[1].querySelector('.text')!.textContent).toBe('Approved: the retry belongs in the scheduler.');
-    expect(lines[1].querySelector('.to')!.textContent).toBe('→ Enginseer Rhodanis-Novum');
+    expect(lines[1].querySelector('.to')!.textContent).toBe("→ @'Enginseer Rhodanis-Novum'");
     view.stop();
   });
 
@@ -125,6 +126,31 @@ describe('startChatView', () => {
     });
     expect(doc.querySelectorAll('#room .line').length).toBe(2);
     expect(doc.getElementById('room')!.textContent).toContain('Now reviewing the diff.');
+    view.stop();
+  });
+
+  it('replaces an existing line when its Korean projection arrives', async () => {
+    const doc = shell();
+    const listeners: { onmessage?: (msg: { data: string }) => void } = {};
+    class FakeSource {
+      set onmessage(fn: (msg: { data: string }) => void) { listeners.onmessage = fn; }
+      close(): void { /* noop */ }
+    }
+    const original = boardEvent({ id: 'localized-later', summary: 'Mention Operator after review.' });
+    const view = startChatView(doc, { fetchImpl: fetchWith([original]), eventSourceImpl: FakeSource });
+    await vi.waitFor(() => expect(doc.getElementById('room')!.textContent).toContain("Mention @'Operator' after review."));
+
+    listeners.onmessage!({
+      data: JSON.stringify({
+        type: 'coordination:event',
+        data: { ...original, summary: '검토 후 Operator에게 알려 주세요.', localizedLocale: 'ko', originalText: { summary: original.summary } },
+      }),
+    });
+    expect(doc.querySelectorAll('#room .line')).toHaveLength(1);
+    expect(doc.getElementById('room')!.textContent).toContain("검토 후 @'Operator'에게 알려 주세요.");
+
+    listeners.onmessage!({ data: JSON.stringify({ type: 'coordination:event', data: original }) });
+    expect(doc.getElementById('room')!.textContent).toContain("검토 후 @'Operator'에게 알려 주세요.");
     view.stop();
   });
 
@@ -243,6 +269,43 @@ describe('renderLine', () => {
     });
     expect(html).not.toContain('class="tag"');
     expect(html).toContain('boo');
+  });
+
+  it('canonicalizes agent and operator mentions without double-prefixing existing mentions', () => {
+    const html = renderMentionText(
+      "Ask QuarryMaker7826, then notify @'Operator' and @QuarryMaker7826.",
+      [{ name: 'QuarryMaker7826', role: 'worker' }, { name: 'Operator', role: 'human' }],
+    );
+    document.body.innerHTML = html;
+    const mentions = [...document.querySelectorAll('.mention')];
+    expect(mentions.map((mention) => mention.textContent)).toEqual([
+      "@'QuarryMaker7826'", "@'Operator'", "@'QuarryMaker7826'",
+    ]);
+    expect(mentions[1].classList.contains('mention-human')).toBe(true);
+    expect(document.body.textContent).not.toContain("@@'");
+  });
+
+  it('does not highlight names inside ASCII identifiers but accepts Korean particles', () => {
+    const html = renderMentionText(
+      'Sablewood is not Sable, but Sable에게 답하세요.',
+      [{ name: 'Sable', role: 'worker' }],
+    );
+    document.body.innerHTML = html;
+    expect(document.body.textContent).toBe("Sablewood is not @'Sable', but @'Sable'에게 답하세요.");
+    expect(document.querySelectorAll('.mention')).toHaveLength(2);
+  });
+
+  it('highlights a recipient as a canonical mention and escapes untrusted prose', () => {
+    const html = renderLine({
+      id: 'x', seq: 1, timestamp: 0, speakerName: 'Worker', role: 'worker', speakerRole: 'worker',
+      recipientName: 'Operator', recipientRole: 'human', text: '<script>bad()</script>',
+      taskLabel: 'AGT-1', status: 'completed', kind: 'advice-request', isOperator: false,
+    }, [{ name: 'Operator', role: 'human' }]);
+    document.body.innerHTML = html;
+    expect(document.querySelector('.to .mention')?.textContent).toBe("@'Operator'");
+    expect(document.querySelector('.to .mention')?.classList.contains('mention-human')).toBe(true);
+    expect(document.querySelector('script')).toBeNull();
+    expect(document.querySelector('.text')?.textContent).toBe('<script>bad()</script>');
   });
 });
 

--- a/web/static/chat.html
+++ b/web/static/chat.html
@@ -16,19 +16,22 @@
     header h1 { font-size: 14px; letter-spacing: 1px; }
     header a { color: var(--dim); text-decoration: none; font-size: 11px; }
     header a:hover { color: var(--cyan); }
-    #room { flex: 1; overflow-y: auto; overflow-x: hidden; padding: 10px 16px;
+    #room { flex: 1; overflow-y: auto; overflow-x: hidden; padding: 14px 16px 20px;
             scrollbar-width: thin; scrollbar-color: #2a3140 transparent; }
     #room::-webkit-scrollbar { width: 6px; }
     #room::-webkit-scrollbar-thumb { background: #2a3140; border-radius: 3px; }
     #room::-webkit-scrollbar-track { background: transparent; }
-    .line { padding: 2px 0 2px 6px; border-left: 2px solid transparent; overflow-wrap: anywhere; }
-    .line .clock { color: var(--dim); font-variant-numeric: tabular-nums; margin-right: 4px; }
+    .line { padding: 5px 9px; margin: 1px 0; border-left: 2px solid transparent; border-radius: 0 4px 4px 0; overflow-wrap: anywhere; line-height: 1.65; }
+    .line:hover { background: rgba(255, 255, 255, 0.025); }
+    .line .clock { color: #5f687c; font-variant-numeric: tabular-nums; margin-right: 6px; }
     .line .who { font-weight: 700; }
-    .line .tag { color: var(--dim); font-size: 11px; margin-right: 4px; }
-    .line .to { color: var(--dim); margin-right: 4px; }
+    .line .tag { color: #778197; font-size: 11px; margin: 0 6px 0 2px; }
+    .line .to { color: var(--dim); margin-right: 6px; }
     .line .sep { color: var(--dim); }
-    .line .text { color: #c9d0dd; white-space: pre-wrap; }
-    .line.from-operator { border-left-color: var(--red); background: #131019; }
+    .line .text { color: #d5d9e2; white-space: pre-wrap; }
+    .mention { display: inline; color: #89c4ff; background: rgba(59, 158, 255, 0.13); border: 1px solid rgba(59, 158, 255, 0.28); border-radius: 4px; padding: 0 3px; font-weight: 700; box-decoration-break: clone; -webkit-box-decoration-break: clone; }
+    .mention-human { color: #ff9fa3; background: rgba(229, 72, 77, 0.13); border-color: rgba(229, 72, 77, 0.3); }
+    .line.from-operator { border-left-color: var(--red); background: rgba(229, 72, 77, 0.045); }
     .line.pending { border-left-color: var(--amber); }
     .line.failed .text { color: var(--red); }
     .composer { display: flex; gap: 6px; padding: 10px 16px; border-top: 1px solid var(--border); }

--- a/web/static/js/chatView.mjs
+++ b/web/static/js/chatView.mjs
@@ -32,18 +32,77 @@ export function isNearBottom({ scrollHeight, scrollTop, clientHeight }, slack = 
   return scrollHeight - scrollTop - clientHeight <= slack;
 }
 
+function mentionMarkup(name, role = '') {
+  const classes = `mention${role === 'human' ? ' mention-human' : ''}`;
+  return `<span class="${classes}">@&#39;${escapeHtml(name)}&#39;</span>`;
+}
+
+/** Canonicalize known participant names inside prose as highlighted @'name' mentions. */
+export function renderMentionText(text, targets = []) {
+  const byName = new Map();
+  for (const target of targets) {
+    const name = String(target?.name ?? '').trim();
+    if (name.length < 2) continue;
+    const current = byName.get(name);
+    if (!current || target.role === 'human') byName.set(name, { name, role: target.role ?? '' });
+  }
+  const names = [...byName.values()].sort((a, b) => b.name.length - a.name.length);
+  if (names.length === 0) return escapeHtml(text);
+
+  const source = String(text ?? '');
+  let cursor = 0;
+  let html = '';
+  while (cursor < source.length) {
+    let found = null;
+    for (const target of names) {
+      let index = source.indexOf(target.name, cursor);
+      while (index >= 0) {
+        const before = source[index - 1] ?? '';
+        const after = source[index + target.name.length] ?? '';
+        // Callsigns may be followed immediately by a Korean particle (`의`,
+        // `에게`), but must not light up inside another ASCII identifier.
+        if (!/[A-Za-z0-9_-]/.test(before) && !/[A-Za-z0-9_-]/.test(after)) break;
+        index = source.indexOf(target.name, index + 1);
+      }
+      if (index < 0) continue;
+      if (!found || index < found.index || (index === found.index && target.name.length > found.target.name.length)) {
+        found = { index, target };
+      }
+    }
+    if (!found) {
+      html += escapeHtml(source.slice(cursor));
+      break;
+    }
+
+    let mentionStart = found.index;
+    let mentionEnd = found.index + found.target.name.length;
+    if (source.slice(Math.max(cursor, mentionStart - 2), mentionStart) === "@'" && source[mentionEnd] === "'") {
+      mentionStart -= 2;
+      mentionEnd += 1;
+    } else if (mentionStart > cursor && source[mentionStart - 1] === '@') {
+      mentionStart -= 1;
+    }
+    html += escapeHtml(source.slice(cursor, mentionStart));
+    html += mentionMarkup(found.target.name, found.target.role);
+    cursor = mentionEnd;
+  }
+  return html;
+}
+
 /** `[14:02] name (worker · AGT-1009): message` as one room line. */
-export function renderLine(line) {
+export function renderLine(line, mentionTargets = []) {
   const color = ROLE_COLORS[line.role] ?? ROLE_COLORS.agent;
   const tagParts = [line.speakerRole, line.taskLabel].filter(Boolean);
   const tag = tagParts.length ? `<span class="tag">(${escapeHtml(tagParts.join(' · '))})</span> ` : '';
   const statusClass = PENDING.has(line.status) ? ' pending'
     : line.status === 'failed' || line.status === 'expired' ? ' failed' : '';
-  const to = line.recipientName ? `<span class="to">→ ${escapeHtml(line.recipientName)}</span>` : '';
+  const to = line.recipientName
+    ? `<span class="to">→ ${mentionMarkup(line.recipientName, line.recipientRole)}</span>`
+    : '';
   return `<div class="line${line.isOperator ? ' from-operator' : ''}${statusClass}" data-line="${escapeHtml(line.id)}">
     <span class="clock">[${escapeHtml(clockOf(line.timestamp))}]</span>
     <span class="who" style="color:${color}">${escapeHtml(line.speakerName)}</span>
-    ${tag}${to}<span class="sep">:</span> <span class="text">${escapeHtml(line.text)}</span>
+    ${tag}${to}<span class="sep">:</span> <span class="text">${renderMentionText(line.text, mentionTargets)}</span>
   </div>`;
 }
 
@@ -159,8 +218,17 @@ export function startChatView(doc, { fetchImpl, eventSourceImpl, pollMs = 30_000
   const redraw = () => {
     const events = [...byId.values()];
     const lines = buildChatLines(events);
+    const mentionTargets = [
+      // The dashboard user is canonically named Operator even before they have
+      // spoken in this retained window, so agents can mention them immediately.
+      { name: 'Operator', role: 'human' },
+      ...lines.flatMap((line) => [
+        { name: line.speakerName, role: line.role },
+        ...(line.recipientName ? [{ name: line.recipientName, role: line.recipientRole }] : []),
+      ]),
+    ];
     room.innerHTML = lines.length
-      ? lines.map(renderLine).join('')
+      ? lines.map((line) => renderLine(line, mentionTargets)).join('')
       : '<div class="empty">No one has said anything yet.</div>';
     // The composer can only address an agent that exists; without one the
     // POST would be unroutable (the API requires repository/taskId/recipient).
@@ -186,7 +254,20 @@ export function startChatView(doc, { fetchImpl, eventSourceImpl, pollMs = 30_000
   };
 
   const absorb = (event) => {
-    if (event && event.id && !byId.has(event.id)) { byId.set(event.id, event); return true; }
+    if (!event?.id) return false;
+    const existing = byId.get(event.id);
+    if (!existing) { byId.set(event.id, event); return true; }
+    // The SSE channel carries immutable source events, while polling/history
+    // carries their locale projection. A late raw copy of the same fingerprint
+    // must not downgrade a Korean line that is already on screen.
+    if (existing.localizedLocale && !event.localizedLocale
+      && existing.fingerprint && existing.fingerprint === event.fingerprint) return false;
+    if (existing.summary !== event.summary
+      || existing.detail !== event.detail
+      || existing.localizedLocale !== event.localizedLocale) {
+      byId.set(event.id, event);
+      return true;
+    }
     return false;
   };
 

--- a/web/static/js/conversationModel.mjs
+++ b/web/static/js/conversationModel.mjs
@@ -131,6 +131,7 @@ export function chatLineOf(event) {
     role: event.actorRole || '',
     speakerRole: ROLE_LABELS[event.actorRole] || event.actorRole || '',
     recipientName: event.recipientName || event.recipient || null,
+    recipientRole: event.recipientRole || '',
     text: event.detail || event.summary || '',
     taskLabel: taskLabelOf(event),
     status: event.status,


### PR DESCRIPTION
## Summary
- render chat recipients and known names in prose as canonical `@'name'` mention chips
- distinguish operator mentions from agent mentions with separate accessible color treatments
- improve line spacing, metadata contrast, hover state, and operator-row readability
- prevent false positives inside ASCII identifiers while supporting Korean particles after callsigns
- keep localized lines from being downgraded by later raw SSE copies of the same event

## Verification
- `npm test -- --run tests/web/chatView.test.ts tests/web/conversationModel.test.ts`: 54 passed
- `npm run test:coverage`: 90.02% statements, threshold passed
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`
- `openswarm review --path .`: APPROVE