### PR TITLE
feat(chat): agent/system 스레드와 Linear 카드 문맥 표시

### DIFF
--- a/src/automation/autonomousRunner.coverage.test.ts
+++ b/src/automation/autonomousRunner.coverage.test.ts
@@ -606,8 +606,10 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
       expect(info[0].name).toBe('WAVE');
       expect(info[0].path).toBe('/x/a');
       expect(info[0].enabled).toBe(true);
-      expect(info[0].running.map((t) => t.id)).toEqual(['running-1']);
-      expect(info[0].pending.map((t) => t.id)).toEqual(['pending-1']);
+      // Dashboard task ids use the same event key as coordination/SSE. A
+      // TaskItem may have a local id distinct from its Linear issue id.
+      expect(info[0].running.map((t) => t.id)).toEqual(['ISSUE-RUNNING']);
+      expect(info[0].pending.map((t) => t.id)).toEqual(['ISSUE-PENDING']);
     });
   });
 

--- a/src/automation/runnerState.coverage.test.ts
+++ b/src/automation/runnerState.coverage.test.ts
@@ -56,14 +56,14 @@ describe('runnerState persistence and helpers', () => {
 
   it('joins a quiet pinned repository to fetched tasks by Linear project id', () => {
     const projects = mod.buildProjectsInfo([
-      task('cgf-1', 'CGF-Portal'),
+      task('cgf-1', 'CGF-Portal', 1, { issueIdentifier: 'AX-1', issueUrl: 'https://linear.app/intrect/issue/AX-1/card' }),
     ] as any, [], [], new Map(), new Set(['/work/cgf-portal']));
 
     expect(projects[0]).toMatchObject({
       path: '',
       name: 'CGF-Portal',
       linearProjectId: 'CGF-Portal-id',
-      pending: [expect.objectContaining({ id: 'cgf-1' })],
+      pending: [expect.objectContaining({ id: 'cgf-1-issue', issueIdentifier: 'AX-1', issueUrl: 'https://linear.app/intrect/issue/AX-1/card' })],
     });
     expect(mod.projectInfoForRepository(projects, {
       path: '/work/cgf-portal',
@@ -92,8 +92,8 @@ describe('runnerState persistence and helpers', () => {
     expect(projects[0]).toMatchObject({
       name: 'CGF-Portal',
       linearProjectId: 'CGF-Portal-id',
-      running: [expect.objectContaining({ id: 'cgf-2' })],
-      queued: [expect.objectContaining({ id: 'cgf-3' })],
+      running: [expect.objectContaining({ id: 'cgf-2-issue' })],
+      queued: [expect.objectContaining({ id: 'cgf-3-issue' })],
     });
   });
 
@@ -267,13 +267,13 @@ describe('runnerState persistence and helpers', () => {
     const info = mod.buildProjectsInfo(fetched as any, running as any, queued as any, new Map([['Beta', '/repo/beta']]), new Set(['/repo/app']));
     const alpha = info.find(p => p.name === 'Alpha')!;
     expect(alpha.enabled).toBe(true);
-    expect(alpha.running).toEqual([{ id: 'r', title: 'Task r', priority: 9 }]);
-    expect(alpha.pending.map(p => p.id)).toEqual(['a']);
+    expect(alpha.running).toEqual([{ id: 'r-issue', title: 'Task r', priority: 9 }]);
+    expect(alpha.pending.map(p => p.id)).toEqual(['a-issue']);
     const gamma = info.find(p => p.name === 'Gamma')!;
-    expect(gamma.queued[0].id).toBe('q');
+    expect(gamma.queued[0].id).toBe('q-issue');
     expect(gamma.enabled).toBe(false);
     const beta = info.find(p => p.name === 'Beta')!;
-    expect(beta.pending[0]).toMatchObject({ id: 'b', issueIdentifier: 'BET-1', linearState: 'Todo' });
+    expect(beta.pending[0]).toMatchObject({ id: 'b-issue', issueIdentifier: 'BET-1', linearState: 'Todo' });
   });
 
   it('formats retry times in friendly units', () => {

--- a/src/automation/runnerState.ts
+++ b/src/automation/runnerState.ts
@@ -6,7 +6,7 @@
 import { existsSync, readFileSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, dirname, isAbsolute, relative, sep } from 'node:path';
-import type { TaskItem } from '../orchestration/decisionEngine.js';
+import { taskEventKey, type TaskItem } from '../orchestration/decisionEngine.js';
 import type { PipelineResult } from '../agents/pairPipelineTypes.js';
 import { atomicWriteFileSync } from '../support/atomicFile.js';
 
@@ -687,9 +687,9 @@ export interface ProjectInfo {
   /** Stable tracker identity used to join a pinned repo without name guessing. */
   linearProjectId?: string;
   enabled: boolean;
-  running: { id: string; title: string; priority: number }[];
-  queued: { id: string; title: string; priority: number }[];
-  pending: { id: string; title: string; priority: number; issueIdentifier?: string; linearState?: string }[];
+  running: { id: string; title: string; priority: number; issueIdentifier?: string; issueUrl?: string }[];
+  queued: { id: string; title: string; priority: number; issueIdentifier?: string; issueUrl?: string }[];
+  pending: { id: string; title: string; priority: number; issueIdentifier?: string; issueUrl?: string; linearState?: string }[];
 }
 
 type RunningEntry = { task: TaskItem; projectPath: string };
@@ -753,11 +753,24 @@ export function buildProjectsInfo(
       ...(proj.id ? { linearProjectId: proj.id } : {}),
       enabled: Boolean(projectPath) && isPathEnabled(projectPath, enabledProjects),
       running: running.filter(r => belongsToProject(r.task))
-        .map(r => ({ id: r.task.id, title: r.task.title, priority: r.task.priority })),
+        .map(r => ({
+          id: taskEventKey(r.task), title: r.task.title, priority: r.task.priority,
+          ...(r.task.issueIdentifier ? { issueIdentifier: r.task.issueIdentifier } : {}),
+          ...(r.task.issueUrl ? { issueUrl: r.task.issueUrl } : {}),
+        })),
       queued: queued.filter(q => belongsToProject(q.task))
-        .map(q => ({ id: q.task.id, title: q.task.title, priority: q.task.priority })),
+        .map(q => ({
+          id: taskEventKey(q.task), title: q.task.title, priority: q.task.priority,
+          ...(q.task.issueIdentifier ? { issueIdentifier: q.task.issueIdentifier } : {}),
+          ...(q.task.issueUrl ? { issueUrl: q.task.issueUrl } : {}),
+        })),
       pending: proj.tasks.filter(t => !activeIds.has(t.issueId || t.id))
-        .map(t => ({ id: t.id, title: t.title, priority: t.priority, issueIdentifier: t.issueIdentifier || t.issueId, linearState: t.linearState })),
+        .map(t => ({
+          id: taskEventKey(t), title: t.title, priority: t.priority,
+          ...(t.issueIdentifier || t.issueId ? { issueIdentifier: t.issueIdentifier || t.issueId } : {}),
+          ...(t.issueUrl ? { issueUrl: t.issueUrl } : {}),
+          ...(t.linearState ? { linearState: t.linearState } : {}),
+        })),
     };
   });
 }

--- a/src/automation/workRunner.ts
+++ b/src/automation/workRunner.ts
@@ -271,6 +271,7 @@ export async function dispatchWork(
       id: issue.id,
       identifier: issue.identifier,
       title: issue.title,
+      url: issue.url,
       description: issue.description,
       priority: issue.priority,
       state: issue.state,

--- a/src/cli/workCommand.ts
+++ b/src/cli/workCommand.ts
@@ -432,6 +432,7 @@ async function runWorkCommandInner(
       id: issue.id,
       identifier: issue.identifier,
       title: issue.title,
+      url: issue.url,
       description: issue.description,
       priority: issue.priority,
       state: issue.state,

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -235,6 +235,7 @@ async function startServiceLocked(config: SwarmConfig): Promise<void> {
           id: issue.id,
           identifier: issue.identifier,
           title: issue.title,
+          url: issue.url,
           description: issue.description,
           priority: issue.priority,
           state: issue.state,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -58,6 +58,8 @@ export type LinearIssueInfo = {
   id: string;
   identifier: string;
   title: string;
+  /** Canonical Linear card URL, fetched with the bulk issue projection. */
+  url?: string;
   description?: string;
   state: string;
   /** Linear workflow-state type, populated by explicit single-issue lookups. */

--- a/src/discord/discordHandlers.ts
+++ b/src/discord/discordHandlers.ts
@@ -885,6 +885,7 @@ export async function handleAuto(msg: Message, args: string[]): Promise<void> {
             id: issue.id,
             identifier: issue.identifier,
             title: issue.title,
+            url: issue.url,
             description: issue.description,
             priority: issue.priority || 3,
             dueDate: issue.dueDate,

--- a/src/linear/linear.test.ts
+++ b/src/linear/linear.test.ts
@@ -20,15 +20,20 @@ describe('effectCommentId', () => {
 describe('fetchIssuesForStates pagination', () => {
   it('collects every page', async () => {
     let page = 0;
+    const queries: string[] = [];
     const linear = {
       client: {
-        rawRequest: async () => ({ data: { issues: {
+        rawRequest: async (query: string) => {
+          queries.push(query);
+          return ({ data: { issues: {
           nodes: [{ id: `id-${page}`, identifier: `INT-${page}`, title: 't', priority: 2 }],
           pageInfo: { hasNextPage: page++ === 0, endCursor: `cursor-${page}` },
-        } } }),
+          } } });
+        },
       },
     } as unknown as LinearClient;
     expect((await fetchIssuesForStates(linear, ['Todo'])).nodes.map((node) => node.id)).toEqual(['id-0', 'id-1']);
+    expect(queries[0]).toMatch(/\burl\b/);
   });
 
   it('reports explicit truncation instead of silently returning a partial set', async () => {

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -75,6 +75,7 @@ interface RawIssueNode {
   id: string;
   identifier: string;
   title: string;
+  url?: string;
   description?: string | null;
   priority: number;
   createdAt?: string;
@@ -92,6 +93,7 @@ const ISSUES_QUERY = `
         id
         identifier
         title
+        url
         description
         priority
         createdAt
@@ -110,6 +112,7 @@ const STUCK_ISSUES_QUERY = `
         id
         identifier
         title
+        url
         description
         priority
         updatedAt
@@ -443,6 +446,7 @@ export async function getInProgressIssues(
       id: issue.id,
       identifier: issue.identifier,
       title: issue.title,
+      url: issue.url,
       description: issue.description ?? undefined,
       state: state?.name ?? 'Unknown',
       priority: issue.priority,
@@ -515,6 +519,7 @@ export async function getNextBacklogIssue(
     id: issue.id,
     identifier: issue.identifier,
     title: issue.title,
+    url: issue.url,
     description: issue.description ?? undefined,
     state: state?.name ?? 'Unknown',
     priority: issue.priority,
@@ -687,6 +692,7 @@ export async function getMyIssues(
           id: issue.id,
           identifier: issue.identifier,
           title: issue.title,
+          url: issue.url,
           description: issue.description ?? undefined,
           state,
           priority: issue.priority,
@@ -719,6 +725,7 @@ export async function getMyIssues(
           id: issue.id,
           identifier: issue.identifier,
           title: issue.title,
+          url: issue.url,
           description: issue.description ?? undefined,
           state: issue.state?.name ?? 'Unknown',
           priority: issue.priority,
@@ -861,6 +868,7 @@ async function fetchIssue(issueIdOrIdentifier: string): Promise<LinearIssueInfo 
       id: issue.id,
       identifier: issue.identifier,
       title: issue.title,
+      url: issue.url,
       description: issue.description ?? undefined,
       state: issueState?.name ?? 'Unknown',
       stateType: issueState?.type ?? undefined,
@@ -1377,6 +1385,7 @@ export async function createIssue(
     id: issue.id,
     identifier: issue.identifier,
     title: issue.title,
+    url: issue.url,
     description: issue.description ?? undefined,
     state: stateName,
     priority: issue.priority,
@@ -1451,6 +1460,7 @@ export async function createSubIssue(
       id: issue.id,
       identifier: issue.identifier,
       title: issue.title,
+      url: issue.url,
       description: issue.description ?? undefined,
       state: stateName,
       priority: issue.priority,
@@ -1626,6 +1636,7 @@ _This issue was auto-created by an agent. Please review and adjust priority or d
     id: issue.id,
     identifier: issue.identifier,
     title: issue.title,
+    url: issue.url,
     description: issue.description ?? undefined,
     state: 'Backlog',
     priority: 4,
@@ -1679,6 +1690,7 @@ export async function getStuckIssues(): Promise<{
         id: issue.id,
         identifier: issue.identifier,
         title: issue.title,
+        url: issue.url,
         description: issue.description ?? undefined,
         state: issue.state?.name ?? 'Unknown',
         priority: issue.priority,
@@ -1722,6 +1734,7 @@ export async function getStuckIssues(): Promise<{
       id: issue.id,
       identifier: issue.identifier,
       title: issue.title,
+      url: issue.url,
       description: issue.description ?? undefined,
       state: issue.state?.name ?? 'Unknown',
       priority: issue.priority,

--- a/src/orchestration/decisionEngine.stuck.test.ts
+++ b/src/orchestration/decisionEngine.stuck.test.ts
@@ -53,11 +53,13 @@ describe('linearIssueToTask — label propagation', () => {
       id: 'uuid-1',
       identifier: 'INT-1',
       title: 'x',
+      url: 'https://linear.app/intrect/issue/INT-1/x',
       priority: 2,
       state: 'Backlog',
       labels: ['swarm:stuck', 'core'],
     });
     expect(task.labels).toEqual(['swarm:stuck', 'core']);
+    expect(task.issueUrl).toBe('https://linear.app/intrect/issue/INT-1/x');
   });
 
   it('leaves labels undefined when none are provided', () => {

--- a/src/orchestration/decisionEngine.ts
+++ b/src/orchestration/decisionEngine.ts
@@ -52,6 +52,7 @@ export interface TaskItem {
   linearProject?: LinearProject;  // Linear project info
   issueId?: string;        // Linear issue ID
   issueIdentifier?: string; // Linear issue identifier (e.g., LIN-123)
+  issueUrl?: string;       // Canonical Linear card URL
   linearState?: string;    // Linear issue state (e.g., 'Todo', 'Backlog', 'In Progress')
   labels?: string[];       // Linear label names (e.g., 'swarm:stuck') — used to gate re-selection
   parentId?: string;       // Parent issue ID (for decomposed sub-tasks)
@@ -977,6 +978,7 @@ export function linearIssueToTask(issue: {
   id: string;
   identifier: string;
   title: string;
+  url?: string;
   description?: string;
   priority: number;
   dueDate?: string;
@@ -995,6 +997,7 @@ export function linearIssueToTask(issue: {
     priority: issue.priority || 3,
     issueId: issue.id,
     issueIdentifier: issue.identifier,
+    issueUrl: issue.url,
     linearState: issue.state,
     labels: issue.labels,
     parentId: issue.parentId,

--- a/tests/web/chatView.test.ts
+++ b/tests/web/chatView.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 // @ts-expect-error — browser ESM asset without type declarations
-import { startChatView, isNearBottom, renderChatText, renderLine, renderMentionText } from '../../web/static/js/chatView.mjs';
+import { buildTaskReferenceIndex, startChatView, isNearBottom, renderChatText, renderIssueReference, renderLine, renderMentionText } from '../../web/static/js/chatView.mjs';
 
 function shell(): Document {
   document.body.innerHTML = `
@@ -44,13 +44,19 @@ function boardEvent(over: Record<string, unknown> = {}) {
   };
 }
 
-function fetchWith(history: unknown[], board: unknown[] = [], messageResponse?: unknown) {
+function fetchWith(history: unknown[], board: unknown[] = [], messageResponse?: unknown, context: { projects?: unknown[]; sessions?: Record<string, unknown> } = {}) {
   return vi.fn(async (url: string) => {
     if (url.startsWith('/api/coordination/message')) {
       return messageResponse ?? { ok: true, json: async () => ({ delivered: true }) };
     }
     if (url.startsWith('/api/coordination/history')) {
       return { ok: true, json: async () => ({ events: history, traceSize: history.length }) };
+    }
+    if (url === '/api/projects') {
+      return { ok: true, json: async () => context.projects ?? [] };
+    }
+    if (url.startsWith('/api/work/sessions')) {
+      return { ok: true, json: async () => context.sessions ?? { sessions: [], recent: [] } };
     }
     return { ok: true, json: async () => ({ events: board, pending: [], lastSeq: 0 }) };
   });
@@ -71,7 +77,9 @@ describe('startChatView', () => {
     const lines = [...doc.querySelectorAll('#room .line')];
     // Oldest first, like a room transcript.
     expect(lines[0].querySelector('.who')!.textContent).toBe('Enginseer Rhodanis-Novum');
-    expect(lines[0].querySelector('.tag')!.textContent).toBe('(worker · AGT-1009)');
+    expect(doc.querySelectorAll('#room .chat-thread')).toHaveLength(1);
+    expect(doc.querySelector('#room .issue-code')!.textContent).toBe('AGT-1009');
+    expect(lines[0].querySelector('.tag')!.textContent).toBe('(worker)');
     expect(lines[0].querySelector('.clock')!.textContent).toMatch(/^\[.+\]$/);
     expect(lines[0].querySelector('.text')!.textContent).toBe('Landed the retry change.');
     // The reply prefers its long form and names its addressee.
@@ -166,6 +174,52 @@ describe('startChatView', () => {
     await vi.waitFor(() => expect(doc.querySelectorAll('#room .line').length).toBe(2));
     expect(doc.querySelectorAll('#room .line.from-operator').length).toBe(1);
     expect(doc.querySelector('#room .line.from-operator .who')!.textContent).toBe('Operator');
+    view.stop();
+  });
+
+  it('renders agent speech and system notices as distinct threaded channels', async () => {
+    const doc = shell();
+    const view = startChatView(doc, {
+      fetchImpl: fetchWith([
+        boardEvent({ id: 'chat', seq: 1, correlationId: 'chat-topic' }),
+        boardEvent({ id: 'system-start', seq: 2, correlationId: 'review-topic', kind: 'review-run', status: 'running', summary: '검토 시작' }),
+        boardEvent({ id: 'system-end', seq: 3, correlationId: 'review-topic', kind: 'review-run', status: 'failed', summary: '196.2초 만에 통과하지 못함' }),
+      ]),
+      eventSourceImpl: null,
+    });
+    await vi.waitFor(() => expect(doc.querySelectorAll('#room .line')).toHaveLength(3));
+    expect(doc.querySelectorAll('#room .thread-chat')).toHaveLength(1);
+    expect(doc.querySelectorAll('#room .thread-system')).toHaveLength(1);
+    expect(doc.querySelector('.thread-chat .channel-badge')?.textContent).toBe('CHAT');
+    expect(doc.querySelector('.thread-system .channel-badge')?.textContent).toBe('SYSTEM');
+    expect(doc.querySelectorAll('.thread-system .line')).toHaveLength(2);
+    view.stop();
+  });
+
+  it('shows the cached Linear card title and canonical hyperlink in the thread header', async () => {
+    const doc = shell();
+    const view = startChatView(doc, {
+      fetchImpl: fetchWith([boardEvent({ id: 'linked', taskId: 'task-1009' })], [], undefined, {
+        projects: [{ pending: [{ id: 'task-1009', issueIdentifier: 'AGT-1009', title: 'Fix retry scheduling', issueUrl: 'https://linear.app/intrect/issue/AGT-1009/fix-retry' }] }],
+      }),
+      eventSourceImpl: null,
+    });
+    await vi.waitFor(() => expect(doc.querySelector('#room .issue-title')?.textContent).toBe('Fix retry scheduling'));
+    const link = doc.querySelector('#room a.issue-link') as HTMLAnchorElement;
+    expect(link.textContent).toContain('AGT-1009');
+    expect(link.href).toBe('https://linear.app/intrect/issue/AGT-1009/fix-retry');
+    view.stop();
+  });
+
+  it('does not let a newer system notice become the composer recipient', async () => {
+    const doc = shell();
+    const fetchImpl = fetchWith([
+      boardEvent({ id: 'agent', seq: 1, actor: 'real-agent', actorName: 'Real Agent' }),
+      boardEvent({ id: 'system', seq: 2, actor: 'daemon', actorName: 'Daemon', actorRole: 'daemon', kind: 'mcp-audit', correlationId: 'audit' }),
+    ]);
+    const view = startChatView(doc, { fetchImpl, eventSourceImpl: null });
+    await vi.waitFor(() => expect(doc.querySelectorAll('#room .line')).toHaveLength(2));
+    expect((doc.getElementById('composer-text') as HTMLInputElement).placeholder).toBe('Message Real Agent…');
     view.stop();
   });
 
@@ -319,6 +373,24 @@ describe('renderLine', () => {
       '<img src=x onerror=alert(1)>', 'web/router.ts',
     ]);
     expect(document.querySelector('img')).toBeNull();
+  });
+});
+
+describe('Linear task references', () => {
+  it('joins project-cache links with recent-session titles by task id and code', () => {
+    const index = buildTaskReferenceIndex(
+      [{ running: [{ id: 'task-1', issueIdentifier: 'AGT-1', title: 'Cached title', issueUrl: 'https://linear.app/intrect/issue/AGT-1/card' }] }],
+      { sessions: [{ taskId: 'task-1', issueIdentifier: 'AGT-1', title: 'Live title' }], recent: [] },
+    );
+    expect(index.get('task-1')).toMatchObject({ code: 'AGT-1', title: 'Live title' });
+    expect(index.get('AGT-1').url).toBe('https://linear.app/intrect/issue/AGT-1/card');
+  });
+
+  it('renders unsafe issue URLs as non-clickable escaped text', () => {
+    document.body.innerHTML = renderIssueReference({ code: 'AGT-9', title: '<script>bad()</script>', url: 'javascript:alert(1)' });
+    expect(document.querySelector('a')).toBeNull();
+    expect(document.querySelector('script')).toBeNull();
+    expect(document.body.textContent).toContain('<script>bad()</script>');
   });
 });
 

--- a/tests/web/conversationModel.test.ts
+++ b/tests/web/conversationModel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 // @ts-expect-error - plain ESM module served to the browser
-import { buildChatLines, buildThreads, chatLineOf, isUtterance, latestAddressable, metadataPairs, openQuestionFor, taskLabelOf, threadFor } from '../../web/static/js/conversationModel.mjs';
+import { buildChatLines, buildChatThreads, buildThreads, chatLineOf, isAgentMessage, isSystemEvent, isUtterance, latestAddressable, metadataPairs, openQuestionFor, taskLabelOf, threadFor } from '../../web/static/js/conversationModel.mjs';
 
 function event(overrides: Record<string, unknown> = {}) {
   return {
@@ -153,6 +153,27 @@ describe('buildChatLines', () => {
       event({ id: 'first', seq: 1 }),
     ]);
     expect(lines.map((line: { id: string }) => line.id)).toEqual(['first', 'later']);
+  });
+});
+
+describe('buildChatThreads', () => {
+  it('groups the same durable exchange and keeps its messages chronological', () => {
+    const threads = buildChatThreads([
+      event({ id: 'done', seq: 8, kind: 'review-run', status: 'failed', summary: '196.2초 만에 통과하지 못함' }),
+      event({ id: 'start', seq: 7, kind: 'review-run', status: 'running', summary: '검토 시작' }),
+      event({ id: 'chat', seq: 2, correlationId: 'chat-1', summary: '작업을 시작합니다' }),
+    ]);
+    expect(threads.map((thread: { correlationId: string }) => thread.correlationId)).toEqual(['chat-1', 'c1']);
+    expect(threads[1].channel).toBe('system');
+    expect(threads[1].lines.map((line: { id: string }) => line.id)).toEqual(['start', 'done']);
+  });
+
+  it('classifies explicit control-plane kinds without hiding them', () => {
+    const system = event({ kind: 'mcp-audit' });
+    expect(isSystemEvent(system)).toBe(true);
+    expect(isAgentMessage(system)).toBe(false);
+    expect(isUtterance(system)).toBe(true);
+    expect(buildChatThreads([system])[0].lines).toHaveLength(1);
   });
 });
 

--- a/web/static/chat.html
+++ b/web/static/chat.html
@@ -21,6 +21,30 @@
     #room::-webkit-scrollbar { width: 6px; }
     #room::-webkit-scrollbar-thumb { background: #2a3140; border-radius: 3px; }
     #room::-webkit-scrollbar-track { background: transparent; }
+    .chat-thread { --thread-accent: var(--cyan); max-width: 1320px; margin: 10px auto; border: 1px solid #202838; border-radius: 8px; background: #0f141d; overflow: hidden; box-shadow: inset 3px 0 var(--thread-accent); }
+    .chat-thread.thread-system { --thread-accent: var(--amber); margin-block: 6px; background: #0d1118; border-color: #292719; box-shadow: inset 2px 0 rgba(232, 179, 57, 0.75); }
+    .thread-head { min-height: 31px; display: flex; align-items: center; gap: 8px; padding: 6px 12px 6px 15px; border-bottom: 1px solid #202838; background: #111824; }
+    .thread-system .thread-head { min-height: 27px; padding-block: 4px; background: #14130e; border-color: #292719; }
+    .channel-badge { flex: none; color: #a9d4ff; background: #102c47; border: 1px solid #285f8d; border-radius: 3px; padding: 0 6px; font-size: 10px; font-weight: 800; letter-spacing: .08em; }
+    .thread-system .channel-badge { color: #f0ca71; background: #332b12; border-color: #746022; }
+    .thread-kind { margin-left: auto; color: #68758c; font-size: 10.5px; white-space: nowrap; }
+    .issue-link { min-width: 0; display: inline-flex; align-items: baseline; gap: 7px; color: inherit; text-decoration: none; overflow: hidden; }
+    a.issue-link:hover .issue-title { color: #cde6ff; text-decoration: underline; text-underline-offset: 2px; }
+    .issue-code { flex: none; color: #83c2ff; font-weight: 750; }
+    .thread-system .issue-code { color: #e8c466; }
+    .issue-sep { flex: none; color: #4d586b; }
+    .issue-title { color: #aeb9ca; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .issue-link-plain .issue-code { color: #9aa6bd; }
+    .thread-lines { position: relative; }
+    .thread-lines .line { position: relative; max-width: none; margin: 0; padding: 10px 14px 11px 31px; border: 0; border-radius: 0; background: transparent; box-shadow: none; }
+    .thread-lines .line + .line { border-top: 1px solid rgba(42, 53, 72, 0.65); }
+    .thread-lines .line::before { content: ""; position: absolute; left: 16px; top: 18px; width: 6px; height: 6px; border-radius: 50%; background: var(--speaker-color); box-shadow: 0 0 7px color-mix(in srgb, var(--speaker-color) 65%, transparent); }
+    .thread-lines .line:not(:last-child)::after { content: ""; position: absolute; left: 18.5px; top: 25px; bottom: -9px; width: 1px; background: #303b4e; }
+    .thread-lines .line:hover { background: #121925; }
+    .thread-system .thread-lines .line { padding-block: 7px 8px; background: transparent; }
+    .thread-system .thread-lines .line:hover { background: #12130f; }
+    .thread-system .line .who, .thread-system .line .tag { color: #8d8b7f !important; }
+    .thread-system .line .text { color: #b9b8ae; font-size: 12.5px; line-height: 1.6; margin-top: 4px; }
     .line { --speaker-color: var(--dim); max-width: 1320px; padding: 11px 14px 12px; margin: 8px auto; border: 1px solid #202838; border-radius: 7px; background: #0f141d; box-shadow: inset 3px 0 var(--speaker-color); overflow-wrap: anywhere; }
     .line:hover { background: #121925; border-color: #2a3548; }
     .line .meta { display: flex; flex-wrap: wrap; align-items: center; gap: 0; min-width: 0; font-size: 11.5px; line-height: 1.55; }
@@ -41,6 +65,12 @@
       #room { padding-inline: 8px; }
       .line { padding: 9px 10px 10px; margin-block: 6px; }
       .line .text { padding-left: 0; }
+      .chat-thread { margin-block: 7px; }
+      .thread-head { padding-inline: 10px; }
+      .thread-kind { display: none; }
+      .thread-lines .line { margin: 0; padding-left: 25px; }
+      .thread-lines .line::before { left: 11px; }
+      .thread-lines .line:not(:last-child)::after { left: 13.5px; }
     }
     .composer { display: flex; gap: 6px; padding: 10px 16px; border-top: 1px solid var(--border); }
     .composer input { flex: 1; background: #0d1117; border: 1px solid var(--border); border-radius: 4px; color: var(--white); padding: 6px 10px; font: inherit; font-size: 12px; }

--- a/web/static/js/chatView.mjs
+++ b/web/static/js/chatView.mjs
@@ -8,7 +8,7 @@
 // (`/api/coordination/history`), live updates from the same SSE channel the
 // orchestration view uses, with the board snapshot as a polling backstop.
 
-import { buildChatLines, latestAddressable, openQuestionFor } from './conversationModel.mjs';
+import { buildChatThreads, latestAddressable, openQuestionFor } from './conversationModel.mjs';
 import { ROLE_COLORS } from './orchestrationView.mjs';
 
 const PENDING = new Set(['open', 'waiting', 'running']);
@@ -100,9 +100,9 @@ export function renderChatText(text, targets = []) {
 }
 
 /** `[14:02] name (worker · AGT-1009): message` as one room line. */
-export function renderLine(line, mentionTargets = []) {
+export function renderLine(line, mentionTargets = [], { hideTask = false } = {}) {
   const color = ROLE_COLORS[line.role] ?? ROLE_COLORS.agent;
-  const tagParts = [line.speakerRole, line.taskLabel].filter(Boolean);
+  const tagParts = [line.speakerRole, hideTask ? '' : line.taskLabel].filter(Boolean);
   const tag = tagParts.length ? `<span class="tag">(${escapeHtml(tagParts.join(' · '))})</span> ` : '';
   const statusClass = PENDING.has(line.status) ? ' pending'
     : line.status === 'failed' || line.status === 'expired' ? ' failed' : '';
@@ -117,10 +117,110 @@ export function renderLine(line, mentionTargets = []) {
   </div>`;
 }
 
+function textOrEmpty(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function issueCodeOf(value) {
+  const code = textOrEmpty(value);
+  return /^[A-Z][A-Z0-9]*-\d+$/.test(code) ? code : '';
+}
+
+/** Only canonical Linear card links are allowed to leave the dashboard. */
+export function safeLinearUrl(value) {
+  try {
+    const url = new URL(textOrEmpty(value));
+    return url.protocol === 'https:' && url.hostname === 'linear.app' ? url.href : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Fold the daemon's already-fetched project/session projections into a lookup.
+ * No browser-side Linear request is made: the bulk runner cache remains the
+ * authority and recent sessions only fill titles missing from that cache.
+ */
+export function buildTaskReferenceIndex(projectsPayload, sessionsPayload) {
+  const index = new Map();
+  const add = (candidate) => {
+    if (!candidate || typeof candidate !== 'object') return;
+    const taskId = textOrEmpty(candidate.id ?? candidate.taskId);
+    const code = issueCodeOf(candidate.issueIdentifier);
+    const title = textOrEmpty(candidate.title);
+    const url = safeLinearUrl(candidate.issueUrl);
+    if (!taskId && !code) return;
+
+    const prior = index.get(taskId) ?? index.get(code) ?? {};
+    const reference = {
+      taskId: taskId || prior.taskId || '',
+      code: code || prior.code || '',
+      title: title || prior.title || '',
+      url: url || prior.url || '',
+    };
+    if (reference.taskId) index.set(reference.taskId, reference);
+    if (reference.code) index.set(reference.code, reference);
+  };
+
+  if (Array.isArray(projectsPayload)) {
+    for (const project of projectsPayload) {
+      for (const bucket of ['running', 'queued', 'pending']) {
+        if (Array.isArray(project?.[bucket])) project[bucket].forEach(add);
+      }
+    }
+  }
+  for (const bucket of ['sessions', 'recent']) {
+    if (Array.isArray(sessionsPayload?.[bucket])) sessionsPayload[bucket].forEach(add);
+  }
+  return index;
+}
+
+export function renderIssueReference(reference) {
+  if (!reference) return '';
+  const code = issueCodeOf(reference.code);
+  const title = textOrEmpty(reference.title);
+  if (!code && !title) return '';
+  const contents = [
+    code ? `<span class="issue-code">${escapeHtml(code)}</span>` : '',
+    title ? `<span class="issue-title">${escapeHtml(title)}</span>` : '',
+  ].filter(Boolean).join('<span class="issue-sep">—</span>');
+  const url = safeLinearUrl(reference.url);
+  return url
+    ? `<a class="issue-link" href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer">${contents}</a>`
+    : `<span class="issue-link issue-link-plain">${contents}</span>`;
+}
+
+function taskReferenceFor(thread, index) {
+  const label = issueCodeOf(thread.taskLabel);
+  return index.get(thread.taskId) ?? index.get(label) ?? (label ? { code: label } : null);
+}
+
+/** One durable exchange, with its issue context shown once in the header. */
+export function renderThread(thread, mentionTargets = [], taskReferences = new Map()) {
+  const system = thread.channel === 'system';
+  const channel = system ? 'SYSTEM' : 'CHAT';
+  const count = thread.lines.length;
+  const kind = system
+    ? String(thread.events[0]?.kind ?? 'system').replaceAll('-', ' ')
+    : `${count} message${count === 1 ? '' : 's'}`;
+  const issue = renderIssueReference(taskReferenceFor(thread, taskReferences));
+  const lines = thread.lines
+    .map((line) => renderLine(line, mentionTargets, { hideTask: true }))
+    .join('');
+  return `<section class="chat-thread thread-${system ? 'system' : 'chat'}" data-correlation="${escapeHtml(thread.correlationId)}">
+    <div class="thread-head">
+      <span class="channel-badge">${channel}</span>
+      ${issue}<span class="thread-kind">${escapeHtml(kind)}</span>
+    </div>
+    <div class="thread-lines">${lines}</div>
+  </section>`;
+}
+
 /** Entry point: backfill from the trace, render, keep live via SSE + polling. */
 export function startChatView(doc, { fetchImpl, eventSourceImpl, pollMs = 30_000 } = {}) {
   const fetcher = fetchImpl ?? ((url, init) => fetch(url, init));
   const byId = new Map();
+  let taskReferences = new Map();
   let stick = true;
 
   const room = doc.getElementById('room');
@@ -228,7 +328,8 @@ export function startChatView(doc, { fetchImpl, eventSourceImpl, pollMs = 30_000
 
   const redraw = () => {
     const events = [...byId.values()];
-    const lines = buildChatLines(events);
+    const threads = buildChatThreads(events);
+    const lines = threads.flatMap((thread) => thread.lines);
     const mentionTargets = [
       // The dashboard user is canonically named Operator even before they have
       // spoken in this retained window, so agents can mention them immediately.
@@ -238,8 +339,8 @@ export function startChatView(doc, { fetchImpl, eventSourceImpl, pollMs = 30_000
         ...(line.recipientName ? [{ name: line.recipientName, role: line.recipientRole }] : []),
       ]),
     ];
-    room.innerHTML = lines.length
-      ? lines.map((line) => renderLine(line, mentionTargets)).join('')
+    room.innerHTML = threads.length
+      ? threads.map((thread) => renderThread(thread, mentionTargets, taskReferences)).join('')
       : '<div class="empty">No one has said anything yet.</div>';
     // The composer can only address an agent that exists; without one the
     // POST would be unroutable (the API requires repository/taskId/recipient).
@@ -372,6 +473,29 @@ export function startChatView(doc, { fetchImpl, eventSourceImpl, pollMs = 30_000
     } catch { /* transient; the next poll retries */ }
   }
 
+  /** Load issue titles/links once from the daemon's local projections. */
+  async function loadTaskReferences() {
+    const results = await Promise.allSettled([
+      fetcher('/api/projects'),
+      fetcher('/api/work/sessions?limit=100'),
+    ]);
+    const payloads = [];
+    for (const result of results) {
+      if (result.status !== 'fulfilled' || !result.value?.ok) {
+        payloads.push(null);
+        continue;
+      }
+      try {
+        payloads.push(await result.value.json());
+      } catch {
+        payloads.push(null);
+      }
+    }
+    taskReferences = buildTaskReferenceIndex(payloads[0], payloads[1]);
+    redraw();
+  }
+
+  loadTaskReferences();
   backfill().then(() => refresh()).then(() => redraw());
   const timer = setInterval(refresh, pollMs);
 

--- a/web/static/js/conversationModel.mjs
+++ b/web/static/js/conversationModel.mjs
@@ -112,9 +112,31 @@ export function threadFor(threads, event) {
  */
 export const NON_CONVERSATION_KINDS = new Set(['instruction-snapshot']);
 
+/**
+ * Control-plane notices written by OpenSwarm itself, rather than words from an
+ * agent or the operator. Keep this list explicit: an unfamiliar event should
+ * remain visible as chat until its publisher declares it to be system state.
+ */
+export const SYSTEM_EVENT_KINDS = new Set([
+  'adapter-route',
+  'review-run',
+  'mcp-audit',
+  'council-update',
+]);
+
 /** True when the event is something an agent or the operator actually said. */
 export function isUtterance(event) {
   return !NON_CONVERSATION_KINDS.has(event.kind);
+}
+
+/** True when an event is visible control-plane state, not addressable speech. */
+export function isSystemEvent(event) {
+  return isUtterance(event) && SYSTEM_EVENT_KINDS.has(event.kind);
+}
+
+/** True when the operator can reasonably treat the event as someone's words. */
+export function isAgentMessage(event) {
+  return isUtterance(event) && !isSystemEvent(event);
 }
 
 /**
@@ -136,6 +158,7 @@ export function chatLineOf(event) {
     taskLabel: taskLabelOf(event),
     status: event.status,
     kind: event.kind,
+    channel: isSystemEvent(event) ? 'system' : 'chat',
     isOperator: event.actorRole === 'human',
   };
 }
@@ -146,6 +169,22 @@ export function buildChatLines(events) {
     .filter(isUtterance)
     .sort((a, b) => a.seq - b.seq)
     .map(chatLineOf);
+}
+
+/**
+ * Chat-room threads, oldest topic first. `correlationId` is the publisher's
+ * durable exchange identity, so it groups retries/results without guessing
+ * from similar prose. Events without one remain honest singleton threads.
+ */
+export function buildChatThreads(events) {
+  return buildThreads(events.filter(isUtterance))
+    .map((thread) => ({
+      ...thread,
+      firstSeq: thread.events[0]?.seq ?? 0,
+      channel: thread.events.every(isSystemEvent) ? 'system' : 'chat',
+      lines: thread.events.map(chatLineOf),
+    }))
+    .sort((a, b) => a.firstSeq - b.firstSeq);
 }
 
 /**
@@ -187,7 +226,7 @@ export function openQuestionFor(events, actorAddress, scope = {}) {
 }
 
 export function latestAddressable(events) {
-  const spoken = events.filter(isUtterance).sort((a, b) => a.seq - b.seq);
+  const spoken = events.filter(isAgentMessage).sort((a, b) => a.seq - b.seq);
   for (let i = spoken.length - 1; i >= 0; i -= 1) {
     if (spoken[i].actorRole !== 'human') return spoken[i];
   }


### PR DESCRIPTION
## 요약

- coordinationId가 아니라 correlationId를 실제 주제 키로 사용해 같은 교환을 한 스레드로 묶습니다.
- agent/operator 대화는 CHAT, review-run 및 mcp-audit 등 제어 이벤트는 SYSTEM으로 구별합니다.
- 기존 Linear bulk cache에 공식 URL을 보존하고 Chat은 로컬 projects/work sessions API만 읽어 카드 코드, 제목, 링크를 표시합니다.
- SYSTEM 이벤트가 composer의 최신 수신자를 가로채지 않도록 addressable speech를 분리했습니다.
- task.id와 issueId가 다른 경우도 taskEventKey로 프로젝트 캐시와 coordination event를 정확히 조인합니다.

## 검증

- npm test: 5,035 passed, 10 skipped
- npm run typecheck: pass
- npm run lint: 0 warnings, 0 errors
- npm run build: pass
- Playwright browser render: CHAT/SYSTEM thread grouping and Linear title/link visually verified
- openswarm review --path .: APPROVE

Linear: AGT-4139