### PR TITLE
style: add rich chat transcript highlighting

### DIFF
--- a/tests/web/chatView.test.ts
+++ b/tests/web/chatView.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 // @ts-expect-error — browser ESM asset without type declarations
-import { startChatView, isNearBottom, renderLine, renderMentionText } from '../../web/static/js/chatView.mjs';
+import { startChatView, isNearBottom, renderChatText, renderLine, renderMentionText } from '../../web/static/js/chatView.mjs';
 
 function shell(): Document {
   document.body.innerHTML = `
@@ -306,6 +306,19 @@ describe('renderLine', () => {
     expect(document.querySelector('.to .mention')?.classList.contains('mention-human')).toBe(true);
     expect(document.querySelector('script')).toBeNull();
     expect(document.querySelector('.text')?.textContent).toBe('<script>bad()</script>');
+  });
+
+  it('renders backtick spans as escaped code chips and leaves mentions outside them highlighted', () => {
+    const html = renderChatText(
+      "Tell Operator to inspect `<img src=x onerror=alert(1)>` in `web/router.ts`.",
+      [{ name: 'Operator', role: 'human' }],
+    );
+    document.body.innerHTML = html;
+    expect(document.querySelector('.mention')?.textContent).toBe("@'Operator'");
+    expect([...document.querySelectorAll('code')].map((node) => node.textContent)).toEqual([
+      '<img src=x onerror=alert(1)>', 'web/router.ts',
+    ]);
+    expect(document.querySelector('img')).toBeNull();
   });
 });
 

--- a/web/static/chat.html
+++ b/web/static/chat.html
@@ -21,23 +21,25 @@
     #room::-webkit-scrollbar { width: 6px; }
     #room::-webkit-scrollbar-thumb { background: #2a3140; border-radius: 3px; }
     #room::-webkit-scrollbar-track { background: transparent; }
-    .line { padding: 8px 11px 9px; margin: 3px 0; border-left: 2px solid transparent; border-bottom: 1px solid rgba(119, 129, 151, 0.09); border-radius: 0 5px 5px 0; overflow-wrap: anywhere; }
-    .line:hover { background: rgba(255, 255, 255, 0.032); }
-    .line .meta { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0; min-width: 0; font-size: 11px; line-height: 1.45; }
-    .line .clock { color: #68738a; font-variant-numeric: tabular-nums; margin-right: 7px; }
+    .line { --speaker-color: var(--dim); max-width: 1320px; padding: 11px 14px 12px; margin: 8px auto; border: 1px solid #202838; border-radius: 7px; background: #0f141d; box-shadow: inset 3px 0 var(--speaker-color); overflow-wrap: anywhere; }
+    .line:hover { background: #121925; border-color: #2a3548; }
+    .line .meta { display: flex; flex-wrap: wrap; align-items: center; gap: 0; min-width: 0; font-size: 11.5px; line-height: 1.55; }
+    .line .clock { color: #748099; font-variant-numeric: tabular-nums; margin-right: 8px; }
     .line .who { font-weight: 700; }
-    .line .tag { color: #8490a8; margin: 0 7px 0 4px; }
+    .line .who::before { content: ""; display: inline-block; width: 6px; height: 6px; margin: 0 6px 1px 0; border-radius: 50%; background: var(--speaker-color); box-shadow: 0 0 7px color-mix(in srgb, var(--speaker-color) 65%, transparent); }
+    .line .tag { color: #9aa6bd; background: #171e2a; border: 1px solid #293347; border-radius: 10px; padding: 0 6px; margin: 0 8px 0 6px; }
     .line .to { color: var(--dim); margin-right: 6px; }
     .line .sep { color: #596276; }
-    .line .text { display: block; color: #dde2ec; white-space: pre-wrap; margin-top: 3px; padding-left: 17px; font-size: 13px; line-height: 1.65; }
-    .mention { display: inline; color: #89c4ff; background: rgba(59, 158, 255, 0.13); border: 1px solid rgba(59, 158, 255, 0.28); border-radius: 4px; padding: 0 3px; font-weight: 700; box-decoration-break: clone; -webkit-box-decoration-break: clone; }
-    .mention-human { color: #ff9fa3; background: rgba(229, 72, 77, 0.13); border-color: rgba(229, 72, 77, 0.3); }
-    .line.from-operator { border-left-color: var(--red); background: rgba(229, 72, 77, 0.045); }
-    .line.pending { border-left-color: var(--amber); }
+    .line .text { display: block; max-width: 112ch; color: #e1e6f0; white-space: pre-wrap; margin-top: 7px; padding-left: 18px; font-size: 14px; line-height: 1.7; }
+    .line .text code { color: #b9d9ff; background: #080c12; border: 1px solid #28354a; border-radius: 4px; padding: 1px 5px; font: 0.92em/1.5 "SF Mono", ui-monospace, Menlo, monospace; box-decoration-break: clone; -webkit-box-decoration-break: clone; }
+    .mention { display: inline; color: #b8dcff; background: #143253; border: 1px solid #2f73aa; border-radius: 4px; padding: 1px 5px; font-weight: 750; box-shadow: 0 0 0 1px rgba(59, 158, 255, 0.08); box-decoration-break: clone; -webkit-box-decoration-break: clone; }
+    .mention-human { color: #ffc4c7; background: #4a2026; border-color: #9b424a; }
+    .line.from-operator { --speaker-color: var(--red); background: #191318; border-color: #3b252c; }
+    .line.pending { outline: 1px solid rgba(232, 179, 57, 0.25); }
     .line.failed .text { color: #ff7479; }
     @media (max-width: 760px) {
       #room { padding-inline: 8px; }
-      .line { padding-inline: 8px; }
+      .line { padding: 9px 10px 10px; margin-block: 6px; }
       .line .text { padding-left: 0; }
     }
     .composer { display: flex; gap: 6px; padding: 10px 16px; border-top: 1px solid var(--border); }

--- a/web/static/js/chatView.mjs
+++ b/web/static/js/chatView.mjs
@@ -89,6 +89,16 @@ export function renderMentionText(text, targets = []) {
   return html;
 }
 
+/** Highlight inline code without allowing it to become executable markup. */
+export function renderChatText(text, targets = []) {
+  return String(text ?? '').split(/(`[^`\n]+`)/g).map((part) => {
+    if (part.length >= 2 && part.startsWith('`') && part.endsWith('`')) {
+      return `<code>${escapeHtml(part.slice(1, -1))}</code>`;
+    }
+    return renderMentionText(part, targets);
+  }).join('');
+}
+
 /** `[14:02] name (worker · AGT-1009): message` as one room line. */
 export function renderLine(line, mentionTargets = []) {
   const color = ROLE_COLORS[line.role] ?? ROLE_COLORS.agent;
@@ -99,11 +109,11 @@ export function renderLine(line, mentionTargets = []) {
   const to = line.recipientName
     ? `<span class="to">→ ${mentionMarkup(line.recipientName, line.recipientRole)}</span>`
     : '';
-  return `<div class="line${line.isOperator ? ' from-operator' : ''}${statusClass}" data-line="${escapeHtml(line.id)}">
+  return `<div class="line${line.isOperator ? ' from-operator' : ''}${statusClass}" data-line="${escapeHtml(line.id)}" style="--speaker-color:${color}">
     <span class="meta"><span class="clock">[${escapeHtml(clockOf(line.timestamp))}]</span>
     <span class="who" style="color:${color}">${escapeHtml(line.speakerName)}</span>
     ${tag}${to}<span class="sep">:</span></span>
-    <span class="text">${renderMentionText(line.text, mentionTargets)}</span>
+    <span class="text">${renderChatText(line.text, mentionTargets)}</span>
   </div>`;
 }
 


### PR DESCRIPTION
## Summary
- present each utterance as a bounded, role-colored transcript card inspired by Claude Code and Codex
- strengthen agent/operator mention chips and role badges
- render escaped backtick spans as code chips and cap text measure for scanning

## Verification
- 
> @intrect/openswarm@0.21.1 test
> node --experimental-vm-modules node_modules/vitest/vitest.mjs run --run tests/web/chatView.test.ts tests/web/conversationModel.test.ts


 RUN  v4.1.8 /Users/unohee/dev/OpenSwarm-swarm/chat-mention-highlights


 Test Files  2 passed (2)
      Tests  55 passed (55)
   Start at  22:40:53
   Duration  2.11s (transform 88ms, setup 28ms, import 90ms, tests 1.60s, environment 335ms) (55 passed)
- 
> @intrect/openswarm@0.21.1 typecheck
> tsc --noEmit -p tsconfig.check.json
- 
> @intrect/openswarm@0.21.1 lint
> oxlint src/

Found 0 warnings and 0 errors.
Finished in 55ms on 706 files with 91 rules using 10 threads.
- 
> @intrect/openswarm@0.21.1 build
> tsc


> @intrect/openswarm@0.21.1 postbuild
> chmod +x dist/cli.js && node -e "const fs=require('node:fs');fs.rmSync('dist/web-static',{recursive:true,force:true});fs.cpSync('web/static','dist/web-static',{recursive:true})"
- 
- • Config loading from /Users/unohee/.config/openswarm/config.yaml
• [Config] TimeWindow loaded enabled: false
No working-tree changes to review. — APPROVE