### PR TITLE
style: separate chat metadata from messages

### DIFF
--- a/web/static/chat.html
+++ b/web/static/chat.html
@@ -21,19 +21,25 @@
     #room::-webkit-scrollbar { width: 6px; }
     #room::-webkit-scrollbar-thumb { background: #2a3140; border-radius: 3px; }
     #room::-webkit-scrollbar-track { background: transparent; }
-    .line { padding: 5px 9px; margin: 1px 0; border-left: 2px solid transparent; border-radius: 0 4px 4px 0; overflow-wrap: anywhere; line-height: 1.65; }
-    .line:hover { background: rgba(255, 255, 255, 0.025); }
-    .line .clock { color: #5f687c; font-variant-numeric: tabular-nums; margin-right: 6px; }
+    .line { padding: 8px 11px 9px; margin: 3px 0; border-left: 2px solid transparent; border-bottom: 1px solid rgba(119, 129, 151, 0.09); border-radius: 0 5px 5px 0; overflow-wrap: anywhere; }
+    .line:hover { background: rgba(255, 255, 255, 0.032); }
+    .line .meta { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0; min-width: 0; font-size: 11px; line-height: 1.45; }
+    .line .clock { color: #68738a; font-variant-numeric: tabular-nums; margin-right: 7px; }
     .line .who { font-weight: 700; }
-    .line .tag { color: #778197; font-size: 11px; margin: 0 6px 0 2px; }
+    .line .tag { color: #8490a8; margin: 0 7px 0 4px; }
     .line .to { color: var(--dim); margin-right: 6px; }
-    .line .sep { color: var(--dim); }
-    .line .text { color: #d5d9e2; white-space: pre-wrap; }
+    .line .sep { color: #596276; }
+    .line .text { display: block; color: #dde2ec; white-space: pre-wrap; margin-top: 3px; padding-left: 17px; font-size: 13px; line-height: 1.65; }
     .mention { display: inline; color: #89c4ff; background: rgba(59, 158, 255, 0.13); border: 1px solid rgba(59, 158, 255, 0.28); border-radius: 4px; padding: 0 3px; font-weight: 700; box-decoration-break: clone; -webkit-box-decoration-break: clone; }
     .mention-human { color: #ff9fa3; background: rgba(229, 72, 77, 0.13); border-color: rgba(229, 72, 77, 0.3); }
     .line.from-operator { border-left-color: var(--red); background: rgba(229, 72, 77, 0.045); }
     .line.pending { border-left-color: var(--amber); }
-    .line.failed .text { color: var(--red); }
+    .line.failed .text { color: #ff7479; }
+    @media (max-width: 760px) {
+      #room { padding-inline: 8px; }
+      .line { padding-inline: 8px; }
+      .line .text { padding-left: 0; }
+    }
     .composer { display: flex; gap: 6px; padding: 10px 16px; border-top: 1px solid var(--border); }
     .composer input { flex: 1; background: #0d1117; border: 1px solid var(--border); border-radius: 4px; color: var(--white); padding: 6px 10px; font: inherit; font-size: 12px; }
     .composer input:disabled { color: var(--dim); }

--- a/web/static/js/chatView.mjs
+++ b/web/static/js/chatView.mjs
@@ -100,9 +100,10 @@ export function renderLine(line, mentionTargets = []) {
     ? `<span class="to">→ ${mentionMarkup(line.recipientName, line.recipientRole)}</span>`
     : '';
   return `<div class="line${line.isOperator ? ' from-operator' : ''}${statusClass}" data-line="${escapeHtml(line.id)}">
-    <span class="clock">[${escapeHtml(clockOf(line.timestamp))}]</span>
+    <span class="meta"><span class="clock">[${escapeHtml(clockOf(line.timestamp))}]</span>
     <span class="who" style="color:${color}">${escapeHtml(line.speakerName)}</span>
-    ${tag}${to}<span class="sep">:</span> <span class="text">${renderMentionText(line.text, mentionTargets)}</span>
+    ${tag}${to}<span class="sep">:</span></span>
+    <span class="text">${renderMentionText(line.text, mentionTargets)}</span>
   </div>`;
 }
 


### PR DESCRIPTION
## Summary
- split each chat entry into a compact metadata header and a separate message body
- increase row spacing and text contrast while retaining status and operator accents
- remove body indentation on narrow screens

## Verification
- 
> @intrect/openswarm@0.21.1 test
> node --experimental-vm-modules node_modules/vitest/vitest.mjs run --run tests/web/chatView.test.ts tests/web/conversationModel.test.ts


 RUN  v4.1.8 /Users/unohee/dev/OpenSwarm-swarm/chat-mention-highlights


 Test Files  2 passed (2)
      Tests  54 passed (54)
   Start at  22:26:07
   Duration  1.92s (transform 74ms, setup 24ms, import 74ms, tests 1.59s, environment 184ms) (54 passed)
- 
> @intrect/openswarm@0.21.1 typecheck
> tsc --noEmit -p tsconfig.check.json
- 
> @intrect/openswarm@0.21.1 lint
> oxlint src/

Found 0 warnings and 0 errors.
Finished in 52ms on 706 files with 91 rules using 10 threads.
- 
> @intrect/openswarm@0.21.1 build
> tsc


> @intrect/openswarm@0.21.1 postbuild
> chmod +x dist/cli.js && node -e "const fs=require('node:fs');fs.rmSync('dist/web-static',{recursive:true,force:true});fs.cpSync('web/static','dist/web-static',{recursive:true})"
- 
- • Config loading from /Users/unohee/.config/openswarm/config.yaml
• [Config] TimeWindow loaded enabled: false
No working-tree changes to review. — APPROVE