### PR TITLE
fix(AGT-4144): enforce human-surface MCP read-only policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,8 +408,8 @@ existing role-scoped write contract.
 
 Native-loop shells additionally reject direct writes to known human-service
 endpoints and service CLIs, and both native and delegated worker processes omit
-human-service credentials from inherited environment variables while retaining
-model, DevOps, database, and sandbox-data settings. Delegated CLIs receive none
+product-scoped human-service credentials from inherited environment variables
+while retaining model, DevOps, database, and sandbox-data settings. Delegated CLIs receive none
 of OpenSwarm's MCP grants (`codex` disables inherited MCP and `claude` uses a
 strict MCP config); use a native-loop adapter when the policy must cover shell
 commands too. OpenSwarm cannot classify an arbitrary program that reads a

--- a/README.md
+++ b/README.md
@@ -407,10 +407,13 @@ Cloudflare, database/server tools, and sandbox-local data tools keep their
 existing role-scoped write contract.
 
 Native-loop shells additionally reject direct writes to known human-service
-endpoints and service CLIs, and both native and delegated worker processes omit
+endpoints and service CLIs. Microsoft Graph is narrowed to mail, message,
+calendar, chat, drive, and other human-facing path/action families so its
+device/directory DevOps APIs retain their existing contract. Both native and
+delegated worker processes omit
 product-scoped human-service credentials from inherited environment variables
-while retaining model, DevOps, database, and sandbox-data settings. Delegated CLIs receive none
-of OpenSwarm's MCP grants (`codex` disables inherited MCP and `claude` uses a
+while retaining model, DevOps, database, and sandbox-data settings. Delegated
+CLIs receive none of OpenSwarm's MCP grants (`codex` disables inherited MCP and `claude` uses a
 strict MCP config); use a native-loop adapter when the policy must cover shell
 commands too. OpenSwarm cannot classify an arbitrary program that reads a
 credential embedded inside the repository and implements its own network

--- a/README.md
+++ b/README.md
@@ -428,8 +428,9 @@ humanSurfaceReadOnly:
 
 With this switch on, OpenSwarm does not attempt to classify arbitrary programs:
 it removes native `bash` and compiler-spawning diagnostics, refuses delegated
-CLI adapters before command construction, and blocks the same hidden tool calls
-at dispatch. This closes `curl --config`, scripts, dynamic URLs, fake CLIs, and
+CLI adapters before availability/model discovery or command construction, and
+blocks the same hidden tool calls at dispatch. This closes `curl --config`,
+scripts, dynamic URLs, fake CLIs, and
 credentials found through inherited `HOME` by making their execution impossible.
 Use a native-loop adapter; local web chat remains available with file tools,
 read-only web access, and policy-filtered MCP tools. Approved typed DevOps/data

--- a/README.md
+++ b/README.md
@@ -406,18 +406,52 @@ decision but cannot turn a mutating action into a read. GitHub, Linear,
 Cloudflare, database/server tools, and sandbox-local data tools keep their
 existing role-scoped write contract.
 
-Native-loop shells additionally reject direct writes to known human-service
-endpoints and service CLIs. Microsoft Graph is narrowed to mail, message,
-calendar, chat, drive, and other human-facing path/action families so its
-device/directory DevOps APIs retain their existing contract. Both native and
-delegated worker processes omit
-product-scoped human-service credentials from inherited environment variables
-while retaining model, DevOps, database, and sandbox-data settings. Delegated
-CLIs receive none of OpenSwarm's MCP grants (`codex` disables inherited MCP and `claude` uses a
-strict MCP config); use a native-loop adapter when the policy must cover shell
-commands too. OpenSwarm cannot classify an arbitrary program that reads a
-credential embedded inside the repository and implements its own network
-protocol, so such credentials must not be placed in an agent worktree.
+Generic MCP HTTP/proxy tools are reclassified again at dispatch from their
+actual destination, method, and body arguments. An explicit `GET`, `HEAD`, or
+`OPTIONS` to Slack, Discord, Notion, Gmail, or a human-facing Microsoft Graph
+path remains readable; a write, dynamic destination, or ambiguous call fails
+before the MCP server is invoked. Concrete writes through a generic transport
+also require a write-declaring tool descriptor, the server to declare
+`surface: devops`, `data`, or `sandbox`, and (for autonomous roles) the same
+exact `writeTools` grant as any other mutation.
+Microsoft Graph device/directory paths remain DevOps; mail, message, calendar,
+chat, drive, and other human-facing paths do not. Specialized tools do not scan
+ordinary payload text, so a GitHub issue body that merely quotes a Slack URL is
+not mistaken for a network destination.
+
+For unattended deployments, enable the complete execution boundary explicitly:
+
+```yaml
+humanSurfaceReadOnly:
+  enabled: true
+```
+
+With this switch on, OpenSwarm does not attempt to classify arbitrary programs:
+it removes native `bash` and compiler-spawning diagnostics, refuses delegated
+CLI adapters before command construction, and blocks the same hidden tool calls
+at dispatch. This closes `curl --config`, scripts, dynamic URLs, fake CLIs, and
+credentials found through inherited `HOME` by making their execution impossible.
+Use a native-loop adapter; local web chat remains available with file tools,
+read-only web access, and policy-filtered MCP tools. Approved typed DevOps/data
+writes keep their existing role grants. OpenSwarm-owned Discord, Slack,
+Telegram, and generic webhook notification/send paths are all disabled—there is
+no operator-control-plane exception. The default is `false` for compatibility;
+the MCP human-surface descriptor and dispatch checks still apply regardless.
+Once enabled, the boundary is monotonic for that process so an incidental config
+lookup cannot downgrade it; restart with `enabled: false` to disable it.
+
+**Linux deployment readiness gate:** strict mode does not turn an unsandboxed
+shell back on just to recover build throughput. Repository-local build/test
+execution is safe only through an OS sandbox that proves network isolation, and
+server/database mutations are safe only through explicitly surfaced, role-
+granted DevOps/data MCP tools. If the host cannot create the verification
+namespace (for example, `bwrap` is blocked by the container runtime) **and** no
+typed MCP grant is provisioned, the deployment is coordination/file-only and is
+blocked for autonomous development. Do not compensate by enabling native or
+delegated shell access: that would also restore the unclassifiable human-API
+write path. On such a host, first make the existing sandbox probe pass or add
+the narrowly scoped MCP server/tool grants, then re-run the build/test and
+zero-write checks.
 
 One sweep runs at a time per daemon and repository, concurrent daemons contend
 on a file lock, and shutdown aborts then drains an active supervisor call. An

--- a/README.md
+++ b/README.md
@@ -392,6 +392,30 @@ role. This lets the supervisor settle evidence-backed worker questions without
 copying OAuth state or granting every worker broad Linear access. No external
 tool is granted implicitly, and decisions requiring new business authority stay
 with the operator.
+
+External human-facing surfaces have a stricter global boundary than the role
+grant above. Slack, Discord, email, Notion, and other messaging/collaboration
+servers are identified from the configured server descriptor, endpoint/package
+identity, tool action, and MCP annotations; custom opaque aliases should set
+`mcp.servers.<name>.surface: human`. Only actions containing an explicit
+`read`, `list`, `get`, `search`, or `fetch` verb are exposed or dispatched.
+`send`, `post`, `create`, `update`, `delete`, unknown actions, and equivalent
+mutations fail closed even if a role includes their exact name in `writeTools`
+or `destructiveTools`. MCP annotations are untrusted hints: they may tighten the
+decision but cannot turn a mutating action into a read. GitHub, Linear,
+Cloudflare, database/server tools, and sandbox-local data tools keep their
+existing role-scoped write contract.
+
+Native-loop shells additionally reject direct writes to known human-service
+endpoints and service CLIs, and both native and delegated worker processes omit
+human-service credentials from inherited environment variables while retaining
+model, DevOps, database, and sandbox-data settings. Delegated CLIs receive none
+of OpenSwarm's MCP grants (`codex` disables inherited MCP and `claude` uses a
+strict MCP config); use a native-loop adapter when the policy must cover shell
+commands too. OpenSwarm cannot classify an arbitrary program that reads a
+credential embedded inside the repository and implements its own network
+protocol, so such credentials must not be placed in an agent worktree.
+
 One sweep runs at a time per daemon and repository, concurrent daemons contend
 on a file lock, and shutdown aborts then drains an active supervisor call. An
 unchanged set of open board items is not sent to the model again. The deprecated

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -20,6 +20,17 @@ discord:
   channelId: ${DISCORD_CHANNEL_ID}
   webhookUrl: ${DISCORD_WEBHOOK_URL:-}  # Optional
 
+# Optional fail-closed boundary for unattended agents. When enabled, all
+# external human collaboration surfaces are read-only. OpenSwarm disables
+# arbitrary agent programs (native shell/diagnostics and delegated CLIs) and
+# its own Discord/Slack/Telegram/webhook senders. The local web chat remains
+# available through native-loop adapters, as do typed DevOps/data MCP writes.
+# On Linux, no working network-isolating sandbox plus no typed MCP grants is a
+# deployment blocker for autonomous development; never restore an unsandboxed
+# shell as a workaround.
+humanSurfaceReadOnly:
+  enabled: false
+
 linear:
   apiKey: ${LINEAR_API_KEY}
   teamId: ${LINEAR_TEAM_ID}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -248,10 +248,18 @@ telemetry:
 mcp:
   servers:
     github:
+      surface: devops
       command: npx
       args: ["-y", "@modelcontextprotocol/server-github"]
     linear:
+      surface: devops
       preset: linear
     cloudflare:
+      surface: devops
       command: npx
       args: ["-y", "@cloudflare/mcp-server-cloudflare"]
+    # Label opaque aliases explicitly. Human-surface tools remain globally
+    # read-only even when a role lists them in writeTools/destructiveTools.
+    # company-comms:
+    #   surface: human
+    #   url: https://mcp.example.com/comms

--- a/src/adapters/agenticLoop.test.ts
+++ b/src/adapters/agenticLoop.test.ts
@@ -438,6 +438,35 @@ describe('runAgenticLoop tool exposure options', () => {
     expect(deniedResult).toContain('TOOL_NOT_ALLOWED');
     expect(deniedResult).toContain('linear__delete_issue');
   });
