### PR TITLE
fix(cli): report why Linear auth failed instead of claiming it is "not configured"

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -2,7 +2,7 @@
 // OpenSwarm - Auth Module
 // ============================================
 
-export { AuthProfileStore, ensureValidToken, type AuthProfile } from './oauthStore.js';
+export { AuthProfileStore, ensureValidToken, TokenRefreshError, type AuthProfile } from './oauthStore.js';
 export {
   runOAuthPkceFlow,
   loginAndSaveProfile,

--- a/src/auth/oauthStore.test.ts
+++ b/src/auth/oauthStore.test.ts
@@ -287,3 +287,47 @@ describe('ensureValidToken', () => {
     await expect(ensureValidToken(new AuthProfileStore(), 'gpt:default')).rejects.toThrow(/auth login/);
   });
 });
+
+// The CLI classifies a dead credential by the *shape* ensureValidToken throws:
+// name 'TokenRefreshError' plus a numeric HTTP status. Those classifier tests
+// build that shape by hand, so without this the two halves of the contract could
+// drift apart silently. (AGT-4148)
+describe('ensureValidToken refresh failures', () => {
+  const expiredProfile = () =>
+    validProfile({ provider: 'linear', expires: Date.now() - 60_000 });
+
+  async function refreshWith(status: number, body: string) {
+    writeStore({ 'linear:default': expiredProfile() });
+    const { AuthProfileStore, ensureValidToken, TokenRefreshError } = await loadModule();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(body, { status })),
+    );
+    return { store: new AuthProfileStore(), ensureValidToken, TokenRefreshError };
+  }
+
+  it('rejects a non-2xx refresh with TokenRefreshError carrying the status', async () => {
+    const { store, ensureValidToken, TokenRefreshError } = await refreshWith(
+      400,
+      '{"error":"invalid_request","error_description":"Refresh token revoked"}',
+    );
+    const err = await ensureValidToken(store, 'linear:default').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(TokenRefreshError);
+    expect((err as InstanceType<typeof TokenRefreshError>).status).toBe(400);
+    // The shape the CLI classifier matches on, asserted independently of the class.
+    expect((err as Error).name).toBe('TokenRefreshError');
+    expect((err as Error).message).toContain('Refresh token revoked');
+  });
+
+  it('preserves a 429 status rather than flattening every failure to one kind', async () => {
+    const { store, ensureValidToken } = await refreshWith(429, 'Too Many Requests');
+    const err = await ensureValidToken(store, 'linear:default').catch((e: unknown) => e);
+    expect((err as Error & { status: number }).status).toBe(429);
+  });
+
+  it('leaves the stored profile untouched when the refresh is rejected', async () => {
+    const { store, ensureValidToken } = await refreshWith(400, 'nope');
+    await ensureValidToken(store, 'linear:default').catch(() => undefined);
+    expect(readStore().profiles['linear:default'].refresh).toBe('refresh-token');
+  });
+});

