### PR TITLE
fix(dashboard): escape stage status before rendering it (AGT-3476)

### DIFF
--- a/src/support/dashboardHtml.test.ts
+++ b/src/support/dashboardHtml.test.ts
@@ -22,3 +22,28 @@ describe('buildDashboardHtml (INT-3284)', () => {
     expect(html).not.toContain('getElementById("provider-claude").classList.toggle');
   });
 });
+
+// The stage row is rendered by the *browser* script embedded in this page, so a
+// server-side test can only pin the emitted source. That is still the useful
+// guard: every other externally-derived field in this row goes through
+// escapeHtml/escapeAttr, and status was the one that did not. (AGT-3476)
+describe('stage row escaping (AGT-3476)', () => {
+  const html = buildDashboardHtml(['claude']);
+
+  it('routes stage status through the escapers in both the class and the label', () => {
+    expect(html).toContain('"<div class=\\"sdot " + escapeAttr(r.status || "") + "\\"></div>"');
+    expect(html).toContain('"<div class=\\"sstatus\\">" + escapeHtml(r.status || "") + "</div>"');
+  });
+
+  it('leaves no unescaped status interpolation behind', () => {
+    // The exact shape the fix replaced. Catches a partial revert of either site.
+    expect(html).not.toContain('"sdot " + (r.status || "")');
+    expect(html).not.toContain('">" + (r.status || "") + "</div>"');
+  });
+
+  it('defines both escapers in the browser script that calls them', () => {
+    // A server-side-only helper would make the row throw ReferenceError at runtime.
+    expect(html).toContain('function escapeHtml(text)');
+    expect(html).toContain('function escapeAttr(text)');
+  });
+});

--- a/src/support/dashboardHtml.ts
+++ b/src/support/dashboardHtml.ts
@@ -1585,7 +1585,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
         return (
           "<div class=\\"stage-block\\" data-stage-idx=\\"" + i + "\\">" +
             "<div class=\\"" + rowClass + "\\"" + onclick + ">" +
-              "<div class=\\"sdot " + (r.status || "") + "\\"></div>" +
+              "<div class=\\"sdot " + escapeAttr(r.status || "") + "\\"></div>" +
               "<div class=\\"srepo\\">" + escapeHtml(repoName) + "</div>" +
               "<div class=\\"sname\\">" + escapeHtml(r.stage) + "</div>" +
               "<div class=\\"stask\\" title=\\"" + escapeAttr(r.taskId || "") + "\\">" + escapeHtml(taskLabel) + "</div>" +
@@ -1593,7 +1593,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
               "<div class=\\"smodel\\">" + escapeHtml(modelStr) + "</div>" +
               "<div class=\\"stokens\\">" + escapeHtml(tokenStr) + "</div>" +
               "<div class=\\"selapsed\\">" + elapsed + "</div>" +
-              "<div class=\\"sstatus\\">" + (r.status || "") + "</div>" +
+              "<div class=\\"sstatus\\">" + escapeHtml(r.status || "") + "</div>" +
             "</div>" +
             (hasDetails ? "<div class=\\"stage-details\\">" + detailsHtml + "</div>" : "") +
           "</div>"


### PR DESCRIPTION
## Summary

The dashboard stage row escaped every externally-derived field it renders — repo, stage, task id, task label, model, tokens — **except `status`**, which went raw into two places:

```js
"<div class=\"sdot " + (r.status || "") + "\"></div>"      // quoted class attribute
"<div class=\"sstatus\">" + (r.status || "") + "</div>"    // text node
```

This file makes 61 `escapeHtml`/`escapeAttr` calls. These two were the row's only interpolations that did not observe that invariant.

## Severity — stated honestly

Not a live escape. The paths feeding this today type status as closed unions (`'queued' | 'running' | 'completed' | 'failed'`). This is defence in depth: the value is one widening away from being attacker-influenced, and the row already had the escapers on hand.

I checked the two other raw interpolations in the same block and left them alone deliberately — `inlineSummary` builds its own escaped HTML (`<span>` included) and `elapsed` is assembled from numeric seconds.

## Fix

Escaped per context: `escapeAttr` inside the class attribute, `escapeHtml` in the text node. Both helpers are already defined in the same browser-side script that renders this row (`function escapeHtml(text)` / `function escapeAttr(text)`), so no new runtime dependency — and being function declarations, hoisting covers the use-before-definition order.

## Verification

- 5 tests pass in `dashboardHtml.test.ts` (3 new).
- **Mutation-checked**: reverting just the `sdot` site turns 2 of the 3 new tests red. They are guards, not decoration.
- The tests pin the emitted source rather than runtime behaviour, because the row is rendered by the embedded browser script — stated in a comment so the next reader knows what they do and do not cover.
- typecheck, lint (0/0), build pass. `openswarm review`: **APPROVE**.

## Scope

AGT-3476 lists seven follow-ups; this closes one of them (`Escape pipeline stage status before dashboard HTML rendering`). The issue stays open — verification this session confirmed at least two others are still present, including the lexical-only destructive-command guard and the non-symlink-safe evidence reads.