### PR TITLE
fix: bind publication and CI evidence to exact head SHA

### DIFF
--- a/src/automation/prProcessor.test.ts
+++ b/src/automation/prProcessor.test.ts
@@ -46,8 +46,13 @@ const gh = vi.hoisted(() => ({
     url: 'https://example/pr/9', author: 'someone', body: '', diff: 'diff --git a/x b/x',
   })),
   checkPRConflicts: vi.fn(async () => false),
+  checkPRCIStatus: vi.fn(async () => ({
+    status: 'failure' as const,
+    headSha: 'head-a',
+    failedChecks: [{ name: 'unit', conclusion: 'failure' }],
+  })),
   commentOnPR: vi.fn(async () => undefined),
-  waitForCICompletion: vi.fn(async () => ({ status: 'success' as const })),
+  waitForCICompletion: vi.fn(async () => ({ status: 'success' as const, headSha: 'head-b' })),
   getPRReviews: vi.fn(async () => [] as Array<{ author: string; state?: string; createdAt: string; body: string }>),
   getPRComments: vi.fn(async () => [] as PRIssueComment[]),
   getPRReviewComments: vi.fn(async () => [] as Array<{ author: string; body: string; path?: string; line?: number; createdAt: string }>),
@@ -138,7 +143,7 @@ vi.mock('../agents/pairPipeline.js', () => ({
 
 const { PRProcessor } = await import('./prProcessor.js');
 
-const pr = { repo: 'o/r', number: 9, title: 'Ship it', branch: 'feat/x', createdAt: '2026-08-05T00:00:00.000Z', url: 'https://example/pr/9' };
+const pr = { repo: 'o/r', number: 9, title: 'Ship it', branch: 'feat/x', headSha: 'head-a', createdAt: '2026-08-05T00:00:00.000Z', url: 'https://example/pr/9' };
 
 function newProcessor(overrides: Partial<import('./prProcessor.js').PRProcessorConfig> = {}) {
   return new PRProcessor({ repos: [], schedule: '0 0 1 1 *', cooldownHours: 0, maxIterations: 3, maxRetries: 3, ...overrides });
@@ -146,7 +151,10 @@ function newProcessor(overrides: Partial<import('./prProcessor.js').PRProcessorC
 
 beforeEach(() => {
   vi.clearAllMocks();
-  gitExecImpl.mockResolvedValue({ stdout: '', stderr: '' });
+  gitExecImpl.mockImplementation(async (args: string[]) => ({
+    stdout: args[0] === 'rev-parse' && args[1] === 'HEAD' ? 'head-b\n' : '',
+    stderr: '',
+  }));
   readFileImpl.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
   existsSyncImpl.mockReturnValue(true);
   schedulerImpl.isProjectBusy.mockReturnValue(false);
@@ -165,8 +173,13 @@ beforeEach(() => {
     url: 'https://example/pr/9', author: 'someone', body: '', diff: 'diff --git a/x b/x',
   });
   gh.checkPRConflicts.mockResolvedValue(false);
+  gh.checkPRCIStatus.mockResolvedValue({
+    status: 'failure',
+    headSha: 'head-a',
+    failedChecks: [{ name: 'unit', conclusion: 'failure' }],
+  });
   gh.commentOnPR.mockResolvedValue(undefined);
-  gh.waitForCICompletion.mockResolvedValue({ status: 'success' });
+  gh.waitForCICompletion.mockResolvedValue({ status: 'success', headSha: 'head-b' });
   gh.getPRReviews.mockResolvedValue([]);
   gh.getPRComments.mockResolvedValue([]);
   gh.getPRReviewComments.mockResolvedValue([]);
@@ -297,8 +310,8 @@ describe('PRProcessor.fixOne (INT-3282)', () => {
 
   it('retries once after a CI failure and succeeds on the second attempt', async () => {
     gh.waitForCICompletion
-      .mockResolvedValueOnce({ status: 'failure', failedChecks: [{ name: 'test', conclusion: 'failure' }] })
-      .mockResolvedValueOnce({ status: 'success' });
+      .mockResolvedValueOnce({ status: 'failure', headSha: 'head-b', failedChecks: [{ name: 'test', conclusion: 'failure' }] })
+      .mockResolvedValueOnce({ status: 'success', headSha: 'head-b' });
     const processor = new PRProcessor({ repos: [], schedule: '0 0 1 1 *', cooldownHours: 0, maxIterations: 3, maxRetries: 2 });
     const result = await processor.fixOne(pr, '/tmp/proj');
     expect(result.success).toBe(true);
@@ -307,13 +320,34 @@ describe('PRProcessor.fixOne (INT-3282)', () => {
   });
 
   it('breaks out immediately with a CI-timeout error when CI neither succeeds nor fails', async () => {
-    gh.waitForCICompletion.mockResolvedValueOnce({ status: 'pending' });
+    gh.waitForCICompletion.mockResolvedValueOnce({ status: 'pending', headSha: 'head-b' });
     const processor = newProcessor();
     const result = await processor.fixOne(pr, '/tmp/proj');
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/CI timeout/);
     expect(pipelineRunImpl.run).toHaveBeenCalledTimes(1);
     expect(gh.commentOnPR).toHaveBeenCalledWith('o/r', 9, expect.stringContaining('Auto-fix failed'));
+  });
+
+  it('waits only for checks belonging to the commit it just pushed', async () => {
+    const processor = newProcessor();
+    const result = await processor.fixOne(pr, '/tmp/proj');
+    expect(result.success).toBe(true);
+    expect(gh.waitForCICompletion).toHaveBeenCalledWith('o/r', 9, expect.objectContaining({
+      expectedHeadSha: 'head-b',
+    }));
+  });
+
+  it('reports an explicit identity failure instead of treating unknown CI as a timeout or success', async () => {
+    gh.waitForCICompletion.mockResolvedValueOnce({
+      status: 'unknown',
+      reason: 'head_mismatch',
+      expectedHeadSha: 'head-b',
+      observedHeadSha: 'head-a',
+    });
+    const result = await newProcessor().fixOne(pr, '/tmp/proj');
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/CI head identity unknown.*head_mismatch/);
   });
 
   it('catches a synchronous pipeline throw and reports it as the error', async () => {
@@ -328,6 +362,9 @@ describe('PRProcessor.fixOne (INT-3282)', () => {
     gitExecImpl.mockImplementation(async (args: string[]) => {
       if (args[0] === 'checkout' && args[1] !== pr.branch) {
         throw new Error('checkout restore failed');
+      }
+      if (args[0] === 'rev-parse' && args[1] === 'HEAD') {
+        return { stdout: 'head-b\n', stderr: '' };
       }
       return { stdout: '', stderr: '' };
     });
@@ -357,6 +394,9 @@ describe('PRProcessor.fixOne (INT-3282)', () => {
       if (args[0] === 'stash' && args[1] === 'list') {
         if (!stashedMessage) return { stdout: '', stderr: '' };
         return { stdout: `abc123\x00stash@{0}\x00${stashedMessage}\n`, stderr: '' };
+      }
+      if (args[0] === 'rev-parse' && args[1] === 'HEAD') {
+        return { stdout: 'head-b\n', stderr: '' };
       }
       return { stdout: '', stderr: '' };
     });
@@ -873,7 +913,7 @@ describe('PRProcessor.processPRs (INT-3282 coverage)', () => {
 
   it('observes merged events after ordinary PR work for the repo', async () => {
     gh.getOpenPRs.mockResolvedValue([pr]);
-    gh.getPRChecks.mockResolvedValue([{ conclusion: 'success' }]);
+    gh.checkPRCIStatus.mockResolvedValue({ status: 'success', headSha: 'head-a' });
     const processor = newScanProcessor({
       postMergeIntegration: {
         getActiveLeaseBranches: () => [],
@@ -885,9 +925,9 @@ describe('PRProcessor.processPRs (INT-3282 coverage)', () => {
 
     await processor.processPRs();
 
-    expect(gh.getPRChecks).toHaveBeenCalled();
+    expect(gh.checkPRCIStatus).toHaveBeenCalledWith('o/r', 9, 'head-a');
     expect(gh.getMergedPRsOrThrow).toHaveBeenCalled();
-    expect(gh.getPRChecks.mock.invocationCallOrder[0])
+    expect(gh.checkPRCIStatus.mock.invocationCallOrder[0])
       .toBeLessThan(gh.getMergedPRsOrThrow.mock.invocationCallOrder[0]);
   });
 
@@ -956,9 +996,25 @@ describe('PRProcessor.processPRs (INT-3282 coverage)', () => {
 
   it('skips a PR with no conflicts, no feedback, and passing CI', async () => {
     gh.getOpenPRs.mockResolvedValue([pr]);
-    gh.getPRChecks.mockResolvedValue([{ conclusion: 'success' }]);
+    gh.checkPRCIStatus.mockResolvedValue({ status: 'success', headSha: 'head-a' });
     const processor = newScanProcessor();
     await processor.processPRs();
+    expect(pipelineRunImpl.run).not.toHaveBeenCalled();
+  });
+
+  it('does not mutate a PR when its listed head and CI observation disagree', async () => {
+    gh.getOpenPRs.mockResolvedValue([pr]);
+    gh.checkPRCIStatus.mockResolvedValue({
+      status: 'unknown',
+      reason: 'head_mismatch',
+      expectedHeadSha: 'head-a',
+      observedHeadSha: 'head-b',
+    });
+
+    const processor = newScanProcessor();
+    await processor.processPRs();
+
+    expect(gh.checkPRCIStatus).toHaveBeenCalledWith('o/r', 9, 'head-a');
     expect(pipelineRunImpl.run).not.toHaveBeenCalled();
   });
 
@@ -992,7 +1048,7 @@ describe('PRProcessor.processPRs (INT-3282 coverage)', () => {
     gh.getPRReviews.mockResolvedValue([
       { author: 'codex', state: 'CHANGES_REQUESTED', createdAt: '2026-08-05T00:00:00.000Z', body: 'please fix' },
     ]);
-    gh.getPRChecks.mockResolvedValue([{ conclusion: 'success' }]);
+    gh.checkPRCIStatus.mockResolvedValue({ status: 'success', headSha: 'head-a' });
     const processor = newScanProcessor();
     const scanPromise = processor.processPRs();
     await vi.advanceTimersByTimeAsync(5_000); // inter-iteration delay between rounds 1 and 2

--- a/src/automation/prProcessor.ts
+++ b/src/automation/prProcessor.ts
@@ -151,6 +151,7 @@ import {
   commentOnPR,
   commentOnPROrThrow,
   checkPRConflicts,
+  checkPRCIStatus,
   waitForCICompletion,
   getPRBaseBranchOrThrow,
   getMergedPRsOrThrow,
@@ -690,15 +691,11 @@ export class PRProcessor {
             console.log(`[PRProcessor] ${key}: review feedback detected (bypassing cooldown)`);
           }
 
-          // If no conflicts and no review feedback, check CI status — only process PRs with failures
           if (!hasConflicts && !hasReviewFeedback) {
-            const { getPRChecks } = await import('../github/index.js');
-            const checks = await getPRChecks(repo, pr.number);
-            const hasFailure = checks.some(
-              (c) => c.conclusion === 'failure' || c.conclusion === 'timed_out'
-            );
-            if (!hasFailure && checks.length > 0) {
-              console.log(`[PRProcessor] ${key}: no conflicts, no review feedback, and CI passing, skipping`);
+            const ciStatus = await checkPRCIStatus(repo, pr.number, pr.headSha);
+            if (ciStatus.status !== 'failure') {
+              const detail = ciStatus.status === 'unknown' ? `CI identity unknown (${ciStatus.reason})` : `CI ${ciStatus.status} at ${ciStatus.headSha}`;
+              console.log(`[PRProcessor] ${key}: no conflicts or review feedback; ${detail}, skipping`);
               continue;
             }
           } else if (hasConflicts) {
@@ -739,17 +736,18 @@ export class PRProcessor {
           };
           await this.saveState(state);
 
-          // If only review feedback (no conflicts, CI passing), handle review feedback directly
           if (hasReviewFeedback && !hasConflicts) {
-            const { getPRChecks } = await import('../github/index.js');
-            const checks = await getPRChecks(repo, pr.number);
-            const hasFailure = checks.some(
-              (c) => c.conclusion === 'failure' || c.conclusion === 'timed_out'
-            );
-            if (!hasFailure && checks.length > 0) {
-              // CI is passing, only need to handle review feedback
+            const ciStatus = await checkPRCIStatus(repo, pr.number, pr.headSha);
+            if (ciStatus.status === 'success') {
               console.log(`[PRProcessor] ${key}: Handling review feedback only (CI passing)`);
               await this.processReviewFeedback(pr, projectPath, state, key, 0);
+              continue;
+            }
+            if (ciStatus.status === 'pending' || ciStatus.status === 'unknown') {
+              const detail = ciStatus.status === 'unknown' ? `identity unknown (${ciStatus.reason})` : `pending at ${ciStatus.headSha}`;
+              state.prs[key].status = 'pending';
+              state.prs[key].lastError = `CI ${detail}`;
+              console.log(`[PRProcessor] ${key}: CI ${detail}; deferring review feedback`);
               continue;
             }
           }
@@ -947,15 +945,15 @@ export class PRProcessor {
           continue;
         }
 
-        // 4c. Pipeline succeeded - push changes
         console.log(`[PRProcessor] ${key}: Pipeline succeeded, pushing changes...`);
+        const publishedHeadSha = (await gitExec(projectPath, 'rev-parse', 'HEAD')).trim();
+        if (!publishedHeadSha) throw new Error('Cannot publish CI remediation: HEAD identity is unavailable');
         await gitExec(projectPath, 'push', 'origin', pr.branch);
-
-        // 4d. Wait for CI completion
         console.log(`[PRProcessor] ${key}: Waiting for CI checks...`);
         const ciStatus = await waitForCICompletion(pr.repo, pr.number, {
           timeoutMs: ciTimeoutMs,
           pollIntervalMs: ciPollIntervalMs,
+          expectedHeadSha: publishedHeadSha,
           onProgress: (status, elapsed) => {
             if (status.status === 'pending') {
               console.log(`[PRProcessor] ${key}: CI pending (${Math.floor(elapsed / 1000)}s elapsed)...`);
@@ -1016,6 +1014,10 @@ export class PRProcessor {
           await gitExec(projectPath, 'pull', 'origin', pr.branch);
           continue;
 
+        } else if (ciStatus.status === 'unknown') {
+          lastError = `CI head identity unknown (${ciStatus.reason};${ciStatus.expectedHeadSha ? ` expected ${ciStatus.expectedHeadSha}` : ''}${ciStatus.observedHeadSha ? ` observed ${ciStatus.observedHeadSha}` : ''})`;
+          console.log(`[PRProcessor] ${key}: ${lastError}`);
+          break;
         } else {
           // CI timeout
           lastError = 'CI timeout - checks did not complete in time';

--- a/src/automation/publishOnPark.test.ts
+++ b/src/automation/publishOnPark.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from 'vitest';
-import { shouldPublishParkedWork } from './publishOnPark.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
+
+const commitAndCreatePRWithHead = vi.hoisted(() => vi.fn());
+vi.mock('../support/worktreeManager.js', () => ({ commitAndCreatePRWithHead }));
+vi.mock('../core/eventHub.js', () => ({ broadcastEvent: vi.fn() }));
+
+import { publishApprovedWork, shouldPublishParkedWork } from './publishOnPark.js';
+
+beforeEach(() => {
+  commitAndCreatePRWithHead.mockReset();
+});
 
 describe('shouldPublishParkedWork (AGT-4076)', () => {
   it('publishes when a run parks for the operator with a worktree', () => {
@@ -27,5 +37,33 @@ describe('shouldPublishParkedWork (AGT-4076)', () => {
 
   it('does not publish without a worktree — there is nothing to publish from', () => {
     expect(shouldPublishParkedWork(false, { finalStatus: 'waiting_on_operator' })).toBe(false);
+  });
+});
+
+describe('publication identity (AGT-4145)', () => {
+  it('durably attaches the exact head returned by a successful reviewed publication', async () => {
+    commitAndCreatePRWithHead.mockResolvedValue({
+      prUrl: 'https://github.com/o/r/pull/17',
+      headSha: 'head-b',
+    });
+    const onPublication = vi.fn(async () => true);
+    const durability = {
+      beforePublish: vi.fn(async () => true),
+      onPublication,
+    } as unknown as ExecutionDurabilityHooks;
+    const result: { success: boolean; finalStatus: string; prUrl?: string } = {
+      success: true,
+      finalStatus: 'approved',
+    };
+
+    await publishApprovedWork(
+      { worktreePath: '/tmp/w', originalPath: '/tmp/r', branchName: 'swarm/AGT-4145', issueId: 'AGT-4145' },
+      { id: 'task-1', issueIdentifier: 'AGT-4145', title: 'Preserve publication identity' },
+      result,
+      durability,
+    );
+
+    expect(result.prUrl).toBe('https://github.com/o/r/pull/17');
+    expect(onPublication).toHaveBeenCalledWith('https://github.com/o/r/pull/17', 'head-b');
   });
 });

--- a/src/automation/publishOnPark.ts
+++ b/src/automation/publishOnPark.ts
@@ -13,7 +13,7 @@
 // Split out of runnerExecution.ts, which sits on the 1500-line pre-commit cap.
 
 import { broadcastEvent } from '../core/eventHub.js';
-import { commitAndCreatePR, type WorktreeInfo } from '../support/worktreeManager.js';
+import { commitAndCreatePRWithHead, type WorktreeInfo } from '../support/worktreeManager.js';
 import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
 
 /** The fields these paths read; narrower than the full pipeline result. */
@@ -77,7 +77,7 @@ export async function publishParkedWork(
     return;
   }
   try {
-    const prUrl = await commitAndCreatePR(
+    const publication = await commitAndCreatePRWithHead(
       worktreeInfo,
       task.title,
       task.issueIdentifier || '',
@@ -96,7 +96,8 @@ export async function publishParkedWork(
     // which frees the repository admission slot and resumes on the answer —
     // into a reconcile row that holds a slot until a sweep releases it. That is
     // the phantom-row shape that idled the whole loop on 2026-08-29.
-    const attached = await durability?.onPublication(prUrl) ?? true;
+    const { prUrl, headSha } = publication;
+    const attached = await durability?.onPublication(prUrl, headSha) ?? true;
     if (attached) {
       console.log(`[Runner] Parked run published as draft for ${task.issueIdentifier}: ${prUrl}`);
     } else {
@@ -135,14 +136,15 @@ export async function publishApprovedWork(
       console.warn(`[Worktree] Publication fenced for ${task.issueIdentifier}; preserving worktree`);
     } else {
       try {
-        const prUrl = await commitAndCreatePR(
+        const publication = await commitAndCreatePRWithHead(
           worktreeInfo,
           task.title,
           task.issueIdentifier || '',
           task.description || '',
         );
+        const { prUrl, headSha } = publication;
         result.prUrl = prUrl;
-        const publicationRecorded = await durability?.onPublication(prUrl) ?? true;
+        const publicationRecorded = await durability?.onPublication(prUrl, headSha) ?? true;
         if (!publicationRecorded) {
           throw new Error('Durable lease fence rejected publication attachment');
         }

--- a/src/automation/runnerExecution.coverage.test.ts
+++ b/src/automation/runnerExecution.coverage.test.ts
@@ -98,10 +98,10 @@ vi.mock('../support/planner.js', () => ({
   runPlanner: plannerRunPlanner,
   formatPlannerResult: plannerFormatPlannerResult,
 }));
-
 vi.mock('../support/worktreeManager.js', () => ({
   createWorktree,
   commitAndCreatePR,
+  commitAndCreatePRWithHead: commitAndCreatePR,
   findOpenPRFileOverlaps,
   hasRecoverableWorktree,
   preserveWorktree,
@@ -311,7 +311,7 @@ describe('runnerExecution.ts coverage extension', () => {
     plannerEstimateTaskDuration.mockReturnValue(45);
     plannerFormatPlannerResult.mockReturnValue('planner result summary');
 
-    commitAndCreatePR.mockResolvedValue('https://github.com/org/repo/pull/1');
+    commitAndCreatePR.mockResolvedValue({ prUrl: 'https://github.com/org/repo/pull/1', headSha: 'published-head' });
     findOpenPRFileOverlaps.mockResolvedValue([]);
     hasRecoverableWorktree.mockResolvedValue(false);
     removeWorktree.mockResolvedValue(undefined);
@@ -772,7 +772,7 @@ describe('runnerExecution.ts coverage extension', () => {
   describe('worktree mode', () => {
     it('creates a worktree, runs the pipeline, and opens a PR on approval', async () => {
       createWorktree.mockResolvedValue(worktreeInfoFixture());
-      commitAndCreatePR.mockResolvedValue('https://github.com/org/repo/pull/1');
+      commitAndCreatePR.mockResolvedValue({ prUrl: 'https://github.com/org/repo/pull/1', headSha: 'published-head' });
       createPipelineFromConfig.mockReturnValue(makeFakePipeline(pipelineResult({ finalStatus: 'approved', success: true })));
 
       const result = await executePipeline(makeCtx({ worktreeMode: true }), task(), '/repo');

--- a/src/automation/runnerExecution.decomposition.test.ts
+++ b/src/automation/runnerExecution.decomposition.test.ts
@@ -90,6 +90,7 @@ vi.mock('../support/planner.js', () => ({
 vi.mock('../support/worktreeManager.js', () => ({
   createWorktree,
   commitAndCreatePR,
+  commitAndCreatePRWithHead: commitAndCreatePR,
   findOpenPRFileOverlaps,
   hasRecoverableWorktree,
   preserveWorktree,
@@ -282,7 +283,10 @@ describe('decomposition limits', () => {
     plannerEstimateTaskDuration.mockReturnValue(45);
     plannerFormatPlannerResult.mockReturnValue('planner result summary');
 
-    commitAndCreatePR.mockResolvedValue('https://github.com/org/repo/pull/1');
+    commitAndCreatePR.mockResolvedValue({
+      prUrl: 'https://github.com/org/repo/pull/1',
+      headSha: 'published-head',
+    });
     findOpenPRFileOverlaps.mockResolvedValue([]);
     hasRecoverableWorktree.mockResolvedValue(false);
     removeWorktree.mockResolvedValue(undefined);

--- a/src/automation/runnerExecution.integration.coverage.test.ts
+++ b/src/automation/runnerExecution.integration.coverage.test.ts
@@ -27,6 +27,7 @@ vi.mock('../support/planner.js', () => ({
 vi.mock('../support/worktreeManager.js', () => ({
   createWorktree: vi.fn(),
   commitAndCreatePR: vi.fn(),
+  commitAndCreatePRWithHead: vi.fn(),
   findOpenPRFileOverlaps: vi.fn(),
   hasRecoverableWorktree: vi.fn(async () => false),
   preserveWorktree: vi.fn(),

--- a/src/cli/prCommand.test.ts
+++ b/src/cli/prCommand.test.ts
@@ -53,35 +53,35 @@ describe('classifyBlocker (INT-3282)', () => {
       hasConflicts: true,
       changesRequestedCount: 1,
       criticalCommentCount: 0,
-      ci: { status: 'failure', failedChecks: [{ name: 't', conclusion: 'failure' }] },
+      ci: { status: 'failure', headSha: 'head-a', failedChecks: [{ name: 't', conclusion: 'failure' }] },
     })).toBe('conflicts');
 
     expect(classifyBlocker({
       hasConflicts: false,
       changesRequestedCount: 1,
       criticalCommentCount: 0,
-      ci: { status: 'failure', failedChecks: [{ name: 't', conclusion: 'failure' }] },
+      ci: { status: 'failure', headSha: 'head-a', failedChecks: [{ name: 't', conclusion: 'failure' }] },
     })).toBe('comments');
 
     expect(classifyBlocker({
       hasConflicts: false,
       changesRequestedCount: 0,
       criticalCommentCount: 0,
-      ci: { status: 'failure', failedChecks: [{ name: 't', conclusion: 'failure' }] },
+      ci: { status: 'failure', headSha: 'head-a', failedChecks: [{ name: 't', conclusion: 'failure' }] },
     })).toBe('ci');
 
     expect(classifyBlocker({
       hasConflicts: false,
       changesRequestedCount: 0,
       criticalCommentCount: 0,
-      ci: { status: 'pending' },
+      ci: { status: 'pending', headSha: 'head-a' },
     })).toBe('pending_ci');
 
     expect(classifyBlocker({
       hasConflicts: false,
       changesRequestedCount: 0,
       criticalCommentCount: 0,
-      ci: { status: 'success' },
+      ci: { status: 'success', headSha: 'head-a' },
     })).toBe('none');
   });
 });
@@ -120,14 +120,15 @@ describe('formatPrStatus (INT-3282)', () => {
       url: 'https://example/pr/1',
       mergeable: true,
       hasConflicts: false,
-      ci: { status: 'success' },
+      ci: { status: 'success', headSha: 'head-a' },
       changesRequested: [],
       criticalComments: [],
       blocker: 'none',
       mergeReady: true,
     };
     expect(formatPrStatus(ready)).toMatch(/ready:\s+yes/);
-    expect(formatPrStatus({ ...ready, blocker: 'ci', mergeReady: false, ci: { status: 'failure', failedChecks: [{ name: 'lint', conclusion: 'failure' }] } }))
+    expect(formatPrStatus(ready)).toMatch(/head:\s+head-a/);
+    expect(formatPrStatus({ ...ready, blocker: 'ci', mergeReady: false, ci: { status: 'failure', headSha: 'head-a', failedChecks: [{ name: 'lint', conclusion: 'failure' }] } }))
       .toMatch(/FAIL \(lint\)/);
   });
 });
@@ -147,7 +148,7 @@ function mkDeps(over: Partial<PrCommandDeps> = {}): PrCommandDeps {
       ...resolved,
       mergeable: true,
       hasConflicts: false,
-      ci: { status: 'success' as const },
+      ci: { status: 'success' as const, headSha: 'head-a' },
       changesRequested: [],
       criticalComments: [],
       blocker: 'none' as const,
@@ -283,7 +284,7 @@ describe('runPrCommand (INT-3282)', () => {
         ...resolved,
         mergeable: false,
         hasConflicts: true,
-        ci: { status: 'pending' as const },
+        ci: { status: 'pending' as const, headSha: 'head-a' },
         changesRequested: [],
         criticalComments: [],
         blocker: 'conflicts' as const,
@@ -525,7 +526,7 @@ describe('runPrCommand (INT-3282)', () => {
             ...resolved,
             mergeable: true,
             hasConflicts: false,
-            ci: { status: 'failure' as const, failedChecks: [{ name: 'test', conclusion: 'failure' }] },
+            ci: { status: 'failure' as const, headSha: 'head-a', failedChecks: [{ name: 'test', conclusion: 'failure' }] },
             changesRequested: [],
             criticalComments: [],
             blocker: 'ci' as const,
@@ -536,7 +537,7 @@ describe('runPrCommand (INT-3282)', () => {
           ...resolved,
           mergeable: true,
           hasConflicts: false,
-          ci: { status: 'success' as const },
+          ci: { status: 'success' as const, headSha: 'head-a' },
           changesRequested: [],
           criticalComments: [],
           blocker: 'none' as const,
@@ -560,7 +561,7 @@ describe('runPrCommand (INT-3282)', () => {
           ...resolved,
           mergeable: false,
           hasConflicts: false,
-          ci: { status: 'pending' as const },
+          ci: { status: 'pending' as const, headSha: 'head-a' },
           changesRequested: [],
           criticalComments: [],
           blocker: calls === 1 ? ('pending_ci' as const) : ('none' as const),
@@ -574,6 +575,31 @@ describe('runPrCommand (INT-3282)', () => {
     expect(result.exitCode).toBe(0);
   });
 
+  it('watch fails closed without running a fix when CI head identity is unknown', async () => {
+    const deps = mkDeps({
+      gatherStatus: vi.fn(async () => ({
+        ...resolved,
+        mergeable: false,
+        hasConflicts: false,
+        ci: {
+          status: 'unknown' as const,
+          reason: 'head_mismatch' as const,
+          expectedHeadSha: 'head-b',
+          observedHeadSha: 'head-a',
+        },
+        changesRequested: [],
+        criticalComments: [],
+        blocker: 'unknown_ci' as const,
+        mergeReady: false,
+      })),
+    });
+
+    const result = await runPrCommand('watch', { rounds: 3 }, deps);
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toMatch(/CI head identity is unknown/);
+    expect(deps.fixOne).not.toHaveBeenCalled();
+  });
+
   it('watch reports a blocked message with exit 1 when the fix pass fails', async () => {
     const deps = mkDeps({
       fixOne: vi.fn(async () => ({ success: false, error: 'still red', iterations: 1 })),
@@ -581,7 +607,7 @@ describe('runPrCommand (INT-3282)', () => {
         ...resolved,
         mergeable: false,
         hasConflicts: false,
-        ci: { status: 'failure' as const, failedChecks: [{ name: 'test', conclusion: 'failure' }] },
+        ci: { status: 'failure' as const, headSha: 'head-a', failedChecks: [{ name: 'test', conclusion: 'failure' }] },
         changesRequested: [],
         criticalComments: [],
         blocker: 'ci' as const,
@@ -599,7 +625,7 @@ describe('runPrCommand (INT-3282)', () => {
         ...resolved,
         mergeable: false,
         hasConflicts: false,
-        ci: { status: 'failure' as const, failedChecks: [{ name: 'test', conclusion: 'failure' }] },
+        ci: { status: 'failure' as const, headSha: 'head-a', failedChecks: [{ name: 'test', conclusion: 'failure' }] },
         changesRequested: [],
         criticalComments: [],
         blocker: 'ci' as const,
@@ -623,7 +649,9 @@ describe('runPrCommand (INT-3282)', () => {
           ...resolved,
           mergeable: calls > 1,
           hasConflicts: false,
-          ci: { status: calls > 1 ? ('success' as const) : ('failure' as const), failedChecks: calls > 1 ? undefined : [{ name: 'test', conclusion: 'failure' }] },
+          ci: calls > 1
+            ? { status: 'success' as const, headSha: 'head-b' }
+            : { status: 'failure' as const, headSha: 'head-a', failedChecks: [{ name: 'test', conclusion: 'failure' }] },
           changesRequested: [],
           criticalComments: [],
           blocker: calls > 1 ? ('none' as const) : ('ci' as const),

--- a/src/cli/prCommand.ts
+++ b/src/cli/prCommand.ts
@@ -393,6 +393,14 @@ export async function runPrCommand(
           continue;
         }
 
+        if (status.blocker === 'unknown_ci') {
+          return {
+            message: `Blocked: CI head identity is unknown for ${resolved.repo}#${resolved.number}\n${resolved.url}`,
+            exitCode: 1,
+            status,
+          };
+        }
+
         // conflicts / comments / ci → one fix pass
         const result = await fix(resolved, cwd, opts);
         if (!result.success) {

--- a/src/cli/prStatus.test.ts
+++ b/src/cli/prStatus.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 
 const gh = vi.hoisted(() => ({
   checkPRConflicts: vi.fn(async () => false),
-  checkPRCIStatus: vi.fn(async () => ({ status: 'success' as const })),
+  checkPRCIStatus: vi.fn(async () => ({ status: 'success' as const, headSha: 'head-a' })),
   getPRReviews: vi.fn(async () => []),
   getPRComments: vi.fn(async () => []),
 }));
@@ -16,7 +16,7 @@ describe('gatherPrStatus (INT-3282)', () => {
   it('reports merge-ready when there are no conflicts, CI is green, and no feedback', async () => {
     const deps = {
       checkConflicts: vi.fn(async () => false),
-      checkCI: vi.fn(async () => ({ status: 'success' as const })),
+      checkCI: vi.fn(async () => ({ status: 'success' as const, headSha: 'head-a' })),
       getReviews: vi.fn(async () => []),
       getComments: vi.fn(async () => []),
     };
@@ -27,7 +27,7 @@ describe('gatherPrStatus (INT-3282)', () => {
   it('classifies conflicts as the top-priority blocker even with other issues present', async () => {
     const deps = {
       checkConflicts: vi.fn(async () => true),
-      checkCI: vi.fn(async () => ({ status: 'failure' as const, failedChecks: [{ name: 'lint', conclusion: 'failure' }] })),
+      checkCI: vi.fn(async () => ({ status: 'failure' as const, headSha: 'head-a', failedChecks: [{ name: 'lint', conclusion: 'failure' }] })),
       getReviews: vi.fn(async () => [{ id: 1, author: 'codex', body: 'fix this', createdAt: '2026-08-05T00:00:00.000Z', state: 'CHANGES_REQUESTED' as const }]),
       getComments: vi.fn(async () => []),
     };
@@ -39,7 +39,7 @@ describe('gatherPrStatus (INT-3282)', () => {
   it('surfaces a formal CHANGES_REQUESTED review as a "comments" blocker', async () => {
     const deps = {
       checkConflicts: vi.fn(async () => false),
-      checkCI: vi.fn(async () => ({ status: 'success' as const })),
+      checkCI: vi.fn(async () => ({ status: 'success' as const, headSha: 'head-a' })),
       getReviews: vi.fn(async () => [{ id: 1, author: 'codex', body: 'please fix', createdAt: '2026-08-05T00:00:00.000Z', state: 'CHANGES_REQUESTED' as const }]),
       getComments: vi.fn(async () => []),
     };
@@ -50,11 +50,28 @@ describe('gatherPrStatus (INT-3282)', () => {
 
   it('falls back to the real github.js-backed deps when none are injected', async () => {
     gh.checkPRConflicts.mockResolvedValueOnce(false);
-    gh.checkPRCIStatus.mockResolvedValueOnce({ status: 'success' });
+    gh.checkPRCIStatus.mockResolvedValueOnce({ status: 'success', headSha: 'head-a' });
     gh.getPRReviews.mockResolvedValueOnce([]);
     gh.getPRComments.mockResolvedValueOnce([]);
     const status = await gatherPrStatus(input);
     expect(status.mergeReady).toBe(true);
     expect(gh.checkPRConflicts).toHaveBeenCalledWith('o/r', 9);
+  });
+
+  it('keeps an unknown CI identity fail-closed instead of merge-ready', async () => {
+    const deps = {
+      checkConflicts: vi.fn(async () => false),
+      checkCI: vi.fn(async () => ({
+        status: 'unknown' as const,
+        reason: 'head_mismatch' as const,
+        expectedHeadSha: 'head-b',
+        observedHeadSha: 'head-a',
+      })),
+      getReviews: vi.fn(async () => []),
+      getComments: vi.fn(async () => []),
+    };
+
+    const status = await gatherPrStatus(input, deps);
+    expect(status).toMatchObject({ blocker: 'unknown_ci', mergeReady: false });
   });
 });

--- a/src/cli/prStatus.ts
+++ b/src/cli/prStatus.ts
@@ -5,7 +5,7 @@
 
 import type { CIStatus, PRReviewComment } from '../github/github.js';
 
-export type PrBlocker = 'conflicts' | 'comments' | 'ci' | 'pending_ci' | 'none';
+export type PrBlocker = 'conflicts' | 'comments' | 'ci' | 'pending_ci' | 'unknown_ci' | 'none';
 
 export interface PrCommentSummary {
   author: string;
@@ -57,6 +57,7 @@ export function classifyBlocker(input: {
   if (input.changesRequestedCount > 0 || input.criticalCommentCount > 0) return 'comments';
   if (input.ci.status === 'failure') return 'ci';
   if (input.ci.status === 'pending') return 'pending_ci';
+  if (input.ci.status === 'unknown') return 'unknown_ci';
   return 'none';
 }
 
@@ -162,15 +163,20 @@ export function formatPrStatus(s: PrStatusSnapshot): string {
   lines.push(`${s.repo}#${s.number} — ${s.title}`);
   lines.push(`  url:      ${s.url}`);
   lines.push(`  branch:   ${s.branch}`);
+  const observedHead = s.ci.status === 'unknown' ? s.ci.observedHeadSha : s.ci.headSha;
+  lines.push(`  head:     ${observedHead ?? 'unknown'}`);
   lines.push(`  conflicts:${s.hasConflicts ? ' YES' : ' no'}`);
 
   if (s.ci.status === 'success') {
     lines.push('  ci:       green');
   } else if (s.ci.status === 'pending') {
     lines.push('  ci:       pending');
-  } else {
+  } else if (s.ci.status === 'failure') {
     const names = s.ci.failedChecks.map((c) => c.name).join(', ');
     lines.push(`  ci:       FAIL (${names})`);
+  } else {
+    const expected = s.ci.expectedHeadSha ? ` expected=${s.ci.expectedHeadSha}` : '';
+    lines.push(`  ci:       unknown (${s.ci.reason}${expected})`);
   }
 
   if (s.changesRequested.length) {
@@ -191,6 +197,7 @@ export function formatPrStatus(s: PrStatusSnapshot): string {
     comments: 'review / critical comments',
     ci: 'failing CI',
     pending_ci: 'CI still running',
+    unknown_ci: 'CI head identity unknown',
     none: 'none — merge-ready',
   };
   lines.push(`  blocker:  ${blockerLabel[s.blocker]}`);

--- a/src/github/github.test.ts
+++ b/src/github/github.test.ts
@@ -17,7 +17,7 @@ vi.mock('node:child_process', () => ({
   spawn: vi.fn(),
 }));
 
-import { checkPRCIStatus, getActiveFailures, getAllFailedRuns, getOpenPRs, getOpenPRsOrThrow, getPRChecks } from './github.js';
+import { checkPRCIStatus, getActiveFailures, getAllFailedRuns, getOpenPRs, getOpenPRsOrThrow, getPRChecks, waitForCICompletion } from './github.js';
 
 function mockGhJson(value: unknown): void {
   execFileMock.mockImplementationOnce((...args: unknown[]) => {
@@ -54,27 +54,102 @@ describe('getPRChecks', () => {
   });
 
   it('reports failed PR CI when gh classifies a check in the fail bucket', async () => {
-    mockGhJson([
-      { name: 'unit', state: 'SUCCESS', bucket: 'pass' },
-      { name: 'lint', state: 'FAILURE', bucket: 'fail' },
-    ]);
+    mockGhJson({
+      headRefOid: 'head-a',
+      statusCheckRollup: [
+        { name: 'unit', status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { name: 'lint', status: 'COMPLETED', conclusion: 'FAILURE' },
+      ],
+    });
 
     await expect(checkPRCIStatus('owner/repo', 42)).resolves.toEqual({
       status: 'failure',
+      headSha: 'head-a',
       failedChecks: [{ name: 'lint', conclusion: 'failure' }],
     });
   });
 
   it('treats every blocking conclusion as a failed PR status', async () => {
-    mockGhJson([
-      { name: 'cancel', state: 'CANCELLED', bucket: 'cancel' },
-      { name: 'approval', state: 'ACTION_REQUIRED', bucket: 'action_required' },
-      { name: 'stale', state: 'STALE', bucket: 'stale' },
-    ]);
+    mockGhJson({
+      headRefOid: 'head-a',
+      statusCheckRollup: [
+        { name: 'cancel', status: 'COMPLETED', conclusion: 'CANCELLED' },
+        { name: 'approval', status: 'COMPLETED', conclusion: 'ACTION_REQUIRED' },
+        { name: 'stale', status: 'COMPLETED', conclusion: 'STALE' },
+      ],
+    });
     const result = await checkPRCIStatus('owner/repo', 42);
     expect(result.status).toBe('failure');
     if (result.status === 'failure') {
       expect(result.failedChecks.map((check) => check.conclusion)).toEqual(['cancelled', 'action_required', 'stale']);
+    }
+  });
+
+  it('binds a successful observation to the exact PR head', async () => {
+    mockGhJson({
+      headRefOid: 'head-a',
+      statusCheckRollup: [{ name: 'unit', status: 'COMPLETED', conclusion: 'SUCCESS' }],
+    });
+
+    await expect(checkPRCIStatus('owner/repo', 42, 'head-a')).resolves.toEqual({
+      status: 'success',
+      headSha: 'head-a',
+    });
+    expect(execFileMock.mock.calls[0][1]).toContain('headRefOid,statusCheckRollup');
+  });
+
+  it('does not let successful checks from head A satisfy expected head B', async () => {
+    mockGhJson({
+      headRefOid: 'head-a',
+      statusCheckRollup: [{ name: 'unit', status: 'COMPLETED', conclusion: 'SUCCESS' }],
+    });
+
+    await expect(checkPRCIStatus('owner/repo', 42, 'head-b')).resolves.toEqual({
+      status: 'unknown',
+      reason: 'head_mismatch',
+      expectedHeadSha: 'head-b',
+      observedHeadSha: 'head-a',
+    });
+  });
+
+  it('fails closed when GitHub does not identify the observed head', async () => {
+    mockGhJson({
+      statusCheckRollup: [{ name: 'unit', status: 'COMPLETED', conclusion: 'SUCCESS' }],
+    });
+
+    await expect(checkPRCIStatus('owner/repo', 42, 'head-a')).resolves.toEqual({
+      status: 'unknown',
+      reason: 'head_unavailable',
+      expectedHeadSha: 'head-a',
+    });
+  });
+
+  it('pins an unbound wait to head A and refuses a later green head B', async () => {
+    vi.useFakeTimers();
+    try {
+      mockGhJson({
+        headRefOid: 'head-a',
+        statusCheckRollup: [{ name: 'unit', status: 'IN_PROGRESS', conclusion: null }],
+      });
+      mockGhJson({
+        headRefOid: 'head-b',
+        statusCheckRollup: [{ name: 'unit', status: 'COMPLETED', conclusion: 'SUCCESS' }],
+      });
+
+      const resultPromise = waitForCICompletion('owner/repo', 42, {
+        timeoutMs: 1_000,
+        pollIntervalMs: 10,
+      });
+      await vi.advanceTimersByTimeAsync(10);
+
+      await expect(resultPromise).resolves.toEqual({
+        status: 'unknown',
+        reason: 'head_mismatch',
+        expectedHeadSha: 'head-a',
+        observedHeadSha: 'head-b',
+      });
+    } finally {
+      vi.useRealTimers();
     }
   });
 });
@@ -229,18 +304,18 @@ describe('getOpenPRs / getOpenPRsOrThrow (INT-3282)', () => {
 
   it('getOpenPRsOrThrow maps PR fields correctly, including isFork from isCrossRepository', async () => {
     mockGhJson([
-      { number: 9, title: 'Ship it', headRefName: 'feat/x', createdAt: '2026-08-05T00:00:00.000Z', url: 'https://example/pr/9', author: { login: 'someone' }, isCrossRepository: false },
-      { number: 10, title: 'Fork contribution', headRefName: 'patch-1', createdAt: '2026-08-06T00:00:00.000Z', url: 'https://example/pr/10', author: { login: 'contributor' }, isCrossRepository: true },
+      { number: 9, title: 'Ship it', headRefName: 'feat/x', headRefOid: 'head-9', createdAt: '2026-08-05T00:00:00.000Z', url: 'https://example/pr/9', author: { login: 'someone' }, isCrossRepository: false },
+      { number: 10, title: 'Fork contribution', headRefName: 'patch-1', headRefOid: 'head-10', createdAt: '2026-08-06T00:00:00.000Z', url: 'https://example/pr/10', author: { login: 'contributor' }, isCrossRepository: true },
     ]);
     const prs = await getOpenPRsOrThrow('owner/repo');
     expect(prs).toEqual([
       {
         repo: 'owner/repo', number: 9, title: 'Ship it', branch: 'feat/x',
-        createdAt: '2026-08-05T00:00:00.000Z', url: 'https://example/pr/9', author: 'someone', isFork: false,
+        createdAt: '2026-08-05T00:00:00.000Z', url: 'https://example/pr/9', author: 'someone', isFork: false, headSha: 'head-9',
       },
       {
         repo: 'owner/repo', number: 10, title: 'Fork contribution', branch: 'patch-1',
-        createdAt: '2026-08-06T00:00:00.000Z', url: 'https://example/pr/10', author: 'contributor', isFork: true,
+        createdAt: '2026-08-06T00:00:00.000Z', url: 'https://example/pr/10', author: 'contributor', isFork: true, headSha: 'head-10',
       },
     ]);
   });

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -32,39 +32,48 @@ export function isBlockingConclusion(conclusion: string): boolean {
   return BLOCKING_CONCLUSIONS.has(conclusion.toLowerCase());
 }
 
-function normalizePRCheck(c: any): { name: string; status: string; conclusion: string } {
-  const bucket = String(c.bucket ?? '').toLowerCase();
-  const state = String(c.state ?? '').toLowerCase();
+export type PRCheck = { name: string; status: string; conclusion: string };
 
-  switch (bucket || state) {
+function normalizePRCheck(c: any): PRCheck {
+  const name = String(c.name ?? c.context ?? 'unknown');
+  const bucket = String(c.bucket ?? '').toLowerCase();
+  const state = String(c.state ?? c.status ?? '').toLowerCase();
+  const conclusion = String(c.conclusion ?? '').toLowerCase();
+  // `gh pr checks` supplies bucket+state. `gh pr view`'s statusCheckRollup
+  // instead supplies status+conclusion for CheckRun entries and state for
+  // StatusContext entries. Prefer a completed check's conclusion so both
+  // surfaces normalize to the same durable shape.
+  const signal = bucket || (state === 'completed' ? conclusion : state) || conclusion;
+
+  switch (signal) {
     case 'pass':
     case 'success':
-      return { name: c.name, status: 'completed', conclusion: 'success' };
+      return { name, status: 'completed', conclusion: 'success' };
     case 'fail':
     case 'failure':
     case 'startup_failure':
-      return { name: c.name, status: 'completed', conclusion: 'failure' };
+      return { name, status: 'completed', conclusion: 'failure' };
     case 'timed_out':
-      return { name: c.name, status: 'completed', conclusion: 'timed_out' };
+      return { name, status: 'completed', conclusion: 'timed_out' };
     case 'pending':
     case 'queued':
     case 'in_progress':
     case 'requested':
     case 'waiting':
-      return { name: c.name, status: 'pending', conclusion: 'pending' };
+      return { name, status: 'pending', conclusion: 'pending' };
     case 'action_required':
-      return { name: c.name, status: 'completed', conclusion: 'action_required' };
+      return { name, status: 'completed', conclusion: 'action_required' };
     case 'stale':
-      return { name: c.name, status: 'completed', conclusion: 'stale' };
+      return { name, status: 'completed', conclusion: 'stale' };
     case 'skipping':
     case 'skipped':
     case 'neutral':
-      return { name: c.name, status: 'completed', conclusion: 'skipped' };
+      return { name, status: 'completed', conclusion: 'skipped' };
     case 'cancel':
     case 'cancelled':
-      return { name: c.name, status: 'completed', conclusion: 'cancelled' };
+      return { name, status: 'completed', conclusion: 'cancelled' };
     default:
-      return { name: c.name, status: state || 'unknown', conclusion: state || 'unknown' };
+      return { name, status: state || 'unknown', conclusion: conclusion || state || 'unknown' };
   }
 }
 
@@ -233,7 +242,7 @@ export async function getFailedJobLogs(
 export async function getPRChecks(
   repo: string,
   prNumber: number
-): Promise<{ name: string; status: string; conclusion: string }[]> {
+): Promise<PRCheck[]> {
   try {
     const stdout = await ghExec('pr', 'checks', String(prNumber), '-R', repo, '--json', 'name,state,bucket');
     const checks = JSON.parse(stdout);
@@ -241,6 +250,45 @@ export async function getPRChecks(
   } catch (err) {
     console.error(`Failed to get PR checks for ${repo}#${prNumber}:`, err);
     return [];
+  }
+}
+
+export type PRCISnapshot =
+  | { identity: 'known'; headSha: string; checks: PRCheck[] }
+  | { identity: 'unknown'; reason: 'head_unavailable' | 'checks_unavailable' };
+
+/**
+ * Read the PR head and its check rollup in one GitHub observation.
+ *
+ * Fetching `headRefOid` separately from `gh pr checks` leaves a race where the
+ * branch advances between the two commands and a green result for head A is
+ * attributed to head B. `statusCheckRollup` keeps identity and evidence in the
+ * same response, and malformed or unavailable identity stays explicitly
+ * unknown instead of degrading to an empty (eventually successful) check set.
+ */
+export async function getPRCISnapshot(repo: string, prNumber: number): Promise<PRCISnapshot> {
+  try {
+    const stdout = await ghExec(
+      'pr', 'view', String(prNumber), '-R', repo,
+      '--json', 'headRefOid,statusCheckRollup',
+    );
+    const view = JSON.parse(stdout) as {
+      headRefOid?: unknown;
+      statusCheckRollup?: unknown;
+    };
+    const headSha = typeof view.headRefOid === 'string' ? view.headRefOid.trim() : '';
+    if (!headSha) return { identity: 'unknown', reason: 'head_unavailable' };
+    if (!Array.isArray(view.statusCheckRollup)) {
+      return { identity: 'unknown', reason: 'checks_unavailable' };
+    }
+    return {
+      identity: 'known',
+      headSha,
+      checks: view.statusCheckRollup.map(normalizePRCheck),
+    };
+  } catch (err) {
+    console.error(`Failed to get PR CI snapshot for ${repo}#${prNumber}:`, err);
+    return { identity: 'unknown', reason: 'head_unavailable' };
   }
 }
 
@@ -529,6 +577,8 @@ export type PRInfo = {
   isFork?: boolean;
   /** Target branch when the listing surface requested it. */
   baseBranch?: string;
+  /** Immutable identity of the head observed by the listing surface. */
+  headSha?: string;
 };
 
 export type PRMergeability = 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN';
@@ -582,7 +632,7 @@ export async function getOpenPRs(repo: string, limit = 30): Promise<PRInfo[]> {
 export async function getOpenPRsOrThrow(repo: string, limit = 30): Promise<PRInfo[]> {
   const stdout = await ghExec(
     'pr', 'list', '-R', repo, '--state', 'open', '--limit', String(limit),
-    '--json', 'number,title,headRefName,baseRefName,createdAt,url,author,isCrossRepository'
+    '--json', 'number,title,headRefName,baseRefName,headRefOid,createdAt,url,author,isCrossRepository'
   );
   const prs = JSON.parse(stdout);
   return prs.map((pr: any) => ({
@@ -595,6 +645,7 @@ export async function getOpenPRsOrThrow(repo: string, limit = 30): Promise<PRInf
     author: pr.author?.login,
     isFork: !!pr.isCrossRepository,
     baseBranch: pr.baseRefName,
+    headSha: pr.headRefOid || undefined,
   }));
 }
 
@@ -640,7 +691,7 @@ export async function getMergedPRsOrThrow(repo: string, limit = 100): Promise<PR
 export async function getPRContext(repo: string, prNumber: number): Promise<PRDetails | null> {
   try {
     const [viewStdout, diffStdout, checks] = await Promise.all([
-      ghExec('pr', 'view', String(prNumber), '-R', repo, '--json', 'title,headRefName,createdAt,url,body,author'),
+      ghExec('pr', 'view', String(prNumber), '-R', repo, '--json', 'title,headRefName,headRefOid,createdAt,url,body,author'),
       ghExecLarge('pr', 'diff', String(prNumber), '-R', repo),
       getPRChecks(repo, prNumber),
     ]);
@@ -658,6 +709,7 @@ export async function getPRContext(repo: string, prNumber: number): Promise<PRDe
       number: prNumber,
       title: view.title,
       branch: view.headRefName,
+      headSha: view.headRefOid || undefined,
       createdAt: view.createdAt,
       url: view.url,
       body: view.body || '',
@@ -877,39 +929,74 @@ export async function getPRMergeability(repo: string, prNumber: number): Promise
  * CI status result
  */
 export type CIStatus =
-  | { status: 'pending' }
-  | { status: 'success' }
-  | { status: 'failure'; failedChecks: { name: string; conclusion: string }[] };
+  | { status: 'pending'; headSha: string }
+  | { status: 'success'; headSha: string }
+  | { status: 'failure'; headSha: string; failedChecks: { name: string; conclusion: string }[] }
+  | {
+      status: 'unknown';
+      reason: 'head_unavailable' | 'expected_head_unavailable' | 'head_mismatch' | 'checks_unavailable';
+      expectedHeadSha?: string;
+      observedHeadSha?: string;
+    };
 
 /**
  * Check current CI status for a PR
  */
-export async function checkPRCIStatus(repo: string, prNumber: number): Promise<CIStatus> {
-  try {
-    const checks = await getPRChecks(repo, prNumber);
-
-    if (checks.length === 0) {
-      return { status: 'pending' };
-    }
-
-    const pending = checks.some(c => c.status === 'in_progress' || c.status === 'queued' || c.status === 'pending');
-    if (pending) {
-      return { status: 'pending' };
-    }
-
-    const failed = checks.filter(c => isBlockingConclusion(c.conclusion));
-    if (failed.length > 0) {
-      return {
-        status: 'failure',
-        failedChecks: failed.map(c => ({ name: c.name, conclusion: c.conclusion }))
-      };
-    }
-
-    return { status: 'success' };
-  } catch (err) {
-    console.error(`[GitHub] Failed to check PR CI status for ${repo}#${prNumber}:`, err);
-    return { status: 'pending' };
+export async function checkPRCIStatus(
+  repo: string,
+  prNumber: number,
+  expectedHeadSha?: string,
+): Promise<CIStatus> {
+  const expected = expectedHeadSha?.trim();
+  if (expectedHeadSha !== undefined && !expected) {
+    return { status: 'unknown', reason: 'expected_head_unavailable' };
   }
+
+  const snapshot = await getPRCISnapshot(repo, prNumber);
+  if (snapshot.identity === 'unknown') {
+    return { status: 'unknown', reason: snapshot.reason, expectedHeadSha: expected };
+  }
+  if (expected && snapshot.headSha !== expected) {
+    return {
+      status: 'unknown',
+      reason: 'head_mismatch',
+      expectedHeadSha: expected,
+      observedHeadSha: snapshot.headSha,
+    };
+  }
+
+  const { checks, headSha } = snapshot;
+  if (checks.length === 0) {
+    return { status: 'pending', headSha };
+  }
+
+  const pending = checks.some(c => c.status === 'in_progress' || c.status === 'queued' || c.status === 'pending');
+  if (pending) {
+    return { status: 'pending', headSha };
+  }
+
+  const failed = checks.filter(c => isBlockingConclusion(c.conclusion));
+  if (failed.length > 0) {
+    return {
+      status: 'failure',
+      headSha,
+      failedChecks: failed.map(c => ({ name: c.name, conclusion: c.conclusion }))
+    };
+  }
+
+  const indeterminate = checks.some(
+    c => c.conclusion !== 'success' && c.conclusion !== 'skipped',
+  );
+  if (indeterminate) {
+    return {
+      status: 'unknown',
+      reason: 'checks_unavailable',
+      expectedHeadSha: expected,
+      observedHeadSha: headSha,
+    };
+  }
+
+  return { status: 'success', headSha };
 }
 
 /**
@@ -925,30 +1012,46 @@ export async function waitForCICompletion(
   options: {
     timeoutMs?: number;
     pollIntervalMs?: number;
+    /** Exact published commit this wait is allowed to accept. */
+    expectedHeadSha?: string;
     onProgress?: (status: CIStatus, elapsed: number) => void;
   } = {}
 ): Promise<CIStatus> {
   const timeoutMs = options.timeoutMs ?? 600_000; // 10 minutes default
   const pollIntervalMs = options.pollIntervalMs ?? 30_000; // 30 seconds default
   const startTime = Date.now();
+  let expectedHeadSha = options.expectedHeadSha?.trim();
+  let lastPending: Extract<CIStatus, { status: 'pending' }> | undefined;
 
   while (true) {
     const elapsed = Date.now() - startTime;
 
     if (elapsed >= timeoutMs) {
       console.log(`[GitHub] CI timeout for ${repo}#${prNumber} (${elapsed}ms)`);
-      return { status: 'pending' };
+      return lastPending ?? {
+        status: 'unknown',
+        reason: expectedHeadSha ? 'head_unavailable' : 'expected_head_unavailable',
+        expectedHeadSha,
+      };
     }
 
-    const status = await checkPRCIStatus(repo, prNumber);
+    const status = await checkPRCIStatus(repo, prNumber, expectedHeadSha);
+
+    // Legacy callers that did not provide an expected SHA are pinned to the
+    // first head they actually observe. A later push can no longer replace a
+    // pending head A with a green head B inside the same wait.
+    if (!expectedHeadSha && status.status !== 'unknown') {
+      expectedHeadSha = status.headSha;
+    }
 
     if (options.onProgress) {
       options.onProgress(status, elapsed);
     }
 
-    if (status.status === 'success' || status.status === 'failure') {
+    if (status.status !== 'pending') {
       return status;
     }
+    lastPending = status;
 
     // Wait before next poll
     await new Promise(resolve => setTimeout(resolve, pollIntervalMs));

--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -6,7 +6,7 @@ import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import Database from 'better-sqlite3';
 import { isProofCapableSpace, processNamespaceId } from './processLiveness.js';
-import {createWorktree, preserveWorktree, removePreservedWorktreeAt, removeWorktree, resolveSharedPaths, computeFileOverlaps, formatOverlapReport, findOpenPRFileOverlaps, resolveBaseRef, commitAndCreatePR, type WorktreeInfo } from './worktreeManager.js';
+import {createWorktree, preserveWorktree, removePreservedWorktreeAt, removeWorktree, resolveSharedPaths, computeFileOverlaps, formatOverlapReport, findOpenPRFileOverlaps, resolveBaseRef, commitAndCreatePR, commitAndCreatePRWithHead, type WorktreeInfo } from './worktreeManager.js';
 
 // The fast-path proof needs a REAL pid space, which only Linux can give (boot
 // id + pid-namespace inode). Elsewhere the recorded id is a machine hint, good
@@ -679,8 +679,17 @@ describe('resolveBaseRef / createWorktree on non-main-default repos (INT-2545)',
     const prevPath = process.env.PATH;
     process.env.PATH = `${bin}:${prevPath}`;
     try {
-      const url = await commitAndCreatePR(info, 'parked', 'INT-76', 'desc', { draft: true, committedOnly: true });
-      expect(url).toBe('https://example.test/park');
+      const publication = await commitAndCreatePRWithHead(
+        info,
+        'parked',
+        'INT-76',
+        'desc',
+        { draft: true, committedOnly: true },
+      );
+      expect(publication).toEqual({
+        prUrl: 'https://example.test/park',
+        headSha: String(git(info.worktreePath, 'rev-parse', 'HEAD')).trim(),
+      });
     } finally {
       process.env.PATH = prevPath;
     }

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -1134,16 +1134,15 @@ async function findOpenPullRequestUrl(worktreePath: string, branchName: string):
     '--json', 'url', '--jq', '.[0].url',
   )).trim();
 }
-
-
-/** Commit changes + push + gh pr create */
-export async function commitAndCreatePR(
+/** PR URL plus the immutable commit this publication call pushed. */
+export type PublishedPullRequest = { prUrl: string; headSha: string };
+export async function commitAndCreatePRWithHead(
   info: WorktreeInfo,
   title: string,
   issueIdentifier: string,
   description: string,
   options: { draft?: boolean; committedOnly?: boolean } = {},
-): Promise<string> {
+): Promise<PublishedPullRequest> {
   const { worktreePath, branchName } = info;
 
   // Check for uncommitted changes and commit them.
@@ -1195,6 +1194,10 @@ export async function commitAndCreatePR(
 
   console.log(`[Worktree] Branch ${branchName} has ${commitsAhead} commit(s) ahead of ${base.ref}`);
 
+  // A successful push below publishes exactly this tip; capture it in-operation.
+  const headSha = (await git(worktreePath, 'rev-parse', 'HEAD')).trim();
+  if (!headSha) throw new Error(`Cannot publish ${branchName}: HEAD identity is unavailable`);
+
   // Push branch to the resolved remote (always push since we have commits ahead)
   await git(worktreePath, 'push', '-u', base.remote, branchName, '--force-with-lease');
   console.log(`[Worktree] Pushed branch ${branchName}`);
@@ -1218,7 +1221,7 @@ export async function commitAndCreatePR(
       const stillDuplicated = await findDuplicateIssuePRs(worktreePath, issueIdentifier, branchName);
       await readyReusedPullRequest(worktreePath, existing, issueIdentifier, stillDuplicated.length);
     }
-    return existing;
+    return { prUrl: existing, headSha };
   }
 
   // Compute file overlap vs other in-flight work (advisory; never blocks). (INT-2392)
@@ -1291,7 +1294,15 @@ export async function commitAndCreatePR(
     }
   }
 
-  return url;
+  return { prUrl: url, headSha };
+}
+
+/** Backwards-compatible URL-only publication surface. */
+export async function commitAndCreatePR(
+  info: WorktreeInfo, title: string, issueIdentifier: string, description: string,
+  options: { draft?: boolean; committedOnly?: boolean } = {},
+): Promise<string> {
+  return (await commitAndCreatePRWithHead(info, title, issueIdentifier, description, options)).prUrl;
 }
 
 // Audit-fix PR (INT-2905)


### PR DESCRIPTION
## Summary

- persist the exact pushed commit through autonomous PR publication and durable ledger attachment
- bind CI snapshots and PR status to `headRefOid`, rejecting missing or mismatched identities
- prevent head A results from satisfying later head B across waits, remediation, scans, and CLI watch
- preserve the existing `DONE` and publication-ledger state semantics

## Verification

- focused Vitest: 313 passed, 1 skipped
- full Vitest: 5,038 passed, 10 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `openswarm review --path .` — APPROVE

A committed-SHA full-suite run initially hit the existing 2-second verify-sandbox timing flake; the named test passed alone and a clean full retry produced the result above.

Linear: AGT-4145