--- a/src/auth/oauthStore.ts
+++ b/src/auth/oauthStore.ts
@@ -231,6 +231,23 @@ export class AuthProfileStore {
 // Token refresh
 
 /**
+ * A refresh the provider answered and rejected. `status` is carried structurally
+ * so callers can separate a dead credential (4xx — only re-auth recovers it)
+ * from a provider fault (5xx — worth retrying) without parsing the message.
+ * A transport failure never becomes one of these; it propagates as the
+ * underlying fetch error, which is itself the signal that nothing was answered.
+ */
+export class TokenRefreshError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'TokenRefreshError';
+    this.status = status;
+  }
+}
+
+/**
  * 유효한 access token 반환. 만료 임박 시 자동 refresh.
  */
 export async function ensureValidToken(store: AuthProfileStore, profileKey: string): Promise<string> {
@@ -272,8 +289,9 @@ export async function ensureValidToken(store: AuthProfileStore, profileKey: stri
   if (!res.ok) {
     const errText = await res.text().catch(() => '');
     const reauth = profile.provider === 'linear' ? 'linear' : 'gpt';
-    throw new Error(
+    throw new TokenRefreshError(
       `Token refresh failed (${res.status}): ${errText.slice(0, 200)}. Run: openswarm auth login --provider ${reauth}`,
+      res.status,
     );
   }
 

--- a/src/cli/reviewCommand.coverage.test.ts
+++ b/src/cli/reviewCommand.coverage.test.ts
@@ -419,7 +419,11 @@ describe('runReviewCommand default deps (no injected review/getBranch/log/fileFo
       },
     );
     expect(fileReviewerFollowupsMock).not.toHaveBeenCalled();
-    expect(logs.join('\n')).toMatch(/Could not file follow-ups/);
+    // Names the cause instead of the old ambiguous "Is Linear connected?", which
+    // read the same whether the credential was dead or simply absent. (AGT-4148)
+    const out = logs.join('\n');
+    expect(out).toContain('Linear is not configured, so it could not file follow-ups');
+    expect(out).toContain('openswarm auth login --provider linear');
   });
 
   it('logs the changed-file count when opts.debug is set', async () => {

--- a/src/cli/reviewCommand.test.ts
+++ b/src/cli/reviewCommand.test.ts
@@ -179,7 +179,11 @@ describe('runReviewCommand --issues branch inference (INT-1967)', () => {
     expect(logs.join('\n')).toContain('inferred from branch');
   });
 
-  it('warns to connect Linear when nothing is filed (INT-1969)', async () => {
+  // A filer that returns 0 without reporting a task-source failure means Linear
+  // worked and there was simply nothing to file. Saying "is Linear connected?"
+  // here sent operators to fix a setup that was fine; the unavailable-source
+  // path is covered separately in reviewCommand.coverage.test.ts. (AGT-4148)
+  it('reports an empty filing run without blaming Linear (INT-1969)', async () => {
     const logs: string[] = [];
     await runReviewCommand(
       { fileIssue: true },
@@ -187,13 +191,16 @@ describe('runReviewCommand --issues branch inference (INT-1967)', () => {
         getChangedFiles: async () => ['x.ts'],
         review: approveWithFollowups,
         getBranch: async () => 'main',
-        fileFollowups: async () => 0, // e.g. Linear not configured
+        fileFollowups: async () => 0,
         ensureProjectMapping: async () => ({ projectId: undefined, abort: false }),
         startProgress: () => null,
         log: (l) => logs.push(l),
       },
     );
-    expect(logs.join('\n')).toMatch(/Linear connected|auth login/);
+    const out = logs.join('\n');
+    expect(out).toContain('Filed 0 follow-ups');
+    expect(out).toContain('the reviewer just produced none to file');
+    expect(out).not.toContain('auth login');
   });
 
   it('uses an explicit id over branch inference', async () => {

--- a/src/cli/reviewCommand.test.ts
+++ b/src/cli/reviewCommand.test.ts
@@ -7,6 +7,7 @@ import {
   ensureProjectMapping,
   scaledReviewMaxTurns,
   scaledReviewTimeoutMs,
+  classifyTaskSourceError,
 } from './reviewCommand.js';
 import type { ReviewResult } from '../agents/agentPair.js';
 
@@ -485,5 +486,74 @@ describe('runReviewCommand machine-readable output (INT-3102)', () => {
     );
     expect(result?.decision).toBe('revise');
     expect(logs.join('\n')).toContain('Could not write SARIF report');
+  });
+});
+
+describe('classifyTaskSourceError (AGT-4148)', () => {
+  // Matches TokenRefreshError's shape without importing it: reviewCommand
+  // recognises it structurally, so the test asserts that contract directly.
+  function refreshError(status: number, message = 'Token refresh failed'): Error {
+    const err = new Error(message);
+    err.name = 'TokenRefreshError';
+    (err as Error & { status: number }).status = status;
+    return err;
+  }
+
+  it('treats a rejected credential (4xx) as needing re-auth', () => {
+    const result = classifyTaskSourceError(
+      refreshError(400, 'Token refresh failed (400): Refresh token revoked'),
+    );
+    expect(result.reason).toBe('credential-rejected');
+    expect(result.detail).toContain('Refresh token revoked');
+  });
+
+  it('treats 401 and 403 as rejected credentials too', () => {
+    expect(classifyTaskSourceError(refreshError(401)).reason).toBe('credential-rejected');
+    expect(classifyTaskSourceError(refreshError(403)).reason).toBe('credential-rejected');
+  });
+
+  // A provider fault is not the operator's credential problem; sending them to
+  // re-authenticate would be wrong advice that also destroys a working grant.
+  it('treats a provider fault (5xx) as transient', () => {
+    expect(classifyTaskSourceError(refreshError(500)).reason).toBe('transient');
+    expect(classifyTaskSourceError(refreshError(503)).reason).toBe('transient');
+  });
+
+  // 429 and 408 are 4xx but say nothing about the grant. Reading them as a dead
+  // credential would tell the operator to re-authenticate and throw away a token
+  // that still works — the asymmetry the allow-list exists to prevent.
+  it('treats rate limiting and request timeout as transient, not a dead credential', () => {
+    expect(classifyTaskSourceError(refreshError(429, 'Too Many Requests')).reason)
+      .toBe('transient');
+    expect(classifyTaskSourceError(refreshError(408, 'Request Timeout')).reason)
+      .toBe('transient');
+  });
+
+  // An unexpected 4xx is not evidence the grant died either; only the enumerated
+  // auth statuses are.
+  it('treats an unenumerated 4xx as transient', () => {
+    expect(classifyTaskSourceError(refreshError(404)).reason).toBe('transient');
+    expect(classifyTaskSourceError(refreshError(422)).reason).toBe('transient');
+  });
+
+  it('treats a transport failure with no status as transient', () => {
+    const result = classifyTaskSourceError(new TypeError('fetch failed'));
+    expect(result.reason).toBe('transient');
+    expect(result.detail).toContain('fetch failed');
+  });
+
+  // Guards the shape check: a same-named error without a numeric status must not
+  // be read as a credential rejection.
+  it('does not treat a same-named error lacking a numeric status as rejected', () => {
+    const err = new Error('nope');
+    err.name = 'TokenRefreshError';
+    expect(classifyTaskSourceError(err).reason).toBe('transient');
+  });
+
+  it('stringifies a non-Error throw rather than losing it', () => {
+    expect(classifyTaskSourceError('plain string failure')).toEqual({
+      reason: 'transient',
+      detail: 'plain string failure',
+    });
   });
 });

--- a/src/cli/reviewCommand.ts
+++ b/src/cli/reviewCommand.ts
@@ -223,6 +223,42 @@ export type TaskSourceFailure =
 export type TaskSourceResult = { source: ITaskSource } | ({ source: null } & TaskSourceFailure);
 
 /**
+ * Turn a task-source failure into operator guidance. Each reason points at a
+ * different repair, which is why the cause is carried this far: telling someone
+ * with a revoked token to "set linearApiKey" wastes their time on a setting that
+ * is already present. `action` names what could not be done, so the same wording
+ * serves both `openswarm work` and `review --issues`. (AGT-4148)
+ */
+export function describeTaskSourceFailure(failure: TaskSourceFailure, action: string): string[] {
+  switch (failure.reason) {
+    case 'credential-rejected': {
+      const lines = [
+        `Linear rejected the stored credential, so it could not ${action} — it is configured, but no longer valid.`,
+        `  ${failure.detail}`,
+      ];
+      // ensureValidToken already appends the remediation to its own message.
+      // Repeating it just makes the operator read the same command twice.
+      if (!failure.detail.includes('auth login --provider linear')) {
+        lines.push('Run `openswarm auth login --provider linear` to re-authenticate, then re-run.');
+      }
+      return lines;
+    }
+    case 'transient':
+      return [
+        `Could not reach Linear to ${action}. This looks temporary rather than a credential problem.`,
+        `  ${failure.detail}`,
+        'Re-run once it is reachable; if it persists, check connectivity and Linear status.',
+      ];
+    case 'unconfigured':
+    default:
+      return [
+        `Linear is not configured, so it could not ${action}.`,
+        'Run `openswarm auth login --provider linear` (or set linearApiKey + linearTeamId in config.yaml), then re-run.',
+      ];
+  }
+}
+
+/**
  * Build a Linear-backed task source, reporting *why* when it cannot. Prefer this
  * over `ensureTaskSource` wherever the outcome is surfaced to a person: a bare
  * null cannot distinguish an unconfigured machine from a revoked token, and the
@@ -524,13 +560,21 @@ export async function runReviewCommand(
       } else {
         // Default path initializes a Linear task source itself (the daemon isn't
         // running here), and files regardless of decision. (INT-1969)
+        // Why the source could not be built, when that is what stopped filing.
+        // "0 filed" otherwise means the reviewer simply had nothing to file, and
+        // blaming Linear for that sends the operator to fix a working setup.
+        // (AGT-4148)
+        let sourceFailure: TaskSourceFailure | undefined;
         const fileFollowups =
           deps.fileFollowups ??
           (async (p: string | undefined, r: ReviewResult) => {
             const { fileReviewerFollowups } = await import('../automation/runnerExecution.js');
-            const source = await ensureTaskSource();
-            if (!source) return 0;
-            return fileReviewerFollowups(source, p, r, { autoFile: true, projectId: mapping.projectId, requireApprove: false });
+            const resolved = await resolveTaskSource();
+            if (!resolved.source) {
+              sourceFailure = resolved;
+              return 0;
+            }
+            return fileReviewerFollowups(resolved.source, p, r, { autoFile: true, projectId: mapping.projectId, requireApprove: false });
           });
         const filed = await fileFollowups(parent, result);
         if (filed > 0) {
@@ -539,10 +583,10 @@ export async function runReviewCommand(
               ? `Filed ${filed} follow-up sub-issue(s) under ${parent}.`
               : `Filed ${filed} standalone follow-up issue(s) (pass \`--issues <id>\` to nest them under an issue).`,
           );
+        } else if (sourceFailure) {
+          for (const line of describeTaskSourceFailure(sourceFailure, 'file follow-ups')) log(line);
         } else {
-          log(
-            `Could not file follow-ups (0 created). Is Linear connected? Run \`openswarm auth login --provider linear\` (or set linearApiKey in config).`,
-          );
+          log('Filed 0 follow-ups — Linear is connected, the reviewer just produced none to file.');
         }
       }
     } else if (followups) {

--- a/src/cli/reviewCommand.ts
+++ b/src/cli/reviewCommand.ts
@@ -207,10 +207,31 @@ export async function ensureProjectMapping(
  * Linear from config (OAuth profile or apiKey) and build a LinearTaskSource.
  * Returns null when Linear isn't configured. (INT-1969)
  */
-export async function ensureTaskSource(): Promise<ITaskSource | null> {
+/**
+ * Why a task source could not be built. `unconfigured` is the only one that
+ * means "nothing to fix here"; the other two are configured-but-failing, and
+ * telling an operator they are "not configured" sends them at the wrong repair.
+ */
+export type TaskSourceFailure =
+  /** No Linear team id, or no OAuth profile and no apiKey. */
+  | { reason: 'unconfigured' }
+  /** The provider answered and rejected the credential — only re-auth recovers it. */
+  | { reason: 'credential-rejected'; detail: string }
+  /** Nothing answered, or the provider faulted. Worth retrying. */
+  | { reason: 'transient'; detail: string };
+
+export type TaskSourceResult = { source: ITaskSource } | ({ source: null } & TaskSourceFailure);
+
+/**
+ * Build a Linear-backed task source, reporting *why* when it cannot. Prefer this
+ * over `ensureTaskSource` wherever the outcome is surfaced to a person: a bare
+ * null cannot distinguish an unconfigured machine from a revoked token, and the
+ * guidance for the two is different. (AGT-4148)
+ */
+export async function resolveTaskSource(): Promise<TaskSourceResult> {
   const { getTaskSource } = await import('../automation/runnerExecution.js');
   const existing = getTaskSource();
-  if (existing) return existing;
+  if (existing) return { source: existing };
   try {
     const linear = await import('../linear/linear.js');
     if (!linear.isLinearInitialized()) {
@@ -227,12 +248,55 @@ export async function ensureTaskSource(): Promise<ITaskSource | null> {
         }
       }
     }
-    if (!linear.isLinearInitialized()) return null;
+    if (!linear.isLinearInitialized()) return { source: null, reason: 'unconfigured' };
     const { LinearTaskSource } = await import('../automation/taskSource.js');
-    return new LinearTaskSource(async () => []); // fetch unused for filing
-  } catch {
-    return null;
+    return { source: new LinearTaskSource(async () => []) }; // fetch unused for filing
+  } catch (err) {
+    return { source: null, ...classifyTaskSourceError(err) };
   }
+}
+
+/**
+ * Statuses on which an OAuth token endpoint is saying the grant itself is no
+ * longer usable: a malformed/revoked grant (400), an unauthenticated client
+ * (401), a forbidden one (403). Deliberately an allow-list rather than the whole
+ * 4xx range — 429 is ordinary rate limiting and 408 a timeout, and both would
+ * otherwise be read as a dead credential.
+ */
+const CREDENTIAL_REJECTED_STATUSES: ReadonlySet<number> = new Set([400, 401, 403]);
+
+/**
+ * Decide whether a failed task-source build means the credential is dead or that
+ * the attempt merely did not land. The asymmetry drives the allow-list above:
+ * calling a transient fault "transient" when it was really a dead credential
+ * costs one wasted retry, while calling rate limiting a dead credential sends
+ * the operator to re-authenticate and discard a grant that still works.
+ *
+ * Recognised by shape rather than `instanceof TokenRefreshError`: every Linear
+ * dependency in this module is imported lazily, and an `instanceof` against a
+ * dynamically imported class silently stops matching if that module is ever
+ * instantiated twice. The name plus a numeric status is the distinguishing shape.
+ *
+ * Exported for test: this is the whole judgement, and driving it through a live
+ * OAuth failure would make the test depend on a revoked token existing.
+ */
+export function classifyTaskSourceError(err: unknown): TaskSourceFailure {
+  const detail = err instanceof Error ? err.message : String(err);
+  const status = err instanceof Error && err.name === 'TokenRefreshError'
+    ? (err as { status?: unknown }).status
+    : undefined;
+  if (typeof status === 'number' && CREDENTIAL_REJECTED_STATUSES.has(status)) {
+    return { reason: 'credential-rejected', detail };
+  }
+  return { reason: 'transient', detail };
+}
+
+/**
+ * Back-compatible wrapper: callers that only branch on availability keep working
+ * unchanged. New code that reports the outcome should call `resolveTaskSource`.
+ */
+export async function ensureTaskSource(): Promise<ITaskSource | null> {
+  return (await resolveTaskSource()).source;
 }
 
 export interface ReviewCommandOptions {

--- a/src/cli/workCommand.test.ts
+++ b/src/cli/workCommand.test.ts
@@ -123,7 +123,7 @@ function baseDeps(overrides: Partial<WorkCommandDeps> = {}): WorkCommandDeps & {
   ) => pipelineResult());
   const deps: WorkCommandDeps = {
     loadConfig: () => ({ autonomous: { maxConcurrentTasks: 4 } }) as unknown as SwarmConfig,
-    ensureTaskSource: async () => fakeSource,
+    resolveTaskSource: async () => ({ source: fakeSource }),
     registerTaskSource: vi.fn(),
     isValidProjectPath: async () => true,
     isGitRepo: () => true,
@@ -332,10 +332,63 @@ describe('runWorkCommand — bootstrap validation', () => {
   });
 
   it('exits 2 with guidance when Linear is not configured', async () => {
-    const deps = baseDeps({ ensureTaskSource: async () => null });
+    const deps = baseDeps({
+      resolveTaskSource: async () => ({ source: null, reason: 'unconfigured' }),
+    });
     expect(await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps))
       .toBe(WORK_EXIT_NOT_RUN);
     expect(deps.logs.join('\n')).toContain('Linear is not configured');
+  });
+
+  // A revoked token used to render as "not configured", sending the operator to
+  // set an apiKey that was already present and also dead. (AGT-4148)
+  it('exits 2 naming the rejected credential, not a missing configuration', async () => {
+    const deps = baseDeps({
+      resolveTaskSource: async () => ({
+        source: null,
+        reason: 'credential-rejected',
+        detail: 'Token refresh failed (400): {"error_description":"Refresh token revoked"}',
+      }),
+    });
+    expect(await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps))
+      .toBe(WORK_EXIT_NOT_RUN);
+    const out = deps.logs.join('\n');
+    expect(out).toContain('rejected the stored credential');
+    expect(out).toContain('Refresh token revoked');
+    expect(out).toContain('openswarm auth login --provider linear');
+    expect(out).not.toContain('Linear is not configured');
+  });
+
+  // ensureValidToken already appends the re-auth command to its message; saying
+  // it again just makes the operator read the same instruction twice.
+  it('does not repeat the re-auth command already carried in the provider detail', async () => {
+    const deps = baseDeps({
+      resolveTaskSource: async () => ({
+        source: null,
+        reason: 'credential-rejected',
+        detail: 'Token refresh failed (400): revoked. Run: openswarm auth login --provider linear',
+      }),
+    });
+    await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps);
+    const occurrences = deps.logs.join('\n').split('auth login --provider linear').length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it('exits 2 calling an unreachable Linear temporary rather than a credential problem', async () => {
+    const deps = baseDeps({
+      resolveTaskSource: async () => ({
+        source: null,
+        reason: 'transient',
+        detail: 'fetch failed',
+      }),
+    });
+    expect(await runWorkCommand({ issueIds: ['INT-1'], path: '/repo', yes: true }, deps))
+      .toBe(WORK_EXIT_NOT_RUN);
+    const out = deps.logs.join('\n');
+    expect(out).toContain('looks temporary');
+    expect(out).toContain('fetch failed');
+    expect(out).not.toContain('Linear is not configured');
+    expect(out).not.toContain('re-authenticate');
   });
 
   it('exits 2 when the config cannot be loaded', async () => {

--- a/src/cli/workCommand.ts
+++ b/src/cli/workCommand.ts
@@ -44,7 +44,43 @@ import { hasRecoverableWorktree } from '../support/worktreeManager.js';
 import { runPool } from '../support/concurrencyPool.js';
 import { fileScopesConflict, resolveTaskFileScope } from '../orchestration/conflictDetector.js';
 import { buildConflictFreeWaves as partitionConflictFreeWaves } from '../orchestration/conflictAdmission.js';
-import { ensureTaskSource } from './reviewCommand.js';
+import { resolveTaskSource, type TaskSourceResult } from './reviewCommand.js';
+
+/**
+ * Turn a task-source failure into operator guidance. Each reason points at a
+ * different repair, which is the whole reason the cause is carried this far:
+ * telling someone with a revoked token to "set linearApiKey" wastes their time
+ * on a setting that is already present. (AGT-4148)
+ */
+function describeTaskSourceFailure(failure: Extract<TaskSourceResult, { source: null }>): string[] {
+  switch (failure.reason) {
+    case 'credential-rejected': {
+      const lines = [
+        'Linear rejected the stored credential — it is configured, but no longer valid.',
+        `  ${failure.detail}`,
+      ];
+      // The provider's own message often already carries the remediation
+      // (ensureValidToken appends it). Only add ours when it does not, so the
+      // operator is not told the same command twice.
+      if (!failure.detail.includes('auth login --provider linear')) {
+        lines.push('Run `openswarm auth login --provider linear` to re-authenticate, then re-run.');
+      }
+      return lines;
+    }
+    case 'transient':
+      return [
+        'Could not reach Linear to build a task source. This looks temporary rather than a credential problem.',
+        `  ${failure.detail}`,
+        'Re-run once it is reachable; if it persists, check connectivity and Linear status.',
+      ];
+    case 'unconfigured':
+    default:
+      return [
+        'Linear is not configured — `openswarm work` picks issues from your tracker.',
+        'Run `openswarm auth login --provider linear` (or set linearApiKey + linearTeamId in config.yaml), then re-run.',
+      ];
+  }
+}
 import { filterRepoIssues, selectIssuesInteractive, WORK_SKIP_STATES } from './workSelect.js';
 import {
   buildWorkCancellationEffect,
@@ -110,7 +146,11 @@ export interface WorkCoordinator {
 
 export interface WorkCommandDeps {
   loadConfig?: () => SwarmConfig;
-  ensureTaskSource?: () => Promise<ITaskSource | null>;
+  /**
+   * Resolves the task source and, on failure, why. The command surfaces the
+   * reason to a person, so it needs more than availability. (AGT-4148)
+   */
+  resolveTaskSource?: () => Promise<TaskSourceResult>;
   /** Registers the source as runnerExecution's module-global task source. */
   registerTaskSource?: (source: ITaskSource) => void;
   isValidProjectPath?: (path: string) => Promise<boolean>;
@@ -324,12 +364,12 @@ async function runWorkCommandInner(
   // already strict process.
   if (config.humanSurfaceReadOnly?.enabled === true) enableHumanSurfaceReadOnly();
 
-  const source = await (deps.ensureTaskSource ?? ensureTaskSource)();
-  if (!source) {
-    log('Linear is not configured — `openswarm work` picks issues from your tracker.');
-    log('Run `openswarm auth login --provider linear` (or set linearApiKey + linearTeamId in config.yaml), then re-run.');
+  const resolved = await (deps.resolveTaskSource ?? resolveTaskSource)();
+  if (!resolved.source) {
+    for (const line of describeTaskSourceFailure(resolved)) log(line);
     return WORK_EXIT_NOT_RUN;
   }
+  const source = resolved.source;
   // executePipeline routes In Progress transitions and audit comments through
   // runnerExecution's module-global task source — registration is mandatory.
   (deps.registerTaskSource ?? setTaskSource)(source);

--- a/src/cli/workCommand.ts
+++ b/src/cli/workCommand.ts
@@ -44,43 +44,7 @@ import { hasRecoverableWorktree } from '../support/worktreeManager.js';
 import { runPool } from '../support/concurrencyPool.js';
 import { fileScopesConflict, resolveTaskFileScope } from '../orchestration/conflictDetector.js';
 import { buildConflictFreeWaves as partitionConflictFreeWaves } from '../orchestration/conflictAdmission.js';
-import { resolveTaskSource, type TaskSourceResult } from './reviewCommand.js';
-
-/**
- * Turn a task-source failure into operator guidance. Each reason points at a
- * different repair, which is the whole reason the cause is carried this far:
- * telling someone with a revoked token to "set linearApiKey" wastes their time
- * on a setting that is already present. (AGT-4148)
- */
-function describeTaskSourceFailure(failure: Extract<TaskSourceResult, { source: null }>): string[] {
-  switch (failure.reason) {
-    case 'credential-rejected': {
-      const lines = [
-        'Linear rejected the stored credential — it is configured, but no longer valid.',
-        `  ${failure.detail}`,
-      ];
-      // The provider's own message often already carries the remediation
-      // (ensureValidToken appends it). Only add ours when it does not, so the
-      // operator is not told the same command twice.
-      if (!failure.detail.includes('auth login --provider linear')) {
-        lines.push('Run `openswarm auth login --provider linear` to re-authenticate, then re-run.');
-      }
-      return lines;
-    }
-    case 'transient':
-      return [
-        'Could not reach Linear to build a task source. This looks temporary rather than a credential problem.',
-        `  ${failure.detail}`,
-        'Re-run once it is reachable; if it persists, check connectivity and Linear status.',
-      ];
-    case 'unconfigured':
-    default:
-      return [
-        'Linear is not configured — `openswarm work` picks issues from your tracker.',
-        'Run `openswarm auth login --provider linear` (or set linearApiKey + linearTeamId in config.yaml), then re-run.',
-      ];
-  }
-}
+import { resolveTaskSource, describeTaskSourceFailure, type TaskSourceResult } from './reviewCommand.js';
 import { filterRepoIssues, selectIssuesInteractive, WORK_SKIP_STATES } from './workSelect.js';
 import {
   buildWorkCancellationEffect,
@@ -366,7 +330,7 @@ async function runWorkCommandInner(
 
   const resolved = await (deps.resolveTaskSource ?? resolveTaskSource)();
   if (!resolved.source) {
-    for (const line of describeTaskSourceFailure(resolved)) log(line);
+    for (const line of describeTaskSourceFailure(resolved, 'pick issues from your tracker')) log(line);
     return WORK_EXIT_NOT_RUN;
   }
   const source = resolved.source;


### PR DESCRIPTION
## Summary

`openswarm work` on a machine with a revoked Linear OAuth token reported **"Linear is not configured"** and told the operator to set `linearApiKey` — a setting that was already present, and independently dead. Linear *was* configured; its refresh was rejected.

`ensureValidToken` already builds an accurate message. `ensureTaskSource` ended in a bare `catch { return null; }` that threw it away, collapsing four distinct causes into one `null` that the caller could only render one way.

## What changed

- `resolveTaskSource()` returns the cause alongside the source: `unconfigured` / `credential-rejected` / `transient`.
- `ensureTaskSource()` remains a thin wrapper, so the six existing call sites in `reviewCommand.ts` and `reviewMaxCommand.tsx` are untouched.
- `TokenRefreshError` carries the HTTP status structurally instead of callers parsing it out of a message.
- `openswarm work` renders guidance per cause, and suppresses its own re-auth line when the provider's message already carries one.

## Why an allow-list, not the 4xx range

Classification treats **400/401/403** as a dead credential and everything else as transient. The first draft used `status >= 400 && status < 500`; review caught that **429 is ordinary rate limiting** (and 408 a timeout), and reading either as a dead credential tells the operator to re-authenticate and discard a grant that still works.

The asymmetry is the point: a wrongly *transient* verdict costs one retry, a wrongly *terminal* one costs a working token.

## Verification

- Measured against the actually-revoked local token, before → after:
  ```
  - Linear is not configured — `openswarm work` picks issues from your tracker.
  - Run `openswarm auth login --provider linear` (or set linearApiKey + linearTeamId ...)
  + Linear rejected the stored credential — it is configured, but no longer valid.
  +   Token refresh failed (400): {"error":"invalid_request","error_description":"Refresh token revoked"}. Run: openswarm auth login --provider linear
  ```
- `src/auth` + `src/cli`: 45 files, 770 tests passed.
- Focused `reviewCommand` + `workCommand`: 97 tests passed (9 new, covering all three causes plus 429/408/404/422 and the non-Error throw).
- typecheck, lint, build: passed.
- `openswarm review`: REVISE (the 429 defect) → fixed → **APPROVE**.

Closes AGT-4148. Same class of defect as AGT-4012.