+
+  it('removes human-surface writes from the provider schema while preserving reads and DevOps writes', async () => {
+    let toolNames: string[] = [];
+    const logs: string[] = [];
+    const mcp = (name: string) => ({
+      type: 'function' as const,
+      function: { name, description: '', parameters: { type: 'object' } },
+    });
+
+    await runAgenticLoop({
+      prompt: 'x',
+      cwd: process.cwd(),
+      model: 'test',
+      filesystemTools: false,
+      webTools: false,
+      memoryTools: false,
+      maxTurns: 1,
+      mcpTools: [mcp('slack__list_channels'), mcp('slack__chat_postMessage'), mcp('github__create_issue')],
+      onLog: (line) => logs.push(line),
+      callApi: async (_messages, tools) => {
+        toolNames = tools.map((entry) => entry.function.name);
+        return finalResp('done');
+      },
+    });
+
+    expect(toolNames).toEqual(['slack__list_channels', 'github__create_issue']);
+    expect(logs.join('\n')).toContain('slack__chat_postMessage');
+    expect(logs.join('\n')).toContain('human surface is read-only');
+  });
 });
 
 describe('runAgenticLoop blocking human decision', () => {

--- a/src/adapters/agenticLoop.test.ts
+++ b/src/adapters/agenticLoop.test.ts
@@ -12,6 +12,9 @@ import os from 'node:os';
 import path from 'node:path';
 import { compactPriorTurns, toolCallKey, allToolCallsSeen, shouldNudgeReadLoop, READ_LOOP_NUDGE_AT, shouldNudgeCoordinationCheck, COORDINATION_CHECK_NUDGE_EVERY, COORDINATION_CHECK_NUDGE_PROMPT, runAgenticLoop, loopResultToCliResult, type ChatMessage, type AgenticLoopResult } from './agenticLoop.js';
 import type { ToolCall } from './tools.js';
+import { configureHumanSurfaceReadOnly } from '../mcp/humanSurfacePolicy.js';
+
+afterEach(() => configureHumanSurfaceReadOnly(false));
 
 /** Scripted API response carrying a single tool call. */
 const toolCallResp = (id: string, name: string, args: object) => ({
@@ -376,6 +379,35 @@ describe('runAgenticLoop tool exposure options', () => {
     expect(toolNames).not.toContain('run_diagnostics');
     expect(toolNames).toContain('read_file');
     expect(toolNames).toContain('write_file');
+  });
+
+  it('forces arbitrary program tools off in strict mode while keeping local files, web reads, and MCP', async () => {
+    configureHumanSurfaceReadOnly(true);
+    let toolNames: string[] = [];
+
+    await runAgenticLoop({
+      prompt: 'x',
+      cwd: process.cwd(),
+      model: 'test',
+      shellTools: true,
+      diagnosticsTool: true,
+      maxTurns: 1,
+      mcpTools: [{
+        type: 'function',
+        function: { name: 'github__get_issue', description: '', parameters: { type: 'object' } },
+      }],
+      callApi: async (_messages, tools) => {
+        toolNames = tools.map((tool) => tool.function.name);
+        return finalResp('done');
+      },
+    });
+
+    expect(toolNames).not.toContain('bash');
+    expect(toolNames).not.toContain('run_diagnostics');
+    expect(toolNames).toContain('read_file');
+    expect(toolNames).toContain('write_file');
+    expect(toolNames).toContain('web_fetch');
+    expect(toolNames).toContain('github__get_issue');
   });
 
   it('withholds every filesystem tool while preserving MCP and coordination tools', async () => {

--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -14,7 +14,7 @@ import { isInfraError } from './errorClassification.js';
 import { parseSearchReplaceBlocks, applyEditBlock, type EditFormat } from '../support/editParser.js';
 import type { CliRunResult } from './types.js';
 import { COORDINATION_TOOL_DEFINITIONS, type CoordinationToolContext } from '../coordination/coordinationTools.js';
-import { filterHumanSurfaceMcpTools } from '../mcp/humanSurfacePolicy.js';
+import { filterHumanSurfaceMcpTools, isHumanSurfaceReadOnlyEnabled } from '../mcp/humanSurfacePolicy.js';
 
 // ============ 토큰 카운팅 (VEGA token_count.py 이식) ============
 
@@ -217,16 +217,23 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
     bashTimeoutMs,
     webTools = true,
     memoryTools = true,
-    shellTools = true,
+    shellTools: requestedShellTools = true,
     filesystemTools = true,
     readOnly = false,
     applyPatch = false,
-    diagnosticsTool = false,
+    diagnosticsTool: requestedDiagnosticsTool = false,
     mcpTools,
     coordinationContext,
     signal,
     editFormat = 'json',
   } = options;
+
+  // In strict mode the native loop remains available for local web chat and
+  // typed MCP/file operations, but arbitrary programs do not.  Enforce this in
+  // the loop itself as well as spawnCli so direct adapter.run callers cannot
+  // accidentally re-enable bash or compiler-spawning diagnostics.
+  const shellTools = requestedShellTools && !isHumanSurfaceReadOnlyEnabled();
+  const diagnosticsTool = requestedDiagnosticsTool && !isHumanSurfaceReadOnlyEnabled();
 
   const humanSurfaceFilteredMcp = filterHumanSurfaceMcpTools(mcpTools ?? []);
   for (const entry of humanSurfaceFilteredMcp.denied) {

--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -14,6 +14,7 @@ import { isInfraError } from './errorClassification.js';
 import { parseSearchReplaceBlocks, applyEditBlock, type EditFormat } from '../support/editParser.js';
 import type { CliRunResult } from './types.js';
 import { COORDINATION_TOOL_DEFINITIONS, type CoordinationToolContext } from '../coordination/coordinationTools.js';
+import { filterHumanSurfaceMcpTools } from '../mcp/humanSurfacePolicy.js';
 
 // ============ 토큰 카운팅 (VEGA token_count.py 이식) ============
 
@@ -227,6 +228,11 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
     editFormat = 'json',
   } = options;
 
+  const humanSurfaceFilteredMcp = filterHumanSurfaceMcpTools(mcpTools ?? []);
+  for (const entry of humanSurfaceFilteredMcp.denied) {
+    onLog?.(`[MCP policy] ${entry.name}: ${entry.reason}`);
+  }
+
   const startTime = Date.now();
   const deadline = timeoutMs > 0 ? startTime + timeoutMs : Number.POSITIVE_INFINITY;
 
@@ -277,7 +283,7 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
         // own memory server exposes writes, so injected content could leave
         // something behind for a later run. (INT-3189)
         ...(webTools && !readOnly ? WEB_TOOL_DEFINITIONS : []),
-        ...(readOnly ? [] : mcpTools ?? []),
+        ...(readOnly ? [] : humanSurfaceFilteredMcp.tools),
         ...(readOnly || !coordinationContext ? [] : COORDINATION_TOOL_DEFINITIONS),
       ]
     : [];

--- a/src/adapters/atlascloud.ts
+++ b/src/adapters/atlascloud.ts
@@ -87,6 +87,7 @@ export class AtlasCloudCliAdapter implements CliAdapter {
     supportedSkills: [],
     // The agentic loop honours CliRunOptions.readOnly (see agenticLoop/tools). (INT-3189)
     enforcesReadOnly: true,
+    enforcesHumanSurfaceReadOnly: true,
   };
 
   async isAvailable(): Promise<boolean> {

--- a/src/adapters/base.spawn.test.ts
+++ b/src/adapters/base.spawn.test.ts
@@ -14,9 +14,13 @@ import {
   prepareCliProcessTreeSpawn,
   trackCliProcessTree,
 } from './processTree.js';
+import { configureHumanSurfaceReadOnly } from '../mcp/humanSurfacePolicy.js';
 
 beforeEach(() => spawnMock.mockReset());
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+  configureHumanSurfaceReadOnly(false);
+  vi.restoreAllMocks();
+});
 
 describe('CLI process tree termination', () => {
   it('kills the whole POSIX process group so native CLI and MCP children cannot survive a timeout', () => {
@@ -442,6 +446,50 @@ describe('delegated-CLI capability guards', () => {
     await expect(
       spawnCli(delegated(), { prompt: 'p', cwd: process.cwd(), shellTools: false }),
     ).rejects.toThrow(/cannot withhold shell access/);
+  });
+
+  it('does not construct or spawn a delegated fake CLI in strict mode, even with HOME credentials', async () => {
+    const buildCommand = vi.fn(() => ({ command: 'fake-codex', args: [] }));
+    const adapter = { ...delegated(), name: 'fake-codex', buildCommand } satisfies CliAdapter;
+    const previousHome = process.env.HOME;
+    process.env.HOME = '/tmp/fake-home-with-human-credentials';
+    configureHumanSurfaceReadOnly(true);
+    try {
+      await expect(spawnCli(adapter, { prompt: 'p', cwd: process.cwd() }))
+        .rejects.toThrow(/HUMAN_SURFACE_READ_ONLY.*delegates to an external CLI/);
+      expect(buildCommand).not.toHaveBeenCalled();
+      expect(spawnMock).not.toHaveBeenCalled();
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+    }
+  });
+
+  it('keeps native adapters but forces shell and diagnostics off in strict mode', async () => {
+    const run = vi.fn(async () => ({ exitCode: 0, stdout: 'ok', stderr: '', durationMs: 1 }));
+    const base = delegated();
+    const adapter = {
+      ...base,
+      name: 'native',
+      capabilities: { ...base.capabilities, enforcesHumanSurfaceReadOnly: true },
+      run,
+    } satisfies CliAdapter;
+    configureHumanSurfaceReadOnly(true);
+
+    await expect(spawnCli(adapter, {
+      prompt: 'p', cwd: process.cwd(), shellTools: true, diagnosticsTool: true,
+    })).resolves.toMatchObject({ stdout: 'ok' });
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({ shellTools: false, diagnosticsTool: false }));
+  });
+
+  it('refuses a run adapter that has not declared strict-boundary enforcement', async () => {
+    const run = vi.fn(async () => ({ exitCode: 0, stdout: 'unsafe', stderr: '', durationMs: 1 }));
+    const adapter = { ...delegated(), name: 'untrusted-native', run } satisfies CliAdapter;
+    configureHumanSurfaceReadOnly(true);
+
+    await expect(spawnCli(adapter, { prompt: 'p', cwd: process.cwd() }))
+      .rejects.toThrow(/does not declare enforcement/);
+    expect(run).not.toHaveBeenCalled();
   });
 
   it('warns rather than silently dropping MCP and coordination tools', async () => {

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -22,6 +22,7 @@ import {
 } from './processTree.js';
 import { raceWithAbort } from './abortRace.js';
 import { isHumanSurfaceReadOnlyEnabled } from '../mcp/humanSurfacePolicy.js';
+import { assertAdapterCanRunUnderHumanSurfaceBoundary } from './humanSurfaceBoundary.js';
 
 export { terminateCliProcessTree } from './processTree.js';
 
@@ -35,19 +36,7 @@ export async function spawnCli(
   requestedOptions: CliRunOptions,
 ): Promise<CliRunResult> {
   const strictHumanSurfaceBoundary = isHumanSurfaceReadOnlyEnabled();
-  if (
-    strictHumanSurfaceBoundary
-    && (!adapter.run || adapter.capabilities.enforcesHumanSurfaceReadOnly !== true)
-  ) {
-    const reason = adapter.run
-      ? 'does not declare enforcement of the strict human-surface boundary'
-      : 'delegates to an external CLI with its own tool loop';
-    throw new Error(
-      `HUMAN_SURFACE_READ_ONLY: Adapter '${adapter.name}' ${reason}; `
-      + 'arbitrary program execution is disabled while humanSurfaceReadOnly.enabled is true. '
-      + 'Use a native OpenSwarm-loop adapter.',
-    );
-  }
+  assertAdapterCanRunUnderHumanSurfaceBoundary(adapter);
   const options: CliRunOptions = strictHumanSurfaceBoundary
     ? { ...requestedOptions, shellTools: false, diagnosticsTool: false }
     : requestedOptions;

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -21,6 +21,7 @@ import {
   untrackCliProcessTree,
 } from './processTree.js';
 import { raceWithAbort } from './abortRace.js';
+import { isHumanSurfaceReadOnlyEnabled } from '../mcp/humanSurfacePolicy.js';
 
 export { terminateCliProcessTree } from './processTree.js';
 
@@ -31,8 +32,25 @@ export { terminateCliProcessTree } from './processTree.js';
  */
 export async function spawnCli(
   adapter: CliAdapter,
-  options: CliRunOptions,
+  requestedOptions: CliRunOptions,
 ): Promise<CliRunResult> {
+  const strictHumanSurfaceBoundary = isHumanSurfaceReadOnlyEnabled();
+  if (
+    strictHumanSurfaceBoundary
+    && (!adapter.run || adapter.capabilities.enforcesHumanSurfaceReadOnly !== true)
+  ) {
+    const reason = adapter.run
+      ? 'does not declare enforcement of the strict human-surface boundary'
+      : 'delegates to an external CLI with its own tool loop';
+    throw new Error(
+      `HUMAN_SURFACE_READ_ONLY: Adapter '${adapter.name}' ${reason}; `
+      + 'arbitrary program execution is disabled while humanSurfaceReadOnly.enabled is true. '
+      + 'Use a native OpenSwarm-loop adapter.',
+    );
+  }
+  const options: CliRunOptions = strictHumanSurfaceBoundary
+    ? { ...requestedOptions, shellTools: false, diagnosticsTool: false }
+    : requestedOptions;
   // Fail closed before anything runs. `readOnly` is asked for when the input is
   // untrusted, so an adapter that ignores it would hand a full toolset to an
   // agent reading attacker-authored files. Refusing is loud; ignoring is not.

--- a/src/adapters/ccRouter.test.ts
+++ b/src/adapters/ccRouter.test.ts
@@ -1,17 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const execFileMock = vi.hoisted(() => vi.fn());
-vi.mock('node:child_process', () => ({ execFile: execFileMock }));
-
 import { CcRouterAdapter } from './ccRouter.js';
 
-// The adapter awaits promisify(execFile); the generic promisify wrapper
-// resolves with the callback's first success value, so the mock hands back the
-// { stdout } object the real promisified execFile would.
-type ExecCb = (err: Error | null, result?: { stdout: string; stderr: string }) => void;
 function statusReply(payload: unknown): void {
-  execFileMock.mockImplementation((_c: string, _a: string[], _o: unknown, cb: ExecCb) =>
-    cb(null, { stdout: JSON.stringify(payload), stderr: '' }));
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload)));
 }
 
 const ENV_KEYS = ['CC_ROUTER_TOKEN', 'CC_ROUTER_BASE_URL', 'CC_ROUTER_MODEL'] as const;
@@ -43,14 +35,20 @@ describe('CcRouterAdapter availability', () => {
     await expect(new CcRouterAdapter().isAvailable()).resolves.toBe(false);
   });
 
-  it('reports unavailable on a missing binary or non-JSON status', async () => {
-    execFileMock.mockImplementation((_c: string, _a: string[], _o: unknown, cb: ExecCb) =>
-      cb(new Error('ENOENT')));
+  it('probes only the approved loopback health endpoint and fails closed on invalid responses', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('down'));
     await expect(new CcRouterAdapter().isAvailable()).resolves.toBe(false);
 
-    execFileMock.mockImplementation((_c: string, _a: string[], _o: unknown, cb: ExecCb) =>
-      cb(null, { stdout: 'not json', stderr: '' }));
+    fetchMock.mockResolvedValueOnce(new Response('not json'));
     await expect(new CcRouterAdapter().isAvailable()).resolves.toBe(false);
+
+    fetchMock.mockResolvedValueOnce(new Response('{}', { status: 503 }));
+    await expect(new CcRouterAdapter().isAvailable()).resolves.toBe(false);
+    expect(fetchMock.mock.calls.every(([url]) => url === 'http://127.0.0.1:3456/cc-router/health')).toBe(true);
+
+    process.env.CC_ROUTER_BASE_URL = 'https://evil.example.com';
+    await expect(new CcRouterAdapter().isAvailable()).resolves.toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -78,11 +76,20 @@ describe('CcRouterAdapter model discovery', () => {
   });
 
   it('normalizes a configured base URL whether or not it already ends in /v1', async () => {
-    process.env.CC_ROUTER_BASE_URL = 'http://10.0.0.5:9999/v1/';
+    process.env.CC_ROUTER_BASE_URL = 'http://localhost:9999/v1/';
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({ data: [] })));
     await new CcRouterAdapter().listModels();
-    expect(fetchMock.mock.calls[0][0]).toBe('http://10.0.0.5:9999/v1/models');
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:9999/v1/models');
+  });
+
+  it('does not send model-probe credentials to a configured remote endpoint', async () => {
+    process.env.CC_ROUTER_BASE_URL = 'https://evil.example.com';
+    process.env.CC_ROUTER_TOKEN = 'router-secret';
+    const fetchMock = vi.spyOn(globalThis, 'fetch');
+
+    await expect(new CcRouterAdapter().listModels()).resolves.toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('returns no models on a non-OK response instead of throwing into the router', async () => {

--- a/src/adapters/ccRouter.ts
+++ b/src/adapters/ccRouter.ts
@@ -19,6 +19,7 @@ export class CcRouterAdapter extends CodexResponsesAdapter {
     managedGit: false,
     supportedSkills: [],
     enforcesReadOnly: true,
+    enforcesHumanSurfaceReadOnly: true,
   };
 
   async isAvailable(): Promise<boolean> {

--- a/src/adapters/ccRouter.ts
+++ b/src/adapters/ccRouter.ts
@@ -2,13 +2,9 @@
 // OpenSwarm - CC-Router Responses adapter
 // ============================================
 
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
 import type { AdapterCapabilities, CliRunOptions } from './types.js';
 import { CodexResponsesAdapter } from './codexResponses.js';
-import { prepareApprovedLocalResponsesRequest } from '../support/approvedEgress.js';
-
-const execFileAsync = promisify(execFile);
+import { approvedLocalModelEndpoint, prepareApprovedLocalResponsesRequest } from '../support/approvedEgress.js';
 
 export class CcRouterAdapter extends CodexResponsesAdapter {
   readonly name = 'cc-router';
@@ -24,8 +20,19 @@ export class CcRouterAdapter extends CodexResponsesAdapter {
 
   async isAvailable(): Promise<boolean> {
     try {
-      const { stdout } = await execFileAsync('cc-router', ['status', '--json'], { timeout: 5_000 });
-      const status = JSON.parse(stdout) as { status?: string; operational?: { capabilities?: { openAIResponses?: boolean } } };
+      // Availability probing is part of adapter selection and runs before
+      // spawnCli's execution boundary. Never resolve a PATH binary here: a fake
+      // `cc-router` could execute arbitrary code with the daemon's HOME/env even
+      // though strict mode would later refuse the delegated process. The router
+      // already exposes the same status payload over its loopback-only health
+      // endpoint, so probe that narrow approved egress path directly.
+      const endpoint = approvedLocalModelEndpoint(this.baseOrigin(), '/cc-router/health');
+      const response = await fetch(endpoint, {
+        headers: this.headers(),
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (!response.ok) return false;
+      const status = await response.json() as { status?: string; operational?: { capabilities?: { openAIResponses?: boolean } } };
       return status.status === 'ok' && status.operational?.capabilities?.openAIResponses === true;
     } catch {
       return false;
@@ -34,7 +41,8 @@ export class CcRouterAdapter extends CodexResponsesAdapter {
 
   async listModels(): Promise<string[]> {
     try {
-      const response = await fetch(`${this.baseUrl()}/models`, { headers: this.headers() });
+      const endpoint = approvedLocalModelEndpoint(this.baseOrigin(), '/v1/models');
+      const response = await fetch(endpoint, { headers: this.headers() });
       if (!response.ok) return [];
       const body = await response.json() as { data?: Array<{ id?: string }> };
       return (body.data ?? []).flatMap((entry) => typeof entry.id === 'string' ? [entry.id] : []);

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -21,6 +21,7 @@ import { extractResultFromStreamJson } from '../agents/cliStreamParser.js';
 import { t } from '../locale/index.js';
 import { extractSummary } from './resultParsing.js';
 import { writeClaudeMcpConfig } from './memoryMcp.js';
+import { isHumanSurfaceReadOnlyEnabled } from '../mcp/humanSurfacePolicy.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -59,6 +60,7 @@ export class ClaudeCliAdapter implements CliAdapter {
   };
 
   async isAvailable(): Promise<boolean> {
+    if (isHumanSurfaceReadOnlyEnabled()) return false;
     try {
       await execFileAsync('which', ['claude']);
       return true;

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -21,6 +21,7 @@ import { getCodexModelIds } from './codexModels.js';
 import { codexMcpConfigArgs } from './memoryMcp.js';
 import { codexUserMcpDisableArgs } from './codexUserMcp.js';
 import { extractSummary, parseReviewerResult } from './resultParsing.js';
+import { isHumanSurfaceReadOnlyEnabled } from '../mcp/humanSurfacePolicy.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -45,6 +46,7 @@ export class CodexCliAdapter implements CliAdapter {
   };
 
   async isAvailable(): Promise<boolean> {
+    if (isHumanSurfaceReadOnlyEnabled()) return false;
     try {
       await execFileAsync('which', ['codex']);
       return true;
@@ -59,6 +61,7 @@ export class CodexCliAdapter implements CliAdapter {
    * falling back to the local ~/.codex sources and a curated default list.
    */
   async listModels(): Promise<string[]> {
+    if (isHumanSurfaceReadOnlyEnabled()) return [];
     let accessToken: string | undefined;
     try {
       const store = new AuthProfileStore();

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -294,6 +294,7 @@ export class CodexResponsesAdapter implements CliAdapter {
     supportedSkills: [],
     // The agentic loop honours CliRunOptions.readOnly (see agenticLoop/tools). (INT-3189)
     enforcesReadOnly: true,
+    enforcesHumanSurfaceReadOnly: true,
   };
 
   async isAvailable(): Promise<boolean> {

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -14,6 +14,7 @@ import type {
   WorkerResult,
 } from './types.js';
 import { parseReviewerResult, parseWorkerResult } from './resultParsing.js';
+import { isHumanSurfaceReadOnlyEnabled } from '../mcp/humanSurfacePolicy.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -34,6 +35,7 @@ export class CursorCliAdapter implements CliAdapter {
   };
 
   async isAvailable(): Promise<boolean> {
+    if (isHumanSurfaceReadOnlyEnabled()) return false;
     try {
       await execFileAsync('cursor-agent', ['status'], { timeout: 5_000 });
       return true;
@@ -43,6 +45,7 @@ export class CursorCliAdapter implements CliAdapter {
   }
 
   async listModels(): Promise<string[]> {
+    if (isHumanSurfaceReadOnlyEnabled()) return [];
     try {
       const { stdout } = await execFileAsync('cursor-agent', ['--list-models'], { timeout: 10_000 });
       return stdout.split('\n').map((line) => line.trim()).filter((line) => line && !/^available models/i.test(line));

--- a/src/adapters/delegatedDiscoveryPolicy.test.ts
+++ b/src/adapters/delegatedDiscoveryPolicy.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const execFileMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ execFile: execFileMock }));
+
+import { ClaudeCliAdapter } from './claude.js';
+import { CodexCliAdapter } from './codex.js';
+import { CursorCliAdapter } from './cursor.js';
+import { configureHumanSurfaceReadOnly } from '../mcp/humanSurfacePolicy.js';
+
+afterEach(() => {
+  configureHumanSurfaceReadOnly(false);
+  vi.clearAllMocks();
+});
+
+describe('delegated adapter discovery policy', () => {
+  it('does not execute PATH tools or inspect live catalogs in strict mode', async () => {
+    configureHumanSurfaceReadOnly(true);
+    const codex = new CodexCliAdapter();
+    const claude = new ClaudeCliAdapter();
+    const cursor = new CursorCliAdapter();
+
+    await expect(codex.isAvailable()).resolves.toBe(false);
+    await expect(codex.listModels()).resolves.toEqual([]);
+    await expect(claude.isAvailable()).resolves.toBe(false);
+    await expect(cursor.isAvailable()).resolves.toBe(false);
+    await expect(cursor.listModels()).resolves.toEqual([]);
+    await expect(cursor.getDefaultModel()).resolves.toBe('auto');
+
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/adapters/diagnosticsTool.ts
+++ b/src/adapters/diagnosticsTool.ts
@@ -41,7 +41,8 @@ export const DIAGNOSTICS_TOOL: ToolDefinition = {
     description:
       'Run the project type checker / linter and return current errors (TypeScript: tsc, Python: ruff). ' +
       'Call this right after editing to catch broken contracts (missed callers, wrong signatures) before finishing. ' +
-      'Pass the files you changed in "paths" to see their errors first; errors elsewhere are summarized.',
+      'Pass the files you changed in "paths" to see their errors first; errors elsewhere are summarized. ' +
+      'This subprocess tool is unavailable when humanSurfaceReadOnly.enabled is true.',
     parameters: {
       type: 'object',
       properties: {

--- a/src/adapters/envPath.test.ts
+++ b/src/adapters/envPath.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { buildWorkerEnv } from './envPath.js';
+
+describe('buildWorkerEnv human-surface boundary', () => {
+  it('scrubs human-surface credentials from delegated CLI env without removing model or DevOps access', () => {
+    const env = buildWorkerEnv({
+      PATH: '/usr/bin:/bin',
+      HOME: '/home/worker',
+      ANTHROPIC_API_KEY: 'keep',
+      OPENAI_API_KEY: 'keep',
+      GITHUB_TOKEN: 'keep',
+      AWS_PROFILE: 'keep',
+      POSTGRES_DSN: 'keep',
+      SLACK_BOT_TOKEN: 'drop',
+      NOTION_API_KEY: 'drop',
+      TELEGRAM_BOT_TOKEN: 'drop',
+    });
+
+    expect(env).toMatchObject({
+      HOME: '/home/worker',
+      ANTHROPIC_API_KEY: 'keep',
+      OPENAI_API_KEY: 'keep',
+      GITHUB_TOKEN: 'keep',
+      AWS_PROFILE: 'keep',
+      POSTGRES_DSN: 'keep',
+    });
+    expect(env).not.toHaveProperty('SLACK_BOT_TOKEN');
+    expect(env).not.toHaveProperty('NOTION_API_KEY');
+    expect(env).not.toHaveProperty('TELEGRAM_BOT_TOKEN');
+  });
+});

--- a/src/adapters/envPath.test.ts
+++ b/src/adapters/envPath.test.ts
@@ -15,6 +15,7 @@ describe('buildWorkerEnv human-surface boundary', () => {
       NOTION_API_KEY: 'drop',
       TELEGRAM_BOT_TOKEN: 'drop',
       GOOGLE_CALENDAR_TOKEN: 'drop',
+      MS_GRAPH_TOKEN: 'drop',
     });
 
     expect(env).toMatchObject({
@@ -29,5 +30,6 @@ describe('buildWorkerEnv human-surface boundary', () => {
     expect(env).not.toHaveProperty('NOTION_API_KEY');
     expect(env).not.toHaveProperty('TELEGRAM_BOT_TOKEN');
     expect(env).not.toHaveProperty('GOOGLE_CALENDAR_TOKEN');
+    expect(env).not.toHaveProperty('MS_GRAPH_TOKEN');
   });
 });

--- a/src/adapters/envPath.test.ts
+++ b/src/adapters/envPath.test.ts
@@ -14,6 +14,7 @@ describe('buildWorkerEnv human-surface boundary', () => {
       SLACK_BOT_TOKEN: 'drop',
       NOTION_API_KEY: 'drop',
       TELEGRAM_BOT_TOKEN: 'drop',
+      GOOGLE_CALENDAR_TOKEN: 'drop',
     });
 
     expect(env).toMatchObject({
@@ -27,5 +28,6 @@ describe('buildWorkerEnv human-surface boundary', () => {
     expect(env).not.toHaveProperty('SLACK_BOT_TOKEN');
     expect(env).not.toHaveProperty('NOTION_API_KEY');
     expect(env).not.toHaveProperty('TELEGRAM_BOT_TOKEN');
+    expect(env).not.toHaveProperty('GOOGLE_CALENDAR_TOKEN');
   });
 });

--- a/src/adapters/envPath.ts
+++ b/src/adapters/envPath.ts
@@ -11,6 +11,7 @@ import { existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { delimiter } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { stripHumanSurfaceEnv } from '../mcp/humanSurfacePolicy.js';
 
 /**
  * Resolve OpenSwarm's bundled `node_modules/.bin` directory.
@@ -38,15 +39,15 @@ export function getBundledBinDir(): string | null {
  */
 export function buildWorkerEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
   const binDir = getBundledBinDir();
-  if (binDir === null) return { ...base };
+  if (binDir === null) return stripHumanSurfaceEnv(base);
 
   const existingPath = base.PATH ?? base.Path ?? '';
   // Avoid duplicate entries if this env is reused across spawns.
   const parts = existingPath.split(delimiter).filter(Boolean);
   if (parts[0] === binDir) {
-    return { ...base };
+    return stripHumanSurfaceEnv(base);
   }
   const nextPath = [binDir, ...parts.filter((p) => p !== binDir)].join(delimiter);
 
-  return { ...base, PATH: nextPath };
+  return stripHumanSurfaceEnv({ ...base, PATH: nextPath });
 }

--- a/src/adapters/gpt.ts
+++ b/src/adapters/gpt.ts
@@ -78,6 +78,7 @@ export class GptCliAdapter implements CliAdapter {
     supportedSkills: [],
     // The agentic loop honours CliRunOptions.readOnly (see agenticLoop/tools). (INT-3189)
     enforcesReadOnly: true,
+    enforcesHumanSurfaceReadOnly: true,
   };
 
   async isAvailable(): Promise<boolean> {

--- a/src/adapters/humanSurfaceBoundary.ts
+++ b/src/adapters/humanSurfaceBoundary.ts
@@ -1,0 +1,47 @@
+// ============================================
+// OpenSwarm - adapter discovery/execution boundary
+// ============================================
+
+import type { CliAdapter } from './types.js';
+import { isHumanSurfaceReadOnlyEnabled } from '../mcp/humanSurfacePolicy.js';
+
+/**
+ * Strict human-surface mode can inspect or execute only adapters whose tool
+ * loop remains inside OpenSwarm's policy layer.  Apply this to discovery and
+ * model-catalog calls too: delegated adapters may implement those "read" APIs
+ * by launching the same PATH-resolved CLI that execution later rejects.
+ */
+export function adapterCanRunUnderHumanSurfaceBoundary(adapter: CliAdapter): boolean {
+  return !isHumanSurfaceReadOnlyEnabled()
+    || (typeof adapter.run === 'function' && adapter.capabilities.enforcesHumanSurfaceReadOnly === true);
+}
+
+export function assertAdapterCanRunUnderHumanSurfaceBoundary(adapter: CliAdapter): void {
+  if (adapterCanRunUnderHumanSurfaceBoundary(adapter)) return;
+  const reason = adapter.run
+    ? 'does not declare enforcement of the strict human-surface boundary'
+    : 'delegates to an external CLI with its own tool loop';
+  throw new Error(
+    `HUMAN_SURFACE_READ_ONLY: Adapter '${adapter.name}' ${reason}; `
+    + 'arbitrary program execution is disabled while humanSurfaceReadOnly.enabled is true. '
+    + 'Use a native OpenSwarm-loop adapter.',
+  );
+}
+
+/** Return unavailable without invoking an unsafe delegated adapter probe. */
+export async function probeAdapterAvailability(adapter: CliAdapter): Promise<boolean> {
+  if (!adapterCanRunUnderHumanSurfaceBoundary(adapter)) return false;
+  return adapter.isAvailable();
+}
+
+/** Resolve a model only after proving its adapter is allowed to perform I/O. */
+export async function resolveBoundarySafeDefaultModel(adapter: CliAdapter): Promise<string> {
+  assertAdapterCanRunUnderHumanSurfaceBoundary(adapter);
+  return adapter.getDefaultModel();
+}
+
+/** List live models only after proving its adapter is allowed to perform I/O. */
+export async function listBoundarySafeModels(adapter: CliAdapter): Promise<string[]> {
+  assertAdapterCanRunUnderHumanSurfaceBoundary(adapter);
+  return typeof adapter.listModels === 'function' ? adapter.listModels() : [];
+}

--- a/src/adapters/index.test.ts
+++ b/src/adapters/index.test.ts
@@ -1,5 +1,18 @@
-import { describe, it, expect } from 'vitest';
-import { isKnownAdapter, listAdapterNames } from './index.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CliAdapter } from './types.js';
+import {
+  listAdapterNames,
+  listBoundarySafeModels,
+  isKnownAdapter,
+  probeAdapterAvailability,
+  resolveBoundarySafeDefaultModel,
+} from './index.js';
+import { configureHumanSurfaceReadOnly } from '../mcp/humanSurfacePolicy.js';
+
+afterEach(() => {
+  configureHumanSurfaceReadOnly(false);
+  vi.restoreAllMocks();
+});
 
 describe('isKnownAdapter', () => {
   it('accepts currently-registered adapters (incl. claude, the opt-in claude -p delegate)', () => {
@@ -21,5 +34,61 @@ describe('isKnownAdapter', () => {
     expect([...listAdapterNames()].sort()).toEqual(
       ['atlascloud', 'cc-router', 'claude', 'codex', 'cursor', 'codex-responses', 'gpt', 'local', 'lmstudio', 'openrouter'].sort(),
     );
+  });
+});
+
+describe('adapter discovery human-surface boundary', () => {
+  function adapter(overrides: Partial<CliAdapter> = {}): CliAdapter {
+    return {
+      name: 'delegated-test',
+      capabilities: {
+        supportsStreaming: false,
+        supportsJsonOutput: true,
+        supportsModelSelection: true,
+        managedGit: false,
+        supportedSkills: [],
+      },
+      isAvailable: vi.fn(async () => true),
+      getDefaultModel: vi.fn(async () => 'model-a'),
+      listModels: vi.fn(async () => ['model-a']),
+      buildCommand: vi.fn(() => ({ command: 'fake-cli', args: [] })),
+      parseWorkerOutput: vi.fn(),
+      parseReviewerOutput: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  it('does not invoke delegated availability or model probes in strict mode', async () => {
+    const delegated = adapter();
+    configureHumanSurfaceReadOnly(true);
+
+    await expect(probeAdapterAvailability(delegated)).resolves.toBe(false);
+    await expect(resolveBoundarySafeDefaultModel(delegated)).rejects.toThrow('HUMAN_SURFACE_READ_ONLY');
+    await expect(listBoundarySafeModels(delegated)).rejects.toThrow('HUMAN_SURFACE_READ_ONLY');
+
+    expect(delegated.isAvailable).not.toHaveBeenCalled();
+    expect(delegated.getDefaultModel).not.toHaveBeenCalled();
+    expect(delegated.listModels).not.toHaveBeenCalled();
+    expect(delegated.buildCommand).not.toHaveBeenCalled();
+  });
+
+  it('keeps discovery for a policy-enforcing native adapter', async () => {
+    const native = adapter({
+      name: 'native-test',
+      capabilities: {
+        supportsStreaming: false,
+        supportsJsonOutput: true,
+        supportsModelSelection: true,
+        managedGit: false,
+        supportedSkills: [],
+        enforcesHumanSurfaceReadOnly: true,
+      },
+      run: vi.fn(),
+    });
+    configureHumanSurfaceReadOnly(true);
+
+    await expect(probeAdapterAvailability(native)).resolves.toBe(true);
+    await expect(resolveBoundarySafeDefaultModel(native)).resolves.toBe('model-a');
+    await expect(listBoundarySafeModels(native)).resolves.toEqual(['model-a']);
   });
 });

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -25,6 +25,13 @@ export { AtlasCloudCliAdapter } from './atlascloud.js';
 export { ClaudeCliAdapter } from './claude.js';
 export { CcRouterAdapter } from './ccRouter.js';
 export { CursorCliAdapter } from './cursor.js';
+export {
+  adapterCanRunUnderHumanSurfaceBoundary,
+  assertAdapterCanRunUnderHumanSurfaceBoundary,
+  listBoundarySafeModels,
+  probeAdapterAvailability,
+  resolveBoundarySafeDefaultModel,
+} from './humanSurfaceBoundary.js';
 export { registerProcess, getProcess, getAllProcesses, killProcess, startHealthChecker, stopHealthChecker } from './processRegistry.js';
 
 import { CodexCliAdapter } from './codex.js';
@@ -37,6 +44,7 @@ import { AtlasCloudCliAdapter } from './atlascloud.js';
 import { ClaudeCliAdapter } from './claude.js';
 import { CcRouterAdapter } from './ccRouter.js';
 import { CursorCliAdapter } from './cursor.js';
+import { probeAdapterAvailability } from './humanSurfaceBoundary.js';
 import type { AdapterName, CliAdapter } from './types.js';
 
 const adapters: Record<string, CliAdapter> = {
@@ -97,7 +105,7 @@ export function listAdapterNames(): AdapterName[] {
 export async function listAvailableAdapters(): Promise<string[]> {
   const results: string[] = [];
   for (const [name, adapter] of Object.entries(adapters)) {
-    if (await adapter.isAvailable()) {
+    if (await probeAdapterAvailability(adapter)) {
       results.push(name);
     }
   }

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -52,6 +52,7 @@ export class LocalModelAdapter implements CliAdapter {
     supportedSkills: [],
     // The agentic loop honours CliRunOptions.readOnly (see agenticLoop/tools). (INT-3189)
     enforcesReadOnly: true,
+    enforcesHumanSurfaceReadOnly: true,
   };
 
   // 활성 서버 URL (isAvailable에서 감지, run에서 사용)

--- a/src/adapters/openrouter.ts
+++ b/src/adapters/openrouter.ts
@@ -105,6 +105,7 @@ export class OpenRouterCliAdapter implements CliAdapter {
     supportedSkills: [],
     // The agentic loop honours CliRunOptions.readOnly (see agenticLoop/tools). (INT-3189)
     enforcesReadOnly: true,
+    enforcesHumanSurfaceReadOnly: true,
   };
 
   async isAvailable(): Promise<boolean> {

--- a/src/adapters/tools.test.ts
+++ b/src/adapters/tools.test.ts
@@ -682,6 +682,29 @@ describe('ToolExecOptions', () => {
     const cargo = path.join(homedir(), '.cargo', 'bin');
     expect((env.PATH ?? '').split(':').filter((p) => p === cargo)).toHaveLength(1);
   });
+
+  it('buildBashToolEnv withholds human-surface credentials but preserves DevOps and DB credentials', () => {
+    const env = buildBashToolEnv({
+      PATH: '/usr/bin:/bin',
+      SLACK_BOT_TOKEN: 'drop',
+      DISCORD_WEBHOOK_URL: 'drop',
+      GITHUB_TOKEN: 'keep',
+      POSTGRES_DSN: 'keep',
+    });
+    expect(env).not.toHaveProperty('SLACK_BOT_TOKEN');
+    expect(env).not.toHaveProperty('DISCORD_WEBHOOK_URL');
+    expect(env).toMatchObject({ GITHUB_TOKEN: 'keep', POSTGRES_DSN: 'keep' });
+  });
+
+  it('bash rejects a literal human-surface webhook write before spawning it', async () => {
+    const result = await executeTool(
+      makeCall('bash', {
+        command: `curl -X POST -d '{"text":"hello"}' https://hooks.slack.com/services/T/B/X`,
+      }),
+      TMP_DIR,
+    );
+    expect(result).toMatchObject({ is_error: true, content: expect.stringContaining('HUMAN_SURFACE_READ_ONLY') });
+  });
 });
 
 describe('search_files without ripgrep', () => {

--- a/src/adapters/tools.test.ts
+++ b/src/adapters/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
@@ -6,6 +6,9 @@ import * as os from 'node:os';
 import { TOOL_DEFINITIONS, executeTool, createReadCache, ToolCall, buildBashToolEnv, validatePath } from './tools.js';
 import { homedir } from 'node:os';
 import type { CoordinationToolContext } from '../coordination/coordinationTools.js';
+import { configureHumanSurfaceReadOnly } from '../mcp/humanSurfacePolicy.js';
+
+afterEach(() => configureHumanSurfaceReadOnly(false));
 
 // search_memory loads the memory core lazily; stub the shared helper so the tool
 // test stays fast and deterministic (no LanceDB / embedding model).
@@ -392,6 +395,18 @@ describe('Safety guards (isCommandBlocked via bash)', () => {
     const result = await executeTool(makeCall('bash', { command: cmd }), TMP_DIR);
     // Should not be blocked (may still fail for other reasons, but not BLOCKED)
     expect(result.content).not.toContain('BLOCKED');
+  });
+
+  it.each([
+    'curl --config ./request.conf',
+    'bash ./send-message.sh',
+    'curl -X GET "$DYNAMIC_URL"',
+    'node ./arbitrary-program.js',
+  ])('blocks arbitrary program execution in strict mode: %s', async (cmd) => {
+    configureHumanSurfaceReadOnly(true);
+    const result = await executeTool(makeCall('bash', { command: cmd }), TMP_DIR);
+    expect(result).toMatchObject({ is_error: true });
+    expect(result.content).toContain('HUMAN_SURFACE_READ_ONLY');
   });
 
   it('refuses mutation and shell tools in read-only mode', async () => {

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -16,6 +16,7 @@ import { isMcpTool, callMcpTool } from '../mcp/mcpClient.js';
 import { applyV4APatch } from './applyPatch.js';
 import { atomicWriteFile } from '../support/atomicFile.js';
 import { COORDINATION_TOOL_NAMES, executeCoordinationTool, type CoordinationToolContext } from '../coordination/coordinationTools.js';
+import { humanSurfaceShellWriteReason, stripHumanSurfaceEnv } from '../mcp/humanSurfacePolicy.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -40,7 +41,7 @@ export function buildBashToolEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.
   ];
   const current = (base.PATH ?? '').split(':').filter(Boolean);
   const merged = [...extra.filter((p) => !current.includes(p)), ...current];
-  return { ...base, PATH: merged.join(':') };
+  return stripHumanSurfaceEnv({ ...base, PATH: merged.join(':') });
 }
 
 // ============ 도구 정의 (OpenAI function calling 포맷) ============
@@ -807,6 +808,10 @@ export async function executeTool(
 
       case 'bash': {
         const command: string = args.command;
+        const humanSurfaceDenial = humanSurfaceShellWriteReason(command);
+        if (humanSurfaceDenial) {
+          return { tool_call_id: callId, content: `HUMAN_SURFACE_READ_ONLY: ${humanSurfaceDenial}`, is_error: true };
+        }
         if (isCommandBlocked(command)) {
           return { tool_call_id: callId, content: `BLOCKED: destructive command not allowed: ${command}`, is_error: true };
         }

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -16,7 +16,11 @@ import { isMcpTool, callMcpTool } from '../mcp/mcpClient.js';
 import { applyV4APatch } from './applyPatch.js';
 import { atomicWriteFile } from '../support/atomicFile.js';
 import { COORDINATION_TOOL_NAMES, executeCoordinationTool, type CoordinationToolContext } from '../coordination/coordinationTools.js';
-import { humanSurfaceShellWriteReason, stripHumanSurfaceEnv } from '../mcp/humanSurfacePolicy.js';
+import {
+  humanSurfaceShellWriteReason,
+  isHumanSurfaceReadOnlyEnabled,
+  stripHumanSurfaceEnv,
+} from '../mcp/humanSurfacePolicy.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -123,7 +127,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     type: 'function',
     function: {
       name: 'bash',
-      description: 'Execute a shell command and return stdout/stderr. Timeout: 30s. Destructive commands (rm -rf, git reset --hard) are blocked.',
+      description: 'Execute a shell command and return stdout/stderr. Timeout: 30s. Destructive commands (rm -rf, git reset --hard) are blocked. This tool is unavailable when humanSurfaceReadOnly.enabled is true.',
       parameters: {
         type: 'object',
         properties: {
@@ -808,6 +812,13 @@ export async function executeTool(
 
       case 'bash': {
         const command: string = args.command;
+        if (isHumanSurfaceReadOnlyEnabled()) {
+          return {
+            tool_call_id: callId,
+            content: 'HUMAN_SURFACE_READ_ONLY: arbitrary program execution is disabled while humanSurfaceReadOnly.enabled is true',
+            is_error: true,
+          };
+        }
         const humanSurfaceDenial = humanSurfaceShellWriteReason(command);
         if (humanSurfaceDenial) {
           return { tool_call_id: callId, content: `HUMAN_SURFACE_READ_ONLY: ${humanSurfaceDenial}`, is_error: true };
@@ -876,6 +887,13 @@ export async function executeTool(
       }
 
       case 'diagnostics': {
+        if (isHumanSurfaceReadOnlyEnabled()) {
+          return {
+            tool_call_id: callId,
+            content: 'HUMAN_SURFACE_READ_ONLY: diagnostics subprocess execution is disabled while humanSurfaceReadOnly.enabled is true',
+            is_error: true,
+          };
+        }
         // Lazy: only loops that opted in (AgenticLoopOptions.diagnosticsTool)
         // expose the schema, so most consumers never load this module.
         const { runDiagnosticsTool } = await import('./diagnosticsTool.js');

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -155,6 +155,12 @@ export interface AdapterCapabilities {
    * flag at all. (INT-3189)
    */
   enforcesReadOnly?: boolean;
+  /**
+   * The adapter executes OpenSwarm's native tool loop and honours the process
+   * humanSurfaceReadOnly boundary.  Strict mode requires both this declaration
+   * and run(); absence fails closed before buildCommand or a child process.
+   */
+  enforcesHumanSurfaceReadOnly?: boolean;
 }
 
 export interface CliCommandSpec {

--- a/src/agents/draftAnalyzer.ts
+++ b/src/agents/draftAnalyzer.ts
@@ -9,7 +9,12 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { getAdapter, getDefaultAdapterName, spawnCli } from '../adapters/index.js';
+import {
+  getAdapter,
+  getDefaultAdapterName,
+  resolveBoundarySafeDefaultModel,
+  spawnCli,
+} from '../adapters/index.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
 import { analyzeIssue } from '../knowledge/index.js';
 import { getRegistryStore } from '../registry/sqliteStore.js';
@@ -641,7 +646,9 @@ export async function runDraftAnalysis(options: DraftAnalyzerOptions): Promise<D
     // Explicit per-provider drafter model (INT-1915); options.model overrides on the
     // primary adapter only, then DRAFT_MODELS, then the adapter's own default.
     const override = isFallbackAttempt ? undefined : options.model;
-    const resolvedModel = override ?? DRAFT_MODELS[adapterName] ?? await adapter.getDefaultModel();
+    const resolvedModel = override
+      ?? DRAFT_MODELS[adapterName]
+      ?? await resolveBoundarySafeDefaultModel(adapter);
 
     if (isFallbackAttempt) {
       onLog?.(`[Draft] Usage limit on ${adaptersToTry[i - 1]}, fallback to ${adapterName}`);

--- a/src/agents/pairWebhook.test.ts
+++ b/src/agents/pairWebhook.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { sendWebhook, type WebhookPayload } from './pairWebhook.js';
+import { sendDiscordWebhook, sendWebhook, type WebhookPayload } from './pairWebhook.js';
+import { configureHumanSurfaceReadOnly } from '../mcp/humanSurfacePolicy.js';
+import type { PairSession } from './agentPair.js';
 
 // These suites cover parsing and backend selection, not the socket layer, so
 // route publicFetch onto the global fetch they stub. The real implementation —
@@ -10,7 +12,10 @@ vi.mock('../support/outboundUrl.js', async (importOriginal) => {
 });
 
 
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  configureHumanSurfaceReadOnly(false);
+  vi.unstubAllGlobals();
+});
 
 const payload: WebhookPayload = {
   event: 'pair_started',
@@ -28,5 +33,20 @@ describe('sendWebhook', () => {
     await expect(sendWebhook('https://example.com/hook', payload)).resolves.toMatchObject({ success: false, statusCode: 500 });
     expect((fetchMock.mock.calls[0][1] as RequestInit).signal).toBeInstanceOf(AbortSignal);
     expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it('does not call generic or Discord webhooks in strict mode', async () => {
+    const fetchMock = vi.fn(async () => new Response('ok'));
+    vi.stubGlobal('fetch', fetchMock);
+    configureHumanSurfaceReadOnly(true);
+
+    await expect(sendWebhook('https://example.com/hook', payload))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining('HUMAN_SURFACE_READ_ONLY') });
+    await expect(sendDiscordWebhook('https://discord.com/api/webhooks/1/x', {
+      id: 's', taskId: 't', taskTitle: 'task', status: 'running',
+      worker: { attempts: 1, maxAttempts: 2 }, reviewer: {},
+    } as PairSession, 'blocked', 0))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining('HUMAN_SURFACE_READ_ONLY') });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/pairWebhook.ts
+++ b/src/agents/pairWebhook.ts
@@ -5,6 +5,7 @@
 
 import type { PairSession } from './agentPair.js';
 import { isPotentiallyPublicHttpUrl, publicFetch } from '../support/outboundUrl.js';
+import { isHumanSurfaceReadOnlyEnabled } from '../mcp/humanSurfacePolicy.js';
 
 // Types
 
@@ -208,6 +209,9 @@ export async function notifyPairCancelled(
 const WEBHOOK_TIMEOUT_MS = 10_000;
 
 export async function sendWebhook(url: string, payload: WebhookPayload): Promise<WebhookResult> {
+  if (isHumanSurfaceReadOnlyEnabled()) {
+    return { success: false, error: 'HUMAN_SURFACE_READ_ONLY: outbound webhooks are disabled' };
+  }
   try {
     const response = await publicFetch(url, {
       method: 'POST',
@@ -248,6 +252,9 @@ export async function sendDiscordWebhook(
   title: string,
   color: number
 ): Promise<WebhookResult> {
+  if (isHumanSurfaceReadOnlyEnabled()) {
+    return { success: false, error: 'HUMAN_SURFACE_READ_ONLY: Discord webhooks are disabled' };
+  }
   const embed = {
     title,
     color,

--- a/src/agents/stageModelResolver.ts
+++ b/src/agents/stageModelResolver.ts
@@ -2,7 +2,7 @@
 // OpenSwarm - Stage model resolution (INT-2393)
 // ============================================
 
-import { getAdapter } from '../adapters/index.js';
+import { getAdapter, resolveBoundarySafeDefaultModel } from '../adapters/index.js';
 
 /**
  * Resolve (and cache) an adapter's default model. `getDefaultModel` is heavy
@@ -18,7 +18,7 @@ export function resolveAdapterDefaultModel(
   let pending = cache.get(cacheKey);
   if (!pending) {
     pending = Promise.resolve()
-      .then(() => getAdapter(adapterName).getDefaultModel())
+      .then(() => resolveBoundarySafeDefaultModel(getAdapter(adapterName)))
       .catch(() => {
         // Drop the failure from the cache so a later call tries again. Storing
         // it meant one transient lookup error — a provider blip during startup

--- a/src/agents/worker.routing.test.ts
+++ b/src/agents/worker.routing.test.ts
@@ -9,6 +9,7 @@ const adapters = vi.hoisted(() => ({
 vi.mock('../adapters/index.js', () => ({
   getAdapter: (name?: keyof typeof adapters) => adapters[name ?? 'codex'],
   getDefaultAdapterName: () => 'codex',
+  probeAdapterAvailability: (adapter: { isAvailable(): Promise<boolean> }) => adapter.isAvailable(),
   spawnCli: (...args: unknown[]) => spawnCli(...args),
 }));
 vi.mock('../support/gitTracker.js', () => ({ isGitRepo: vi.fn(async () => false), takeSnapshot: vi.fn() }));

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -9,7 +9,7 @@ import { t, getPrompts } from '../locale/index.js';
 import type { WorkerContext } from '../locale/types.js';
 import type { AdapterName, ProcessContext } from '../adapters/types.js';
 import type { ToolDefinition } from '../adapters/tools.js';
-import { getAdapter, getDefaultAdapterName, spawnCli } from '../adapters/index.js';
+import { getAdapter, getDefaultAdapterName, probeAdapterAvailability, spawnCli } from '../adapters/index.js';
 import { expandPath } from '../core/config.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
 import { isInfraError } from '../adapters/errorClassification.js';
@@ -237,7 +237,7 @@ async function planWorkerAdapters(primary: AdapterName, policy?: AdapterRoutePol
   const candidates = new Set<AdapterName>(policy.fallbacks ?? []);
   candidates.delete(primary);
   if (isRouteReasonAllowed(policy, 'capability')) candidates.add(primary);
-  for (const candidate of candidates) available[candidate] = await getAdapter(candidate).isAvailable();
+  for (const candidate of candidates) available[candidate] = await probeAdapterAvailability(getAdapter(candidate));
   return planAdapterAttempts({ policy, primary, available });
 }
 

--- a/src/cli/initWizard.ts
+++ b/src/cli/initWizard.ts
@@ -16,7 +16,7 @@ import { select, input, password, confirm } from '@inquirer/prompts';
 import { writeEnvVars } from '../core/envFile.js';
 import { generateSampleConfig } from '../core/config.js';
 import { AuthProfileStore, loginAndSaveLinearProfile, ensureValidToken } from '../auth/index.js';
-import { getAdapter } from '../adapters/index.js';
+import { getAdapter, probeAdapterAvailability } from '../adapters/index.js';
 import { type LinearCredential } from '../linear/index.js';
 import { pickAndSaveLinearMapping } from './linearMapping.js';
 import { banner } from '../support/banner.js';
@@ -104,7 +104,7 @@ async function bootstrapProvider(
 ): Promise<{ doAuthNow: boolean; plan: ReturnType<typeof authPlanFor> }> {
   let available = false;
   try {
-    available = await getAdapter(provider).isAvailable();
+    available = await probeAdapterAvailability(getAdapter(provider));
   } catch { // cxt-ignore: error_swallow,exception_hiding — unknown/unconfigured provider treated as unavailable
     available = false;
   }

--- a/src/coordination/humanQuestions.test.ts
+++ b/src/coordination/humanQuestions.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { configureHumanSurfaceReadOnly } from '../mcp/humanSurfacePolicy.js';
 
 // vitest.setup.ts points this at a temp path; restore it rather than deleting,
 // so a later suite in this worker never falls back to the real ~/.openswarm store.
@@ -12,6 +13,7 @@ const ORIGINAL_COORDINATION_FILE = process.env.OPENSWARM_COORDINATION_FILE;
 const ORIGINAL_AUTOMATION_DB = process.env.OPENSWARM_AUTOMATION_DB;
 let dir = '';
 afterEach(async () => {
+  configureHumanSurfaceReadOnly(false);
   const store = await import('./coordinationStore.js');
   store.resetCoordinationStoreForTests();
   (await import('./coordinationTrace.js')).resetTraceDbForTests();
@@ -31,6 +33,20 @@ async function modules() {
 }
 
 describe('human questions', () => {
+  it('records the blocker but never invokes an injected operator sender in strict mode', async () => {
+    const h = await modules();
+    const notify = vi.fn(async () => true);
+    configureHumanSurfaceReadOnly(true);
+
+    const posted = await h.postHumanQuestion({
+      repository: '/repo', taskId: 'strict-task', actor: 'a', question: 'Ship?', notify,
+    });
+
+    expect(posted.delivered).toBe(false);
+    expect(notify).not.toHaveBeenCalled();
+    expect((await import('./coordinationStore.js')).getCoordinationStore().findQuestion(posted.correlationId))
+      .toMatchObject({ status: 'waiting', summary: 'Ship?' });
+  });
   it('pages the operator and routes the answer back to the agent that asked', async () => {
     const h = await modules();
     const notify = vi.fn(async () => true);

--- a/src/coordination/humanQuestions.ts
+++ b/src/coordination/humanQuestions.ts
@@ -13,6 +13,7 @@ import { createHash } from 'node:crypto';
 import { getCoordinationStore, type CoordinationEvent } from './coordinationStore.js';
 import { t } from '../locale/index.js';
 import { answerHint } from './answerHint.js';
+import { isHumanSurfaceReadOnlyEnabled } from '../mcp/humanSurfacePolicy.js';
 
 export interface HumanQuestionInput {
   repository: string;
@@ -152,7 +153,7 @@ export async function postHumanQuestion(input: HumanQuestionInput): Promise<Huma
   }
 
   const notify = input.notify ?? notifyOperatorViaDiscord;
-  const delivered = await notify(
+  const delivered = isHumanSurfaceReadOnlyEnabled() ? false : await notify(
     `OpenSwarm needs a decision for ${input.taskLabel ?? input.taskId}` +
       `${input.actorName ? ` (asked by ${input.actorName})` : ''}.\n${input.question}\n\n` +
       answerHint(correlationId),

--- a/src/coordination/mcpPolicy.test.ts
+++ b/src/coordination/mcpPolicy.test.ts
@@ -8,6 +8,8 @@ describe('MCP role policy', () => {
   it('classifies read, write, and destructive operations conservatively', () => {
     expect(classifyMcpTool('github__get_issue')).toBe('read');
     expect(classifyMcpTool('linear__save_comment')).toBe('write');
+    expect(classifyMcpTool('slack__chat_postMessage')).toBe('write');
+    expect(classifyMcpTool('discord__send_message')).toBe('write');
     expect(classifyMcpTool('cloudflare__delete_worker')).toBe('destructive');
   });
 
@@ -36,5 +38,28 @@ describe('MCP role policy', () => {
       writeTools: ['linear__save_comment'],
       destructiveTools: ['github__merge_pull_request'],
     }).tools).toEqual(tools);
+  });
+
+  it('does not let an exact role grant widen human-surface authority', () => {
+    const tools = [tool('slack__list_channels'), tool('slack__chat_postMessage'), tool('notion__create_page')];
+    const result = filterMcpToolsForRole(tools, {
+      servers: ['slack', 'notion'],
+      writeTools: ['slack__chat_postMessage', 'notion__create_page'],
+    });
+    expect(result.tools.map((entry) => entry.function.name)).toEqual(['slack__list_channels']);
+    expect(result.denied).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'slack__chat_postMessage', reason: expect.stringContaining('human surface is read-only') }),
+      expect.objectContaining({ name: 'notion__create_page', reason: expect.stringContaining('human surface is read-only') }),
+    ]));
+  });
+
+  it('preserves exact DevOps and data mutations', () => {
+    const tools = [tool('github__create_issue'), tool('cloudflare__delete_worker'), tool('postgres__update_row')];
+    const result = filterMcpToolsForRole(tools, {
+      servers: ['github', 'cloudflare', 'postgres'],
+      writeTools: ['github__create_issue', 'postgres__update_row'],
+      destructiveTools: ['cloudflare__delete_worker'],
+    });
+    expect(result.tools).toEqual(tools);
   });
 });

--- a/src/coordination/mcpPolicy.test.ts
+++ b/src/coordination/mcpPolicy.test.ts
@@ -53,6 +53,18 @@ describe('MCP role policy', () => {
     ]));
   });
 
+  it('keeps generic human reads dispatchable and requires exact grants for generic DevOps writes', () => {
+    const humanRequest = tool('slack__request');
+    const devopsRequest = tool('github__http_post_request');
+
+    expect(filterMcpToolsForRole([humanRequest], { servers: ['slack'] }).tools).toEqual([humanRequest]);
+    expect(filterMcpToolsForRole([devopsRequest], { servers: ['github'] }).tools).toEqual([]);
+    expect(filterMcpToolsForRole([devopsRequest], {
+      servers: ['github'],
+      writeTools: ['github__http_post_request'],
+    }).tools).toEqual([devopsRequest]);
+  });
+
   it('preserves exact DevOps and data mutations', () => {
     const tools = [tool('github__create_issue'), tool('cloudflare__delete_worker'), tool('postgres__update_row')];
     const result = filterMcpToolsForRole(tools, {

--- a/src/coordination/mcpPolicy.ts
+++ b/src/coordination/mcpPolicy.ts
@@ -3,8 +3,12 @@
 // ============================================
 
 import type { ToolDefinition } from '../adapters/tools.js';
+import {
+  describeMcpToolPolicy,
+  type McpAccess,
+} from '../mcp/humanSurfacePolicy.js';
 
-export type McpAccess = 'read' | 'write' | 'destructive';
+export type { McpAccess } from '../mcp/humanSurfacePolicy.js';
 
 export interface RoleMcpPolicy {
   servers: string[];
@@ -13,18 +17,8 @@ export interface RoleMcpPolicy {
   destructiveTools?: string[];
 }
 
-const MUTATION_WORDS = /(^|_)(create|update|save|write|edit|delete|remove|archive|close|merge|approve|submit|reply|resolve|trigger|run|execute|upload|move|share|unshare)(_|$)/i;
-const DESTRUCTIVE_WORDS = /(^|_)(delete|remove|archive|merge|execute|run|trigger|unshare)(_|$)/i;
-
 export function classifyMcpTool(toolName: string): McpAccess {
-  // Everything after the server prefix, not just the next segment: a nested
-  // name like `github__pulls__merge` puts the verb in the last segment, and
-  // reading only `pulls` classified a merge as a harmless read.
-  const segments = toolName.split('__');
-  const raw = segments.length > 1 ? segments.slice(1).join('__') : toolName;
-  if (DESTRUCTIVE_WORDS.test(raw)) return 'destructive';
-  if (MUTATION_WORDS.test(raw)) return 'write';
-  return 'read';
+  return describeMcpToolPolicy(toolName).access;
 }
 
 export function filterMcpToolsForRole(
@@ -40,10 +34,12 @@ export function filterMcpToolsForRole(
   const denied: Array<{ name: string; reason: string }> = [];
   for (const tool of tools) {
     const name = tool.function.name;
-    const [server] = name.split('__');
-    const access = classifyMcpTool(name);
+    const decision = describeMcpToolPolicy(tool);
+    const { server, access } = decision;
     let reason: string | undefined;
-    if (!servers.has(server)) reason = `server ${server} is not allowlisted`;
+    if (decision.surface === 'human' && !decision.humanSurfaceReadAllowed) {
+      reason = 'external human surface is read-only; only read/list/get/search/fetch actions are allowed';
+    } else if (!servers.has(server)) reason = `server ${server} is not allowlisted`;
     else if (allow && !allow.has(name)) reason = 'tool is not on the exact allowlist';
     else if (access === 'write' && !writes.has(name)) reason = 'write capability was not granted';
     else if (access === 'destructive' && !destructive.has(name)) reason = 'destructive capability was not granted';

--- a/src/coordination/mcpPolicy.ts
+++ b/src/coordination/mcpPolicy.ts
@@ -5,6 +5,7 @@
 import type { ToolDefinition } from '../adapters/tools.js';
 import {
   describeMcpToolPolicy,
+  isGenericMcpTransport,
   type McpAccess,
 } from '../mcp/humanSurfacePolicy.js';
 
@@ -37,7 +38,8 @@ export function filterMcpToolsForRole(
     const decision = describeMcpToolPolicy(tool);
     const { server, access } = decision;
     let reason: string | undefined;
-    if (decision.surface === 'human' && !decision.humanSurfaceReadAllowed) {
+    const dispatchClassified = isGenericMcpTransport(decision, tool.function.parameters);
+    if (decision.surface === 'human' && !decision.humanSurfaceReadAllowed && !dispatchClassified) {
       reason = 'external human surface is read-only; only read/list/get/search/fetch actions are allowed';
     } else if (!servers.has(server)) reason = `server ${server} is not allowlisted`;
     else if (allow && !allow.has(name)) reason = 'tool is not on the exact allowlist';

--- a/src/coordination/orchestratorAgent.test.ts
+++ b/src/coordination/orchestratorAgent.test.ts
@@ -13,7 +13,11 @@ const getAdapter = vi.hoisted(() => vi.fn(() => ({
   run: vi.fn(),
   getDefaultModel: vi.fn(async () => 'gpt-5.6-terra'),
 })));
-vi.mock('../adapters/index.js', () => ({ getAdapter, spawnCli }));
+vi.mock('../adapters/index.js', () => ({
+  adapterCanRunUnderHumanSurfaceBoundary: (adapter: { run?: unknown }) => typeof adapter.run === 'function',
+  getAdapter,
+  spawnCli,
+}));
 vi.mock('../mcp/mcpClient.js', () => ({ getMcpTools }));
 
 const tool = (name: string): ToolDefinition => ({ type: 'function', function: { name, description: '', parameters: { type: 'object' } } });

--- a/src/coordination/orchestratorAgent.ts
+++ b/src/coordination/orchestratorAgent.ts
@@ -15,7 +15,7 @@ import { randomUUID } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { getAdapter, spawnCli } from '../adapters/index.js';
+import { adapterCanRunUnderHumanSurfaceBoundary, getAdapter, spawnCli } from '../adapters/index.js';
 import type { ToolDefinition } from '../adapters/tools.js';
 import { getMcpTools } from '../mcp/mcpClient.js';
 import { filterMcpToolsForRole, type RoleMcpPolicy } from './mcpPolicy.js';
@@ -87,7 +87,7 @@ export async function runOrchestrator(options: OrchestratorRunOptions): Promise<
   const callSign = assignCallSign({ repository: cell.repoKey, executionId: options.taskId, role: 'orchestrator' });
   const adapter = getAdapter(options.adapterName);
   const routeCorrelationId = `orchestrator-route:${randomUUID()}`;
-  if (!adapter.run) {
+  if (!adapter.run || !adapterCanRunUnderHumanSurfaceBoundary(adapter)) {
     // Do not invoke delegated adapter discovery here. Some implementations
     // consult a live account/model catalog, which is unnecessary provider work
     // for a route that must be rejected before any delegated CLI activity.

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -10,6 +10,10 @@ import {
   generateSampleConfig,
 } from './config.js';
 import * as fs from 'node:fs';
+import {
+  configureHumanSurfaceReadOnly,
+  isHumanSurfaceReadOnlyEnabled,
+} from '../mcp/humanSurfacePolicy.js';
 
 // Mock fs module
 vi.mock('node:fs', async () => {
@@ -31,6 +35,7 @@ describe('config', () => {
   });
 
   afterEach(() => {
+    configureHumanSurfaceReadOnly(false);
     delete process.env.DISCORD_TOKEN;
     delete process.env.DISCORD_CHANNEL_ID;
     delete process.env.LINEAR_API_KEY;
@@ -42,6 +47,21 @@ describe('config', () => {
   // ============================================
 
   describe('loadConfig', () => {
+    it('wires the explicit strict boundary and never downgrades it from a later utility config load', () => {
+      const base = {
+        language: 'en',
+        agents: [{ name: 'main', projectPath: '/p', enabled: true, paused: false }],
+      };
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync)
+        .mockReturnValueOnce(JSON.stringify({ ...base, humanSurfaceReadOnly: { enabled: true } }))
+        .mockReturnValueOnce(JSON.stringify(base));
+
+      expect(loadConfig('/tmp/config.json').humanSurfaceReadOnly).toEqual({ enabled: true });
+      expect(isHumanSurfaceReadOnlyEnabled()).toBe(true);
+      expect(loadConfig('/tmp/config.json').humanSurfaceReadOnly).toEqual({ enabled: false });
+      expect(isHumanSurfaceReadOnlyEnabled()).toBe(true);
+    });
     it('should load YAML config file', () => {
       const yamlContent = `
 language: en

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -265,7 +265,7 @@ agents:
         mcp: {
           servers: {
             linear: { command: 'npx', args: ['-y', 'mcp-remote', 'https://mcp.linear.app/mcp'] },
-            docs: { url: 'https://example.com/mcp', transport: 'http' },
+            docs: { url: 'https://example.com/mcp', transport: 'http', surface: 'human' },
           },
         },
       });
@@ -276,6 +276,7 @@ agents:
       const config = loadConfig('/tmp/config.json');
       expect(config.mcp?.servers.linear.command).toBe('npx');
       expect(config.mcp?.servers.docs.url).toBe('https://example.com/mcp');
+      expect(config.mcp?.servers.docs.surface).toBe('human');
     });
 
     it('should accept an mcp server declared via preset (INT-1952)', () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -433,6 +433,8 @@ const McpServerSchema = z
   .object({
     /** Reference a built-in preset (e.g. `linear`) instead of command/url. (INT-1952) */
     preset: z.string().optional(),
+    /** Explicit trust-domain label; `human` makes unknown actions fail closed. */
+    surface: z.enum(['human', 'devops', 'data', 'sandbox', 'unknown']).optional(),
     command: z.string().optional(),
     args: z.array(z.string()).optional(),
     env: z.record(z.string(), z.string()).optional(),

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -10,6 +10,7 @@ import YAML from 'yaml';
 import type { SwarmConfig, AgentSession, LongRunningMonitorConfig, ConflictResolverConfig, McpConfig } from './types.js';
 import { setTimeWindowConfig, DEFAULT_TIME_WINDOW } from '../support/timeWindow.js';
 import { c, status } from '../support/colors.js';
+import { configureHumanSurfaceReadOnly } from '../mcp/humanSurfacePolicy.js';
 
 // Constants
 
@@ -427,6 +428,14 @@ const NotificationsSchema = z.object({
   webhookUrl: z.string().optional(),
 }).optional();
 
+const HumanSurfaceReadOnlySchema = z.object({
+  /**
+   * Strict mode blocks arbitrary agent programs and all OpenSwarm-owned
+   * Slack/Discord/Telegram/webhook sends.  Local web chat remains available.
+   */
+  enabled: z.boolean().default(false),
+}).default({ enabled: false });
+
 // MCP server entry: stdio (`command`/`args`/`env`) or remote (`url`/`headers`).
 // Mirrors the ~/.openswarm/mcp.json shape so config.yaml is a single source. (INT-1949)
 const McpServerSchema = z
@@ -470,6 +479,7 @@ const RawConfigSchema = z.object({
   language: z.enum(['en', 'ko']).default('en'),
   discord: DiscordConfigSchema,
   notifications: NotificationsSchema,
+  humanSurfaceReadOnly: HumanSurfaceReadOnlySchema,
   linear: LinearConfigSchema,
   github: GitHubConfigSchema,
   timeWindow: TimeWindowConfigSchema,
@@ -630,6 +640,7 @@ function transformConfig(raw: RawConfig): SwarmConfig {
           webhookUrl: raw.notifications.webhookUrl,
         }
       : undefined,
+    humanSurfaceReadOnly: { enabled: raw.humanSurfaceReadOnly.enabled },
     linearApiKey: raw.linear?.apiKey ?? '',
     linearTeamId: raw.linear?.teamId ?? '',
     agents: raw.agents.map(agent => ({
@@ -793,6 +804,12 @@ export function loadConfig(customPath?: string): SwarmConfig {
   // 5. Transform to SwarmConfig
   const config = transformConfig(parseResult.data);
 
+  // Enabling is process-lifetime monotonic. Utility callers also load config
+  // (MCP discovery, telemetry, provider lookup); a later lookup resolving a
+  // different/default file must never silently downgrade an active boundary.
+  // Disabling therefore requires a process restart with enabled:false.
+  if (config.humanSurfaceReadOnly?.enabled === true) configureHumanSurfaceReadOnly(true);
+
   // 6. Apply time window config
   if (config.timeWindow) {
     setTimeWindowConfig(config.timeWindow);
@@ -883,6 +900,15 @@ notifications:
   # telegramBotToken: \${TELEGRAM_BOT_TOKEN:-}
   # telegramChatId: \${TELEGRAM_CHAT_ID:-}
   # webhookUrl: \${NOTIFY_WEBHOOK_URL:-}
+
+# Fail closed on writes to human-facing collaboration surfaces. In strict mode
+# agent shell/diagnostics and delegated CLI adapters are disabled, as are core
+# Discord/Slack/Telegram/webhook senders. Local web chat and approved MCP
+# DevOps/data writes remain available. On Linux, no working network-isolating
+# sandbox plus no typed MCP grants is a deployment blocker for autonomous
+# development; never restore an unsandboxed shell as a workaround.
+humanSurfaceReadOnly:
+  enabled: false
 
 # Task source: when the linear block below is unset, OpenSwarm falls back to a
 # local SQLite issue store (~/.openswarm/issues.db) — no external account needed.

--- a/src/core/service.test.ts
+++ b/src/core/service.test.ts
@@ -11,6 +11,7 @@ import {
 import { setDefaultAdapter } from '../adapters/index.js';
 import { readProviderOverride } from './providerOverride.js';
 import * as autonomousRunner from '../automation/autonomousRunner.js';
+import { configureHumanSurfaceReadOnly } from '../mcp/humanSurfacePolicy.js';
 
 // Mock external dependencies
 // Mock auth so service.test never reads the real ~/.openswarm/auth-profiles.json
@@ -213,6 +214,7 @@ describe('service', () => {
 
   afterEach(async () => {
     await stopService();
+    configureHumanSurfaceReadOnly(false);
   });
 
   // AGT-4122: service.ts forwarded only four decomposition fields and never the
@@ -366,6 +368,20 @@ describe('service', () => {
         mockConfig.discordToken,
         mockConfig.discordChannelId
       );
+    });
+
+    it('keeps local web serving but never initializes Discord in strict human-surface mode', async () => {
+      const { initDiscord, stopDiscord } = await import('../discord/index.js');
+      const { startWebServer } = await import('../support/web.js');
+
+      await startService({
+        ...mockConfig,
+        humanSurfaceReadOnly: { enabled: true },
+      });
+
+      expect(initDiscord).not.toHaveBeenCalled();
+      expect(stopDiscord).toHaveBeenCalled();
+      expect(startWebServer).toHaveBeenCalledWith(3847);
     });
 
     it('should reapply a persisted provider override when it differs from config default', async () => {

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -29,6 +29,10 @@ import { enrichTaskFromState, hydrateTaskStateFromComments, updateTaskLinearStat
 import { probeDaemonPort } from '../cli/daemon.js';
 import { rotateServiceLogs } from '../support/logRotation.js';
 import { acquireServiceInstanceLock, type ServiceInstanceLock } from '../support/serviceInstanceLock.js';
+import {
+  configureHumanSurfaceReadOnly,
+  isHumanSurfaceReadOnlyEnabled,
+} from '../mcp/humanSurfacePolicy.js';
 
 let state: ServiceState = {
   running: false,
@@ -73,6 +77,7 @@ export async function startService(config: SwarmConfig): Promise<void> {
 }
 
 async function startServiceLocked(config: SwarmConfig): Promise<void> {
+  if (config.humanSurfaceReadOnly?.enabled === true) configureHumanSurfaceReadOnly(true);
   let postMergeIntegration: PRProcessorConfig['postMergeIntegration'];
   // The lifetime SQLite lock above is the atomic single-instance authority.
   // Keep the port probe as a diagnostic for older daemons or unrelated
@@ -136,7 +141,13 @@ async function startServiceLocked(config: SwarmConfig): Promise<void> {
   }
 
   // Discord initialization (optional)
-  if (config.discordToken && config.discordChannelId) {
+  if (isHumanSurfaceReadOnlyEnabled()) {
+    // A connected bot can reply, type, and post through many handler paths.
+    // Do not retain that capability in strict mode; local web chat is the
+    // supported human control surface.
+    await discord.stopDiscord();
+    console.log('⏭ Discord disabled by humanSurfaceReadOnly policy');
+  } else if (config.discordToken && config.discordChannelId) {
     console.log('🤖 Connecting Discord bot...');
     await discord.initDiscord(config.discordToken, config.discordChannelId);
     console.log('✅ Discord bot connected successfully');

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -133,6 +133,11 @@ export type SwarmConfig = {
   discordWebhookUrl?: string;
   /** Outbound notification channel (Discord/Slack/Telegram/webhook) — INT-1576 */
   notifications?: NotificationsConfig;
+  /**
+   * Fail-closed human-surface boundary.  When enabled, external collaboration
+   * surfaces are read-only and arbitrary agent program execution is disabled.
+   */
+  humanSurfaceReadOnly?: { enabled: boolean };
   /** Linear API key */
   linearApiKey: string;
   /** Linear team ID */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -102,6 +102,8 @@ export type SwarmEvent = {
 export type McpServerConfig = {
   /** Reference a built-in preset (e.g. `linear`) instead of command/url. (INT-1952) */
   preset?: string;
+  /** Trust-domain label used by the external human-surface policy. */
+  surface?: 'human' | 'devops' | 'data' | 'sandbox' | 'unknown';
   command?: string;
   args?: string[];
   env?: Record<string, string>;

--- a/src/discord/discordCore.helpers.test.ts
+++ b/src/discord/discordCore.helpers.test.ts
@@ -4,8 +4,10 @@ import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { clampDiscordText, getChatHistory, questionCorrelationIdFrom, saveChatHistory, startTypingIndicator } from './discordCore.js';
+import { configureHumanSurfaceReadOnly } from '../mcp/humanSurfacePolicy.js';
 
 afterEach(() => {
+  configureHumanSurfaceReadOnly(false);
   vi.useRealTimers();
   vi.restoreAllMocks();
   delete process.env.OPENSWARM_CHAT_HISTORY_FILE;
@@ -49,6 +51,15 @@ describe('Discord outbound bounds', () => {
     clearInterval(timer);
     expect(sendTyping.mock.calls.length).toBeGreaterThanOrEqual(2);
     expect(warn).toHaveBeenCalled();
+  });
+
+  it('does not emit typing activity in strict mode', async () => {
+    const sendTyping = vi.fn(async () => {});
+    configureHumanSurfaceReadOnly(true);
+    const timer = startTypingIndicator({ sendTyping }, 10);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    clearTimeout(timer);
+    expect(sendTyping).not.toHaveBeenCalled();
   });
 });
 

--- a/src/discord/discordCore.lifecycle.test.ts
+++ b/src/discord/discordCore.lifecycle.test.ts
@@ -35,10 +35,19 @@ vi.mock('discord.js', async () => {
   };
 });
 
-import { client, initDiscord, stopDiscord } from './discordCore.js';
+import {
+  client,
+  hasDiscordChannel,
+  initDiscord,
+  sendToChannel,
+  sendToThread,
+  stopDiscord,
+} from './discordCore.js';
+import { configureHumanSurfaceReadOnly } from '../mcp/humanSurfacePolicy.js';
 
 describe('Discord client lifecycle', () => {
   afterEach(async () => {
+    configureHumanSurfaceReadOnly(false);
     await stopDiscord();
     discord.instances.length = 0;
     discord.nextLoginError = null;
@@ -60,6 +69,25 @@ describe('Discord client lifecycle', () => {
     await expect(initDiscord('bad-token', 'channel')).rejects.toThrow('login failed');
 
     expect(discord.instances[0].destroy).toHaveBeenCalledTimes(1);
+    expect(client).toBeNull();
+  });
+
+  it('destroys an existing client and suppresses every direct outbound route in strict mode', async () => {
+    await initDiscord('first-token', 'channel');
+    const first = discord.instances[0];
+    const send = vi.fn(async () => {});
+    first.channels.fetch.mockResolvedValue({ send, isThread: () => true });
+
+    configureHumanSurfaceReadOnly(true);
+    expect(hasDiscordChannel()).toBe(false);
+    await sendToChannel('blocked');
+    await sendToThread('thread', 'blocked');
+    await initDiscord('second-token', 'channel');
+
+    expect(send).not.toHaveBeenCalled();
+    expect(first.channels.fetch).not.toHaveBeenCalled();
+    expect(first.destroy).toHaveBeenCalledOnce();
+    expect(discord.instances).toHaveLength(1);
     expect(client).toBeNull();
   });
 });

--- a/src/discord/discordCore.ts
+++ b/src/discord/discordCore.ts
@@ -23,6 +23,7 @@ import * as memory from '../memory/index.js';
 import { t, getPrompts, getDateLocale } from '../locale/index.js';
 import { atomicWriteFileSync } from '../support/atomicFile.js';
 import { safeConsole as console } from '../support/safeLog.js';
+import { isHumanSurfaceReadOnlyEnabled } from '../mcp/humanSurfacePolicy.js';
 
 // Handler module (for routing)
 import { handlePair } from './discordPair.js';
@@ -298,6 +299,11 @@ export function setCallbacks(callbacks: {
  * Initialize and start Discord bot
  */
 export async function initDiscord(token: string, channelId: string): Promise<void> {
+  if (isHumanSurfaceReadOnlyEnabled()) {
+    await stopDiscord();
+    reportChannelId = '';
+    return;
+  }
   reportChannelId = channelId;
 
   // Reconfiguration/restart must not leave the old websocket client alive.
@@ -402,6 +408,7 @@ async function tryAnswerByReply(msg: Message): Promise<boolean> {
  * Message handler
  */
 async function handleMessage(msg: Message): Promise<void> {
+  if (isHumanSurfaceReadOnlyEnabled()) return;
   if (msg.author.bot) return;
 
   // A reply to a question we posted answers that question.
@@ -568,6 +575,7 @@ async function handleHelp(msg: Message): Promise<void> {
  * Report event to Discord
  */
 export async function reportEvent(event: SwarmEvent): Promise<void> {
+  if (isHumanSurfaceReadOnlyEnabled()) return;
   if (!client) return;
 
   let channel: TextChannel | null = null;
@@ -643,6 +651,11 @@ export function startTypingIndicator(
   channel: { sendTyping: () => Promise<unknown> },
   intervalMs = 8_000,
 ): NodeJS.Timeout {
+  if (isHumanSurfaceReadOnlyEnabled()) {
+    const timer = setTimeout(() => {}, 0);
+    timer.unref?.();
+    return timer;
+  }
   const send = () => {
     void channel.sendTyping().catch((error) => {
       console.warn('[Discord] Typing indicator failed:', error instanceof Error ? error.message : String(error));
@@ -672,13 +685,14 @@ export async function stopDiscord(): Promise<void> {
  * question, for one — check here first rather than assuming the send landed.
  */
 export function hasDiscordChannel(): boolean {
-  return Boolean(client && reportChannelId);
+  return !isHumanSurfaceReadOnlyEnabled() && Boolean(client && reportChannelId);
 }
 
 /**
  * Send message to default Discord channel (for external callers)
  */
 export async function sendToChannel(content: string | { embeds: EmbedBuilder[] }): Promise<void> {
+  if (isHumanSurfaceReadOnlyEnabled()) return;
   if (!client || !reportChannelId) return;
 
   try {
@@ -766,6 +780,7 @@ function splitForDiscord(text: string, maxLen: number): string[] {
  * Send message to Discord thread (for external callers)
  */
 export async function sendToThread(threadId: string, content: string | EmbedBuilder): Promise<void> {
+  if (isHumanSurfaceReadOnlyEnabled()) return;
   if (!client) return;
 
   try {

--- a/src/mcp/humanSurfacePolicy.test.ts
+++ b/src/mcp/humanSurfacePolicy.test.ts
@@ -70,6 +70,8 @@ describe('human-surface shell boundary', () => {
       DISCORD_WEBHOOK_URL: 'secret',
       NOTION_API_KEY: 'secret',
       GOOGLE_DRIVE_TOKEN: 'secret',
+      GOOGLE_CALENDAR_API_KEY: 'secret',
+      CALENDAR_TOKEN: 'secret',
       GITHUB_TOKEN: 'keep',
       POSTGRES_DSN: 'keep',
       OPENAI_API_KEY: 'keep',
@@ -80,6 +82,8 @@ describe('human-surface shell boundary', () => {
     expect(env).not.toHaveProperty('DISCORD_WEBHOOK_URL');
     expect(env).not.toHaveProperty('NOTION_API_KEY');
     expect(env).not.toHaveProperty('GOOGLE_DRIVE_TOKEN');
+    expect(env).not.toHaveProperty('GOOGLE_CALENDAR_API_KEY');
+    expect(env).not.toHaveProperty('CALENDAR_TOKEN');
     expect(env).toMatchObject({
       GITHUB_TOKEN: 'keep',
       POSTGRES_DSN: 'keep',
@@ -107,6 +111,10 @@ describe('human-surface shell boundary', () => {
     expect(humanSurfaceShellWriteReason('slack chat send --channel ops --text hello')).toContain('service slack');
     expect(humanSurfaceShellWriteReason("bash -c 'slack chat send --channel ops --text hello'"))
       .toContain('service slack');
+    expect(humanSurfaceShellWriteReason('npx @company/slack-cli post --channel ops --text hello'))
+      .toContain('service slack');
+    expect(humanSurfaceShellWriteReason('pnpm dlx notion-cli create page'))
+      .toContain('service notion');
     expect(humanSurfaceShellWriteReason("python -c \"requests.post('https://discord.com/api/webhooks/x')\"")).toContain('discord.com');
 
     expect(humanSurfaceShellWriteReason('curl -X GET https://api.slack.com/methods/conversations.list')).toBeUndefined();

--- a/src/mcp/humanSurfacePolicy.test.ts
+++ b/src/mcp/humanSurfacePolicy.test.ts
@@ -23,6 +23,22 @@ describe('human-surface MCP policy', () => {
     expect(describeMcpToolPolicy(tool('slackarchive__get_record')).surface).toBe('unknown');
     expect(describeMcpToolPolicy(tool('google-drive__create_file')).surface).toBe('human');
     expect(describeMcpToolPolicy(tool('relay__create_page', 'Create a page in Notion')).surface).toBe('human');
+    expect(describeMcpToolPolicy(tool('relay__sendMail')).surface).toBe('human');
+  });
+
+  it('narrows Microsoft Graph classification to human-facing actions', () => {
+    const identity = { serverIdentityHints: ['https://graph.microsoft.com/v1.0'] };
+    expect(describeMcpToolPolicy(tool('graph__create_message'), identity)).toMatchObject({
+      surface: 'human',
+      access: 'write',
+      humanSurfaceReadAllowed: false,
+    });
+    expect(describeMcpToolPolicy(tool('graph__list_messages'), identity)).toMatchObject({
+      surface: 'human',
+      access: 'read',
+      humanSurfaceReadAllowed: true,
+    });
+    expect(describeMcpToolPolicy(tool('graph__update_device'), identity).surface).toBe('unknown');
   });
 
   it('allows only explicit read/list/get/search/fetch actions on a human surface', () => {
@@ -72,7 +88,11 @@ describe('human-surface shell boundary', () => {
       GOOGLE_DRIVE_TOKEN: 'secret',
       GOOGLE_CALENDAR_API_KEY: 'secret',
       CALENDAR_TOKEN: 'secret',
+      MS_GRAPH_TOKEN: 'secret',
+      MICROSOFT_GRAPH_ACCESS_TOKEN: 'secret',
       GITHUB_TOKEN: 'keep',
+      AZURE_CLIENT_SECRET: 'keep',
+      GRAPH_DATABASE_PASSWORD: 'keep',
       POSTGRES_DSN: 'keep',
       OPENAI_API_KEY: 'keep',
       OPENAI_CHAT_MODEL: 'keep',
@@ -84,8 +104,12 @@ describe('human-surface shell boundary', () => {
     expect(env).not.toHaveProperty('GOOGLE_DRIVE_TOKEN');
     expect(env).not.toHaveProperty('GOOGLE_CALENDAR_API_KEY');
     expect(env).not.toHaveProperty('CALENDAR_TOKEN');
+    expect(env).not.toHaveProperty('MS_GRAPH_TOKEN');
+    expect(env).not.toHaveProperty('MICROSOFT_GRAPH_ACCESS_TOKEN');
     expect(env).toMatchObject({
       GITHUB_TOKEN: 'keep',
+      AZURE_CLIENT_SECRET: 'keep',
+      GRAPH_DATABASE_PASSWORD: 'keep',
       POSTGRES_DSN: 'keep',
       OPENAI_API_KEY: 'keep',
       OPENAI_CHAT_MODEL: 'keep',
@@ -116,8 +140,21 @@ describe('human-surface shell boundary', () => {
     expect(humanSurfaceShellWriteReason('pnpm dlx notion-cli create page'))
       .toContain('service notion');
     expect(humanSurfaceShellWriteReason("python -c \"requests.post('https://discord.com/api/webhooks/x')\"")).toContain('discord.com');
+    expect(humanSurfaceShellWriteReason(
+      "curl -X POST -H 'Authorization: Bearer '$MS_GRAPH_TOKEN -d '{}' https://graph.microsoft.com/v1.0/me/messages",
+    )).toContain('Microsoft Graph human API messages');
+    expect(humanSurfaceShellWriteReason(
+      "curl -X POST -d '{}' https://graph.microsoft.com/v1.0/chats/123/messages",
+    )).toContain('Microsoft Graph human API chats');
+    expect(humanSurfaceShellWriteReason(
+      "curl -X POST -d '{}' https://graph.microsoft.com/v1.0/me/sendMail",
+    )).toContain('Microsoft Graph human API mail');
 
     expect(humanSurfaceShellWriteReason('curl -X GET https://api.slack.com/methods/conversations.list')).toBeUndefined();
+    expect(humanSurfaceShellWriteReason('curl -X GET https://graph.microsoft.com/v1.0/me/messages')).toBeUndefined();
+    expect(humanSurfaceShellWriteReason(
+      "curl -X PATCH -d '{}' https://graph.microsoft.com/v1.0/devices/123/extensionAttributes",
+    )).toBeUndefined();
     expect(humanSurfaceShellWriteReason("curl -G -d'channel=C1' https://api.slack.com/methods/conversations.list")).toBeUndefined();
     expect(humanSurfaceShellWriteReason("curl -X POST -d '{}' https://api.github.com/repos/o/r/issues")).toBeUndefined();
     expect(humanSurfaceShellWriteReason("psql '$POSTGRES_DSN' -c 'select 1'")).toBeUndefined();

--- a/src/mcp/humanSurfacePolicy.test.ts
+++ b/src/mcp/humanSurfacePolicy.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import type { ToolDefinition } from '../adapters/tools.js';
+import {
+  attachMcpToolPolicy,
+  describeMcpToolPolicy,
+  filterHumanSurfaceMcpTools,
+  humanSurfaceShellWriteReason,
+  stripHumanSurfaceEnv,
+} from './humanSurfacePolicy.js';
+
+const tool = (name: string, description = ''): ToolDefinition => ({
+  type: 'function',
+  function: { name, description, parameters: { type: 'object' } },
+});
+
+describe('human-surface MCP policy', () => {
+  it('recognizes server, camelCase action, and descriptor instead of one substring', () => {
+    const decision = describeMcpToolPolicy(tool('slack__chat_postMessage'));
+    expect(decision).toMatchObject({ server: 'slack', action: 'chat_postMessage', surface: 'human', access: 'write' });
+    expect(decision.humanSurfaceReadAllowed).toBe(false);
+
+    // Exact identifier tokens avoid treating an unrelated server as Slack.
+    expect(describeMcpToolPolicy(tool('slackarchive__get_record')).surface).toBe('unknown');
+    expect(describeMcpToolPolicy(tool('google-drive__create_file')).surface).toBe('human');
+    expect(describeMcpToolPolicy(tool('relay__create_page', 'Create a page in Notion')).surface).toBe('human');
+  });
+
+  it('allows only explicit read/list/get/search/fetch actions on a human surface', () => {
+    const tools = [
+      tool('slack__list_channels'),
+      tool('notion__fetch_page'),
+      tool('discord__chat_history'),
+      tool('email__send_message'),
+      tool('notion__get_or_create_page'),
+    ];
+    const result = filterHumanSurfaceMcpTools(tools);
+    expect(result.tools.map((entry) => entry.function.name)).toEqual(['slack__list_channels', 'notion__fetch_page']);
+    expect(result.denied.map((entry) => entry.name)).toEqual([
+      'discord__chat_history',
+      'email__send_message',
+      'notion__get_or_create_page',
+    ]);
+  });
+
+  it('uses an explicit surface label for opaque custom server aliases', () => {
+    const definition = tool('company_portal__history');
+    attachMcpToolPolicy(definition, {
+      server: 'company_portal',
+      action: 'history',
+      declaredSurface: 'human',
+      annotations: { readOnlyHint: true },
+    });
+    const decision = describeMcpToolPolicy(definition);
+    expect(decision.surface).toBe('human');
+    // An untrusted readOnlyHint cannot expand the five-action allowlist.
+    expect(decision.humanSurfaceReadAllowed).toBe(false);
+  });
+
+  it('lets annotations tighten access but never excuse a mutating name', () => {
+    expect(describeMcpToolPolicy('github__get_issue', { annotations: { readOnlyHint: false } }).access).toBe('write');
+    expect(describeMcpToolPolicy('slack__post_message', { annotations: { readOnlyHint: true } }).access).toBe('write');
+    expect(describeMcpToolPolicy('cloudflare__get_worker', { annotations: { destructiveHint: true } }).access).toBe('destructive');
+  });
+});
+
+describe('human-surface shell boundary', () => {
+  it('removes human-surface credentials while preserving provider, DevOps, DB, and sandbox data env', () => {
+    const env = stripHumanSurfaceEnv({
+      SLACK_BOT_TOKEN: 'secret',
+      DISCORD_WEBHOOK_URL: 'secret',
+      NOTION_API_KEY: 'secret',
+      GOOGLE_DRIVE_TOKEN: 'secret',
+      GITHUB_TOKEN: 'keep',
+      POSTGRES_DSN: 'keep',
+      OPENAI_API_KEY: 'keep',
+      OPENAI_CHAT_MODEL: 'keep',
+      SANDBOX_DATA_PATH: '/warehouse',
+    });
+    expect(env).not.toHaveProperty('SLACK_BOT_TOKEN');
+    expect(env).not.toHaveProperty('DISCORD_WEBHOOK_URL');
+    expect(env).not.toHaveProperty('NOTION_API_KEY');
+    expect(env).not.toHaveProperty('GOOGLE_DRIVE_TOKEN');
+    expect(env).toMatchObject({
+      GITHUB_TOKEN: 'keep',
+      POSTGRES_DSN: 'keep',
+      OPENAI_API_KEY: 'keep',
+      OPENAI_CHAT_MODEL: 'keep',
+      SANDBOX_DATA_PATH: '/warehouse',
+    });
+  });
+
+  it('blocks direct human-surface writes but preserves reads and DevOps/data commands', () => {
+    expect(humanSurfaceShellWriteReason("curl -X POST -d '{\"text\":\"hi\"}' https://hooks.slack.com/services/T/B/X"))
+      .toContain('hooks.slack.com');
+    expect(humanSurfaceShellWriteReason("curl -d'{\"text\":\"hi\"}' https://hooks.slack.com/services/T/B/X"))
+      .toContain('hooks.slack.com');
+    expect(humanSurfaceShellWriteReason("curl --json '{\"text\":\"hi\"}' https://hooks.slack.com/services/T/B/X"))
+      .toContain('hooks.slack.com');
+    expect(humanSurfaceShellWriteReason("env -i curl --data-binary @payload.json https://hooks.slack.com/services/T/B/X"))
+      .toContain('hooks.slack.com');
+    expect(humanSurfaceShellWriteReason("bash -c \"curl -d'{}' https://hooks.slack.com/services/T/B/X\""))
+      .toContain('hooks.slack.com');
+    expect(humanSurfaceShellWriteReason("sender=curl; $sender -d'{}' https://hooks.slack.com/services/T/B/X"))
+      .toContain('hooks.slack.com');
+    expect(humanSurfaceShellWriteReason("wget --method=POST https://discord.com/api/webhooks/x"))
+      .toContain('discord.com');
+    expect(humanSurfaceShellWriteReason('slack chat send --channel ops --text hello')).toContain('service slack');
+    expect(humanSurfaceShellWriteReason("bash -c 'slack chat send --channel ops --text hello'"))
+      .toContain('service slack');
+    expect(humanSurfaceShellWriteReason("python -c \"requests.post('https://discord.com/api/webhooks/x')\"")).toContain('discord.com');
+
+    expect(humanSurfaceShellWriteReason('curl -X GET https://api.slack.com/methods/conversations.list')).toBeUndefined();
+    expect(humanSurfaceShellWriteReason("curl -G -d'channel=C1' https://api.slack.com/methods/conversations.list")).toBeUndefined();
+    expect(humanSurfaceShellWriteReason("curl -X POST -d '{}' https://api.github.com/repos/o/r/issues")).toBeUndefined();
+    expect(humanSurfaceShellWriteReason("psql '$POSTGRES_DSN' -c 'select 1'")).toBeUndefined();
+    expect(humanSurfaceShellWriteReason("rg 'slack post' src")).toBeUndefined();
+  });
+});

--- a/src/mcp/humanSurfacePolicy.ts
+++ b/src/mcp/humanSurfacePolicy.ts
@@ -123,12 +123,13 @@ const HUMAN_SURFACE_IDENTIFIERS = new Set([
   'zulip',
 ]);
 
-// Environment keys need a narrower set than server descriptors. Generic words
-// such as CHAT and CALENDAR occur in harmless model/build settings; stripping
-// them would break execution without removing a usable service credential.
+// Environment keys need a narrower set than server descriptors. Generic CHAT
+// settings occur in harmless model/build configuration; service-specific
+// Calendar credentials are still removed because Calendar is a human surface.
 const HUMAN_SURFACE_ENV_IDENTIFIERS = new Set([
   'airtable',
   'asana',
+  'calendar',
   'canva',
   'clickup',
   'discord',
@@ -326,6 +327,7 @@ export function stripHumanSurfaceEnv(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv
 const SHELL_NETWORK_EXECUTORS = new Set([
   'bash',
   'bun',
+  'bunx',
   'curl',
   'deno',
   'discord',
@@ -338,9 +340,13 @@ const SHELL_NETWORK_EXECUTORS = new Set([
   'mutt',
   'node',
   'notion',
+  'npm',
+  'npx',
   'parallel',
   'perl',
   'php',
+  'pipx',
+  'pnpm',
   'python',
   'python3',
   'powershell',
@@ -349,8 +355,10 @@ const SHELL_NETWORK_EXECUTORS = new Set([
   'sendmail',
   'sh',
   'slack',
+  'uvx',
   'wget',
   'xargs',
+  'yarn',
   'zsh',
 ]);
 

--- a/src/mcp/humanSurfacePolicy.ts
+++ b/src/mcp/humanSurfacePolicy.ts
@@ -169,6 +169,33 @@ const HUMAN_SURFACE_HOST_SUFFIXES = [
   'api.mailgun.net',
 ] as const;
 
+// Microsoft Graph mixes human collaboration and administrator APIs behind one
+// host. Blocking graph.microsoft.com wholesale would also remove legitimate
+// device/directory DevOps access, so only human-facing path families tighten
+// the shell policy.
+const MICROSOFT_GRAPH_HUMAN_PATH_IDENTIFIERS = new Set([
+  'calendar',
+  'calendars',
+  'calendarview',
+  'channel',
+  'channels',
+  'chat',
+  'chats',
+  'drive',
+  'drives',
+  'event',
+  'events',
+  'mail',
+  'mailfolders',
+  'message',
+  'messages',
+  'onenote',
+  'onlinemeetings',
+  'planner',
+  'sites',
+  'todo',
+]);
+
 const descriptorByTool = new WeakMap<ToolDefinition, McpToolPolicyDecision>();
 
 export function identifierTokens(value: string): string[] {
@@ -197,6 +224,17 @@ function knownHumanHost(host: string): boolean {
   return HUMAN_SURFACE_HOST_SUFFIXES.some((suffix) => host === suffix || host.endsWith(`.${suffix}`));
 }
 
+function microsoftGraphHumanPath(hint: string): string | undefined {
+  try {
+    const url = new URL(hint);
+    if (url.hostname.toLowerCase() !== 'graph.microsoft.com') return undefined;
+    return identifierTokens(decodeURIComponent(url.pathname))
+      .find((token) => MICROSOFT_GRAPH_HUMAN_PATH_IDENTIFIERS.has(token));
+  } catch {
+    return undefined;
+  }
+}
+
 function hasHumanIdentifier(value: string): string | undefined {
   const tokens = identifierTokens(value);
   const exact = tokens.find((token) => HUMAN_SURFACE_IDENTIFIERS.has(token));
@@ -222,10 +260,18 @@ function classifyAccess(action: string, annotations?: McpToolAnnotations): McpAc
 
 function inferSurface(source: McpToolPolicySource): { surface: McpSurface; evidence: string[] } {
   const evidence: string[] = [];
+  let microsoftGraphIdentity = false;
   if (source.declaredSurface === 'human') evidence.push('server is declared as a human surface');
 
   for (const hint of [source.server, ...(source.serverIdentityHints ?? [])]) {
     const host = hostFromHint(hint);
+    const tokens = identifierTokens(hint);
+    if (
+      host === 'graph.microsoft.com'
+      || tokens.includes('msgraph')
+      || tokens.includes('microsoftgraph')
+      || (tokens.includes('microsoft') && tokens.includes('graph'))
+    ) microsoftGraphIdentity = true;
     if (host && knownHumanHost(host)) {
       evidence.push(`known human-surface endpoint ${host}`);
       continue;
@@ -239,6 +285,14 @@ function inferSurface(source: McpToolPolicySource): { surface: McpSurface; evide
   // never relax it or prove that a tool is read-only.
   const descriptionIdentifier = hasHumanIdentifier(source.description ?? '');
   if (descriptionIdentifier) evidence.push(`tool descriptor identifies ${descriptionIdentifier}`);
+  const actionIdentifier = hasHumanIdentifier(source.action ?? '');
+  if (actionIdentifier) evidence.push(`tool action identifies ${actionIdentifier}`);
+  if (
+    microsoftGraphIdentity
+    && identifierTokens(source.action ?? '').some((token) => MICROSOFT_GRAPH_HUMAN_PATH_IDENTIFIERS.has(token))
+  ) {
+    evidence.push('Microsoft Graph action targets a human-facing API');
+  }
 
   if (evidence.length > 0) return { surface: 'human', evidence: [...new Set(evidence)] };
   return { surface: source.declaredSurface ?? 'unknown', evidence: [] };
@@ -318,7 +372,16 @@ export function stripHumanSurfaceEnv(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv
     const tokens = identifierTokens(key);
     const googleCollaborationCredential = tokens.includes('google')
       && (tokens.includes('drive') || tokens.includes('docs') || tokens.includes('sheets'));
-    if (googleCollaborationCredential || tokens.some((token) => HUMAN_SURFACE_ENV_IDENTIFIERS.has(token))) continue;
+    const microsoftGraphProduct = tokens.includes('msgraph')
+      || tokens.includes('microsoftgraph')
+      || (tokens.includes('graph') && (tokens.includes('ms') || tokens.includes('microsoft')));
+    const microsoftGraphCredential = microsoftGraphProduct
+      && tokens.some((token) => ['credential', 'key', 'password', 'pat', 'secret', 'token', 'webhook'].includes(token));
+    if (
+      googleCollaborationCredential
+      || microsoftGraphCredential
+      || tokens.some((token) => HUMAN_SURFACE_ENV_IDENTIFIERS.has(token))
+    ) continue;
     env[key] = value;
   }
   return env;
@@ -409,22 +472,32 @@ function shellExecutors(command: string): string[] {
  * stripHumanSurfaceEnv; this catches literal webhooks and service CLIs.
  */
 export function humanSurfaceShellWriteReason(command: string): string | undefined {
-  const hosts = [...command.matchAll(/https?:\/\/[^\s'"`]+/gi)]
-    .map((match) => hostFromHint(match[0]))
+  const urls = [...command.matchAll(/https?:\/\/[^\s'"`]+/gi)].map((match) => match[0]);
+  const hosts = urls
+    .map((url) => hostFromHint(url))
     .filter((host): host is string => !!host);
   const humanIdentifier = hasHumanIdentifier(command);
   const humanHost = hosts.find(knownHumanHost);
-  if (!humanIdentifier && !humanHost) return undefined;
+  const graphHumanPath = urls.map(microsoftGraphHumanPath).find((identifier) => !!identifier);
+  if (!humanIdentifier && !humanHost && !graphHumanPath) return undefined;
   if (!hasShellWriteSignal(command)) return undefined;
 
   // A literal protected endpoint plus a write signal is sufficient evidence,
   // regardless of how many shell wrappers surround the network client. This
   // closes `bash -c`, `xargs`, aliases, and variable-command wrappers without
   // treating a plain `rg 'slack post'` search as network execution.
-  if (!humanHost && !shellExecutors(command).some((executable) => SHELL_NETWORK_EXECUTORS.has(executable))) {
+  if (
+    !humanHost
+    && !graphHumanPath
+    && !shellExecutors(command).some((executable) => SHELL_NETWORK_EXECUTORS.has(executable))
+  ) {
     return undefined;
   }
 
-  const target = humanHost ? `endpoint ${humanHost}` : `service ${humanIdentifier}`;
+  const target = humanHost
+    ? `endpoint ${humanHost}`
+    : graphHumanPath
+      ? `Microsoft Graph human API ${graphHumanPath}`
+      : `service ${humanIdentifier}`;
   return `external human-surface write blocked (${target}); use read-only access or ask the operator`;
 }

--- a/src/mcp/humanSurfacePolicy.ts
+++ b/src/mcp/humanSurfacePolicy.ts
@@ -1,0 +1,422 @@
+// ============================================
+// OpenSwarm - external human-surface safety policy
+// ============================================
+
+import type { ToolDefinition } from '../adapters/tools.js';
+
+export type McpAccess = 'read' | 'write' | 'destructive';
+export type McpSurface = 'human' | 'devops' | 'data' | 'sandbox' | 'unknown';
+
+export interface McpToolAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+export interface McpToolPolicySource {
+  server: string;
+  action?: string;
+  description?: string;
+  declaredSurface?: McpSurface;
+  /** Server id, endpoint host, command, and package names. Never persisted. */
+  serverIdentityHints?: readonly string[];
+  annotations?: McpToolAnnotations;
+}
+
+export interface McpToolPolicyDecision {
+  name: string;
+  server: string;
+  action: string;
+  surface: McpSurface;
+  access: McpAccess;
+  /** True only for the explicit read/list/get/search/fetch contract. */
+  humanSurfaceReadAllowed: boolean;
+  evidence: readonly string[];
+}
+
+const READ_ACTIONS = new Set(['read', 'list', 'get', 'search', 'fetch']);
+const WRITE_ACTIONS = new Set([
+  'add',
+  'approve',
+  'cancel',
+  'close',
+  'comment',
+  'create',
+  'edit',
+  'invite',
+  'mark',
+  'move',
+  'patch',
+  'pin',
+  'post',
+  'publish',
+  'put',
+  'react',
+  'rename',
+  'reply',
+  'resolve',
+  'save',
+  'schedule',
+  'send',
+  'set',
+  'share',
+  'submit',
+  'unpin',
+  'update',
+  'upload',
+  'write',
+]);
+const DESTRUCTIVE_ACTIONS = new Set([
+  'archive',
+  'delete',
+  'execute',
+  'merge',
+  'purge',
+  'remove',
+  'revoke',
+  'run',
+  'trigger',
+  'unshare',
+]);
+
+/**
+ * Products whose mutations are visible to, or act directly on, people.
+ *
+ * Exact identifier tokens are used, not substring matching: `signal` is not in
+ * this set because it is too common in developer/data tools, and `teams` does
+ * not match `upstreamteamsync` unless a descriptor actually separates it.
+ * GitHub, Linear, Jira, Cloudflare, databases, and infrastructure providers are
+ * intentionally absent: their existing DevOps grants remain role-scoped by
+ * mcpPolicy.ts.
+ */
+const HUMAN_SURFACE_IDENTIFIERS = new Set([
+  'airtable',
+  'asana',
+  'calendar',
+  'canva',
+  'clickup',
+  'confluence',
+  'discord',
+  'dropbox',
+  'email',
+  'facebook',
+  'figma',
+  'gmail',
+  'instagram',
+  'linkedin',
+  'mail',
+  'mailgun',
+  'mattermost',
+  'matrix',
+  'notion',
+  'outlook',
+  'sendgrid',
+  'slack',
+  'smtp',
+  'sms',
+  'teams',
+  'telegram',
+  'trello',
+  'twilio',
+  'whatsapp',
+  'zulip',
+]);
+
+// Environment keys need a narrower set than server descriptors. Generic words
+// such as CHAT and CALENDAR occur in harmless model/build settings; stripping
+// them would break execution without removing a usable service credential.
+const HUMAN_SURFACE_ENV_IDENTIFIERS = new Set([
+  'airtable',
+  'asana',
+  'canva',
+  'clickup',
+  'discord',
+  'dropbox',
+  'email',
+  'figma',
+  'gmail',
+  'mail',
+  'mailgun',
+  'mattermost',
+  'matrix',
+  'notion',
+  'outlook',
+  'sendgrid',
+  'slack',
+  'smtp',
+  'teams',
+  'telegram',
+  'trello',
+  'twilio',
+  'whatsapp',
+  'zulip',
+]);
+
+const HUMAN_SURFACE_HOST_SUFFIXES = [
+  'api.slack.com',
+  'hooks.slack.com',
+  'slack.com',
+  'discord.com',
+  'discordapp.com',
+  'api.notion.com',
+  'notion.so',
+  'gmail.googleapis.com',
+  'api.telegram.org',
+  'api.twilio.com',
+  'api.sendgrid.com',
+  'api.mailgun.net',
+] as const;
+
+const descriptorByTool = new WeakMap<ToolDefinition, McpToolPolicyDecision>();
+
+export function identifierTokens(value: string): string[] {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+function splitQualifiedName(name: string): { server: string; action: string } {
+  const separator = name.indexOf('__');
+  if (separator < 0) return { server: '', action: name };
+  return { server: name.slice(0, separator), action: name.slice(separator + 2) };
+}
+
+function hostFromHint(hint: string): string | undefined {
+  try {
+    return new URL(hint).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+function knownHumanHost(host: string): boolean {
+  return HUMAN_SURFACE_HOST_SUFFIXES.some((suffix) => host === suffix || host.endsWith(`.${suffix}`));
+}
+
+function hasHumanIdentifier(value: string): string | undefined {
+  const tokens = identifierTokens(value);
+  const exact = tokens.find((token) => HUMAN_SURFACE_IDENTIFIERS.has(token));
+  if (exact) return exact;
+  if (tokens.includes('google') && tokens.includes('drive')) return 'google-drive';
+  if (tokens.includes('google') && tokens.includes('docs')) return 'google-docs';
+  if (tokens.includes('google') && tokens.includes('sheets')) return 'google-sheets';
+  return undefined;
+}
+
+function classifyAccess(action: string, annotations?: McpToolAnnotations): McpAccess {
+  const tokens = identifierTokens(action);
+  if (annotations?.destructiveHint || tokens.some((token) => DESTRUCTIVE_ACTIONS.has(token))) {
+    return 'destructive';
+  }
+  // MCP annotations are untrusted hints. They may make the decision stricter,
+  // but readOnlyHint=true never turns a mutating action name into a read.
+  if (annotations?.readOnlyHint === false || tokens.some((token) => WRITE_ACTIONS.has(token))) {
+    return 'write';
+  }
+  return 'read';
+}
+
+function inferSurface(source: McpToolPolicySource): { surface: McpSurface; evidence: string[] } {
+  const evidence: string[] = [];
+  if (source.declaredSurface === 'human') evidence.push('server is declared as a human surface');
+
+  for (const hint of [source.server, ...(source.serverIdentityHints ?? [])]) {
+    const host = hostFromHint(hint);
+    if (host && knownHumanHost(host)) {
+      evidence.push(`known human-surface endpoint ${host}`);
+      continue;
+    }
+    const identifier = hasHumanIdentifier(hint);
+    if (identifier) evidence.push(`human-surface identifier ${identifier}`);
+  }
+
+  // A server may be configured under an opaque alias. Tool descriptions are
+  // untrusted, so they can only tighten policy (identify a human surface),
+  // never relax it or prove that a tool is read-only.
+  const descriptionIdentifier = hasHumanIdentifier(source.description ?? '');
+  if (descriptionIdentifier) evidence.push(`tool descriptor identifies ${descriptionIdentifier}`);
+
+  if (evidence.length > 0) return { surface: 'human', evidence: [...new Set(evidence)] };
+  return { surface: source.declaredSurface ?? 'unknown', evidence: [] };
+}
+
+export function describeMcpToolPolicy(
+  tool: ToolDefinition | string,
+  source: Partial<McpToolPolicySource> = {},
+): McpToolPolicyDecision {
+  if (typeof tool !== 'string') {
+    const attached = descriptorByTool.get(tool);
+    if (attached && Object.keys(source).length === 0) return attached;
+  }
+
+  const name = typeof tool === 'string' ? tool : tool.function.name;
+  const split = splitQualifiedName(name);
+  const server = source.server ?? split.server;
+  const action = source.action ?? split.action;
+  const description = source.description ?? (typeof tool === 'string' ? '' : tool.function.description);
+  const normalizedSource: McpToolPolicySource = {
+    server,
+    action,
+    description,
+    declaredSurface: source.declaredSurface,
+    serverIdentityHints: source.serverIdentityHints,
+    annotations: source.annotations,
+  };
+  const { surface, evidence } = inferSurface(normalizedSource);
+  const access = classifyAccess(action, normalizedSource.annotations);
+  const hasExplicitReadAction = identifierTokens(action).some((token) => READ_ACTIONS.has(token));
+  const humanSurfaceReadAllowed = surface !== 'human'
+    || (access === 'read' && normalizedSource.annotations?.readOnlyHint !== false && hasExplicitReadAction);
+
+  return {
+    name,
+    server,
+    action,
+    surface,
+    access,
+    humanSurfaceReadAllowed,
+    evidence,
+  };
+}
+
+export function attachMcpToolPolicy(
+  tool: ToolDefinition,
+  source: McpToolPolicySource,
+): McpToolPolicyDecision {
+  const decision = describeMcpToolPolicy(tool, source);
+  descriptorByTool.set(tool, decision);
+  return decision;
+}
+
+export function filterHumanSurfaceMcpTools(
+  tools: ToolDefinition[],
+): { tools: ToolDefinition[]; denied: Array<{ name: string; reason: string }> } {
+  const accepted: ToolDefinition[] = [];
+  const denied: Array<{ name: string; reason: string }> = [];
+  for (const tool of tools) {
+    const decision = describeMcpToolPolicy(tool);
+    if (decision.surface === 'human' && !decision.humanSurfaceReadAllowed) {
+      denied.push({
+        name: decision.name,
+        reason: 'external human surface is read-only; only read/list/get/search/fetch actions are allowed',
+      });
+    } else {
+      accepted.push(tool);
+    }
+  }
+  return { tools: accepted, denied };
+}
+
+/** Remove credentials that would turn an agent shell into a human-surface writer. */
+export function stripHumanSurfaceEnv(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(base)) {
+    const tokens = identifierTokens(key);
+    const googleCollaborationCredential = tokens.includes('google')
+      && (tokens.includes('drive') || tokens.includes('docs') || tokens.includes('sheets'));
+    if (googleCollaborationCredential || tokens.some((token) => HUMAN_SURFACE_ENV_IDENTIFIERS.has(token))) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+const SHELL_NETWORK_EXECUTORS = new Set([
+  'bash',
+  'bun',
+  'curl',
+  'deno',
+  'discord',
+  'http',
+  'httpie',
+  'eval',
+  'fish',
+  'mail',
+  'mailx',
+  'mutt',
+  'node',
+  'notion',
+  'parallel',
+  'perl',
+  'php',
+  'python',
+  'python3',
+  'powershell',
+  'pwsh',
+  'ruby',
+  'sendmail',
+  'sh',
+  'slack',
+  'wget',
+  'xargs',
+  'zsh',
+]);
+
+function hasShellWriteSignal(command: string): boolean {
+  if (/(?:^|\s)(?:-X|--request|--method|-Method)(?:=|\s*)(?:POST|PUT|PATCH|DELETE)\b/i.test(command)) return true;
+  const forceGet = /(?:^|\s)(?:-G|--get)(?=\s|$)/i.test(command);
+  if (!forceGet && /(?:^|\s)(?:-d|-F|-T)(?=\S|\s|$)/i.test(command)) return true;
+  if (!forceGet && /(?:^|\s)(?:--data(?:-[a-z-]+)?|--form(?:-[a-z-]+)?|--upload-file|--post-data|--post-file|--body-data|--json|--config)(?:=|\s|$)/i.test(command)) return true;
+  if (!forceGet && /(?:^|\s)-K(?=\S|\s|$)/.test(command)) return true;
+  if (/\b(?:requests?|client|fetch|axios)\s*\.\s*(?:post|put|patch|delete)\b/i.test(command)) return true;
+  return identifierTokens(command).some((token) => WRITE_ACTIONS.has(token) || DESTRUCTIVE_ACTIONS.has(token));
+}
+
+function shellExecutors(command: string): string[] {
+  const executors: string[] = [];
+  for (const segment of command.split(/&&|\|\||[;|\n]/)) {
+    const words = segment.match(/(?:[^\s"'`]+|"[^"]*"|'[^']*'|`[^`]*`)+/g) ?? [];
+    let index = 0;
+    while (index < words.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index])) index++;
+
+    // Common process wrappers do not change the executable's authority. Skip
+    // their flags and fixed operands so `env -i curl ...` cannot bypass the
+    // same check as a direct `curl` call.
+    while (index < words.length) {
+      const word = words[index].replace(/^["']|["']$/g, '');
+      const base = (word.split('/').pop() ?? word).toLowerCase();
+      if (!['command', 'env', 'nohup', 'sudo', 'time', 'timeout'].includes(base)) break;
+      index++;
+      while (index < words.length && words[index].startsWith('-')) {
+        const option = words[index++];
+        if ((base === 'sudo' && ['-u', '-g', '-h', '-p', '-C', '-T'].includes(option)) && index < words.length) index++;
+      }
+      if (base === 'timeout' && index < words.length) index++; // duration
+      while (index < words.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index])) index++;
+    }
+
+    if (index >= words.length) continue;
+    const word = words[index].replace(/^["']|["']$/g, '');
+    const executable = word.split('/').pop() ?? word;
+    executors.push(executable.toLowerCase());
+  }
+  return executors;
+}
+
+/**
+ * Guard the direct, common shell escape hatch without disabling DevOps or DB
+ * networking wholesale. Credentials are independently removed by
+ * stripHumanSurfaceEnv; this catches literal webhooks and service CLIs.
+ */
+export function humanSurfaceShellWriteReason(command: string): string | undefined {
+  const hosts = [...command.matchAll(/https?:\/\/[^\s'"`]+/gi)]
+    .map((match) => hostFromHint(match[0]))
+    .filter((host): host is string => !!host);
+  const humanIdentifier = hasHumanIdentifier(command);
+  const humanHost = hosts.find(knownHumanHost);
+  if (!humanIdentifier && !humanHost) return undefined;
+  if (!hasShellWriteSignal(command)) return undefined;
+
+  // A literal protected endpoint plus a write signal is sufficient evidence,
+  // regardless of how many shell wrappers surround the network client. This
+  // closes `bash -c`, `xargs`, aliases, and variable-command wrappers without
+  // treating a plain `rg 'slack post'` search as network execution.
+  if (!humanHost && !shellExecutors(command).some((executable) => SHELL_NETWORK_EXECUTORS.has(executable))) {
+    return undefined;
+  }
+
+  const target = humanHost ? `endpoint ${humanHost}` : `service ${humanIdentifier}`;
+  return `external human-surface write blocked (${target}); use read-only access or ask the operator`;
+}

--- a/src/mcp/humanSurfacePolicy.ts
+++ b/src/mcp/humanSurfacePolicy.ts
@@ -35,6 +35,23 @@ export interface McpToolPolicyDecision {
   evidence: readonly string[];
 }
 
+/**
+ * Process-wide execution boundary loaded from config.  MCP tool descriptors are
+ * always filtered, while this stricter switch also removes arbitrary program
+ * execution and OpenSwarm-owned human-surface senders.  Keeping the switch in
+ * one module lets low-level dispatch paths fail closed even when a caller did
+ * not thread the config object through.
+ */
+let humanSurfaceReadOnlyEnabled = false;
+
+export function configureHumanSurfaceReadOnly(enabled: boolean): void {
+  humanSurfaceReadOnlyEnabled = enabled === true;
+}
+
+export function isHumanSurfaceReadOnlyEnabled(): boolean {
+  return humanSurfaceReadOnlyEnabled;
+}
+
 const READ_ACTIONS = new Set(['read', 'list', 'get', 'search', 'fetch']);
 const WRITE_ACTIONS = new Set([
   'add',
@@ -167,6 +184,8 @@ const HUMAN_SURFACE_HOST_SUFFIXES = [
   'api.twilio.com',
   'api.sendgrid.com',
   'api.mailgun.net',
+  'api.dropboxapi.com',
+  'content.dropboxapi.com',
 ] as const;
 
 // Microsoft Graph mixes human collaboration and administrator APIs behind one
@@ -181,6 +200,14 @@ const MICROSOFT_GRAPH_HUMAN_PATH_IDENTIFIERS = new Set([
   'channels',
   'chat',
   'chats',
+  'communication',
+  'communications',
+  'contact',
+  'contacts',
+  'conversation',
+  'conversations',
+  'call',
+  'calls',
   'drive',
   'drives',
   'event',
@@ -192,9 +219,69 @@ const MICROSOFT_GRAPH_HUMAN_PATH_IDENTIFIERS = new Set([
   'onenote',
   'onlinemeetings',
   'planner',
+  'post',
+  'posts',
   'sites',
+  'team',
+  'teams',
+  'thread',
+  'threads',
   'todo',
 ]);
+
+const GOOGLE_HUMAN_API_PATH_IDENTIFIERS = new Set([
+  'calendar',
+  'chat',
+  'doc',
+  'docs',
+  'document',
+  'documents',
+  'drive',
+  'gmail',
+  'meet',
+  'sheet',
+  'sheets',
+  'spreadsheet',
+  'spreadsheets',
+]);
+
+const GENERIC_TRANSPORT_ACTIONS = new Set([
+  'api',
+  'call',
+  'fetch',
+  'forward',
+  'http',
+  'invoke',
+  'proxy',
+  'request',
+  'transport',
+  'webhook',
+]);
+
+const DESTINATION_FIELD_NAMES = new Set([
+  'baseurl',
+  'destination',
+  'endpoint',
+  'host',
+  'hostname',
+  'origin',
+  'requesturl',
+  'target',
+  'targeturl',
+  'uri',
+  'url',
+  'webhook',
+  'webhookurl',
+]);
+
+const METHOD_FIELD_NAMES = new Set(['httpmethod', 'method', 'requestmethod', 'verb']);
+const BODY_FIELD_NAMES = new Set(['body', 'data', 'form', 'json', 'payload', 'requestbody']);
+const READ_HTTP_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+const WRITE_HTTP_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+function normalizedFieldName(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
 
 const descriptorByTool = new WeakMap<ToolDefinition, McpToolPolicyDecision>();
 
@@ -230,6 +317,38 @@ function microsoftGraphHumanPath(hint: string): string | undefined {
     if (url.hostname.toLowerCase() !== 'graph.microsoft.com') return undefined;
     return identifierTokens(decodeURIComponent(url.pathname))
       .find((token) => MICROSOFT_GRAPH_HUMAN_PATH_IDENTIFIERS.has(token));
+  } catch {
+    return undefined;
+  }
+}
+
+function microsoftGraphHumanRelativePath(hint: string): string | undefined {
+  if (!hint.startsWith('/')) return undefined;
+  try {
+    return identifierTokens(decodeURIComponent(hint))
+      .find((token) => MICROSOFT_GRAPH_HUMAN_PATH_IDENTIFIERS.has(token));
+  } catch {
+    return undefined;
+  }
+}
+
+function isMicrosoftGraphBatchDestination(hint: string): boolean {
+  try {
+    const url = new URL(hint);
+    return url.hostname.toLowerCase() === 'graph.microsoft.com'
+      && identifierTokens(decodeURIComponent(url.pathname)).includes('batch');
+  } catch {
+    return false;
+  }
+}
+
+function googleHumanApiPath(hint: string): string | undefined {
+  try {
+    const url = new URL(hint);
+    const host = url.hostname.toLowerCase();
+    if (host !== 'www.googleapis.com' && !host.endsWith('.googleapis.com')) return undefined;
+    return identifierTokens(decodeURIComponent(url.pathname))
+      .find((token) => GOOGLE_HUMAN_API_PATH_IDENTIFIERS.has(token));
   } catch {
     return undefined;
   }
@@ -353,7 +472,8 @@ export function filterHumanSurfaceMcpTools(
   const denied: Array<{ name: string; reason: string }> = [];
   for (const tool of tools) {
     const decision = describeMcpToolPolicy(tool);
-    if (decision.surface === 'human' && !decision.humanSurfaceReadAllowed) {
+    const dispatchClassified = isGenericMcpTransport(decision, tool.function.parameters);
+    if (decision.surface === 'human' && !decision.humanSurfaceReadAllowed && !dispatchClassified) {
       denied.push({
         name: decision.name,
         reason: 'external human surface is read-only; only read/list/get/search/fetch actions are allowed',
@@ -363,6 +483,195 @@ export function filterHumanSurfaceMcpTools(
     }
   }
   return { tools: accepted, denied };
+}
+
+type GenericCallAccess = 'read' | 'write' | 'unknown';
+type DestinationKind = 'human' | 'nonhuman' | 'unresolved';
+
+interface GenericCallFacts {
+  destinationFields: string[];
+  methods: string[];
+  hasBody: boolean;
+  truncated: boolean;
+  schemaSuggestsTransport: boolean;
+}
+
+function isDynamicDestination(value: string): boolean {
+  // OData uses literal lower-case segments such as Graph's `$batch` and
+  // `$filter`; shell/env placeholders conventionally use upper-case names.
+  return /\$\{|\$[A-Z_][A-Z0-9_]*|\{\{/.test(value)
+    || /<[^>]*(?:url|host|target|destination)[^>]*>|\b(?:env|args?|params?)\./i.test(value);
+}
+
+function collectGenericCallFacts(
+  args: Record<string, unknown>,
+  inputSchema?: Record<string, unknown>,
+): GenericCallFacts {
+  const destinationFields: string[] = [];
+  const methods: string[] = [];
+  let hasBody = false;
+  let truncated = false;
+  let visited = 0;
+
+  const visit = (value: unknown, depth: number): void => {
+    if (visited++ >= 512 || depth > 8) {
+      truncated = true;
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item, depth + 1);
+      return;
+    }
+    if (!value || typeof value !== 'object') return;
+    for (const [rawKey, item] of Object.entries(value as Record<string, unknown>)) {
+      const key = normalizedFieldName(rawKey);
+      if (DESTINATION_FIELD_NAMES.has(key) && typeof item === 'string' && item.trim()) {
+        destinationFields.push(item.trim());
+      }
+      if (METHOD_FIELD_NAMES.has(key) && typeof item === 'string' && item.trim()) {
+        methods.push(item.trim().toUpperCase());
+      }
+      if (BODY_FIELD_NAMES.has(key) && item !== undefined && item !== null) {
+        hasBody = true;
+        // Microsoft Graph and other generic APIs can carry batched requests in
+        // a JSON body. Inspect bounded structured JSON so a POST to `$batch`
+        // cannot hide `/me/messages` behind a string payload.
+        const trimmedBody = typeof item === 'string' ? item.trimStart() : '';
+        if (trimmedBody.startsWith('{') || trimmedBody.startsWith('[')) {
+          try {
+            visit(JSON.parse(trimmedBody), depth + 1);
+          } catch {
+            // Opaque/non-JSON bodies remain writes; they do not become reads.
+          }
+        }
+      }
+      visit(item, depth + 1);
+    }
+  };
+  visit(args, 0);
+
+  const schemaKeys = new Set<string>();
+  const inspectSchema = (value: unknown, depth: number): void => {
+    if (depth > 8 || !value || typeof value !== 'object') return;
+    for (const [rawKey, item] of Object.entries(value as Record<string, unknown>)) {
+      if (rawKey === 'properties' && item && typeof item === 'object' && !Array.isArray(item)) {
+        for (const propertyName of Object.keys(item as Record<string, unknown>)) {
+          schemaKeys.add(normalizedFieldName(propertyName));
+        }
+      }
+      inspectSchema(item, depth + 1);
+    }
+  };
+  inspectSchema(inputSchema, 0);
+
+  const schemaSuggestsTransport = [...schemaKeys].some((key) => DESTINATION_FIELD_NAMES.has(key))
+    && [...schemaKeys].some((key) => METHOD_FIELD_NAMES.has(key) || BODY_FIELD_NAMES.has(key));
+  return { destinationFields, methods, hasBody, truncated, schemaSuggestsTransport };
+}
+
+function destinationKind(value: string): { kind: DestinationKind; evidence: string } {
+  if (isDynamicDestination(value)) return { kind: 'unresolved', evidence: 'dynamic destination' };
+
+  let candidate = value;
+  if (/^[A-Za-z0-9.-]+(?::\d+)?(?:\/|$)/.test(candidate) && !candidate.includes('://')) {
+    candidate = `https://${candidate}`;
+  }
+  const host = hostFromHint(candidate);
+  if (host) {
+    if (knownHumanHost(host)) return { kind: 'human', evidence: `endpoint ${host}` };
+    const hostIdentifier = hasHumanIdentifier(host);
+    if (hostIdentifier) return { kind: 'human', evidence: `service ${hostIdentifier}` };
+    const graphPath = microsoftGraphHumanPath(candidate);
+    if (graphPath) return { kind: 'human', evidence: `Microsoft Graph human API ${graphPath}` };
+    const googlePath = googleHumanApiPath(candidate);
+    if (googlePath) return { kind: 'human', evidence: `Google human API ${googlePath}` };
+    return { kind: 'nonhuman', evidence: `endpoint ${host}` };
+  }
+
+  const humanIdentifier = hasHumanIdentifier(value);
+  if (humanIdentifier) return { kind: 'human', evidence: `service ${humanIdentifier}` };
+  return { kind: 'unresolved', evidence: 'unparseable destination' };
+}
+
+function genericCallAccess(policy: McpToolPolicyDecision, facts: GenericCallFacts): GenericCallAccess {
+  if (facts.methods.some((method) => WRITE_HTTP_METHODS.has(method))) return 'write';
+  if (facts.methods.length > 0 && facts.methods.every((method) => READ_HTTP_METHODS.has(method)) && !facts.hasBody) {
+    return 'read';
+  }
+  if (facts.methods.length > 0) return 'unknown';
+  if (facts.hasBody) return 'write';
+  if (policy.access === 'write' || policy.access === 'destructive') return 'write';
+  if (identifierTokens(policy.action).some((token) => READ_ACTIONS.has(token))) return 'read';
+  return 'unknown';
+}
+
+/** True when destination/method arguments, not the static action name, decide access. */
+export function isGenericMcpTransport(
+  policy: McpToolPolicyDecision,
+  inputSchema?: Record<string, unknown>,
+): boolean {
+  const actionIsGeneric = identifierTokens(policy.action).some((token) => GENERIC_TRANSPORT_ACTIONS.has(token));
+  if (actionIsGeneric) return true;
+  return collectGenericCallFacts({}, inputSchema).schemaSuggestsTransport;
+}
+
+/**
+ * Reclassify generic HTTP/proxy MCP calls from their actual arguments.
+ *
+ * A static tool name cannot tell whether `request(url, method, body)` points at
+ * Slack or a database.  At dispatch, explicit GET/HEAD/OPTIONS calls to human
+ * surfaces remain readable, while writes and ambiguous/dynamic destinations
+ * fail closed.  Concrete non-human writes retain an explicit devops/data/
+ * sandbox server grant; specialized tools are still governed by their normal
+ * descriptor policy and do not scan arbitrary issue/comment bodies for URLs.
+ */
+export function humanSurfaceMcpCallWriteReason(
+  policy: McpToolPolicyDecision,
+  args: Record<string, unknown>,
+  inputSchema?: Record<string, unknown>,
+): string | undefined {
+  const facts = collectGenericCallFacts(args, inputSchema);
+  if (!isGenericMcpTransport(policy, inputSchema)) return undefined;
+
+  const access = genericCallAccess(policy, facts);
+  const graphTransport = facts.destinationFields.some((value) => hostFromHint(value) === 'graph.microsoft.com');
+  const graphBatch = facts.destinationFields.some(isMicrosoftGraphBatchDestination);
+  const graphRelativeDestinations = facts.destinationFields.filter((value) => value.startsWith('/'));
+  const destinations = facts.destinationFields.map((value) => {
+    const graphPath = graphTransport ? microsoftGraphHumanRelativePath(value) : undefined;
+    if (graphPath) return { kind: 'human' as const, evidence: `Microsoft Graph human API ${graphPath}` };
+    if (graphTransport && value.startsWith('/')) {
+      return { kind: 'nonhuman' as const, evidence: 'Microsoft Graph non-human API path' };
+    }
+    return destinationKind(value);
+  });
+  const humanDestination = destinations.find((entry) => entry.kind === 'human');
+  const unresolvedDestination = destinations.find((entry) => entry.kind === 'unresolved');
+
+  if (humanDestination) {
+    if (access === 'read') return undefined;
+    return `generic MCP ${access === 'write' ? 'write' : 'call'} blocked (${humanDestination.evidence}); `
+      + 'human-surface transports require an explicit GET/HEAD/OPTIONS request';
+  }
+
+  if (access === 'read') return undefined;
+  if (graphBatch && graphRelativeDestinations.length === 0) {
+    return 'generic MCP write blocked because a Microsoft Graph batch has no inspectable nested destinations';
+  }
+  if (facts.truncated) return 'generic MCP write blocked because argument inspection exceeded the safety bound';
+  if (unresolvedDestination) {
+    return `generic MCP write blocked because its ${unresolvedDestination.evidence} cannot be classified`;
+  }
+  if (destinations.length === 0) {
+    return 'generic MCP write blocked because no concrete destination was provided';
+  }
+  if (policy.access === 'read') {
+    return 'generic MCP write blocked because the tool descriptor does not declare a write capability';
+  }
+  if (!['devops', 'data', 'sandbox'].includes(policy.surface)) {
+    return 'generic MCP write blocked because the server has no explicit devops/data/sandbox surface grant';
+  }
+  return undefined;
 }
 
 /** Remove credentials that would turn an agent shell into a human-surface writer. */

--- a/src/mcp/humanSurfacePolicy.ts
+++ b/src/mcp/humanSurfacePolicy.ts
@@ -648,6 +648,23 @@ export function humanSurfaceMcpCallWriteReason(
   const humanDestination = destinations.find((entry) => entry.kind === 'human');
   const unresolvedDestination = destinations.find((entry) => entry.kind === 'unresolved');
 
+  // Destination classification is an independent boundary from the HTTP verb.
+  // A nominal GET to `${TARGET_URL}` is not the "same GET" we promise to keep:
+  // the daemon cannot prove which surface receives it (or whether that endpoint
+  // honours GET as read-only).  Resolve the target completely before allowing
+  // even a read, otherwise method=GET turns the dynamic-destination fail-close
+  // contract into a bypass.
+  if (facts.truncated) return 'generic MCP call blocked because argument inspection exceeded the safety bound';
+  if (unresolvedDestination) {
+    return `generic MCP call blocked because its ${unresolvedDestination.evidence} cannot be classified`;
+  }
+  if (destinations.length === 0) {
+    return 'generic MCP call blocked because no concrete destination was provided';
+  }
+  if (graphBatch && graphRelativeDestinations.length === 0) {
+    return 'generic MCP call blocked because a Microsoft Graph batch has no inspectable nested destinations';
+  }
+
   if (humanDestination) {
     if (access === 'read') return undefined;
     return `generic MCP ${access === 'write' ? 'write' : 'call'} blocked (${humanDestination.evidence}); `
@@ -655,16 +672,6 @@ export function humanSurfaceMcpCallWriteReason(
   }
 
   if (access === 'read') return undefined;
-  if (graphBatch && graphRelativeDestinations.length === 0) {
-    return 'generic MCP write blocked because a Microsoft Graph batch has no inspectable nested destinations';
-  }
-  if (facts.truncated) return 'generic MCP write blocked because argument inspection exceeded the safety bound';
-  if (unresolvedDestination) {
-    return `generic MCP write blocked because its ${unresolvedDestination.evidence} cannot be classified`;
-  }
-  if (destinations.length === 0) {
-    return 'generic MCP write blocked because no concrete destination was provided';
-  }
   if (policy.access === 'read') {
     return 'generic MCP write blocked because the tool descriptor does not declare a write capability';
   }

--- a/src/mcp/mcpClient.test.ts
+++ b/src/mcp/mcpClient.test.ts
@@ -233,6 +233,161 @@ describe('initMcpTools / callMcpTool regressions', () => {
     expect(clientMock.callTool).toHaveBeenCalledOnce();
   });
 
+  it('reclassifies generic proxy destinations and HTTP methods at dispatch', async () => {
+    clientMock.listTools.mockResolvedValue({
+      tools: [{
+        name: 'http_post_request',
+        description: 'Send an HTTP request to a caller-provided destination',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            url: { type: 'string' },
+            method: { type: 'string' },
+            body: { type: 'object', additionalProperties: true },
+          },
+        },
+      }],
+    });
+    await initMcpTools({ proxy: { transport: 'stdio', command: 'mock-mcp', surface: 'devops' } });
+    clientMock.callTool.mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+
+    const humanWrites = [
+      'https://hooks.slack.com/services/T/B/X',
+      'https://discord.com/api/webhooks/1/x',
+      'https://api.notion.com/v1/pages',
+      'https://gmail.googleapis.com/gmail/v1/users/me/messages/send',
+      'https://www.googleapis.com/gmail/v1/users/me/messages/send',
+      'https://docs.googleapis.com/v1/documents/doc-1:batchUpdate',
+      'https://api.dropboxapi.com/2/files/upload',
+      'https://graph.microsoft.com/v1.0/me/messages',
+      'https://graph.microsoft.com/v1.0/teams/team-1/channels/channel-1/messages',
+    ];
+    for (const url of humanWrites) {
+      const result = await callMcpTool('proxy__http_post_request', { url, method: 'POST', body: { text: 'hi' } });
+      expect(result).toMatchObject({ isError: true, content: expect.stringContaining('HUMAN_SURFACE_READ_ONLY') });
+    }
+    const graphBatch = await callMcpTool('proxy__http_post_request', {
+      url: 'https://graph.microsoft.com/v1.0/$batch',
+      method: 'POST',
+      body: JSON.stringify({ requests: [{ id: '1', method: 'POST', url: '/me/messages', body: { subject: 'hi' } }] }),
+    });
+    expect(graphBatch).toMatchObject({ isError: true, content: expect.stringContaining('Microsoft Graph') });
+    await expect(callMcpTool('proxy__http_post_request', {
+      url: 'https://graph.microsoft.com/v1.0/$batch', method: 'POST', body: 'opaque-batch-payload',
+    })).resolves.toMatchObject({ isError: true, content: expect.stringContaining('no inspectable nested destinations') });
+    expect(clientMock.callTool).not.toHaveBeenCalled();
+
+    // The same human destinations remain available for an explicit read.
+    for (const url of humanWrites) {
+      await expect(callMcpTool('proxy__http_post_request', { url, method: 'GET' }))
+        .resolves.toEqual({ content: 'ok', isError: false });
+    }
+    expect(clientMock.callTool).toHaveBeenCalledTimes(humanWrites.length);
+
+    // Concrete DevOps and data-plane writes retain the server's explicit grant.
+    await expect(callMcpTool('proxy__http_post_request', {
+      url: 'https://api.github.com/repos/intrect/openswarm/issues', method: 'POST', body: { title: 'x' },
+    })).resolves.toEqual({ content: 'ok', isError: false });
+    await expect(callMcpTool('proxy__http_post_request', {
+      url: 'https://graph.microsoft.com/v1.0/devices/device-1', method: 'PATCH', body: { accountEnabled: true },
+    })).resolves.toEqual({ content: 'ok', isError: false });
+    await expect(callMcpTool('proxy__http_post_request', {
+      url: 'https://graph.microsoft.com/v1.0/$batch',
+      method: 'POST',
+      body: JSON.stringify({ requests: [{ id: '1', method: 'PATCH', url: '/devices/device-1', body: { accountEnabled: true } }] }),
+    })).resolves.toEqual({ content: 'ok', isError: false });
+  });
+
+  it('fails closed for nested or dynamic generic write destinations without scanning specialized payloads', async () => {
+    clientMock.listTools.mockResolvedValue({
+      tools: [
+        {
+          name: 'proxy',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              request: {
+                type: 'object',
+                properties: { destination: { type: 'string' }, verb: { type: 'string' }, payload: { type: 'object' } },
+              },
+            },
+          },
+        },
+        {
+          name: 'create_issue',
+          inputSchema: { type: 'object', properties: { body: { type: 'string' } } },
+        },
+      ],
+    });
+    await initMcpTools({ gateway: { transport: 'stdio', command: 'mock-mcp', surface: 'devops' } });
+    clientMock.callTool.mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+
+    await expect(callMcpTool('gateway__proxy', {
+      request: { destination: 'https://hooks.slack.com/services/T/B/X', verb: 'POST', payload: { text: 'hi' } },
+    })).resolves.toMatchObject({ isError: true, content: expect.stringContaining('HUMAN_SURFACE_READ_ONLY') });
+    await expect(callMcpTool('gateway__proxy', {
+      request: { destination: '${TARGET_URL}', verb: 'POST', payload: { text: 'hi' } },
+    })).resolves.toMatchObject({ isError: true, content: expect.stringContaining('dynamic destination') });
+    expect(clientMock.callTool).not.toHaveBeenCalled();
+
+    // A URL quoted inside an issue body is data, not the generic request target.
+    await expect(callMcpTool('gateway__create_issue', {
+      body: 'Investigate https://hooks.slack.com/services/redacted without calling it',
+    })).resolves.toEqual({ content: 'ok', isError: false });
+    expect(clientMock.callTool).toHaveBeenCalledOnce();
+  });
+
+  it('requires an explicit surface grant before a generic non-human write', async () => {
+    clientMock.listTools.mockResolvedValue({
+      tools: [{
+        name: 'post_request',
+        inputSchema: { type: 'object', properties: { url: { type: 'string' }, method: { type: 'string' } } },
+      }],
+    });
+    await initMcpTools({ opaque: { transport: 'stdio', command: 'mock-mcp' } });
+
+    const result = await callMcpTool('opaque__post_request', {
+      url: 'https://api.github.com/repos/intrect/openswarm/issues', method: 'POST',
+    });
+    expect(result).toMatchObject({ isError: true, content: expect.stringContaining('no explicit devops/data/sandbox') });
+    expect(clientMock.callTool).not.toHaveBeenCalled();
+  });
+
+  it('does not let a read-declared generic tool become a DevOps writer from call arguments alone', async () => {
+    clientMock.listTools.mockResolvedValue({
+      tools: [{
+        name: 'request',
+        inputSchema: { type: 'object', properties: { url: { type: 'string' }, method: { type: 'string' } } },
+      }],
+    });
+    await initMcpTools({ proxy: { transport: 'stdio', command: 'mock-mcp', surface: 'devops' } });
+
+    await expect(callMcpTool('proxy__request', {
+      url: 'https://api.github.com/repos/intrect/openswarm/issues', method: 'POST',
+    })).resolves.toMatchObject({ isError: true, content: expect.stringContaining('does not declare a write capability') });
+    expect(clientMock.callTool).not.toHaveBeenCalled();
+  });
+
+  it('exposes a generic human transport for explicit reads but still denies its writes', async () => {
+    clientMock.listTools.mockResolvedValue({
+      tools: [{
+        name: 'request',
+        inputSchema: { type: 'object', properties: { url: { type: 'string' }, method: { type: 'string' }, body: { type: 'string' } } },
+      }],
+    });
+    const definitions = await initMcpTools({ comms: { transport: 'stdio', command: 'mock-mcp', surface: 'human' } });
+    clientMock.callTool.mockResolvedValue({ content: [{ type: 'text', text: 'read result' }] });
+
+    expect(await resolveMcpTools(definitions)).toEqual(definitions);
+    await expect(callMcpTool('comms__request', {
+      url: 'https://api.notion.com/v1/pages/page-1', method: 'GET',
+    })).resolves.toEqual({ content: 'read result', isError: false });
+    await expect(callMcpTool('comms__request', {
+      url: 'https://api.notion.com/v1/pages', method: 'POST', body: '{}',
+    })).resolves.toMatchObject({ isError: true, content: expect.stringContaining('HUMAN_SURFACE_READ_ONLY') });
+    expect(clientMock.callTool).toHaveBeenCalledOnce();
+  });
+
   it('keeps the truncation marker inside the configured result cap', async () => {
     clientMock.listTools.mockResolvedValue({ tools: [{ name: 'large', inputSchema: { type: 'object' } }] });
     await initMcpTools(registry);

--- a/src/mcp/mcpClient.test.ts
+++ b/src/mcp/mcpClient.test.ts
@@ -62,6 +62,17 @@ describe('loadRegistry', () => {
     expect(reg.fs).toEqual({ transport: 'stdio', command: 'npx', args: ['-y', 'server-filesystem', '/tmp'], env: { A: '1' } });
   });
 
+  it('preserves an explicit trust-domain surface label', () => {
+    const p = writeMcpJson({
+      mcpServers: { communications: { command: 'company-mcp', surface: 'human' } },
+    });
+    expect(loadRegistry(p).communications).toMatchObject({
+      transport: 'stdio',
+      command: 'company-mcp',
+      surface: 'human',
+    });
+  });
+
   it('normalizes a remote entry (url → http; sse honored)', () => {
     const p = writeMcpJson({
       mcpServers: {
@@ -154,6 +165,13 @@ describe('resolveMcpTools (INT-1951)', () => {
       }),
     ).toEqual([]);
   });
+
+  it('filters human-surface mutations from provided and discovered adapter tools', async () => {
+    const safe = { ...tool, function: { ...tool.function, name: 'slack__list_channels' } };
+    const write = { ...tool, function: { ...tool.function, name: 'slack__chat_postMessage' } };
+    expect(await resolveMcpTools([safe, write])).toEqual([safe]);
+    expect(await resolveMcpTools(undefined, async () => [safe, write])).toEqual([safe]);
+  });
 });
 
 describe('initMcpTools / callMcpTool regressions', () => {
@@ -195,6 +213,24 @@ describe('initMcpTools / callMcpTool regressions', () => {
     await initMcpTools(registry);
     clientMock.callTool.mockResolvedValue({ content: [{ type: 'text', text: 'done' }] });
     await expect(callMcpTool('svc__ok', {})).resolves.toEqual({ content: 'done', isError: false });
+  });
+
+  it('denies a human-surface mutation at dispatch even when a hidden call bypasses tool exposure', async () => {
+    clientMock.listTools.mockResolvedValue({
+      tools: [
+        { name: 'chat_postMessage', description: 'Post a message', inputSchema: { type: 'object' } },
+        { name: 'list_channels', description: 'List channels', inputSchema: { type: 'object' } },
+      ],
+    });
+    await initMcpTools({ slack: { transport: 'stdio', command: 'mock-mcp', surface: 'human' } });
+
+    const denied = await callMcpTool('slack__chat_postMessage', { text: 'hello' });
+    expect(denied).toMatchObject({ isError: true, content: expect.stringContaining('HUMAN_SURFACE_READ_ONLY') });
+    expect(clientMock.callTool).not.toHaveBeenCalled();
+
+    clientMock.callTool.mockResolvedValue({ content: [{ type: 'text', text: 'general' }] });
+    await expect(callMcpTool('slack__list_channels', {})).resolves.toEqual({ content: 'general', isError: false });
+    expect(clientMock.callTool).toHaveBeenCalledOnce();
   });
 
   it('keeps the truncation marker inside the configured result cap', async () => {

--- a/src/mcp/mcpClient.test.ts
+++ b/src/mcp/mcpClient.test.ts
@@ -328,6 +328,12 @@ describe('initMcpTools / callMcpTool regressions', () => {
     await expect(callMcpTool('gateway__proxy', {
       request: { destination: '${TARGET_URL}', verb: 'POST', payload: { text: 'hi' } },
     })).resolves.toMatchObject({ isError: true, content: expect.stringContaining('dynamic destination') });
+    await expect(callMcpTool('gateway__proxy', {
+      request: { destination: '${TARGET_URL}', verb: 'GET' },
+    })).resolves.toMatchObject({ isError: true, content: expect.stringContaining('dynamic destination') });
+    await expect(callMcpTool('gateway__proxy', {
+      request: { verb: 'GET' },
+    })).resolves.toMatchObject({ isError: true, content: expect.stringContaining('no concrete destination') });
     expect(clientMock.callTool).not.toHaveBeenCalled();
 
     // A URL quoted inside an issue body is data, not the generic request target.

--- a/src/mcp/mcpClient.ts
+++ b/src/mcp/mcpClient.ts
@@ -18,6 +18,13 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { ToolDefinition } from '../adapters/tools.js';
 import { safeInheritedEnv } from '../support/spawnEnv.js';
+import {
+  attachMcpToolPolicy,
+  filterHumanSurfaceMcpTools,
+  type McpSurface,
+  type McpToolAnnotations,
+  type McpToolPolicyDecision,
+} from './humanSurfacePolicy.js';
 
 /** Qualified tool name separator: `<server>__<tool>`. */
 const SEP = '__';
@@ -29,6 +36,7 @@ const EMPTY_INPUT_SCHEMA: Record<string, unknown> = { type: 'object', properties
 
 interface ServerConfig {
   transport: 'stdio' | 'http' | 'sse';
+  surface?: McpSurface;
   command?: string;
   args?: string[];
   env?: Record<string, string>;
@@ -45,6 +53,7 @@ interface ServerConfig {
 export const BUILTIN_MCP_SERVERS: Record<string, ServerConfig> = {
   linear: {
     transport: 'stdio',
+    surface: 'devops',
     command: 'npx',
     args: ['-y', 'mcp-remote', 'https://mcp.linear.app/mcp'],
   },
@@ -72,6 +81,10 @@ function stringRecordOrNull(value: unknown): Record<string, string> | undefined 
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function isMcpSurface(value: unknown): value is McpSurface {
+  return value === 'human' || value === 'devops' || value === 'data' || value === 'sandbox' || value === 'unknown';
 }
 
 function isJsonSchemaObject(schema: unknown, depth = 0): schema is Record<string, unknown> {
@@ -117,8 +130,11 @@ function sanitizeInputSchema(schema: unknown): Record<string, unknown> {
 /** A persisted entry: `{preset}`, `{command,args,env}` (stdio) or `{url,headers,transport?}` (remote). */
 function normalizeEntry(raw: unknown): ServerConfig | null {
   if (!isRecord(raw)) return null;
+  if (raw.surface !== undefined && !isMcpSurface(raw.surface)) return null;
+  const surface = raw.surface as McpSurface | undefined;
   if (typeof raw.preset === 'string' && raw.preset) {
-    return BUILTIN_MCP_SERVERS[raw.preset] ?? null;
+    const preset = BUILTIN_MCP_SERVERS[raw.preset];
+    return preset ? { ...preset, ...(surface ? { surface } : {}) } : null;
   }
   if (typeof raw.command === 'string' && raw.command) {
     const args = stringArrayOrNull(raw.args);
@@ -126,6 +142,7 @@ function normalizeEntry(raw: unknown): ServerConfig | null {
     if (!args || env === null) return null;
     return {
       transport: 'stdio',
+      ...(surface ? { surface } : {}),
       command: raw.command,
       args,
       env,
@@ -135,7 +152,7 @@ function normalizeEntry(raw: unknown): ServerConfig | null {
     const headers = stringRecordOrNull(raw.headers);
     if (headers === null) return null;
     const t = raw.transport === 'sse' ? 'sse' : 'http';
-    return { transport: t, url: raw.url, headers };
+    return { transport: t, ...(surface ? { surface } : {}), url: raw.url, headers };
   }
   return null;
 }
@@ -238,12 +255,19 @@ function isValidToolName(name: string): boolean {
 }
 
 // Resolved at initMcpTools(); callMcpTool() looks the server up here.
-let serverByTool: Record<string, { cfg: ServerConfig; toolName: string }> = {};
+interface McpToolRoute {
+  cfg: ServerConfig;
+  toolName: string;
+  policy: McpToolPolicyDecision;
+}
+
+let serverByTool: Record<string, McpToolRoute> = {};
 
 interface McpTool {
   name: string;
   description?: string;
   inputSchema?: Record<string, unknown>;
+  annotations?: McpToolAnnotations;
 }
 
 /**
@@ -253,7 +277,7 @@ interface McpTool {
  */
 interface DiscoveryResult {
   defs: ToolDefinition[];
-  routing: Record<string, { cfg: ServerConfig; toolName: string }>;
+  routing: Record<string, McpToolRoute>;
   /** Servers skipped because they could not be reached. Empty when complete. */
   unreachable: string[];
 }
@@ -274,7 +298,7 @@ interface DiscoveryResult {
  */
 async function discoverMcpTools(registry: Record<string, ServerConfig>): Promise<DiscoveryResult> {
   const defs: ToolDefinition[] = [];
-  const routing: Record<string, { cfg: ServerConfig; toolName: string }> = {};
+  const routing: Record<string, McpToolRoute> = {};
   const unreachable: string[] = [];
   const entries = Object.entries(registry);
   let next = 0;
@@ -290,15 +314,24 @@ async function discoverMcpTools(registry: Record<string, ServerConfig>): Promise
             console.warn(`[MCP] server "${server}" returned invalid tool name "${tool.name}" — skipped`);
             continue;
           }
-          routing[qualified] = { cfg, toolName: tool.name };
-          defs.push({
+          const definition: ToolDefinition = {
             type: 'function',
             function: {
               name: qualified,
               description: (tool.description ?? '').slice(0, 1024),
               parameters: sanitizeInputSchema(tool.inputSchema),
             },
+          };
+          const policy = attachMcpToolPolicy(definition, {
+            server,
+            action: tool.name,
+            description: tool.description,
+            declaredSurface: cfg.surface,
+            serverIdentityHints: [cfg.url ?? '', cfg.command ?? '', ...(cfg.args ?? [])].filter(Boolean),
+            annotations: tool.annotations,
           });
+          routing[qualified] = { cfg, toolName: tool.name, policy };
+          defs.push(definition);
         }
       } catch (err) {
         unreachable.push(server);
@@ -405,9 +438,9 @@ export async function resolveMcpTools(
   provided?: ToolDefinition[],
   source: () => Promise<ToolDefinition[]> = getMcpTools,
 ): Promise<ToolDefinition[]> {
-  if (provided) return provided;
+  if (provided) return filterHumanSurfaceMcpTools(provided).tools;
   try {
-    return await source();
+    return filterHumanSurfaceMcpTools(await source()).tools;
   } catch {
     return [];
   }
@@ -422,6 +455,13 @@ export interface McpCallResult {
 export async function callMcpTool(qualified: string, args: Record<string, unknown>): Promise<McpCallResult> {
   const entry = serverByTool[qualified];
   if (!entry) return { content: `MCP tool not registered: ${qualified}`, isError: true };
+  if (entry.policy.surface === 'human' && !entry.policy.humanSurfaceReadAllowed) {
+    return {
+      content: `HUMAN_SURFACE_READ_ONLY: ${qualified} cannot mutate an external human-facing service. `
+        + 'Only read/list/get/search/fetch MCP actions are allowed.',
+      isError: true,
+    };
+  }
   try {
     const result = (await withClient(entry.cfg, (c) =>
       c.callTool({ name: entry.toolName, arguments: args }),

--- a/src/mcp/mcpClient.ts
+++ b/src/mcp/mcpClient.ts
@@ -21,6 +21,8 @@ import { safeInheritedEnv } from '../support/spawnEnv.js';
 import {
   attachMcpToolPolicy,
   filterHumanSurfaceMcpTools,
+  humanSurfaceMcpCallWriteReason,
+  isGenericMcpTransport,
   type McpSurface,
   type McpToolAnnotations,
   type McpToolPolicyDecision,
@@ -259,6 +261,7 @@ interface McpToolRoute {
   cfg: ServerConfig;
   toolName: string;
   policy: McpToolPolicyDecision;
+  inputSchema: Record<string, unknown>;
 }
 
 let serverByTool: Record<string, McpToolRoute> = {};
@@ -330,7 +333,12 @@ async function discoverMcpTools(registry: Record<string, ServerConfig>): Promise
             serverIdentityHints: [cfg.url ?? '', cfg.command ?? '', ...(cfg.args ?? [])].filter(Boolean),
             annotations: tool.annotations,
           });
-          routing[qualified] = { cfg, toolName: tool.name, policy };
+          routing[qualified] = {
+            cfg,
+            toolName: tool.name,
+            policy,
+            inputSchema: definition.function.parameters,
+          };
           defs.push(definition);
         }
       } catch (err) {
@@ -455,10 +463,18 @@ export interface McpCallResult {
 export async function callMcpTool(qualified: string, args: Record<string, unknown>): Promise<McpCallResult> {
   const entry = serverByTool[qualified];
   if (!entry) return { content: `MCP tool not registered: ${qualified}`, isError: true };
-  if (entry.policy.surface === 'human' && !entry.policy.humanSurfaceReadAllowed) {
+  const dispatchClassified = isGenericMcpTransport(entry.policy, entry.inputSchema);
+  if (entry.policy.surface === 'human' && !entry.policy.humanSurfaceReadAllowed && !dispatchClassified) {
     return {
       content: `HUMAN_SURFACE_READ_ONLY: ${qualified} cannot mutate an external human-facing service. `
         + 'Only read/list/get/search/fetch MCP actions are allowed.',
+      isError: true,
+    };
+  }
+  const dynamicDenial = humanSurfaceMcpCallWriteReason(entry.policy, args, entry.inputSchema);
+  if (dynamicDenial) {
+    return {
+      content: `HUMAN_SURFACE_READ_ONLY: ${qualified}: ${dynamicDenial}`,
       isError: true,
     };
   }

--- a/src/notify/notifier.test.ts
+++ b/src/notify/notifier.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { EmbedBuilder } from 'discord.js';
 vi.mock('node:dns/promises', () => ({ lookup: vi.fn(async () => [{ address: '93.184.216.34', family: 4 }]) }));
 import { createNotifier, messageToText } from './notifier.js';
+import { configureHumanSurfaceReadOnly } from '../mcp/humanSurfacePolicy.js';
 
 // These suites cover parsing and backend selection, not the socket layer, so
 // route publicFetch onto the global fetch they stub. The real implementation —
@@ -13,6 +14,7 @@ vi.mock('../support/outboundUrl.js', async (importOriginal) => {
 
 
 afterEach(() => {
+  configureHumanSurfaceReadOnly(false);
   vi.unstubAllGlobals();
   vi.clearAllMocks();
 });
@@ -87,5 +89,25 @@ describe('createNotifier — channel selection', () => {
   it('defaults to Noop when no config and no discord sender', async () => {
     const n = createNotifier(undefined);
     await expect(n.notify('x')).resolves.toBeUndefined();
+  });
+
+  it('fail-closes Discord, Slack, Telegram, and generic webhook senders when strict policy is enabled', async () => {
+    const send = vi.fn(async () => {});
+    const fetchMock = vi.fn(async () => new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const notifiers = [
+      createNotifier({ channel: 'discord' }, send),
+      createNotifier({ channel: 'slack', slackWebhookUrl: 'https://hooks.slack/x' }),
+      createNotifier({ channel: 'telegram', telegramBotToken: 'TKN', telegramChatId: '42' }),
+      createNotifier({ channel: 'webhook', webhookUrl: 'https://example.com/human-hook' }),
+    ];
+
+    // Toggle after construction as well: an already registered notifier must
+    // not retain a latent sender when a config reload tightens the boundary.
+    configureHumanSurfaceReadOnly(true);
+    await Promise.all(notifiers.map((notifier) => notifier.notify('must not leave the process')));
+
+    expect(send).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/notify/notifier.ts
+++ b/src/notify/notifier.ts
@@ -9,6 +9,7 @@
 
 import type { EmbedBuilder } from 'discord.js';
 import { publicFetch } from '../support/outboundUrl.js';
+import { isHumanSurfaceReadOnlyEnabled } from '../mcp/humanSurfacePolicy.js';
 
 export interface Notifier {
   /** Send one outbound notification. Implementations must not throw. */
@@ -52,6 +53,7 @@ export function messageToText(message: string | EmbedBuilder): string {
 }
 
 async function postJson(url: string, body: unknown): Promise<void> {
+  if (isHumanSurfaceReadOnlyEnabled()) return;
   const controller = new AbortController();
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
@@ -89,6 +91,7 @@ class NoopNotifier implements Notifier {
 class DiscordNotifier implements Notifier {
   constructor(private readonly send: DiscordSend) {}
   async notify(message: string | EmbedBuilder): Promise<void> {
+    if (isHumanSurfaceReadOnlyEnabled()) return;
     try {
       if (typeof message === 'string') {
         // Lazy import keeps discord.js out of the load path for non-Discord users.
@@ -146,6 +149,7 @@ class WebhookNotifier implements Notifier {
  * optional. Falls back to Noop when the chosen channel lacks its credential.
  */
 export function createNotifier(config: NotificationsConfig | undefined, discordSend?: DiscordSend): Notifier {
+  if (isHumanSurfaceReadOnlyEnabled()) return new NoopNotifier();
   const channel = config?.channel ?? (discordSend ? 'discord' : 'none');
   switch (channel) {
     case 'discord':

--- a/src/runners/cliRunner.test.ts
+++ b/src/runners/cliRunner.test.ts
@@ -15,6 +15,7 @@ vi.mock('../adapters/index.js', () => ({
   getAdapter: () => ({ isAvailable: mocks.isAvailable }),
   getDefaultAdapterName: () => 'test',
   listAvailableAdapters: mocks.availableAdapters,
+  probeAdapterAvailability: (adapter: { isAvailable(): Promise<boolean> }) => adapter.isAvailable(),
 }));
 
 vi.mock('../agents/pairPipeline.js', () => ({

--- a/src/runners/cliRunner.ts
+++ b/src/runners/cliRunner.ts
@@ -9,7 +9,7 @@ import { homedir } from 'node:os';
 import { PairPipeline, type PipelineResult } from '../agents/pairPipeline.js';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
 import type { PipelineStage, RoleConfig } from '../core/types.js';
-import { getAdapter, getDefaultAdapterName, listAvailableAdapters } from '../adapters/index.js';
+import { getAdapter, getDefaultAdapterName, listAvailableAdapters, probeAdapterAvailability } from '../adapters/index.js';
 import { initLocale } from '../locale/index.js';
 import { expandPath } from '../core/config.js';
 import { startProgressHeartbeat, type ReviewProgress } from '../cli/reviewProgress.js';
@@ -37,7 +37,7 @@ export interface CliRunOptions {
 
 /** Check if the configured/default adapter can run before starting the pipeline */
 async function checkDefaultAdapter(): Promise<boolean> {
-  return getAdapter(getDefaultAdapterName()).isAvailable();
+  return probeAdapterAvailability(getAdapter(getDefaultAdapterName()));
 }
 
 function validateMaxIterations(value: number | undefined): number {

--- a/src/support/approvedEgress.test.ts
+++ b/src/support/approvedEgress.test.ts
@@ -30,6 +30,8 @@ describe('prepareApprovedModelRequest', () => {
 
   it('uses the same loopback boundary for local API-key model probes', () => {
     expect(approvedLocalModelEndpoint('http://localhost:1234', '/v1/models')).toBe('http://localhost:1234/v1/models');
+    expect(approvedLocalModelEndpoint('http://127.0.0.1:3456', '/cc-router/health'))
+      .toBe('http://127.0.0.1:3456/cc-router/health');
     expect(() => approvedLocalModelEndpoint('https://models.example.com', '/v1/models')).toThrow('unapproved local endpoint');
   });
 });

--- a/src/support/approvedEgress.ts
+++ b/src/support/approvedEgress.ts
@@ -38,7 +38,7 @@ export function prepareApprovedModelRequest(endpoint: string, payload: unknown):
  */
 export function approvedLocalModelEndpoint(
   baseUrl: string,
-  path: '/v1/models' | '/v1/chat/completions' | '/v1/responses',
+  path: '/v1/models' | '/v1/chat/completions' | '/v1/responses' | '/cc-router/health',
 ): string {
   let base: URL;
   try {

--- a/src/support/chatBackend.execution.test.ts
+++ b/src/support/chatBackend.execution.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { CliAdapter } from '../adapters/types.js';
+import type { CliAdapter, CliRunOptions } from '../adapters/types.js';
 
 const getAdapter = vi.hoisted(() => vi.fn());
 const resolveMcpTools = vi.hoisted(() => vi.fn(async () => []));
@@ -15,6 +15,7 @@ vi.mock('../adapters/index.js', async (importOriginal) => {
 vi.mock('../mcp/mcpClient.js', () => ({ resolveMcpTools }));
 
 import { runChatCompletion } from './chatBackend.js';
+import { configureHumanSurfaceReadOnly } from '../mcp/humanSurfacePolicy.js';
 
 function cliAdapter(buildCommand: CliAdapter['buildCommand'], name: CliAdapter['name'] = 'codex'): CliAdapter {
   return {
@@ -34,7 +35,10 @@ function cliAdapter(buildCommand: CliAdapter['buildCommand'], name: CliAdapter['
   };
 }
 
-afterEach(() => vi.clearAllMocks());
+afterEach(() => {
+  configureHumanSurfaceReadOnly(false);
+  vi.clearAllMocks();
+});
 
 describe('runChatCompletion CLI fallback', () => {
   it('stores prompts in an unpredictable owner-only temp path and removes it', async () => {
@@ -180,6 +184,40 @@ describe('runChatCompletion CLI fallback', () => {
       .resolves.toMatchObject({ response: 'done' });
     expect(resolveMcpTools).toHaveBeenCalledOnce();
     expect(seenTools).toEqual([safeTool]);
+  });
+
+  it('keeps local web chat on a native loop while forcing shell and diagnostics off in strict mode', async () => {
+    configureHumanSurfaceReadOnly(true);
+    let seenOptions: CliRunOptions | undefined;
+    const native = cliAdapter(() => ({ command: 'unused', args: [] }));
+    getAdapter.mockReturnValue({
+      ...native,
+      capabilities: { ...native.capabilities, enforcesHumanSurfaceReadOnly: true },
+      run: async (options) => {
+        seenOptions = options;
+        return { exitCode: 0, stdout: 'local chat still works', stderr: '', durationMs: 1 };
+      },
+    });
+
+    await expect(runChatCompletion({ prompt: 'inspect', provider: 'codex', timeoutMs: 5000 }))
+      .resolves.toMatchObject({ response: 'local chat still works' });
+    expect(seenOptions).toMatchObject({ shellTools: false, diagnosticsTool: false, webTools: true });
+  });
+
+  it('refuses delegated chat before buildCommand can reach a fake CLI or HOME credential', async () => {
+    configureHumanSurfaceReadOnly(true);
+    const buildCommand = vi.fn(() => ({ command: 'fake-codex', args: [] }));
+    getAdapter.mockReturnValue(cliAdapter(buildCommand));
+    const previousHome = process.env.HOME;
+    process.env.HOME = '/tmp/fake-home-with-human-credentials';
+    try {
+      await expect(runChatCompletion({ prompt: 'send', provider: 'codex', timeoutMs: 5000 }))
+        .rejects.toThrow(/HUMAN_SURFACE_READ_ONLY.*delegates to an external CLI/);
+      expect(buildCommand).not.toHaveBeenCalled();
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+    }
   });
 
   it.skipIf(process.platform === 'win32')('terminates descendant processes when the caller aborts', async () => {

--- a/src/support/chatBackend.execution.test.ts
+++ b/src/support/chatBackend.execution.test.ts
@@ -5,14 +5,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { CliAdapter } from '../adapters/types.js';
 
 const getAdapter = vi.hoisted(() => vi.fn());
-const getMcpTools = vi.hoisted(() => vi.fn(async () => []));
+const resolveMcpTools = vi.hoisted(() => vi.fn(async () => []));
 
 vi.mock('../adapters/index.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../adapters/index.js')>();
   return { ...actual, getAdapter };
 });
 
-vi.mock('../mcp/mcpClient.js', () => ({ getMcpTools }));
+vi.mock('../mcp/mcpClient.js', () => ({ resolveMcpTools }));
 
 import { runChatCompletion } from './chatBackend.js';
 
@@ -159,6 +159,27 @@ describe('runChatCompletion CLI fallback', () => {
     })).rejects.toThrow('Chat response timeout');
     expect(Date.now() - startedAt).toBeLessThan(150);
     await new Promise((resolve) => setTimeout(resolve, 325));
+  });
+
+  it('sources the globally filtered MCP set for native chat runs', async () => {
+    const safeTool = {
+      type: 'function' as const,
+      function: { name: 'slack__list_channels', description: '', parameters: { type: 'object' } },
+    };
+    resolveMcpTools.mockResolvedValueOnce([safeTool]);
+    let seenTools: unknown;
+    getAdapter.mockReturnValue({
+      ...cliAdapter(() => ({ command: 'unused', args: [] })),
+      run: async (options: { mcpTools?: unknown }) => {
+        seenTools = options.mcpTools;
+        return { exitCode: 0, stdout: 'done', stderr: '', durationMs: 1 };
+      },
+    });
+
+    await expect(runChatCompletion({ prompt: 'inspect', provider: 'codex', timeoutMs: 5000 }))
+      .resolves.toMatchObject({ response: 'done' });
+    expect(resolveMcpTools).toHaveBeenCalledOnce();
+    expect(seenTools).toEqual([safeTool]);
   });
 
   it.skipIf(process.platform === 'win32')('terminates descendant processes when the caller aborts', async () => {

--- a/src/support/chatBackend.ts
+++ b/src/support/chatBackend.ts
@@ -22,6 +22,7 @@ import {
 } from '../adapters/processTree.js';
 import { raceWithAbort } from '../adapters/abortRace.js';
 import { buildWorkerEnv } from '../adapters/envPath.js';
+import { isHumanSurfaceReadOnlyEnabled } from '../mcp/humanSurfacePolicy.js';
 
 export interface ChatCompletionOptions {
   prompt: string;
@@ -316,6 +317,8 @@ async function runChatViaAdapter(
         : BASE_CHAT_SYSTEM_PROMPT,
       enableTools: true,
       webTools: true,
+      shellTools: !isHumanSurfaceReadOnlyEnabled(),
+      diagnosticsTool: false,
       mcpTools,
       // A high safety ceiling, not a task limit — normal work ends when the model
       // stops calling tools; the progress-based stop catches stuck loops earlier.
@@ -363,7 +366,23 @@ export async function runChatCompletion(options: ChatCompletionOptions): Promise
   const cwd = options.cwd ?? process.cwd();
 
   if (typeof adapter.run === 'function') {
+    if (
+      isHumanSurfaceReadOnlyEnabled()
+      && adapter.capabilities.enforcesHumanSurfaceReadOnly !== true
+    ) {
+      throw new Error(
+        `HUMAN_SURFACE_READ_ONLY: Chat adapter '${adapter.name}' does not declare enforcement of the strict `
+        + 'human-surface boundary; use a native OpenSwarm-loop provider.',
+      );
+    }
     return runChatViaAdapter(adapter, provider, model, cwd, options);
+  }
+
+  if (isHumanSurfaceReadOnlyEnabled()) {
+    throw new Error(
+      `HUMAN_SURFACE_READ_ONLY: Chat adapter '${adapter.name}' delegates to an external CLI with its own tool loop; `
+      + 'use a native OpenSwarm-loop provider while humanSurfaceReadOnly.enabled is true.',
+    );
   }
 
   // CLI command construction can itself perform I/O (Codex enumerates the

--- a/src/support/chatBackend.ts
+++ b/src/support/chatBackend.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 import type { AdapterName } from '../adapters/index.js';
-import { getAdapter, getDefaultAdapterName } from '../adapters/index.js';
+import { getAdapter, getDefaultAdapterName, listBoundarySafeModels } from '../adapters/index.js';
 // Single source for each provider's default model — see getDefaultChatModel.
 import { CODEX_DEFAULT_MODEL } from '../adapters/codex.js';
 import { DEFAULT_MODEL as CODEX_RESPONSES_DEFAULT_MODEL } from '../adapters/codexResponses.js';
@@ -180,7 +180,7 @@ export async function listChatModels(provider: AdapterName): Promise<string[]> {
   try {
     const adapter = getAdapter(provider);
     if (typeof adapter.listModels === 'function') {
-      const live = await adapter.listModels();
+      const live = await listBoundarySafeModels(adapter);
       if (live?.length) return Array.from(new Set(live));
     }
   } catch {

--- a/src/support/chatBackend.ts
+++ b/src/support/chatBackend.ts
@@ -21,6 +21,7 @@ import {
   untrackCliProcessTree,
 } from '../adapters/processTree.js';
 import { raceWithAbort } from '../adapters/abortRace.js';
+import { buildWorkerEnv } from '../adapters/envPath.js';
 
 export interface ChatCompletionOptions {
   prompt: string;
@@ -293,9 +294,9 @@ async function runChatViaAdapter(
   // so it can actually read/edit/run in the working directory. Tokens stream via
   // onToken; tool executions surface through onLog.
   // Expose any MCP servers configured in ~/.openswarm/mcp.json as tools (cached).
-  const { getMcpTools } = await import('../mcp/mcpClient.js');
+  const { resolveMcpTools } = await import('../mcp/mcpClient.js');
   const mcpTools = await raceWithAbort(
-    getMcpTools().catch(() => []),
+    resolveMcpTools(),
     runSignal,
     'Chat response cancelled',
   );
@@ -415,7 +416,7 @@ export async function runChatCompletion(options: ChatCompletionOptions): Promise
     if (runSignal.aborted) throw chatAbortError(runSignal);
 
     return await new Promise<ChatCompletionResult>((resolve, reject) => {
-      const cliSpawn = prepareCliProcessTreeSpawn(command, args, process.env);
+      const cliSpawn = prepareCliProcessTreeSpawn(command, args, buildWorkerEnv(process.env));
       const proc = spawn(cliSpawn.command, cliSpawn.args, {
         shell: false,
         detached: process.platform !== 'win32',


### PR DESCRIPTION
## Summary

- add an explicit MCP trust-domain/action classifier using server descriptors, endpoint/package identity, action tokens, and MCP annotations
- fail closed on Slack/Discord/email/Notion and other human-surface mutations at provider exposure, role grant, and dispatch time; only read/list/get/search/fetch actions survive
- preserve existing GitHub/Linear/Cloudflare/DB and sandbox-data grants
- scrub human-surface credentials from native and delegated child environments and block direct native-shell writes, including common shell wrappers
- document `mcp.servers.<name>.surface` for opaque custom aliases

## Safety contract

Exact `writeTools`/`destructiveTools` grants cannot widen human-surface authority. MCP annotations may tighten but never relax classification. Delegated CLIs receive no OpenSwarm MCP grants; child env inheritance is scrubbed. Arbitrary programs that read credentials embedded inside a worktree remain outside app-layer semantic classification and are explicitly documented as unsupported.

## Verification

- `npm test` — 365 files passed, 1 skipped; 5,044 tests passed, 10 skipped
- `npm run typecheck`
- `npm run lint` — 0 warnings/errors
- `npm run build`
- `openswarm review --path . --json` — `approve`, no findings

Linear: [AGT-4144](https://linear.app/intrect/issue/AGT-4144/fixpolicy-fail-closed-on-human-surface-mcp-writes-across-native)
