### PR TITLE
fix(auth): always print the OAuth URL, not only when the launcher fails

### DIFF
--- a/src/auth/openBrowser.test.ts
+++ b/src/auth/openBrowser.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+const spawnMock = vi.fn();
+vi.mock('node:child_process', () => ({ spawn: (...a: unknown[]) => spawnMock(...a) }));
+
+const { openBrowser } = await import('./openBrowser.js');
+
+/** A spawn() stand-in whose exit can be driven per test. */
+function fakeChild(): EventEmitter {
+  const child = new EventEmitter();
+  spawnMock.mockReturnValue(child);
+  return child;
+}
+
+let errors: string[];
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  errors = [];
+  spawnMock.mockReset();
+  errSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    errors.push(args.map(String).join(' '));
+  });
+});
+
+afterEach(() => {
+  errSpy.mockRestore();
+});
+
+const URL = 'https://linear.app/oauth/authorize?client_id=x&code_challenge=y';
+
+describe('openBrowser', () => {
+  // The launcher exiting 0 does not mean a human saw the page — over SSH or in a
+  // container it can succeed and go nowhere, and the caller then blocks on a
+  // callback that never arrives. So the URL is printed unconditionally.
+  it('prints the URL even when the launcher succeeds', () => {
+    const child = fakeChild();
+    openBrowser(URL);
+    child.emit('close', 0);
+    expect(errors.join('\n')).toContain(URL);
+  });
+
+  it('prints the URL before spawning, not after the child settles', () => {
+    fakeChild();
+    openBrowser(URL);
+    // No close/error emitted yet: the URL must already be out.
+    expect(errors.join('\n')).toContain(URL);
+  });
+
+  it('adds a distinct notice when the launcher fails to start', () => {
+    const child = fakeChild();
+    openBrowser(URL);
+    child.emit('error', new Error('ENOENT'));
+    expect(errors.join('\n')).toMatch(/열지 못했습니다/);
+  });
+
+  it('adds the notice on a non-zero exit', () => {
+    const child = fakeChild();
+    openBrowser(URL);
+    child.emit('close', 1);
+    expect(errors.join('\n')).toMatch(/열지 못했습니다/);
+  });
+
+  it('does not add the failure notice on a clean exit', () => {
+    const child = fakeChild();
+    openBrowser(URL);
+    child.emit('close', 0);
+    expect(errors.join('\n')).not.toMatch(/열지 못했습니다/);
+  });
+
+  it('reports the launcher failure only once', () => {
+    const child = fakeChild();
+    openBrowser(URL);
+    child.emit('error', new Error('ENOENT'));
+    child.emit('close', 1);
+    const hits = errors.filter((l) => /열지 못했습니다/.test(l)).length;
+    expect(hits).toBe(1);
+  });
+});

--- a/src/auth/openBrowser.ts
+++ b/src/auth/openBrowser.ts
@@ -10,7 +10,24 @@ function getOpenCommand(url: string): { command: string; args: string[] } {
   return { command: 'xdg-open', args: [url] };
 }
 
+/**
+ * Launch the user's browser at `url`, and always print the URL first.
+ *
+ * The launcher exiting 0 means the *launcher* succeeded, not that a human saw
+ * the page: over SSH, in a container, or on a headless box, `open`/`xdg-open`
+ * can hand the URL to something that goes nowhere and still exit 0. Only
+ * printing on failure therefore leaves exactly the sessions that most need the
+ * URL — the ones with no reachable browser — staring at a callback server that
+ * never resolves.
+ *
+ * Every caller is an OAuth PKCE flow that then blocks waiting for the callback,
+ * so one extra line is cheap next to a hang, and it makes the flow completable
+ * by hand or by relaying the link to whoever is actually at a browser.
+ */
 export function openBrowser(url: string): void {
+  console.error('[Auth] 로그인 페이지를 엽니다. 열리지 않으면 직접 열어주세요:');
+  console.error(url);
+
   const { command, args } = getOpenCommand(url);
   const child = spawn(command, args, {
     stdio: 'ignore',
@@ -18,11 +35,13 @@ export function openBrowser(url: string): void {
   });
   let reported = false;
 
+  // Still worth saying when the launcher itself failed: it tells the user the
+  // link above is now their only route, rather than leaving them to guess
+  // whether a browser is on its way.
   const reportFallback = (): void => {
     if (reported) return;
     reported = true;
-    console.error('[Auth] 브라우저를 자동으로 열 수 없습니다. 직접 열어주세요:');
-    console.error(url);
+    console.error('[Auth] 브라우저를 자동으로 열지 못했습니다 — 위 주소를 직접 열어주세요.');
   };
 
   child.on('error', reportFallback);


### PR DESCRIPTION
## Problem

`openBrowser` printed the authorization URL only from the child process's `error` and non-zero-`close` handlers. That covers *the launcher failing to start*. It does not cover the launcher starting fine and reaching nobody — over SSH, inside a container, or on a headless box, `open`/`xdg-open` can hand the URL to something invisible and still exit `0`.

All three callers (`linearPkce`, `oauthPkce`, `openrouterPkce`) then block on a localhost callback. So the failure mode is a CLI that hangs forever with no link to follow — and the sessions that most need the URL printed were precisely the ones never shown it.

Found while trying to complete `openswarm auth login --provider linear` on a machine whose stored credential is revoked.

## Change

The URL is printed unconditionally, before the spawn — so it is there even if the process is killed while waiting. The launcher-failure notice stays, but now points at the link already printed instead of repeating it, and still fires at most once across both handlers.

One extra line of output against a hang that has no exit.

## Verification

- `openBrowser` had **no tests**. Six added: the unconditional print, its ordering relative to `spawn`, both failure signals (`error`, non-zero `close`), the clean-exit case, and the once-only dedupe.
- **Mutation-checked**: removing the unconditional print turns 2 of the 6 red.
- `src/auth`: 5 files, 50 tests pass. typecheck, lint (0/0), build pass.
- `openswarm review`: **APPROVE** — verified all three callers start their callback server before calling this, so nothing races the print.