### PR TITLE
fix(orchestration): admit greedy conflict wave (AGT-4143)

### DIFF
--- a/src/cli/workCommand.ts
+++ b/src/cli/workCommand.ts
@@ -42,6 +42,7 @@ import { loadRepoMetadata, type RepoMetadata } from '../support/repoMetadata.js'
 import { hasRecoverableWorktree } from '../support/worktreeManager.js';
 import { runPool } from '../support/concurrencyPool.js';
 import { fileScopesConflict, resolveTaskFileScope } from '../orchestration/conflictDetector.js';
+import { buildConflictFreeWaves as partitionConflictFreeWaves } from '../orchestration/conflictAdmission.js';
 import { ensureTaskSource } from './reviewCommand.js';
 import { filterRepoIssues, selectIssuesInteractive, WORK_SKIP_STATES } from './workSelect.js';
 import {
@@ -154,14 +155,10 @@ interface PlanRow {
  * reported as superseded instead of running in the next safe wave.
  */
 export function buildConflictFreeWaves<T extends { task: TaskItem }>(rows: readonly T[]): T[][] {
-  const waves: T[][] = [];
-  for (const row of rows) {
-    const wave = waves.find((candidate) => candidate.every((peer) =>
-      !fileScopesConflict(row.task.fileScope, peer.task.fileScope)));
-    if (wave) wave.push(row);
-    else waves.push([row]);
-  }
-  return waves;
+  return partitionConflictFreeWaves(
+    rows,
+    (left, right) => fileScopesConflict(left.task.fileScope, right.task.fileScope),
+  );
 }
 
 export interface WorkIssueSummary {

--- a/src/orchestration/conflictAdmission.test.ts
+++ b/src/orchestration/conflictAdmission.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildConflictFreeWaves,
+  selectGreedyMaximalIndependentSet,
+} from './conflictAdmission.js';
+
+describe('deterministic conflict admission', () => {
+  const conflicts = (left: string, right: string): boolean =>
+    new Set(['A:B', 'B:A', 'B:C', 'C:B']).has(`${left}:${right}`);
+
+  it('puts directly disjoint endpoints of a conflict chain in the first wave', () => {
+    expect(buildConflictFreeWaves(['A', 'B', 'C'], conflicts)).toEqual([
+      ['A', 'C'],
+      ['B'],
+    ]);
+  });
+
+  it('returns the first wave as the greedy maximal independent set', () => {
+    expect(selectGreedyMaximalIndependentSet(['A', 'B', 'C'], conflicts)).toEqual(['A', 'C']);
+    expect(selectGreedyMaximalIndependentSet([], conflicts)).toEqual([]);
+  });
+});

--- a/src/orchestration/conflictAdmission.ts
+++ b/src/orchestration/conflictAdmission.ts
@@ -1,0 +1,32 @@
+// ============================================
+// OpenSwarm - Deterministic conflict admission
+// ============================================
+
+/**
+ * Partition ordered candidates into deterministic pairwise-compatible waves.
+ *
+ * The caller owns ordering policy. With candidates ordered by priority and a
+ * stable input-position tie-break, the first wave is a deterministic greedy
+ * maximal independent set: every later candidate conflicts with at least one
+ * candidate already admitted to that first wave.
+ */
+export function buildConflictFreeWaves<T>(
+  candidates: readonly T[],
+  conflicts: (left: T, right: T) => boolean,
+): T[][] {
+  const waves: T[][] = [];
+  for (const candidate of candidates) {
+    const wave = waves.find((peers) => peers.every((peer) => !conflicts(candidate, peer)));
+    if (wave) wave.push(candidate);
+    else waves.push([candidate]);
+  }
+  return waves;
+}
+
+/** Select the first deterministic conflict-free wave without exposing later waves. */
+export function selectGreedyMaximalIndependentSet<T>(
+  candidates: readonly T[],
+  conflicts: (left: T, right: T) => boolean,
+): T[] {
+  return buildConflictFreeWaves(candidates, conflicts)[0] ?? [];
+}

--- a/src/orchestration/conflictDetector.coverage.test.ts
+++ b/src/orchestration/conflictDetector.coverage.test.ts
@@ -38,7 +38,7 @@ function impact(directModules: string[], dependentModules: string[] = []): Impac
 }
 
 describe('detectFileConflicts UnionFind rank tie-break branches', () => {
-  it('exercises both non-equal rank comparisons and the same-root early-return when a 4-task overlap chain merges asymmetrically', async () => {
+  it('keeps one diagnostic cohort while admitting both directly disjoint winners from an asymmetric overlap chain', async () => {
     // Overlap graph (by shared file), in the order the i<j pair loop visits them:
     //   0-2 share 'shared-02.ts'   fresh(0) vs fresh(2)              -> equal-rank tie, root=0, rank[0]=1
     //   0-3 share 'shared-03.ts'   root(0,rank1) vs fresh(3,rank0)   -> rankX>rankY branch
@@ -50,7 +50,7 @@ describe('detectFileConflicts UnionFind rank tie-break branches', () => {
       [
         task('A', 3, ['shared-02.ts', 'shared-03.ts']),
         task('B', 3, ['shared-12.ts', 'shared-13.ts']),
-        task('C', 1, ['shared-02.ts', 'shared-12.ts']), // highest priority (1) -> wins the group
+        task('C', 1, ['shared-02.ts', 'shared-12.ts']), // highest priority and directly disjoint from D
         task('D', 3, ['shared-03.ts', 'shared-13.ts']),
       ],
       PROJECT,
@@ -61,7 +61,7 @@ describe('detectFileConflicts UnionFind rank tie-break branches', () => {
     expect(new Set(result.conflictGroups[0].sharedModules)).toEqual(
       new Set(['shared-02.ts', 'shared-03.ts', 'shared-12.ts', 'shared-13.ts']),
     );
-    expect(result.safe.map((t) => t.id)).toEqual(['C']);
+    expect(result.safe.map((t) => t.id)).toEqual(['C', 'D']);
   });
 });
 

--- a/src/orchestration/conflictDetector.test.ts
+++ b/src/orchestration/conflictDetector.test.ts
@@ -79,6 +79,35 @@ describe('detectFileConflicts (planner-declared file scope)', () => {
     expect(result.safe).toHaveLength(2);
   });
 
+  it('admits directly disjoint endpoints from a transitive conflict chain', async () => {
+    const result = await detectFileConflicts(
+      [
+        task('A', 1, ['src/a-b.ts']),
+        task('B', 2, ['src/a-b.ts', 'src/b-c.ts']),
+        task('C', 1, ['src/b-c.ts']),
+      ],
+      PROJECT,
+    );
+
+    expect(result.conflictGroups).toHaveLength(1);
+    expect(result.conflictGroups[0].tasks.map((t) => t.id)).toEqual(['A', 'C', 'B']);
+    expect(result.safe.map((t) => t.id)).toEqual(['A', 'C']);
+  });
+
+  it('breaks equal-priority conflicts by stable input order', async () => {
+    const result = await detectFileConflicts(
+      [
+        task('first', 2, ['src/shared.ts']),
+        task('second', 2, ['src/shared.ts']),
+        task('third', 2, ['src/shared.ts']),
+      ],
+      PROJECT,
+    );
+
+    expect(result.conflictGroups[0].tasks.map((t) => t.id)).toEqual(['first', 'second', 'third']);
+    expect(result.safe.map((t) => t.id)).toEqual(['first']);
+  });
+
   it('ignores stale generated/worktree scope entries instead of creating false conflicts', async () => {
     const result = await detectFileConflicts(
       [
@@ -92,13 +121,17 @@ describe('detectFileConflicts (planner-declared file scope)', () => {
     expect(result.conflictGroups).toHaveLength(0);
   });
 
-  it('serializes unknown scope because merge safety cannot be proven', async () => {
+  it('serializes unknown scope against every peer because merge safety cannot be proven', async () => {
     const result = await detectFileConflicts(
-      [task('A', 2, ['unknown-file-scope']), task('B', 2, ['src/shared.ts'])],
+      [
+        task('unknown', 1, ['unknown-file-scope']),
+        task('known-a', 2, ['src/a.ts']),
+        task('known-b', 2, ['src/b.ts']),
+      ],
       PROJECT,
     );
 
-    expect(result.safe).toHaveLength(1);
+    expect(result.safe.map((t) => t.id)).toEqual(['unknown']);
     expect(result.conflictGroups).toHaveLength(1);
     expect(result.conflictGroups[0].sharedModules).toEqual(['unknown-file-scope']);
   });

--- a/src/orchestration/conflictDetector.ts
+++ b/src/orchestration/conflictDetector.ts
@@ -11,6 +11,7 @@ import {
   conflictScopesOverlap,
   normalizeConflictScope,
 } from './conflictScope.js';
+import { selectGreedyMaximalIndependentSet } from './conflictAdmission.js';
 
 // Types
 
@@ -74,6 +75,11 @@ function normalizeScope(entries: string[] | undefined): Set<string> {
 }
 
 const UNKNOWN_SCOPE = 'unknown-file-scope';
+
+function pairKey(left: number, right: number): string {
+  return left < right ? `${left}:${right}` : `${right}:${left}`;
+}
+
 /**
  * Resolve the best available preflight write scope for one task. The normalized
  * result is written back to the task so the scheduler and durable admission
@@ -127,8 +133,9 @@ export function fileScopesConflict(left: string[] | undefined, right: string[] |
  * Detect file-scope overlap between tasks. Each task's scope prefers the
  * planner-declared `fileScope` (authoritative), falling back to Knowledge Graph
  * inference (`analyzeIssue`) only when no explicit scope is available.
- * Overlapping tasks are grouped into a ConflictGroup; only the highest-priority
- * task in each group is returned as safe to run concurrently.
+ * Overlapping tasks are grouped into a ConflictGroup for diagnostics. Within
+ * each group, a priority-stable greedy maximal independent set is returned as
+ * safe, so transitively connected but directly disjoint tasks can still run.
  */
 export async function detectFileConflicts(
   tasks: TaskItem[],
@@ -215,8 +222,12 @@ export async function detectFileConflicts(
       continue;
     }
 
-    // 충돌 그룹: 최고 우선순위(낮은 숫자) 태스크만 safe에 포함
-    const groupTasks = indices.map(i => tasks[i]);
+    // Priority first (1=Urgent > 4=Low), then original input position. The
+    // explicit position tie-break keeps admission deterministic even if the
+    // runtime's Array#sort stability changes.
+    const orderedIndices = [...indices].sort((left, right) =>
+      tasks[left].priority - tasks[right].priority || left - right);
+    const groupTasks = orderedIndices.map(index => tasks[index]);
     const sharedModuleSet = new Set<string>();
     for (let a = 0; a < indices.length; a++) {
       for (let b = a + 1; b < indices.length; b++) {
@@ -229,11 +240,14 @@ export async function detectFileConflicts(
     }
     const sharedModules = Array.from(sharedModuleSet);
 
-    // 우선순위 기준 정렬 (1=Urgent > 4=Low)
-    groupTasks.sort((a, b) => a.priority - b.priority);
-
-    // 최고 우선순위 태스크만 safe
-    safe.push(groupTasks[0]);
+    // The first greedy wave is maximal: every deferred task has a direct edge
+    // to at least one admitted task. Unknown scopes have an edge to every peer,
+    // so uncertainty remains fail-closed and at most one unknown can be safe.
+    const admittedIndices = selectGreedyMaximalIndependentSet(
+      orderedIndices,
+      (left, right) => pairShared.has(pairKey(left, right)),
+    );
+    safe.push(...admittedIndices.map(index => tasks[index]));
 
     // 나머지는 충돌 그룹으로 기록
     conflictGroups.push({


### PR DESCRIPTION
## Summary

- admit a priority-stable, input-order-deterministic greedy maximal independent set from each conflict cohort
- preserve union-find cohorts, shared-module diagnostics, and fail-closed unknown-scope behavior
- share the deterministic conflict-free wave helper with the work CLI without changing its public contract

## Verification

- focused conflict, concurrency, CLI, and ledger tests: 181 passed
- full test suite: 5,032 passed, 10 skipped
- npm run typecheck
- npm run lint: 0 warnings, 0 errors
- npm run build
- openswarm review --path .: APPROVE

Linear: AGT-4143