### PR TITLE
fix(cli): stop a revoked OAuth profile from shadowing a working Linear API key

### DIFF
--- a/src/cli/reviewCommand.coverage.test.ts
+++ b/src/cli/reviewCommand.coverage.test.ts
@@ -96,6 +96,7 @@ const {
   resolveProjectId,
   ensureProjectMapping,
   ensureTaskSource,
+  resolveTaskSource,
   runReviewCommand,
 } = await import('./reviewCommand.js');
 
@@ -255,6 +256,57 @@ describe('ensureTaskSource (INT-1969)', () => {
 
     expect(ensureValidTokenMock).not.toHaveBeenCalled();
     expect(initLinearMock).toHaveBeenCalledWith('key-xyz', 'team-2');
+  });
+
+  // A revoked or expired OAuth grant used to take the profile branch, throw, and
+  // leave a configured-and-valid apiKey untried. The two credentials are
+  // independent, so a dead one is a reason to try the other. (AGT-4152)
+  it('falls back to the apiKey when the OAuth profile refresh is rejected', async () => {
+    isLinearInitializedMock.mockReturnValueOnce(false).mockReturnValueOnce(true);
+    loadConfigMock.mockReturnValueOnce({ linearTeamId: 'team-3', linearApiKey: 'key-live' });
+    getProfileMock.mockReturnValueOnce({ id: 'linear:default' });
+    const revoked = Object.assign(new Error('Token refresh failed (400): Refresh token revoked'), {
+      name: 'TokenRefreshError',
+      status: 400,
+    });
+    ensureValidTokenMock.mockRejectedValueOnce(revoked);
+
+    const result = await resolveTaskSource();
+
+    expect(initLinearMock).toHaveBeenCalledWith('key-live', 'team-3');
+    expect(result).toEqual({ source: { kind: 'linear-task-source' } });
+  });
+
+  // Without an apiKey there is nothing to fall back to, and the OAuth cause is
+  // what the operator needs — it must not flatten to "unconfigured". (AGT-4148)
+  it('reports the rejected credential when no apiKey is configured', async () => {
+    // Exactly one queued value: the rethrow exits before the confirmation check,
+    // and a leftover mockReturnValueOnce would leak into the next test.
+    isLinearInitializedMock.mockReturnValueOnce(false);
+    loadConfigMock.mockReturnValueOnce({ linearTeamId: 'team-4', linearApiKey: '' });
+    getProfileMock.mockReturnValueOnce({ id: 'linear:default' });
+    ensureValidTokenMock.mockRejectedValueOnce(Object.assign(new Error('Token refresh failed (400): revoked'), {
+      name: 'TokenRefreshError',
+      status: 400,
+    }));
+
+    const result = await resolveTaskSource();
+
+    expect(initLinearMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ source: null, reason: 'credential-rejected' });
+  });
+
+  // A live OAuth profile must still win; the apiKey is a fallback, not a peer.
+  it('does not touch the apiKey when the OAuth profile works', async () => {
+    isLinearInitializedMock.mockReturnValueOnce(false).mockReturnValueOnce(true);
+    loadConfigMock.mockReturnValueOnce({ linearTeamId: 'team-5', linearApiKey: 'key-unused' });
+    getProfileMock.mockReturnValueOnce({ id: 'linear:default' });
+    ensureValidTokenMock.mockResolvedValueOnce('token-live');
+
+    await resolveTaskSource();
+
+    expect(initLinearMock).toHaveBeenCalledTimes(1);
+    expect(initLinearMock).toHaveBeenCalledWith('token-live', 'team-5', true);
   });
 
   it('returns null when there is no linearTeamId configured at all', async () => {

--- a/src/cli/reviewCommand.ts
+++ b/src/cli/reviewCommand.ts
@@ -276,12 +276,30 @@ export async function resolveTaskSource(): Promise<TaskSourceResult> {
       if (config.linearTeamId) {
         const { AuthProfileStore, ensureValidToken } = await import('../auth/index.js');
         const authStore = new AuthProfileStore();
+        // A stored OAuth profile is preferred, but it must not *shadow* a working
+        // API key: a revoked or expired grant used to take this branch, throw, and
+        // leave `linearApiKey` untried even though it was configured and valid.
+        // The two credentials are independent, so a dead one is a reason to try the
+        // other, not to give up. (AGT-4152)
+        let oauthFailure: unknown;
+        let initialised = false;
         if (authStore.getProfile('linear:default')) {
-          const token = await ensureValidToken(authStore, 'linear:default');
-          linear.initLinear(token, config.linearTeamId, true);
-        } else if (config.linearApiKey) {
-          linear.initLinear(config.linearApiKey, config.linearTeamId);
+          try {
+            const token = await ensureValidToken(authStore, 'linear:default');
+            linear.initLinear(token, config.linearTeamId, true);
+            initialised = true;
+          } catch (err) {
+            oauthFailure = err;
+          }
         }
+        if (!initialised && config.linearApiKey) {
+          linear.initLinear(config.linearApiKey, config.linearTeamId);
+          initialised = true;
+        }
+        // Nothing else worked, so the OAuth cause is the useful one to report —
+        // rethrowing keeps AGT-4148's credential-rejected/transient classification
+        // instead of flattening it to "unconfigured".
+        if (!initialised && oauthFailure !== undefined) throw oauthFailure;
       }
     }
     if (!linear.isLinearInitialized()) return { source: null, reason: 'unconfigured' };


### PR DESCRIPTION
## Problem

```ts
if (authStore.getProfile('linear:default')) {
  const token = await ensureValidToken(...);   // throws when revoked
  linear.initLinear(token, teamId, true);
} else if (config.linearApiKey) {              // never reached
  linear.initLinear(config.linearApiKey, teamId);
}
```

The **existence** of a stored OAuth profile takes the branch. If its refresh is rejected, the configured `linearApiKey` is never tried — the fallback is unreachable exactly when it is needed.

## Measured

This machine is that case: `linear:default` refreshes to `400 … "Refresh token revoked"`, and `config.yaml` already wires `linear.apiKey: ${LINEAR_API_KEY}` plus a `linear.teamId`. **So putting a valid key in `.env` would still not have worked.**

(Separately worth recording: the key in this machine's `.env` returns 401 while the one deployed in the VELA container returns 200 — two different keys, only the deployed one live. That makes AGT-4028 and AGT-4075's "the injected key is dead" claims stale as of today.)

## Change

- Rejected OAuth → fall through to `linearApiKey` when configured.
- Working OAuth still wins; the apiKey is a fallback, not a peer, and is not initialised when OAuth succeeded.
- Nothing to fall back to → rethrow the OAuth error, so AGT-4148's `credential-rejected` / `transient` classification survives instead of flattening to `unconfigured`.
- The attempt is tracked in a local flag rather than re-querying `isLinearInitialized()`, keeping that at two calls (entry guard + confirmation). That is why the existing `ensureTaskSource` tests hold unchanged — the first draft re-queried and broke two of them.

## Verification

- `src/cli` + `src/auth`: 45 files, **778 tests pass**; existing `ensureTaskSource` tests unmodified.
- 3 new tests: fallback on rejection, `credential-rejected` preserved with no apiKey, and apiKey untouched when OAuth works.
- **Mutation-checked**: restoring the shadowing behaviour turns 4 tests red.
- One new test queues exactly one `mockReturnValueOnce` because the rethrow path exits before the confirmation check — a leftover leaked into the next test and broke it. Noted in a comment.
- typecheck, lint (0/0), build pass. `openswarm review`: **APPROVE**.

Closes AGT-4152.