### PR TITLE
fix(scheduler): enforce project-fair admission (AGT-4146)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -50,7 +50,7 @@ autonomous:
   maxConcurrentTasks: 4  # Number of concurrent tasks
   worktreeMode: true  # Required for same-project parallel tasks
   allowSameProjectConcurrent: true
-  maxConcurrentPerProject: 2  # Optional cap for same-project worktree parallelism
+  maxConcurrentPerProject: 2  # Optional hard cap; omit for weighted, work-conserving project fairness
   automationLedgerMode: primary  # off | shadow | primary (durable fail-closed execution truth)
   automationLeaseMs: 600000      # Renewed every ~3m; stale callbacks are fenced
   shutdownGraceMs: 30000         # Wait for real executor exit before service teardown

--- a/src/automation/autonomousRunner.coverage.test.ts
+++ b/src/automation/autonomousRunner.coverage.test.ts
@@ -352,6 +352,9 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
       }));
       const internal = r as unknown as Internal;
       expect(internal.sameProjectCandidateCap()).toBe(4);
+      expect((internal.scheduler as unknown as {
+        config: { maxConcurrentPerProject?: number };
+      }).config.maxConcurrentPerProject).toBeUndefined();
     });
 
     it('sameProjectCandidateCap clamps between 1 and maxConcurrentTasks', () => {

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -446,7 +446,12 @@ export class AutonomousRunner {
     this.scheduler = initScheduler({
       maxConcurrent: config.maxConcurrentTasks ?? 1,
       allowSameProjectConcurrent: config.allowSameProjectConcurrent ?? true,
-      maxConcurrentPerProject: effectiveProjectConcurrency(config),
+      // Preserve omission for TaskScheduler: undefined activates its weighted,
+      // work-conserving fairness without inventing a hidden hard project cap.
+      // Durable admission still receives the effective global safety ceiling.
+      maxConcurrentPerProject: config.maxConcurrentPerProject == null
+        ? undefined
+        : effectiveProjectConcurrency(config),
       worktreeMode: config.worktreeMode ?? false,
     });
 

--- a/src/automation/runnerTypes.ts
+++ b/src/automation/runnerTypes.ts
@@ -34,6 +34,7 @@ export interface AutonomousConfig {
    */
   autonomousHeartbeat?: boolean;
   maxConcurrentTasks?: number;
+  /** Optional hard cap; omitted uses work-conserving weighted project fairness. */
   maxConcurrentPerProject?: number;
   defaultRoles?: DefaultRolesConfig;
   projectAgents?: ProjectAgentConfig[];

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -558,7 +558,7 @@ export type AutonomousStartupConfig = {
   reviewerTimeoutMs?: number;
   /** Max concurrent tasks */
   maxConcurrentTasks?: number;
-  /** Max concurrent tasks from the same project when same-project parallelism is enabled. */
+  /** Optional hard cap; omitted uses work-conserving weighted project fairness. */
   maxConcurrentPerProject?: number;
   /** Durable execution ledger rollout mode. */
   automationLedgerMode?: 'off' | 'shadow' | 'primary';

--- a/src/orchestration/taskScheduler.concurrency.test.ts
+++ b/src/orchestration/taskScheduler.concurrency.test.ts
@@ -4,12 +4,21 @@ import { TaskScheduler } from './taskScheduler.js';
 import type { TaskItem } from './decisionEngine.js';
 import type { PipelineResult } from '../agents/pairPipeline.js';
 
-const task = (id: string): TaskItem => ({ id, title: id, priority: 3 } as TaskItem);
+const task = (id: string, priority = 3): TaskItem => ({ id, title: id, priority } as TaskItem);
 
 // Executor that never resolves — keeps the task "running" so isProjectBusy is testable.
 function pendingExecutor() {
   return () => new Promise<PipelineResult>(() => {});
 }
+
+const approvedResult = (): PipelineResult => ({
+  success: true,
+  sessionId: 'fairness-test',
+  stages: [],
+  finalStatus: 'approved',
+  totalDuration: 1,
+  iterations: 1,
+});
 
 describe('TaskScheduler same-project concurrency (INT-1975)', () => {
   let warn: ReturnType<typeof vi.spyOn>;
@@ -63,13 +72,19 @@ describe('TaskScheduler same-project concurrency (INT-1975)', () => {
     s.startTask(first!.task, first!.projectPath, pendingExecutor());
     expect(s.isProjectBusy('/repo')).toBe(false);
 
+    // Fair selection gives the idle project a slot before /repo fills its cap.
+    const other = s.getNextExecutable();
+    expect(other?.task.id).toBe('d');
+    s.startTask(other!.task, other!.projectPath, pendingExecutor());
+
     const second = s.getNextExecutable();
+    expect(second?.task.id).toBe('b');
     s.startTask(second!.task, second!.projectPath, pendingExecutor());
     expect(s.isProjectBusy('/repo')).toBe(true);
     expect(s.getBusyProjects()).toEqual(['/repo']);
 
-    // Third same-repo task is held back, but another project can still use slots.
-    expect(s.getNextExecutable()?.task.id).toBe('d');
+    // Third same-repo task is held back at the explicit project cap.
+    expect(s.getNextExecutable()).toBeNull();
   });
 
   it('reapplies the same-project worktree guard when config is updated', () => {
@@ -79,5 +94,116 @@ describe('TaskScheduler same-project concurrency (INT-1975)', () => {
 
     expect(s.isProjectBusy('/repo')).toBe(true);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('requires worktreeMode'));
+  });
+});
+
+describe('TaskScheduler project-fair selection (AGT-4146)', () => {
+  it('admits other projects before one dominant queue fills every slot', async () => {
+    const s = new TaskScheduler({
+      maxConcurrent: 5,
+      worktreeMode: true,
+      allowSameProjectConcurrent: true,
+    });
+    for (let i = 1; i <= 8; i++) s.enqueue(task(`a${i}`), '/repo-a');
+    s.enqueue(task('b1'), '/repo-b');
+    s.enqueue(task('c1'), '/repo-c');
+
+    await s.runAvailable(async () => new Promise<PipelineResult>(() => {}));
+
+    const byProject = s.getRunningTasks().reduce<Record<string, number>>((counts, running) => {
+      counts[running.projectPath] = (counts[running.projectPath] ?? 0) + 1;
+      return counts;
+    }, {});
+    expect(byProject).toEqual({ '/repo-a': 3, '/repo-b': 1, '/repo-c': 1 });
+  });
+
+  it('remains work-conserving when only one project has queued work', async () => {
+    const s = new TaskScheduler({
+      maxConcurrent: 4,
+      worktreeMode: true,
+      allowSameProjectConcurrent: true,
+    });
+    for (let i = 1; i <= 4; i++) s.enqueue(task(`a${i}`), '/repo-a');
+
+    expect(await s.runAvailable(async () => new Promise<PipelineResult>(() => {}))).toBe(4);
+    expect(s.getRunningTasks()).toHaveLength(4);
+  });
+
+  it('gives urgent work a larger deterministic share without starving low priority', async () => {
+    const s = new TaskScheduler({
+      maxConcurrent: 5,
+      worktreeMode: true,
+      allowSameProjectConcurrent: true,
+    });
+    for (let i = 1; i <= 8; i++) s.enqueue(task(`urgent-${i}`, 1), '/urgent');
+    for (let i = 1; i <= 3; i++) s.enqueue(task(`low-${i}`, 4), '/low');
+
+    await s.runAvailable(async () => new Promise<PipelineResult>(() => {}));
+
+    expect(s.getRunningTasks().filter((running) => running.projectPath === '/urgent')).toHaveLength(4);
+    expect(s.getRunningTasks().filter((running) => running.projectPath === '/low')).toHaveLength(1);
+  });
+
+  it('does not reset fairness after every completion when only one slot exists', async () => {
+    const s = new TaskScheduler({
+      maxConcurrent: 1,
+      worktreeMode: true,
+      allowSameProjectConcurrent: true,
+    });
+    for (let i = 1; i <= 10; i++) s.enqueue(task(`urgent-${i}`, 1), '/urgent');
+    for (let i = 1; i <= 3; i++) s.enqueue(task(`low-${i}`, 4), '/low');
+
+    const selected: string[] = [];
+    for (let i = 0; i < 7; i++) {
+      const next = s.getNextExecutable();
+      selected.push(next!.projectPath);
+      s.startTask(next!.task, next!.projectPath, async () => approvedResult());
+      await vi.waitFor(() => expect(s.getRunningTasks()).toHaveLength(0));
+    }
+
+    expect(selected).toEqual(['/urgent', '/low', '/urgent', '/urgent', '/urgent', '/urgent', '/low']);
+  });
+
+  it('preserves FIFO order within each project while rotating across projects', () => {
+    const s = new TaskScheduler({
+      maxConcurrent: 3,
+      worktreeMode: true,
+      allowSameProjectConcurrent: true,
+    });
+    s.enqueue(task('a-first'), '/repo-a');
+    s.enqueue(task('a-second'), '/repo-a');
+    s.enqueue(task('b-first'), '/repo-b');
+
+    const selected: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      const next = s.getNextExecutable();
+      selected.push(next!.task.id);
+      s.startTask(next!.task, next!.projectPath, pendingExecutor());
+    }
+
+    expect(selected).toEqual(['a-first', 'b-first', 'a-second']);
+  });
+
+  it('uses only the priority/FIFO head of each project as a fairness candidate', () => {
+    const s = new TaskScheduler({
+      maxConcurrent: 4,
+      worktreeMode: true,
+      allowSameProjectConcurrent: true,
+    });
+    s.enqueue(task('a-low-first', 4), '/repo-a');
+    s.enqueue(task('b-normal', 3), '/repo-b');
+    s.enqueue(task('a-urgent-later', 1), '/repo-a');
+    s.enqueue(task('a-low-second', 4), '/repo-a');
+
+    const selected: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      const next = s.getNextExecutable();
+      selected.push(next!.task.id);
+      s.startTask(next!.task, next!.projectPath, pendingExecutor());
+    }
+
+    // Linear priority leads inside /repo-a; equal-priority lows remain FIFO.
+    // /repo-b still receives a slot before /repo-a fills the pool.
+    expect(selected).toEqual(['a-urgent-later', 'b-normal', 'a-low-first', 'a-low-second']);
   });
 });

--- a/src/orchestration/taskScheduler.concurrency.test.ts
+++ b/src/orchestration/taskScheduler.concurrency.test.ts
@@ -184,6 +184,41 @@ describe('TaskScheduler project-fair selection (AGT-4146)', () => {
     expect(selected).toEqual(['a-first', 'b-first', 'a-second']);
   });
 
+  it('exposes the last weighted decision and per-project blocking state', () => {
+    const s = new TaskScheduler({
+      maxConcurrent: 1,
+      worktreeMode: true,
+      allowSameProjectConcurrent: true,
+    });
+    s.enqueue(task('urgent', 1), '/repo-a');
+    s.enqueue(task('low', 4), '/repo-b');
+
+    const selected = s.getNextExecutable()!;
+    s.startTask(selected.task, selected.projectPath, pendingExecutor());
+
+    const fairness = s.getStats().fairness;
+    expect(fairness.lastSelection).toMatchObject({
+      taskId: 'urgent',
+      projectPath: '/repo-a',
+      weight: 4,
+      virtualRuntimeBefore: 0,
+      virtualRuntimeAfter: 0.25,
+    });
+    expect(fairness.lastSelection?.contenders).toEqual([
+      expect.objectContaining({ projectPath: '/repo-a', taskId: 'urgent', weight: 4 }),
+      expect.objectContaining({ projectPath: '/repo-b', taskId: 'low', weight: 1 }),
+    ]);
+    expect(fairness.projects).toEqual([
+      expect.objectContaining({ projectPath: '/repo-a', running: 1, queued: 0 }),
+      expect.objectContaining({
+        projectPath: '/repo-b',
+        running: 0,
+        queued: 1,
+        blockedReason: 'global-capacity',
+      }),
+    ]);
+  });
+
   it('uses only the priority/FIFO head of each project as a fairness candidate', () => {
     const s = new TaskScheduler({
       maxConcurrent: 4,

--- a/src/orchestration/taskScheduler.ts
+++ b/src/orchestration/taskScheduler.ts
@@ -48,6 +48,19 @@ function isSameProjectOrDescendant(candidatePath: string, projectPath: string): 
   return candidate === project || candidate.startsWith(`${project}/`);
 }
 
+/**
+ * Weighted project fairness: Urgent work may consume more parallel capacity,
+ * but every project with executable work receives a slot before a busy peer
+ * can keep filling indefinitely. Running/weight is a compact weighted-fair
+ * virtual load; queue order remains the deterministic tie-breaker.
+ */
+function priorityWeight(priority: number): number {
+  if (priority <= 1) return 4;
+  if (priority === 2) return 3;
+  if (priority === 3) return 2;
+  return 1;
+}
+
 // Types
 
 export interface QueuedTask {
@@ -81,7 +94,10 @@ export interface SchedulerConfig {
   maxConcurrent: number;
   /** Allow concurrent execution on same project */
   allowSameProjectConcurrent?: boolean;
-  /** Maximum concurrent tasks per project when same-project parallelism is enabled. */
+  /**
+   * Hard maximum per project. When omitted, weighted project fairness shares
+   * the pool while still letting a lone project consume every idle slot.
+   */
   maxConcurrentPerProject?: number;
   /** Git worktree mode: each task runs in its own isolated worktree (bypasses project busy check) */
   worktreeMode?: boolean;
@@ -144,6 +160,12 @@ export class TaskScheduler extends EventEmitter {
   private deferredWakeAt?: number;
   /** Queue snapshot being assembled while shutdown waits for in-flight results. */
   private shutdownDiscardedQueue?: QueuedTask[];
+  /**
+   * Persistent weighted-fair service received by each currently active project.
+   * Unlike running counts this survives slot completion, so a one-slot daemon
+   * cannot reset every candidate to zero and starve lower-priority projects.
+   */
+  private projectVirtualRuntime = new Map<string, number>();
 
   constructor(config: SchedulerConfig) {
     super();
@@ -270,10 +292,9 @@ export class TaskScheduler extends EventEmitter {
   }
 
   /**
-   * Check if project is currently busy. One worker per project at a time (so the
-   * global slot budget spreads across projects instead of piling onto one). Only
-   * `allowSameProjectConcurrent` opts out — worktreeMode keeps per-task isolation
-   * but no longer implies same-project parallelism.
+   * Check whether a project has reached its hard concurrency boundary.
+   * Cross-project fairness is handled separately by getNextExecutable; this
+   * method remains the safety/cap gate.
    */
   isProjectBusy(projectPath: string): boolean {
     const normalizedProject = normalizeProjectPath(projectPath);
@@ -361,6 +382,15 @@ export class TaskScheduler extends EventEmitter {
       return null;
     }
 
+    const candidates: Array<{
+      index: number;
+      queued: QueuedTask;
+      project: string;
+      running: number;
+      weight: number;
+    }> = [];
+    const runningByProject = this.runningCountByProject();
+    const candidateProjects = new Set<string>();
     for (let i = 0; i < this.taskQueue.length; i++) {
       const queued = this.taskQueue[i];
 
@@ -373,12 +403,65 @@ export class TaskScheduler extends EventEmitter {
         continue;
       }
 
-      // Executable
-      this.taskQueue.splice(i, 1);
-      return queued;
+      const normalizedProject = normalizeProjectPath(queued.projectPath);
+      // taskQueue is priority-ordered and FIFO within one priority. Only the
+      // first currently executable row from each project may represent that
+      // project in the fairness comparison; a later sibling cannot leapfrog
+      // its own project head because it happens to have a different weight.
+      if (candidateProjects.has(normalizedProject)) continue;
+      candidateProjects.add(normalizedProject);
+      candidates.push({
+        index: i,
+        queued,
+        project: normalizedProject,
+        running: runningByProject.get(normalizedProject) ?? 0,
+        weight: priorityWeight(queued.priority),
+      });
     }
 
-    return null;
+    if (candidates.length === 0) return null;
+
+    const activeProjects = new Set([...candidateProjects, ...runningByProject.keys()]);
+    for (const project of this.projectVirtualRuntime.keys()) {
+      if (!activeProjects.has(project)) this.projectVirtualRuntime.delete(project);
+    }
+    const activeVirtualRuntimes = [...this.projectVirtualRuntime.entries()]
+      .filter(([project]) => activeProjects.has(project))
+      .map(([, virtualRuntime]) => virtualRuntime);
+    const baseline = activeVirtualRuntimes.length > 0 ? Math.min(...activeVirtualRuntimes) : 0;
+    for (const candidate of candidates) {
+      if (!this.projectVirtualRuntime.has(candidate.project)) {
+        this.projectVirtualRuntime.set(candidate.project, baseline);
+      }
+    }
+
+    let selectedCandidate = candidates[0];
+    let selectedScore = this.projectVirtualRuntime.get(selectedCandidate.project)!;
+    for (const candidate of candidates.slice(1)) {
+      const score = this.projectVirtualRuntime.get(candidate.project)!;
+      // candidates retain taskQueue order, so strict < preserves priority/FIFO
+      // as the deterministic tie-breaker.
+      if (score < selectedScore) {
+        selectedCandidate = candidate;
+        selectedScore = score;
+      }
+    }
+
+    if (candidates.length > 1) {
+      this.projectVirtualRuntime.set(
+        selectedCandidate.project,
+        selectedScore + (1 / selectedCandidate.weight),
+      );
+    }
+
+    const [selected] = this.taskQueue.splice(selectedCandidate.index, 1);
+    console.log(
+      `[Scheduler] Fair selection: ${selected.task.title} ` +
+      `(project=${selected.projectPath}, running=${selectedCandidate.running}, ` +
+      `weight=${selectedCandidate.weight}, virtualRuntime=${selectedScore.toFixed(3)}, ` +
+      `contenders=${candidates.length})`,
+    );
+    return selected;
   }
 
   /**

--- a/src/orchestration/taskScheduler.ts
+++ b/src/orchestration/taskScheduler.ts
@@ -113,6 +113,38 @@ export interface SchedulerStats {
   /** Timed-out executors that have not acknowledged cancellation yet. */
   quarantined: number;
   byProject: Map<string, number>;
+  fairness: {
+    projects: SchedulerProjectFairness[];
+    lastSelection?: SchedulerFairSelection;
+  };
+}
+
+export interface SchedulerProjectFairness {
+  projectPath: string;
+  running: number;
+  queued: number;
+  virtualRuntime: number;
+  nextPriority?: number;
+  nextAvailableAt?: number;
+  blockedReason?: 'global-capacity' | 'project-capacity' | 'quarantined' | 'retry-at';
+}
+
+export interface SchedulerFairSelection {
+  selectedAt: number;
+  taskId: string;
+  issueIdentifier?: string;
+  projectPath: string;
+  priority: number;
+  weight: number;
+  virtualRuntimeBefore: number;
+  virtualRuntimeAfter: number;
+  contenders: Array<{
+    projectPath: string;
+    taskId: string;
+    priority: number;
+    weight: number;
+    virtualRuntime: number;
+  }>;
 }
 
 function normalizeSchedulerConfig(config: SchedulerConfig): SchedulerConfig {
@@ -166,6 +198,8 @@ export class TaskScheduler extends EventEmitter {
    * cannot reset every candidate to zero and starve lower-priority projects.
    */
   private projectVirtualRuntime = new Map<string, number>();
+  /** Last fairness decision, exposed through /api/stats for live evidence. */
+  private lastFairSelection?: SchedulerFairSelection;
 
   constructor(config: SchedulerConfig) {
     super();
@@ -447,12 +481,31 @@ export class TaskScheduler extends EventEmitter {
       }
     }
 
+    const selectedScoreAfter = candidates.length > 1
+      ? selectedScore + (1 / selectedCandidate.weight)
+      : selectedScore;
+    const contenderSnapshots = candidates.map((candidate) => ({
+      projectPath: candidate.queued.projectPath,
+      taskId: candidate.queued.task.id,
+      priority: candidate.queued.priority,
+      weight: candidate.weight,
+      virtualRuntime: this.projectVirtualRuntime.get(candidate.project) ?? baseline,
+    }));
     if (candidates.length > 1) {
-      this.projectVirtualRuntime.set(
-        selectedCandidate.project,
-        selectedScore + (1 / selectedCandidate.weight),
-      );
+      this.projectVirtualRuntime.set(selectedCandidate.project, selectedScoreAfter);
     }
+
+    this.lastFairSelection = {
+      selectedAt: Date.now(),
+      taskId: selectedCandidate.queued.task.id,
+      issueIdentifier: selectedCandidate.queued.task.issueIdentifier,
+      projectPath: selectedCandidate.queued.projectPath,
+      priority: selectedCandidate.queued.priority,
+      weight: selectedCandidate.weight,
+      virtualRuntimeBefore: selectedScore,
+      virtualRuntimeAfter: selectedScoreAfter,
+      contenders: contenderSnapshots,
+    };
 
     const [selected] = this.taskQueue.splice(selectedCandidate.index, 1);
     console.log(
@@ -844,11 +897,51 @@ export class TaskScheduler extends EventEmitter {
    */
   getStats(): SchedulerStats {
     const byProject = new Map<string, number>();
+    const runningByProject = this.runningCountByProject();
+    const displayPathByProject = new Map<string, string>();
+    const queuedByProject = new Map<string, QueuedTask[]>();
 
     for (const running of this.runningTasks.values()) {
       const count = byProject.get(running.projectPath) || 0;
       byProject.set(running.projectPath, count + 1);
+      displayPathByProject.set(normalizeProjectPath(running.projectPath), running.projectPath);
     }
+    for (const queued of this.taskQueue) {
+      const project = normalizeProjectPath(queued.projectPath);
+      const tasks = queuedByProject.get(project) ?? [];
+      tasks.push(queued);
+      queuedByProject.set(project, tasks);
+      displayPathByProject.set(project, queued.projectPath);
+    }
+
+    const projectKeys = new Set([
+      ...runningByProject.keys(),
+      ...queuedByProject.keys(),
+      ...this.projectVirtualRuntime.keys(),
+    ]);
+    const now = Date.now();
+    const projects = [...projectKeys].sort().map((project): SchedulerProjectFairness => {
+      const queued = queuedByProject.get(project) ?? [];
+      const runnable = queued.find((entry) => entry.availableAt == null || entry.availableAt <= now);
+      const nextAvailableAt = queued
+        .map((entry) => entry.availableAt)
+        .filter((value): value is number => value != null && value > now)
+        .sort((left, right) => left - right)[0];
+      let blockedReason: SchedulerProjectFairness['blockedReason'];
+      if (queued.length > 0 && !this.hasAvailableSlot()) blockedReason = 'global-capacity';
+      else if (queued.length > 0 && this.quarantinedProjects.has(project)) blockedReason = 'quarantined';
+      else if (queued.length > 0 && this.isProjectBusy(project)) blockedReason = 'project-capacity';
+      else if (queued.length > 0 && !runnable) blockedReason = 'retry-at';
+      return {
+        projectPath: displayPathByProject.get(project) ?? project,
+        running: runningByProject.get(project) ?? 0,
+        queued: queued.length,
+        virtualRuntime: this.projectVirtualRuntime.get(project) ?? 0,
+        nextPriority: queued[0]?.priority,
+        nextAvailableAt,
+        blockedReason,
+      };
+    });
 
     return {
       queued: this.taskQueue.length,
@@ -857,6 +950,10 @@ export class TaskScheduler extends EventEmitter {
       failed: this.failedCount,
       quarantined: this.quarantinedExecutorCount(),
       byProject,
+      fairness: {
+        projects,
+        lastSelection: this.lastFairSelection,
+      },
     };
   }
 

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -516,6 +516,7 @@ export async function startWebServer(port: number = 3847): Promise<void> {
           runningTasks: stats?.schedulerStats?.running ?? 0,
           queuedTasks: stats?.schedulerStats?.queued ?? 0,
           completedToday: stats?.schedulerStats?.completed ?? 0,
+          schedulerFairness: stats?.schedulerStats?.fairness ?? { projects: [] },
           uptime: state?.startedAt ? Date.now() - state.startedAt : 0,
           isRunning: stats?.isRunning ?? false,
           sseClients: getActiveSSECount(),


### PR DESCRIPTION
## Summary
- select only the priority/FIFO head of each executable project
- persist weighted virtual runtime across completions so one-slot daemons cannot starve other projects
- keep scheduling work-conserving when only one project has backlog
- preserve explicit project caps while making omitted-cap weighted fairness reachable from AutonomousRunner

## Validation
- focused: 4 files / 109 tests passed
- full: 363 files passed, 1 skipped; 5,043 tests passed, 10 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`
- `openswarm review --path .`: APPROVE after two REVISE rounds fixed project-head selection and single-slot starvation

## Stack
This PR is based on #489 because it composes fairness with deadline-aware deferred queue retention. Rebase/retarget to `main` after #489 lands.

Linear: AGT-4146