### PR TITLE
feat(cli): reach the coordination plane from the terminal

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -730,9 +730,13 @@ program
   .argument('<issueId>', 'Linear issue id or identifier (e.g. AGT-123)')
   .argument('[files...]', 'Local file path(s) to upload (optional when -m is given)')
   .option('-m, --message <text>', 'Message to send with the file(s)')
-  .action(async (issueId: string, files: string[], opts: { message?: string }) => {
+  .option('-c, --correlation <id>', 'Answer one exchange by the correlationId `openswarm board` prints')
+  .action(async (issueId: string, files: string[], opts: { message?: string; correlation?: string }) => {
     const { runAttachCommand } = await import('./cli/attachHandler.js');
-    process.exitCode = await runAttachCommand(issueId, files, opts);
+    process.exitCode = await runAttachCommand(issueId, files, {
+      message: opts.message,
+      correlationId: opts.correlation,
+    });
   });
 
 // openswarm board / openswarm threads — the read half of the coordination plane

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -726,13 +726,40 @@ program
 
 program
   .command('attach')
-  .description("Upload file(s) to a task's coordination inbox and notify its agent")
+  .description("Send a message and/or file(s) to a task's coordination inbox and notify its agent")
   .argument('<issueId>', 'Linear issue id or identifier (e.g. AGT-123)')
-  .argument('<files...>', 'Local file path(s) to upload')
+  .argument('[files...]', 'Local file path(s) to upload (optional when -m is given)')
   .option('-m, --message <text>', 'Message to send with the file(s)')
   .action(async (issueId: string, files: string[], opts: { message?: string }) => {
     const { runAttachCommand } = await import('./cli/attachHandler.js');
     process.exitCode = await runAttachCommand(issueId, files, opts);
+  });
+
+// openswarm board / openswarm threads — the read half of the coordination plane
+
+program
+  .command('board')
+  .description('Show the coordination board: questions waiting on you, then recent activity')
+  .option('-p, --port <port>', 'Daemon port', parseTcpPortOption, 3847)
+  .option('-r, --repository <path>', 'Limit to one repository')
+  .option('-n, --limit <count>', 'Recent events to show', (v: string) => Number.parseInt(v, 10), 20)
+  .option('--json', "Print the daemon's raw payload")
+  .action(async (opts: { port: number; repository?: string; limit: number; json?: boolean }) => {
+    const { runBoardCommand } = await import('./cli/coordinationHandler.js');
+    process.exitCode = await runBoardCommand(opts);
+  });
+
+program
+  .command('threads')
+  .description('List coordination threads for a repository (defaults to the working directory)')
+  .option('-p, --port <port>', 'Daemon port', parseTcpPortOption, 3847)
+  .option('-r, --repository <path>', 'Repository path (default: cwd)')
+  .option('-s, --status <status>', 'Filter by status: open | resolved')
+  .option('-n, --limit <count>', 'Maximum threads to list', (v: string) => Number.parseInt(v, 10))
+  .option('--json', "Print the daemon's raw payload")
+  .action(async (opts: { port: number; repository?: string; status?: string; limit?: number; json?: boolean }) => {
+    const { runThreadsCommand } = await import('./cli/coordinationHandler.js');
+    process.exitCode = await runThreadsCommand(opts);
   });
 
 // openswarm dash

--- a/src/cli/attachHandler.test.ts
+++ b/src/cli/attachHandler.test.ts
@@ -360,3 +360,63 @@ describe('runAttachCommand without files', () => {
     consoleError.mockRestore();
   });
 });
+
+// ---- Addressing one exchange -------------------------------------------------
+// `openswarm board` prints a correlationId per exchange. Without a way to hand
+// one back, the board advertised an address the answer command could not take
+// and the reply rode whichever exchange was newest.
+
+describe('runAttachCommand --correlation', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    readFileSyncMock.mockReset();
+    deps.ensureTaskSource.mockClear();
+    deps.getIssue.mockClear();
+  });
+
+  it('answers the named exchange, not the newest one', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    fetchMock
+      .mockResolvedValueOnce(statsOk())
+      .mockResolvedValueOnce(historyOk([
+        event({ id: 'q', seq: 5, correlationId: 'hq-older', actor: 'sable', actorRole: 'worker' }),
+        event({ id: 'l', seq: 6, correlationId: 'c-newer', actor: 'rowan', actorRole: 'worker' }),
+      ]))
+      .mockResolvedValueOnce(messageOk());
+
+    const code = await runAttachCommand('AGT-123', [], { message: 'the older one', correlationId: 'hq-older', deps });
+
+    expect(code).toBe(0);
+    const body = JSON.parse(fetchMock.mock.calls[2][1].body as string);
+    expect(body.correlationId).toBe('hq-older');
+    expect(body.recipient).toBe('sable');
+  });
+
+  it('refuses an unknown correlationId instead of silently answering another', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchMock
+      .mockResolvedValueOnce(statsOk())
+      .mockResolvedValueOnce(historyOk([event({ actor: 'sable', actorRole: 'worker' })]));
+
+    const code = await runAttachCommand('AGT-123', [], { message: 'hi', correlationId: 'hq-nope', deps });
+
+    expect(code).toBe(1);
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('hq-nope'));
+    // No message POST — the third call never happens.
+    expect(fetchMock.mock.calls).toHaveLength(2);
+    consoleError.mockRestore();
+  });
+
+  it('still auto-selects the parked question when no id is given', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    fetchMock
+      .mockResolvedValueOnce(statsOk())
+      .mockResolvedValueOnce(historyOk([event({ seq: 5, correlationId: 'hq-1', actor: 'sable', actorRole: 'worker' })]))
+      .mockResolvedValueOnce(messageOk());
+
+    const code = await runAttachCommand('AGT-123', [], { message: 'hi', deps });
+
+    expect(code).toBe(0);
+    expect(JSON.parse(fetchMock.mock.calls[2][1].body as string).correlationId).toBe('hq-1');
+  });
+});

--- a/src/cli/attachHandler.test.ts
+++ b/src/cli/attachHandler.test.ts
@@ -303,3 +303,60 @@ describe('runAttachCommand', () => {
     consoleError.mockRestore();
   });
 });
+
+// ---- Message-only ------------------------------------------------------------
+// The dashboard's chat box can send a bare message, and an operator answering a
+// parked question usually has nothing to upload. `attach` required a file until
+// this change, so the CLI could not answer a question at all.
+
+describe('runAttachCommand without files', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    readFileSyncMock.mockReset();
+    deps.ensureTaskSource.mockClear();
+    deps.getIssue.mockClear();
+  });
+
+  it('delivers a message with no upload and no attachment note', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    fetchMock
+      .mockResolvedValueOnce(statsOk())
+      .mockResolvedValueOnce(historyOk([event({ actor: 'sable', actorRole: 'worker', actorName: 'Sable' })]))
+      .mockResolvedValueOnce(messageOk());
+
+    const code = await runAttachCommand('AGT-123', [], { message: 'use the staging bucket', deps });
+
+    expect(code).toBe(0);
+    // Health probe, history, message — no attachment POST in between.
+    expect(fetchMock.mock.calls).toHaveLength(3);
+    expect(readFileSyncMock).not.toHaveBeenCalled();
+    const [messageUrl, messageInit] = fetchMock.mock.calls[2];
+    expect(messageUrl).toContain('/api/coordination/message');
+    const sentBody = JSON.parse(messageInit.body as string);
+    expect(sentBody.recipient).toBe('sable');
+    expect(sentBody.text).toBe('use the staging bucket');
+    expect(sentBody.text).not.toContain('Attached files');
+    consoleLog.mockRestore();
+  });
+
+  it('refuses a call with neither a file nor a message before touching the daemon', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const code = await runAttachCommand('AGT-123', [], { deps });
+
+    expect(code).toBe(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('or a message with -m'));
+    consoleError.mockRestore();
+  });
+
+  it('treats a whitespace-only message as no message', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const code = await runAttachCommand('AGT-123', [], { message: '   ', deps });
+
+    expect(code).toBe(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/src/cli/attachHandler.test.ts
+++ b/src/cli/attachHandler.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CoordinationEvent } from '../coordination/coordinationStore.js';
 import {
   latestAddressable,
@@ -418,5 +418,47 @@ describe('runAttachCommand --correlation', () => {
 
     expect(code).toBe(0);
     expect(JSON.parse(fetchMock.mock.calls[2][1].body as string).correlationId).toBe('hq-1');
+  });
+});
+
+describe('runAttachCommand endpoint misconfiguration', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    deps.ensureTaskSource.mockClear();
+    deps.getIssue.mockClear();
+  });
+
+  afterEach(() => {
+    delete process.env.OPENSWARM_DAEMON_HOST;
+    delete process.env.OPENSWARM_DAEMON_TOKEN;
+  });
+
+  // "start it first" is unactionable when the daemon is already running and
+  // the host is simply malformed. Third instance of this swallow across the
+  // CLI; the URL is now resolved before the catch at every entry point.
+  it('reports a malformed host instead of telling the operator to start a daemon', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.OPENSWARM_DAEMON_HOST = 'http://vela';
+
+    const code = await runAttachCommand('AGT-123', [], { message: 'hi', deps });
+
+    expect(code).toBe(1);
+    const text = consoleError.mock.calls.flat().join('\n');
+    expect(text).toContain('is not a bare host');
+    expect(text).not.toContain('openswarm start');
+    expect(fetchMock).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it('reports a refused plaintext token the same way', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.OPENSWARM_DAEMON_HOST = 'vela';
+    process.env.OPENSWARM_DAEMON_TOKEN = 's3cret';
+
+    const code = await runAttachCommand('AGT-123', [], { message: 'hi', deps });
+
+    expect(code).toBe(1);
+    expect(consoleError.mock.calls.flat().join('\n')).toContain('Refusing to send');
+    consoleError.mockRestore();
   });
 });

--- a/src/cli/attachHandler.ts
+++ b/src/cli/attachHandler.ts
@@ -2,8 +2,8 @@
 // OpenSwarm - `openswarm attach <issueId> <files...>`
 // ============================================
 //
-// Upload file(s) to a running task's coordination inbox and notify its
-// agent — the CLI's counterpart to the dashboard's /chat attach button
+// Send a message and/or file(s) to a running task's coordination inbox and
+// notify its agent — the CLI's counterpart to the dashboard's /chat attach button
 // (AGT-4031, web/static/js/chatView.mjs). Neither
 // POST /api/coordination/attachment nor POST /api/coordination/message had
 // a CLI consumer before this (AGT-4058).
@@ -12,10 +12,8 @@ import { readFileSync } from 'node:fs';
 import { basename } from 'node:path';
 import type { CoordinationEvent } from '../coordination/coordinationStore.js';
 import { DAEMON_PORT } from './daemon.js';
+import { daemonBaseUrl as baseUrl } from './daemonEndpoint.js';
 
-function baseUrl(port: number): string {
-  return `http://127.0.0.1:${port}`;
-}
 
 export interface ResolvedIssue {
   id: string;
@@ -216,8 +214,11 @@ export async function runAttachCommand(
 ): Promise<number> {
   const port = opts.port ?? DAEMON_PORT;
 
-  if (filepaths.length === 0) {
-    console.error('Pass at least one file to attach.');
+  // Files are optional: the dashboard's chat box can send a bare message, and
+  // an operator answering a parked question usually has nothing to upload.
+  const message = opts.message?.trim() ?? '';
+  if (filepaths.length === 0 && !message) {
+    console.error('Pass at least one file to attach, or a message with -m.');
     return 1;
   }
 
@@ -260,14 +261,16 @@ export async function runAttachCommand(
       console.error(`Failed to upload ${filepath}: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
-  if (uploaded.length === 0) {
+  // Every requested upload failing is still a failure; asking for none is not.
+  if (filepaths.length > 0 && uploaded.length === 0) {
     console.error('No files uploaded — nothing to notify the agent about.');
     return 1;
   }
 
-  const text = opts.message?.trim()
-    ? `${opts.message.trim()}\n\nAttached files (read them at these paths):\n${uploaded.map((u) => u.path).join('\n')}`
-    : `Attached files (read them at these paths):\n${uploaded.map((u) => u.path).join('\n')}`;
+  const attachmentNote = uploaded.length > 0
+    ? `Attached files (read them at these paths):\n${uploaded.map((u) => u.path).join('\n')}`
+    : '';
+  const text = [message, attachmentNote].filter(Boolean).join('\n\n');
 
   try {
     await postMessage(exchange, target.actor, text, port);

--- a/src/cli/attachHandler.ts
+++ b/src/cli/attachHandler.ts
@@ -203,6 +203,8 @@ async function isDaemonReachable(port: number): Promise<boolean> {
 
 export interface RunAttachOptions {
   message?: string;
+  /** Address one exchange by the id `openswarm board` prints for it. */
+  correlationId?: string;
   port?: number;
   deps?: ResolveIssueDeps;
 }
@@ -242,13 +244,29 @@ export async function runAttachCommand(
     return 1;
   }
 
-  const target = latestAddressable(events);
+  // `openswarm board` prints a correlationId per exchange, so the operator has
+  // to be able to hand one back — otherwise the board advertises an address
+  // the answer command cannot take, and the reply silently rides whichever
+  // exchange happened to be newest.
+  const wanted = opts.correlationId?.trim();
+  const chosen = wanted ? events.filter((e) => e.correlationId === wanted).at(-1) : undefined;
+  if (wanted && !chosen) {
+    console.error(`No exchange with correlationId ${wanted} on ${issue.identifier}. `
+      + 'Run `openswarm board` for the current list.');
+    return 1;
+  }
+
+  const target = chosen ?? latestAddressable(events);
   if (!target) {
     console.error(`No agent is addressable yet for ${issue.identifier} — it hasn't spoken on the coordination board.`);
     return 1;
   }
-  const question = openQuestionFor(events, target.actor, { repository: target.repository, taskId: target.taskId });
-  const exchange = question ?? target;
+  // An explicit correlationId is the operator naming the exchange; only fall
+  // back to "whichever question this actor is parked on" when they did not.
+  const question = chosen
+    ? undefined
+    : openQuestionFor(events, target.actor, { repository: target.repository, taskId: target.taskId });
+  const exchange = chosen ?? question ?? target;
 
   const uploaded: UploadedAttachment[] = [];
   let hadFailure = false;

--- a/src/cli/attachHandler.ts
+++ b/src/cli/attachHandler.ts
@@ -12,7 +12,7 @@ import { readFileSync } from 'node:fs';
 import { basename } from 'node:path';
 import type { CoordinationEvent } from '../coordination/coordinationStore.js';
 import { DAEMON_PORT } from './daemon.js';
-import { daemonBaseUrl as baseUrl } from './daemonEndpoint.js';
+import { daemonAuthHeaders, daemonBaseUrl as baseUrl } from './daemonEndpoint.js';
 
 
 export interface ResolvedIssue {
@@ -120,7 +120,7 @@ const UPLOAD_TIMEOUT_MS = 60_000;
 async function fetchTaskHistory(taskId: string, port: number): Promise<CoordinationEvent[]> {
   const res = await fetch(
     `${baseUrl(port)}/api/coordination/history?taskId=${encodeURIComponent(taskId)}&limit=200`,
-    { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) },
+    { headers: daemonAuthHeaders(), signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) },
   );
   if (!res.ok) throw new Error(`Could not read the coordination board (HTTP ${res.status})`);
   const body = await res.json() as { events?: CoordinationEvent[] };
@@ -142,6 +142,7 @@ async function uploadAttachment(taskId: string, filepath: string, port: number):
   const query = `?taskId=${encodeURIComponent(taskId)}&filename=${encodeURIComponent(filename)}`;
   const res = await fetch(`${baseUrl(port)}/api/coordination/attachment${query}`, {
     method: 'POST',
+    headers: daemonAuthHeaders(),
     body: bytes,
     signal: AbortSignal.timeout(UPLOAD_TIMEOUT_MS),
   });
@@ -168,7 +169,7 @@ async function postMessage(
 ): Promise<void> {
   const res = await fetch(`${baseUrl(port)}/api/coordination/message`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...daemonAuthHeaders() },
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     body: JSON.stringify({
       correlationId: exchange.correlationId,
@@ -193,7 +194,7 @@ async function postMessage(
 
 async function isDaemonReachable(port: number): Promise<boolean> {
   try {
-    const res = await fetch(`${baseUrl(port)}/api/stats`, { signal: AbortSignal.timeout(1500) });
+    const res = await fetch(`${baseUrl(port)}/api/stats`, { headers: daemonAuthHeaders(), signal: AbortSignal.timeout(1500) });
     return res.ok;
   } catch {
     return false;

--- a/src/cli/attachHandler.ts
+++ b/src/cli/attachHandler.ts
@@ -193,8 +193,14 @@ async function postMessage(
 }
 
 async function isDaemonReachable(port: number): Promise<boolean> {
+  // Outside the try: daemonBaseUrl throws for a malformed host or a token it
+  // will not send in the clear, and returning false for those tells the
+  // operator to start a daemon that is already running. Third instance of this
+  // swallow (providerCommand had two); the URL is now resolved before the
+  // catch at every entry point.
+  const url = `${baseUrl(port)}/api/stats`;
   try {
-    const res = await fetch(`${baseUrl(port)}/api/stats`, { headers: daemonAuthHeaders(), signal: AbortSignal.timeout(1500) });
+    const res = await fetch(url, { headers: daemonAuthHeaders(), signal: AbortSignal.timeout(1500) });
     return res.ok;
   } catch {
     return false;
@@ -225,7 +231,15 @@ export async function runAttachCommand(
     return 1;
   }
 
-  if (!(await isDaemonReachable(port))) {
+  let reachable: boolean;
+  try {
+    reachable = await isDaemonReachable(port);
+  } catch (error) {
+    // A configuration or safety refusal, not an absent daemon.
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+  if (!reachable) {
     console.error('OpenSwarm daemon is not reachable — start it first (`openswarm start`).');
     return 1;
   }

--- a/src/cli/coordinationHandler.test.ts
+++ b/src/cli/coordinationHandler.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CoordinationEvent } from '../coordination/coordinationStore.js';
 import type { CoordinationThread } from '../coordination/coordinationThreads.js';
-import { DAEMON_HOST_ENV } from './daemonEndpoint.js';
+import { DAEMON_HOST_ENV, DAEMON_TOKEN_ENV } from './daemonEndpoint.js';
 import { formatBoard, formatThreads, runBoardCommand, runThreadsCommand } from './coordinationHandler.js';
 
 function event(overrides: Partial<CoordinationEvent> = {}): CoordinationEvent {
@@ -45,6 +45,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks();
   delete process.env[DAEMON_HOST_ENV];
+  delete process.env[DAEMON_TOKEN_ENV];
 });
 
 describe('formatBoard', () => {
@@ -144,6 +145,24 @@ describe('runBoardCommand', () => {
 
     expect(fetchImpl.mock.calls[0][0]).toBe('http://vela:3847/api/coordination');
     expect(logs[0]).toBe('(daemon: vela)');
+  });
+
+  it('presents the daemon token so a secured daemon answers at all', async () => {
+    process.env[DAEMON_TOKEN_ENV] = 's3cret';
+    const fetchImpl = vi.fn().mockResolvedValue(ok({ events: [], pending: [], lastSeq: 0 }));
+
+    await runBoardCommand({ fetchImpl: fetchImpl as never });
+
+    expect(fetchImpl.mock.calls[0][1].headers).toEqual({ 'x-openswarm-token': 's3cret' });
+  });
+
+  it.each([401, 403])('names a missing token on HTTP %s instead of blaming the board', async (status) => {
+    const fetchImpl = vi.fn().mockResolvedValue(err(status, ''));
+
+    const code = await runBoardCommand({ fetchImpl: fetchImpl as never });
+
+    expect(code).toBe(1);
+    expect(errors.join('\n')).toContain(DAEMON_TOKEN_ENV);
   });
 
   it('surfaces the daemon error text rather than a bare status', async () => {

--- a/src/cli/coordinationHandler.test.ts
+++ b/src/cli/coordinationHandler.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CoordinationEvent } from '../coordination/coordinationStore.js';
 import type { CoordinationThread } from '../coordination/coordinationThreads.js';
-import { DAEMON_HOST_ENV, DAEMON_TOKEN_ENV } from './daemonEndpoint.js';
+import { DAEMON_HOST_ENV, DAEMON_SCHEME_ENV, DAEMON_TOKEN_ENV } from './daemonEndpoint.js';
 import { formatBoard, formatThreads, runBoardCommand, runThreadsCommand } from './coordinationHandler.js';
 
 function event(overrides: Partial<CoordinationEvent> = {}): CoordinationEvent {
@@ -46,6 +46,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   delete process.env[DAEMON_HOST_ENV];
   delete process.env[DAEMON_TOKEN_ENV];
+  delete process.env[DAEMON_SCHEME_ENV];
 });
 
 describe('formatBoard', () => {
@@ -144,7 +145,20 @@ describe('runBoardCommand', () => {
     await runBoardCommand({ fetchImpl: fetchImpl as never });
 
     expect(fetchImpl.mock.calls[0][0]).toBe('http://vela:3847/api/coordination');
-    expect(logs[0]).toBe('(daemon: vela)');
+    // The daemon serves plain http, so name the transport rather than let a
+    // remote read look the same as a local one.
+    expect(logs[0]).toBe('(daemon: vela, plaintext http)');
+  });
+
+  it('says https when a TLS proxy fronts the daemon', async () => {
+    process.env[DAEMON_HOST_ENV] = 'vela';
+    process.env[DAEMON_SCHEME_ENV] = 'https';
+    const fetchImpl = vi.fn().mockResolvedValue(ok({ events: [], pending: [], lastSeq: 0 }));
+
+    await runBoardCommand({ fetchImpl: fetchImpl as never });
+
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://vela:3847/api/coordination');
+    expect(logs[0]).toBe('(daemon: vela, https)');
   });
 
   it('presents the daemon token so a secured daemon answers at all', async () => {

--- a/src/cli/coordinationHandler.test.ts
+++ b/src/cli/coordinationHandler.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CoordinationEvent } from '../coordination/coordinationStore.js';
+import type { CoordinationThread } from '../coordination/coordinationThreads.js';
+import { DAEMON_HOST_ENV } from './daemonEndpoint.js';
+import { formatBoard, formatThreads, runBoardCommand, runThreadsCommand } from './coordinationHandler.js';
+
+function event(overrides: Partial<CoordinationEvent> = {}): CoordinationEvent {
+  return {
+    id: 'e1', seq: 1, timestamp: 1_700_000_000_000, repository: '/repo', taskId: 'uuid-1',
+    taskLabel: 'AGT-123', actor: 'sable', actorName: 'Sable', actorRole: 'worker',
+    kind: 'advice-request', status: 'open', correlationId: 'hq-1', summary: 'which bucket?',
+    fingerprint: 'fp1',
+    ...overrides,
+  };
+}
+
+function thread(overrides: Partial<CoordinationThread> = {}): CoordinationThread {
+  return {
+    id: 'th-1', repository: '/repo', subject: 'Rate limit strategy', status: 'open', version: 1,
+    createdByActor: 'sable', createdByTaskId: 'uuid-1', relatedTaskIds: ['uuid-1'],
+    relatedFiles: [], relatedPullRequests: [], createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_500_000, messageCount: 4, participantCount: 2,
+    ...overrides,
+  };
+}
+
+function ok(body: unknown) {
+  return { ok: true, json: async () => body } as unknown as Response;
+}
+
+function err(status: number, body: string) {
+  return { ok: false, status, text: async () => body } as unknown as Response;
+}
+
+let logs: string[];
+let errors: string[];
+
+beforeEach(() => {
+  logs = [];
+  errors = [];
+  vi.spyOn(console, 'log').mockImplementation((...args) => { logs.push(args.join(' ')); });
+  vi.spyOn(console, 'error').mockImplementation((...args) => { errors.push(args.join(' ')); });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env[DAEMON_HOST_ENV];
+});
+
+describe('formatBoard', () => {
+  it('leads with the questions waiting on an operator', () => {
+    const out = formatBoard({ events: [event()], pending: [event()], lastSeq: 1 }, 20);
+    expect(out.split('\n')[0]).toBe('Waiting on an operator (1):');
+    // The correlationId is why an operator reads this at all — it is what
+    // `attach` needs to answer the right exchange.
+    expect(out).toContain('correlationId: hq-1');
+    expect(out).toContain('openswarm attach');
+  });
+
+  it('says so plainly when nothing is parked', () => {
+    const out = formatBoard({ events: [], pending: [], lastSeq: 0 }, 20);
+    expect(out).toContain('Waiting on an operator: none.');
+    expect(out).toContain('No board activity.');
+    expect(out).not.toContain('openswarm attach');
+  });
+
+  it('shows the newest events when the board is longer than the limit', () => {
+    const events = Array.from({ length: 5 }, (_, i) => event({ id: `e${i}`, seq: i, summary: `s${i}` }));
+    const out = formatBoard({ events, pending: [], lastSeq: 5 }, 2);
+    expect(out).toContain('Recent board activity (2 of 5)');
+    expect(out).toContain('s4');
+    expect(out).not.toContain('s0');
+  });
+
+  it('survives a payload missing its arrays', () => {
+    const out = formatBoard({ lastSeq: 0 } as never, 20);
+    expect(out).toContain('Waiting on an operator: none.');
+  });
+
+  // `-n` reaches here straight from Number.parseInt, so NaN and negatives are
+  // reachable inputs, and `slice(-limit)` mishandles both: NaN returns the
+  // whole board, a negative count slices from the wrong end.
+  it.each([Number.NaN, -5, 0])('clamps a nonsense limit (%s) instead of slicing wrongly', (limit) => {
+    const events = Array.from({ length: 5 }, (_, i) => event({ id: `e${i}`, seq: i, summary: `s${i}` }));
+    const out = formatBoard({ events, pending: [], lastSeq: 5 }, limit as number);
+    // Whatever it shows, it must be a bounded tail of the board, never the
+    // head and never silently everything for a limit the operator set low.
+    expect(out).toContain('s4');
+    expect(out).toMatch(/Recent board activity \(\d+ of 5\)/);
+    const shown = Number(/Recent board activity \((\d+) of 5\)/.exec(out)?.[1]);
+    expect(shown).toBeGreaterThanOrEqual(1);
+    expect(shown).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('formatThreads', () => {
+  it('lists status, id and message count', () => {
+    const out = formatThreads([thread()], '/repo');
+    expect(out).toContain('[open] Rate limit strategy');
+    expect(out).toContain('id: th-1');
+    expect(out).toContain('messages: 4');
+  });
+
+  it('reports an empty repository without inventing rows', () => {
+    expect(formatThreads([], '/repo')).toBe('No coordination threads for /repo.');
+  });
+});
+
+describe('runBoardCommand', () => {
+  it('reads the board and prints it', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(ok({ events: [event()], pending: [event()], lastSeq: 1 }));
+
+    const code = await runBoardCommand({ fetchImpl: fetchImpl as never });
+
+    expect(code).toBe(0);
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe('http://127.0.0.1:3847/api/coordination');
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect(logs.join('\n')).toContain('Waiting on an operator (1):');
+  });
+
+  it('scopes to a repository when asked', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(ok({ events: [], pending: [], lastSeq: 0 }));
+
+    await runBoardCommand({ repository: '/work/OpenSwarm', fetchImpl: fetchImpl as never });
+
+    expect(fetchImpl.mock.calls[0][0]).toContain('?repository=%2Fwork%2FOpenSwarm');
+  });
+
+  it('prints the raw payload under --json', async () => {
+    const payload = { events: [], pending: [], lastSeq: 7 };
+    const fetchImpl = vi.fn().mockResolvedValue(ok(payload));
+
+    await runBoardCommand({ json: true, fetchImpl: fetchImpl as never });
+
+    expect(JSON.parse(logs.join('\n'))).toEqual(payload);
+  });
+
+  it('names the remote daemon so a remote read is not mistaken for a local one', async () => {
+    process.env[DAEMON_HOST_ENV] = 'vela';
+    const fetchImpl = vi.fn().mockResolvedValue(ok({ events: [], pending: [], lastSeq: 0 }));
+
+    await runBoardCommand({ fetchImpl: fetchImpl as never });
+
+    expect(fetchImpl.mock.calls[0][0]).toBe('http://vela:3847/api/coordination');
+    expect(logs[0]).toBe('(daemon: vela)');
+  });
+
+  it('surfaces the daemon error text rather than a bare status', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(err(500, JSON.stringify({ error: 'board is locked' })));
+
+    const code = await runBoardCommand({ fetchImpl: fetchImpl as never });
+
+    expect(code).toBe(1);
+    expect(errors.join('\n')).toContain('board is locked');
+  });
+
+  it('tells a local operator how to start the daemon it could not reach', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    const code = await runBoardCommand({ fetchImpl: fetchImpl as never });
+
+    expect(code).toBe(1);
+    const text = errors.join('\n');
+    expect(text).toContain('openswarm start');
+    // The underlying cause still has to survive, or a DNS failure and a
+    // stopped daemon become the same message.
+    expect(text).toContain('ECONNREFUSED');
+  });
+
+  it('names the remote host instead of suggesting a local start', async () => {
+    process.env[DAEMON_HOST_ENV] = 'vela';
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('getaddrinfo ENOTFOUND vela'));
+
+    const code = await runBoardCommand({ fetchImpl: fetchImpl as never });
+
+    expect(code).toBe(1);
+    const text = errors.join('\n');
+    expect(text).toContain('vela:3847');
+    expect(text).not.toContain('openswarm start');
+  });
+});
+
+describe('runThreadsCommand', () => {
+  it('defaults the repository to the working directory the route requires', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(ok({ items: [thread()] }));
+
+    const code = await runThreadsCommand({ fetchImpl: fetchImpl as never });
+
+    expect(code).toBe(0);
+    expect(fetchImpl.mock.calls[0][0]).toContain(`repository=${encodeURIComponent(process.cwd())}`);
+    expect(logs.join('\n')).toContain('Rate limit strategy');
+  });
+
+  it('passes status and limit through', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(ok({ items: [] }));
+
+    await runThreadsCommand({ repository: '/repo', status: 'open', limit: 5, fetchImpl: fetchImpl as never });
+
+    const url = fetchImpl.mock.calls[0][0] as string;
+    expect(url).toContain('status=open');
+    expect(url).toContain('limit=5');
+  });
+
+  it('never puts an unparseable limit on the wire', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(ok({ items: [] }));
+
+    await runThreadsCommand({ repository: '/repo', limit: Number.NaN, fetchImpl: fetchImpl as never });
+
+    expect(fetchImpl.mock.calls[0][0]).not.toContain('limit=');
+  });
+
+  it('handles a page with no items key', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(ok({}));
+
+    const code = await runThreadsCommand({ repository: '/repo', fetchImpl: fetchImpl as never });
+
+    expect(code).toBe(0);
+    expect(logs.join('\n')).toContain('No coordination threads for /repo.');
+  });
+
+  it('reports the route error when repository is rejected', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(err(400, JSON.stringify({ error: 'repository query parameter is required' })));
+
+    const code = await runThreadsCommand({ repository: '/repo', fetchImpl: fetchImpl as never });
+
+    expect(code).toBe(1);
+    expect(errors.join('\n')).toContain('repository query parameter is required');
+  });
+});

--- a/src/cli/coordinationHandler.ts
+++ b/src/cli/coordinationHandler.ts
@@ -18,7 +18,7 @@
 import type { CoordinationEvent } from '../coordination/coordinationStore.js';
 import type { CoordinationThread } from '../coordination/coordinationThreads.js';
 import { DAEMON_PORT } from './daemon.js';
-import { daemonBaseUrl, isRemoteDaemon, daemonHost } from './daemonEndpoint.js';
+import { DAEMON_TOKEN_ENV, daemonAuthHeaders, daemonBaseUrl, daemonHost, isRemoteDaemon } from './daemonEndpoint.js';
 
 /** Matches attachHandler.ts: a daemon that answers /api/stats can still stall. */
 const REQUEST_TIMEOUT_MS = 10_000;
@@ -56,7 +56,7 @@ async function getJson<T>(path: string, port: number, doFetch: typeof fetch, fal
   const url = `${daemonBaseUrl(port)}${path}`;
   let res: Response;
   try {
-    res = await doFetch(url, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+    res = await doFetch(url, { headers: daemonAuthHeaders(), signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
   } catch (cause) {
     // `fetch failed` on its own tells an operator nothing about which daemon
     // was tried or what to do next, and a wrong OPENSWARM_DAEMON_HOST looks
@@ -67,6 +67,10 @@ async function getJson<T>(path: string, port: number, doFetch: typeof fetch, fal
         ? `Check that it is running there and that ${port} is reachable.`
         : 'Start it with `openswarm start`, or point at another host with OPENSWARM_DAEMON_HOST.')
       + ` (${cause instanceof Error ? cause.message : String(cause)})`);
+  }
+  if (res.status === 401 || res.status === 403) {
+    throw new Error(`The daemon at ${daemonHost()} rejected this request (HTTP ${res.status}). `
+      + `Set ${DAEMON_TOKEN_ENV} to its OPENSWARM_WEB_TOKEN.`);
   }
   if (!res.ok) throw new Error(await readError(res, fallback));
   return await res.json() as T;

--- a/src/cli/coordinationHandler.ts
+++ b/src/cli/coordinationHandler.ts
@@ -1,0 +1,187 @@
+// ============================================
+// OpenSwarm - `openswarm board` / `openswarm threads`
+// ============================================
+//
+// The read half of the coordination plane. `attach` (AGT-4058) gave the CLI a
+// way to speak to a running agent, but no way to see who was waiting to be
+// spoken to — the operator had to open the dashboard to find the question and
+// then come back to the terminal to answer it. These two commands cover the
+// GETs behind web/static/{orchestration,chat,threads}.html:
+//
+//   GET /api/coordination          -> board snapshot (pending questions first)
+//   GET /api/coordination/threads  -> thread list
+//
+// Rendering is deliberately thin. `--json` hands back the daemon's own payload
+// so a script can pipe it, and the human format only promises to make the
+// parked questions findable.
+
+import type { CoordinationEvent } from '../coordination/coordinationStore.js';
+import type { CoordinationThread } from '../coordination/coordinationThreads.js';
+import { DAEMON_PORT } from './daemon.js';
+import { daemonBaseUrl, isRemoteDaemon, daemonHost } from './daemonEndpoint.js';
+
+/** Matches attachHandler.ts: a daemon that answers /api/stats can still stall. */
+const REQUEST_TIMEOUT_MS = 10_000;
+
+export interface BoardSnapshot {
+  events: CoordinationEvent[];
+  pending: CoordinationEvent[];
+  lastSeq: number;
+  traceSize?: number;
+}
+
+export interface CoordinationCommandOptions {
+  port?: number;
+  repository?: string;
+  json?: boolean;
+  limit?: number;
+  status?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/** Shared error shape: the daemon answers 4xx with `{ error }`, plain text otherwise. */
+async function readError(res: Response, fallback: string): Promise<string> {
+  const detail = await res.text().catch(() => '');
+  if (!detail) return `${fallback} (HTTP ${res.status})`;
+  try {
+    const parsed = JSON.parse(detail) as { error?: string };
+    if (parsed.error) return parsed.error;
+  } catch {
+    return detail.slice(0, 200);
+  }
+  return `${fallback} (HTTP ${res.status})`;
+}
+
+async function getJson<T>(path: string, port: number, doFetch: typeof fetch, fallback: string): Promise<T> {
+  const url = `${daemonBaseUrl(port)}${path}`;
+  let res: Response;
+  try {
+    res = await doFetch(url, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+  } catch (cause) {
+    // `fetch failed` on its own tells an operator nothing about which daemon
+    // was tried or what to do next, and a wrong OPENSWARM_DAEMON_HOST looks
+    // identical to a stopped daemon from here.
+    const where = isRemoteDaemon() ? `${daemonHost()}:${port}` : `port ${port}`;
+    throw new Error(`Could not reach the OpenSwarm daemon at ${where}. `
+      + (isRemoteDaemon()
+        ? `Check that it is running there and that ${port} is reachable.`
+        : 'Start it with `openswarm start`, or point at another host with OPENSWARM_DAEMON_HOST.')
+      + ` (${cause instanceof Error ? cause.message : String(cause)})`);
+  }
+  if (!res.ok) throw new Error(await readError(res, fallback));
+  return await res.json() as T;
+}
+
+// ---- Formatting -------------------------------------------------------------
+
+function clock(timestamp: number): string {
+  return new Date(timestamp).toISOString().replace('T', ' ').slice(0, 19);
+}
+
+/** One line per event. The correlationId is the point: `attach` needs it. */
+function formatEvent(event: CoordinationEvent): string {
+  const who = event.actorName ?? event.actor;
+  const task = event.taskLabel ?? event.taskId;
+  const to = event.recipientName ?? event.recipient;
+  return `  ${clock(event.timestamp)}  ${task}  ${who}${to ? ` -> ${to}` : ''}\n`
+    + `    ${event.kind}/${event.status}  ${event.summary}\n`
+    + `    correlationId: ${event.correlationId}`;
+}
+
+/**
+ * `--limit` arrives from `Number.parseInt`, so it can be NaN or negative, and
+ * `slice(-limit)` silently does the wrong thing with both: NaN returns the
+ * whole board and a negative count slices from the wrong end.
+ */
+function sliceCount(limit: number, fallback = 20): number {
+  if (!Number.isFinite(limit)) return fallback;
+  return Math.max(1, Math.trunc(limit));
+}
+
+export function formatBoard(snapshot: BoardSnapshot, limit: number): string {
+  const count = sliceCount(limit);
+  const lines: string[] = [];
+  const pending = snapshot.pending ?? [];
+
+  lines.push(pending.length
+    ? `Waiting on an operator (${pending.length}):`
+    : 'Waiting on an operator: none.');
+  for (const event of pending) lines.push(formatEvent(event));
+
+  const events = snapshot.events ?? [];
+  const recent = events.slice(-count);
+  lines.push('');
+  lines.push(recent.length ? `Recent board activity (${recent.length} of ${events.length}):` : 'No board activity.');
+  for (const event of recent) lines.push(formatEvent(event));
+
+  if (pending.length) {
+    lines.push('');
+    lines.push('Answer one with:');
+    lines.push(`  openswarm attach <issue> -m "your reply"`);
+  }
+  return lines.join('\n');
+}
+
+export function formatThreads(threads: CoordinationThread[], repository: string): string {
+  if (!threads.length) return `No coordination threads for ${repository}.`;
+  const lines = [`Coordination threads for ${repository} (${threads.length}):`];
+  for (const thread of threads) {
+    lines.push(`  [${thread.status}] ${thread.subject}`);
+    lines.push(`    id: ${thread.id}  messages: ${thread.messageCount}  participants: ${thread.participantCount}`);
+    lines.push(`    updated: ${clock(thread.updatedAt)}  tasks: ${thread.relatedTaskIds.join(', ') || '-'}`);
+  }
+  return lines.join('\n');
+}
+
+// ---- Commands ---------------------------------------------------------------
+
+/** Printed once before output so a remote read is never mistaken for a local one. */
+function hostNotice(): string | null {
+  return isRemoteDaemon() ? `(daemon: ${daemonHost()})` : null;
+}
+
+export async function runBoardCommand(opts: CoordinationCommandOptions = {}): Promise<number> {
+  const port = opts.port ?? DAEMON_PORT;
+  const doFetch = opts.fetchImpl ?? fetch;
+  const query = opts.repository ? `?repository=${encodeURIComponent(opts.repository)}` : '';
+  try {
+    const snapshot = await getJson<BoardSnapshot>(`/api/coordination${query}`, port, doFetch, 'Could not read the coordination board');
+    if (opts.json) {
+      console.log(JSON.stringify(snapshot, null, 2));
+      return 0;
+    }
+    const notice = hostNotice();
+    if (notice) console.log(notice);
+    console.log(formatBoard(snapshot, opts.limit ?? 20));
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+export async function runThreadsCommand(opts: CoordinationCommandOptions = {}): Promise<number> {
+  const port = opts.port ?? DAEMON_PORT;
+  const doFetch = opts.fetchImpl ?? fetch;
+  // The route requires a repository; the working directory is the only
+  // defensible default for a command run from inside a checkout.
+  const repository = opts.repository ?? process.cwd();
+  const params = new URLSearchParams({ repository });
+  if (opts.status) params.set('status', opts.status);
+  if (opts.limit !== undefined && Number.isFinite(opts.limit)) params.set('limit', String(Math.max(1, Math.trunc(opts.limit))));
+  try {
+    const page = await getJson<{ items: CoordinationThread[] }>(
+      `/api/coordination/threads?${params.toString()}`, port, doFetch, 'Could not list coordination threads');
+    if (opts.json) {
+      console.log(JSON.stringify(page, null, 2));
+      return 0;
+    }
+    const notice = hostNotice();
+    if (notice) console.log(notice);
+    console.log(formatThreads(page.items ?? [], repository));
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}

--- a/src/cli/coordinationHandler.ts
+++ b/src/cli/coordinationHandler.ts
@@ -121,7 +121,7 @@ export function formatBoard(snapshot: BoardSnapshot, limit: number): string {
   if (pending.length) {
     lines.push('');
     lines.push('Answer one with:');
-    lines.push(`  openswarm attach <issue> -m "your reply"`);
+    lines.push('  openswarm attach <issue> -c <correlationId> -m "your reply"');
   }
   return lines.join('\n');
 }

--- a/src/cli/coordinationHandler.ts
+++ b/src/cli/coordinationHandler.ts
@@ -18,7 +18,7 @@
 import type { CoordinationEvent } from '../coordination/coordinationStore.js';
 import type { CoordinationThread } from '../coordination/coordinationThreads.js';
 import { DAEMON_PORT } from './daemon.js';
-import { DAEMON_TOKEN_ENV, daemonAuthHeaders, daemonBaseUrl, daemonHost, isRemoteDaemon } from './daemonEndpoint.js';
+import { DAEMON_TOKEN_ENV, daemonAuthHeaders, daemonBaseUrl, daemonHost, daemonScheme, isRemoteDaemon } from './daemonEndpoint.js';
 
 /** Matches attachHandler.ts: a daemon that answers /api/stats can still stall. */
 const REQUEST_TIMEOUT_MS = 10_000;
@@ -141,7 +141,12 @@ export function formatThreads(threads: CoordinationThread[], repository: string)
 
 /** Printed once before output so a remote read is never mistaken for a local one. */
 function hostNotice(): string | null {
-  return isRemoteDaemon() ? `(daemon: ${daemonHost()})` : null;
+  if (!isRemoteDaemon()) return null;
+  // The daemon serves plain http (web.ts uses node:http), so a remote read is
+  // in the clear unless a TLS proxy fronts it. Say which, rather than block a
+  // configuration that is normally fine because the link itself is encrypted.
+  const transport = daemonScheme() === 'https' ? 'https' : 'plaintext http';
+  return `(daemon: ${daemonHost()}, ${transport})`;
 }
 
 export async function runBoardCommand(opts: CoordinationCommandOptions = {}): Promise<number> {

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -76,6 +76,11 @@ function readPidFile(): number | null {
  */
 export async function probeDaemonPort(port = DAEMON_PORT, timeoutMs = 800): Promise<boolean> {
   try {
+    // Deliberately loopback, not daemonBaseUrl(): this asks whether THIS
+    // machine's port is already taken, so that start/stop does not spawn a
+    // second daemon on the same queue. Routing it through
+    // OPENSWARM_DAEMON_HOST would answer about a different machine and let
+    // exactly that happen.
     const res = await fetch(`http://127.0.0.1:${port}/api/stats`, {
       signal: AbortSignal.timeout(timeoutMs),
     });

--- a/src/cli/daemonEndpoint.test.ts
+++ b/src/cli/daemonEndpoint.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   DAEMON_HOST_ENV,
+  ALLOW_PLAINTEXT_TOKEN_ENV,
+  DAEMON_SCHEME_ENV,
   DAEMON_TOKEN_ENV,
   daemonAuthHeaders,
+  daemonScheme,
   DEFAULT_DAEMON_HOST,
   InvalidDaemonHostError,
   daemonBaseUrl,
@@ -13,6 +16,8 @@ import {
 afterEach(() => {
   delete process.env[DAEMON_HOST_ENV];
   delete process.env[DAEMON_TOKEN_ENV];
+  delete process.env[DAEMON_SCHEME_ENV];
+  delete process.env[ALLOW_PLAINTEXT_TOKEN_ENV];
 });
 
 describe('daemonHost', () => {
@@ -94,5 +99,57 @@ describe('daemonAuthHeaders', () => {
   it('ignores a blank token rather than sending an empty header', () => {
     process.env[DAEMON_TOKEN_ENV] = '   ';
     expect(daemonAuthHeaders()).toEqual({});
+  });
+});
+
+describe('daemonScheme', () => {
+  it('defaults to http, matching the daemon\'s own listener', () => {
+    expect(daemonScheme(undefined)).toBe('http');
+    expect(daemonScheme('')).toBe('http');
+  });
+
+  it.each(['https', 'HTTPS', ' https ', 'https:'])('accepts %s', (value) => {
+    expect(daemonScheme(value)).toBe('https');
+  });
+
+  it('rejects anything else instead of building a nonsense URL', () => {
+    expect(() => daemonScheme('ftp')).toThrow(/must be "http" or "https"/);
+  });
+});
+
+describe('plaintext credential guard', () => {
+  // The token is bearer-equivalent. Over http to another machine it, and the
+  // coordination content around it, are on the wire in the clear.
+  it('refuses to send the token to a remote host over http', () => {
+    process.env[DAEMON_HOST_ENV] = 'vela';
+    process.env[DAEMON_TOKEN_ENV] = 's3cret';
+    expect(() => daemonBaseUrl(3847)).toThrow(/Refusing to send/);
+  });
+
+  it('allows it over https', () => {
+    process.env[DAEMON_HOST_ENV] = 'vela';
+    process.env[DAEMON_TOKEN_ENV] = 's3cret';
+    process.env[DAEMON_SCHEME_ENV] = 'https';
+    expect(daemonBaseUrl(3847)).toBe('https://vela:3847');
+  });
+
+  it('allows it when the operator states the link is already encrypted', () => {
+    process.env[DAEMON_HOST_ENV] = 'vela';
+    process.env[DAEMON_TOKEN_ENV] = 's3cret';
+    process.env[ALLOW_PLAINTEXT_TOKEN_ENV] = 'true';
+    expect(daemonBaseUrl(3847)).toBe('http://vela:3847');
+  });
+
+  it('never blocks loopback, which does not leave the machine', () => {
+    process.env[DAEMON_TOKEN_ENV] = 's3cret';
+    expect(daemonBaseUrl(3847)).toBe('http://127.0.0.1:3847');
+    process.env[DAEMON_HOST_ENV] = 'localhost';
+    expect(daemonBaseUrl(3847)).toBe('http://localhost:3847');
+  });
+
+  it('never blocks a remote host when no token is configured', () => {
+    // Tailscale already encrypts the link; a tokenless read exposes no credential.
+    process.env[DAEMON_HOST_ENV] = '100.95.200.28';
+    expect(daemonBaseUrl(3847)).toBe('http://100.95.200.28:3847');
   });
 });

--- a/src/cli/daemonEndpoint.test.ts
+++ b/src/cli/daemonEndpoint.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   DAEMON_HOST_ENV,
+  DAEMON_TOKEN_ENV,
+  daemonAuthHeaders,
   DEFAULT_DAEMON_HOST,
   InvalidDaemonHostError,
   daemonBaseUrl,
@@ -10,6 +12,7 @@ import {
 
 afterEach(() => {
   delete process.env[DAEMON_HOST_ENV];
+  delete process.env[DAEMON_TOKEN_ENV];
 });
 
 describe('daemonHost', () => {
@@ -72,5 +75,24 @@ describe('daemonBaseUrl', () => {
 
   it.each([0, 65_536, 1.5, Number.NaN])('rejects out-of-range port %s', (port) => {
     expect(() => daemonBaseUrl(port)).toThrow(/between 1 and 65535/);
+  });
+});
+
+describe('daemonAuthHeaders', () => {
+  // web.ts authorises on token OR loopback OR trusted Tailscale. A remote CLI
+  // has only the token, so a daemon secured with OPENSWARM_WEB_TOKEN refuses
+  // every remote command without this.
+  it('sends nothing when no token is configured', () => {
+    expect(daemonAuthHeaders()).toEqual({});
+  });
+
+  it('presents the token in the header the daemon reads without parsing', () => {
+    process.env[DAEMON_TOKEN_ENV] = 's3cret';
+    expect(daemonAuthHeaders()).toEqual({ 'x-openswarm-token': 's3cret' });
+  });
+
+  it('ignores a blank token rather than sending an empty header', () => {
+    process.env[DAEMON_TOKEN_ENV] = '   ';
+    expect(daemonAuthHeaders()).toEqual({});
   });
 });

--- a/src/cli/daemonEndpoint.test.ts
+++ b/src/cli/daemonEndpoint.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  DAEMON_HOST_ENV,
+  DEFAULT_DAEMON_HOST,
+  InvalidDaemonHostError,
+  daemonBaseUrl,
+  daemonHost,
+  isRemoteDaemon,
+} from './daemonEndpoint.js';
+
+afterEach(() => {
+  delete process.env[DAEMON_HOST_ENV];
+});
+
+describe('daemonHost', () => {
+  it('defaults to loopback so coordination traffic stays on this machine', () => {
+    expect(daemonHost(undefined)).toBe(DEFAULT_DAEMON_HOST);
+    expect(daemonHost('')).toBe(DEFAULT_DAEMON_HOST);
+    expect(daemonHost('   ')).toBe(DEFAULT_DAEMON_HOST);
+  });
+
+  it('accepts a bare hostname or address', () => {
+    expect(daemonHost('vela')).toBe('vela');
+    expect(daemonHost('100.95.200.28')).toBe('100.95.200.28');
+    expect(daemonHost('  vela  ')).toBe('vela');
+    expect(daemonHost('[::1]')).toBe('[::1]');
+  });
+
+  it.each([
+    ['http://vela', 'a scheme'],
+    ['vela:3847', 'a port'],
+    ['vela/api', 'a path'],
+    ['vela?x=1', 'a query'],
+    ['user@vela', 'credentials'],
+    ['ve la', 'whitespace'],
+  ])('rejects %s (%s) rather than silently using loopback', (value) => {
+    expect(() => daemonHost(value)).toThrow(InvalidDaemonHostError);
+  });
+
+  it('names the scheme, not the slashes, when a URL is pasted in', () => {
+    // `http://vela` trips the separator check too; the operator needs to be
+    // told which part to delete.
+    expect(() => daemonHost('http://vela')).toThrow(/includes a scheme/);
+  });
+
+  it('reads the environment when no argument is passed', () => {
+    process.env[DAEMON_HOST_ENV] = 'vela';
+    expect(daemonHost()).toBe('vela');
+    expect(isRemoteDaemon()).toBe(true);
+  });
+
+  it.each([undefined, DEFAULT_DAEMON_HOST, 'localhost', '[::1]'])(
+    'reports loopback spelled as %s as local', (value) => {
+      // isRemoteDaemon gates auto-starting the daemon, which only makes sense
+      // on this machine — calling `localhost` remote would refuse a start it
+      // could perfectly well do.
+      if (value === undefined) delete process.env[DAEMON_HOST_ENV];
+      else process.env[DAEMON_HOST_ENV] = value;
+      expect(isRemoteDaemon()).toBe(false);
+    });
+});
+
+describe('daemonBaseUrl', () => {
+  it('builds a loopback URL by default', () => {
+    expect(daemonBaseUrl(3847)).toBe('http://127.0.0.1:3847');
+  });
+
+  it('honours the host override', () => {
+    process.env[DAEMON_HOST_ENV] = 'vela';
+    expect(daemonBaseUrl(3847)).toBe('http://vela:3847');
+  });
+
+  it.each([0, 65_536, 1.5, Number.NaN])('rejects out-of-range port %s', (port) => {
+    expect(() => daemonBaseUrl(port)).toThrow(/between 1 and 65535/);
+  });
+});

--- a/src/cli/daemonEndpoint.ts
+++ b/src/cli/daemonEndpoint.ts
@@ -59,6 +59,24 @@ export function daemonHost(raw: string | undefined = process.env[DAEMON_HOST_ENV
   return parsed.hostname;
 }
 
+/** Env var holding the daemon's OPENSWARM_WEB_TOKEN, for a secured daemon. */
+export const DAEMON_TOKEN_ENV = 'OPENSWARM_DAEMON_TOKEN';
+
+/**
+ * Auth headers for a daemon request.
+ *
+ * web.ts authorises a request that carries a valid token, OR comes from
+ * loopback, OR comes over trusted Tailscale. A remote CLI has only the first
+ * of those unless the operator turned on OPENSWARM_TRUST_TAILSCALE, so without
+ * this a daemon secured with OPENSWARM_WEB_TOKEN refuses every remote command
+ * — exactly the deployment that most wants one. The daemon accepts this header
+ * or `Authorization: Bearer`; the bare header avoids its parsing entirely.
+ */
+export function daemonAuthHeaders(): Record<string, string> {
+  const token = process.env[DAEMON_TOKEN_ENV]?.trim();
+  return token ? { 'x-openswarm-token': token } : {};
+}
+
 /** Base URL for a daemon request, e.g. `http://127.0.0.1:3847`. */
 export function daemonBaseUrl(port: number): string {
   if (!Number.isInteger(port) || port < 1 || port > 65_535) {

--- a/src/cli/daemonEndpoint.ts
+++ b/src/cli/daemonEndpoint.ts
@@ -1,0 +1,81 @@
+// ============================================
+// OpenSwarm - Daemon HTTP endpoint resolution
+// ============================================
+//
+// One place to decide which daemon a CLI command talks to. Three callers had
+// grown their own copy of `http://127.0.0.1:${port}` (attachHandler.ts,
+// providerCommand.ts, promptHandler.ts), which made the daemon unreachable
+// from another machine without an SSH tunnel and meant a fix had to be made
+// three times.
+//
+// The default stays loopback on purpose: `OPENSWARM_DAEMON_HOST` sends
+// coordination traffic — operator answers, attachment bytes — off this
+// machine, so it is opt-in and the value is validated rather than pasted into
+// a template literal.
+
+/** Where the daemon lives when nothing overrides it. */
+export const DEFAULT_DAEMON_HOST = '127.0.0.1';
+
+/** Env var naming the host to reach instead of loopback. */
+export const DAEMON_HOST_ENV = 'OPENSWARM_DAEMON_HOST';
+
+export class InvalidDaemonHostError extends Error {
+  constructor(value: string, reason: string) {
+    super(`${DAEMON_HOST_ENV}=${JSON.stringify(value)} is not a bare host (${reason}). `
+      + 'Pass a hostname or IP only — no scheme, port, or path (e.g. "vela" or "100.95.200.28").');
+    this.name = 'InvalidDaemonHostError';
+  }
+}
+
+/**
+ * The host portion of every daemon URL.
+ *
+ * Throws rather than falling back to loopback: an operator who set this
+ * deliberately would otherwise have their message delivered to the wrong
+ * daemon — silently, and to a board that looks plausible.
+ */
+export function daemonHost(raw: string | undefined = process.env[DAEMON_HOST_ENV]): string {
+  const value = raw?.trim();
+  if (!value) return DEFAULT_DAEMON_HOST;
+
+  // Checked before parsing because URL tolerates some of these by encoding
+  // them, which would hand back a host that is not the one that was written.
+  // Scheme first: `http://vela` also trips the separator check, and "includes
+  // a scheme" is the message that tells the operator what to delete.
+  if (value.includes('://')) throw new InvalidDaemonHostError(value, 'includes a scheme');
+  if (/[\s/?#@\\]/.test(value)) throw new InvalidDaemonHostError(value, 'contains a separator or whitespace');
+
+  let parsed: URL;
+  try {
+    parsed = new URL(`http://${value}`);
+  } catch {
+    throw new InvalidDaemonHostError(value, 'is not a parseable host');
+  }
+  if (parsed.port !== '') throw new InvalidDaemonHostError(value, 'includes a port');
+  // Round-trip: anything URL normalised away was not a bare host to begin with.
+  if (parsed.hostname !== value.toLowerCase()) {
+    throw new InvalidDaemonHostError(value, 'is not a bare host');
+  }
+  return parsed.hostname;
+}
+
+/** Base URL for a daemon request, e.g. `http://127.0.0.1:3847`. */
+export function daemonBaseUrl(port: number): string {
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`Daemon port must be an integer between 1 and 65535, got ${port}`);
+  }
+  return `http://${daemonHost()}:${port}`;
+}
+
+/**
+ * Loopback spelled every way an operator plausibly would. `isRemoteDaemon`
+ * gates behaviour that only makes sense on this machine (auto-starting the
+ * daemon), so `localhost` has to count as local or `openswarm exec` refuses to
+ * start a daemon it could perfectly well start.
+ */
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '[::1]', '0.0.0.0']);
+
+/** True when the configured host is not this machine. */
+export function isRemoteDaemon(): boolean {
+  return !LOOPBACK_HOSTS.has(daemonHost());
+}

--- a/src/cli/daemonEndpoint.ts
+++ b/src/cli/daemonEndpoint.ts
@@ -77,12 +77,49 @@ export function daemonAuthHeaders(): Record<string, string> {
   return token ? { 'x-openswarm-token': token } : {};
 }
 
-/** Base URL for a daemon request, e.g. `http://127.0.0.1:3847`. */
+/** True when a non-blank token is configured. */
+function hasDaemonToken(): boolean {
+  return Boolean(process.env[DAEMON_TOKEN_ENV]?.trim());
+}
+
+/** Env var selecting https for a daemon behind TLS or a reverse proxy. */
+export const DAEMON_SCHEME_ENV = 'OPENSWARM_DAEMON_SCHEME';
+
+/** Env var acknowledging that a token will cross the network in the clear. */
+export const ALLOW_PLAINTEXT_TOKEN_ENV = 'OPENSWARM_DAEMON_ALLOW_PLAINTEXT_TOKEN';
+
+/** `http` (default, matching the daemon's own listener) or `https`. */
+export function daemonScheme(raw: string | undefined = process.env[DAEMON_SCHEME_ENV]): 'http' | 'https' {
+  const value = raw?.trim().toLowerCase().replace(/:$/, '');
+  if (!value) return 'http';
+  if (value !== 'http' && value !== 'https') {
+    throw new Error(`${DAEMON_SCHEME_ENV}=${JSON.stringify(raw)} must be "http" or "https".`);
+  }
+  return value;
+}
+
+/**
+ * Base URL for a daemon request, e.g. `http://127.0.0.1:3847`.
+ *
+ * Sending the token to a remote host over http puts a bearer-equivalent
+ * credential — and the coordination content around it — on the wire in the
+ * clear. Loopback never leaves the machine, so it is exempt; anything else has
+ * to either use https or say plainly that the network is already trusted (a
+ * WireGuard/Tailscale link, typically). Caught by `openswarm pr review`.
+ */
 export function daemonBaseUrl(port: number): string {
   if (!Number.isInteger(port) || port < 1 || port > 65_535) {
     throw new Error(`Daemon port must be an integer between 1 and 65535, got ${port}`);
   }
-  return `http://${daemonHost()}:${port}`;
+  const scheme = daemonScheme();
+  const host = daemonHost();
+  if (scheme === 'http' && isRemoteDaemon() && hasDaemonToken()
+      && process.env[ALLOW_PLAINTEXT_TOKEN_ENV]?.trim() !== 'true') {
+    throw new Error(`Refusing to send ${DAEMON_TOKEN_ENV} to ${host} over plaintext http. `
+      + `Set ${DAEMON_SCHEME_ENV}=https, or ${ALLOW_PLAINTEXT_TOKEN_ENV}=true if the link is `
+      + 'already encrypted (e.g. Tailscale/WireGuard).');
+  }
+  return `${scheme}://${host}:${port}`;
 }
 
 /**

--- a/src/cli/promptHandler.ts
+++ b/src/cli/promptHandler.ts
@@ -8,6 +8,7 @@ import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { spawn, execFile } from 'node:child_process';
 import { expandPath } from '../core/config.js';
+import { DAEMON_HOST_ENV, daemonBaseUrl, daemonHost, isRemoteDaemon } from './daemonEndpoint.js';
 
 // Types
 
@@ -43,7 +44,9 @@ interface ExecTaskStatus {
 // Constants
 
 const SERVICE_PORT = 3847;
-const BASE_URL = `http://127.0.0.1:${SERVICE_PORT}`;
+/** Resolved per call: the host comes from the environment, which a test
+ * (or an operator between commands) can change after this module loads. */
+const BASE_URL = () => daemonBaseUrl(SERVICE_PORT);
 const HEALTH_TIMEOUT_MS = 3000;
 const AUTO_START_TIMEOUT_MS = 30000;
 const DEFAULT_TASK_TIMEOUT_S = 600;
@@ -66,7 +69,7 @@ async function checkServiceHealth(): Promise<boolean> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS);
   try {
-    const res = await fetch(`${BASE_URL}/api/stats`, { signal: controller.signal });
+    const res = await fetch(`${BASE_URL()}/api/stats`, { signal: controller.signal });
     return res.ok;
   } catch {
     return false;
@@ -127,7 +130,7 @@ async function submitTask(opts: ExecOptions, projectPath: string): Promise<ExecT
     verbose: opts.verbose,
   };
 
-  const res = await fetch(`${BASE_URL}/api/exec`, {
+  const res = await fetch(`${BASE_URL()}/api/exec`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
@@ -159,7 +162,7 @@ async function pollForResult(taskId: string, timeoutS: number): Promise<ExecTask
         Math.min(POLL_REQUEST_TIMEOUT_MS, remainingMs),
       );
       try {
-        const res = await fetch(`${BASE_URL}/api/exec/${taskId}`, { signal: controller.signal });
+        const res = await fetch(`${BASE_URL()}/api/exec/${taskId}`, { signal: controller.signal });
         if (!res.ok) continue;
 
         const status = (await res.json()) as ExecTaskStatus;
@@ -221,6 +224,17 @@ export async function executePrompt(opts: ExecOptions): Promise<void> {
   const healthy = await checkServiceHealth();
 
   if (!healthy) {
+    // startServiceAuto() only ever starts a daemon on THIS machine. When
+    // OPENSWARM_DAEMON_HOST points somewhere else, doing that would spawn a
+    // daemon nobody asked for and then poll the remote host for 30s anyway,
+    // so the unreachable remote is reported instead (caught by openswarm
+    // review, not self-caught).
+    if (isRemoteDaemon()) {
+      console.error(`Error: no OpenSwarm daemon answered at ${daemonHost()}:${SERVICE_PORT}.`);
+      console.error('Auto-start only applies to a local daemon — start it on that host, '
+        + `or unset ${DAEMON_HOST_ENV} to use this machine.`);
+      process.exit(1);
+    }
     if (!autoStart) {
       console.error('Error: Service is not running. Use --auto-start or start it manually.');
       process.exit(1);

--- a/src/cli/promptHandler.ts
+++ b/src/cli/promptHandler.ts
@@ -68,10 +68,14 @@ function getProjectRoot(): string {
 // Service Health Check
 
 async function checkServiceHealth(): Promise<boolean> {
+  // Resolved before the try: a malformed host or a refused plaintext token is
+  // a configuration error, and answering `false` here would send the caller
+  // into auto-start instead of reporting it.
+  const url = `${BASE_URL()}/api/stats`;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS);
   try {
-    const res = await fetch(`${BASE_URL()}/api/stats`, { headers: daemonAuthHeaders(), signal: controller.signal });
+    const res = await fetch(url, { headers: daemonAuthHeaders(), signal: controller.signal });
     return res.ok;
   } catch {
     return false;
@@ -154,6 +158,10 @@ async function submitTask(opts: ExecOptions, projectPath: string): Promise<ExecT
 // Task Polling
 
 async function pollForResult(taskId: string, timeoutS: number): Promise<ExecTaskStatus> {
+  // Resolved once, before the loop: the endpoint cannot change mid-poll, and
+  // resolving inside the per-iteration try would swallow a configuration error
+  // as just another failed poll until the deadline expired.
+  const pollUrl = BASE_URL();
   const deadline = Date.now() + timeoutS * 1000;
 
   while (Date.now() < deadline) {
@@ -168,7 +176,7 @@ async function pollForResult(taskId: string, timeoutS: number): Promise<ExecTask
         Math.min(POLL_REQUEST_TIMEOUT_MS, remainingMs),
       );
       try {
-        const res = await fetch(`${BASE_URL()}/api/exec/${taskId}`, { headers: daemonAuthHeaders(), signal: controller.signal });
+        const res = await fetch(`${pollUrl}/api/exec/${taskId}`, { headers: daemonAuthHeaders(), signal: controller.signal });
         if (!res.ok) continue;
 
         const status = (await res.json()) as ExecTaskStatus;

--- a/src/cli/promptHandler.ts
+++ b/src/cli/promptHandler.ts
@@ -8,7 +8,7 @@ import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { spawn, execFile } from 'node:child_process';
 import { expandPath } from '../core/config.js';
-import { DAEMON_HOST_ENV, daemonBaseUrl, daemonHost, isRemoteDaemon } from './daemonEndpoint.js';
+import { DAEMON_HOST_ENV, daemonAuthHeaders, daemonBaseUrl, daemonHost, isRemoteDaemon } from './daemonEndpoint.js';
 
 // Types
 
@@ -49,6 +49,8 @@ const SERVICE_PORT = 3847;
 const BASE_URL = () => daemonBaseUrl(SERVICE_PORT);
 const HEALTH_TIMEOUT_MS = 3000;
 const AUTO_START_TIMEOUT_MS = 30000;
+/** Submitting a task is a small JSON POST; it should never outlast this. */
+const SUBMIT_TIMEOUT_MS = 30000;
 const DEFAULT_TASK_TIMEOUT_S = 600;
 const POLL_INTERVAL_MS = 3000;
 const POLL_REQUEST_TIMEOUT_MS = 5000;
@@ -69,7 +71,7 @@ async function checkServiceHealth(): Promise<boolean> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS);
   try {
-    const res = await fetch(`${BASE_URL()}/api/stats`, { signal: controller.signal });
+    const res = await fetch(`${BASE_URL()}/api/stats`, { headers: daemonAuthHeaders(), signal: controller.signal });
     return res.ok;
   } catch {
     return false;
@@ -130,10 +132,14 @@ async function submitTask(opts: ExecOptions, projectPath: string): Promise<ExecT
     verbose: opts.verbose,
   };
 
+  // The only daemon call here without a bound. Over loopback that rarely bit;
+  // over a network it hangs forever with no way out (caught by openswarm pr
+  // review, not self-caught).
   const res = await fetch(`${BASE_URL()}/api/exec`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...daemonAuthHeaders() },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(SUBMIT_TIMEOUT_MS),
   });
 
   if (!res.ok) {
@@ -162,7 +168,7 @@ async function pollForResult(taskId: string, timeoutS: number): Promise<ExecTask
         Math.min(POLL_REQUEST_TIMEOUT_MS, remainingMs),
       );
       try {
-        const res = await fetch(`${BASE_URL()}/api/exec/${taskId}`, { signal: controller.signal });
+        const res = await fetch(`${BASE_URL()}/api/exec/${taskId}`, { headers: daemonAuthHeaders(), signal: controller.signal });
         if (!res.ok) continue;
 
         const status = (await res.json()) as ExecTaskStatus;

--- a/src/cli/providerCommand.test.ts
+++ b/src/cli/providerCommand.test.ts
@@ -308,3 +308,34 @@ describe('providerCommand daemon auth', () => {
     expect(fetchMock.mock.calls[0][1].headers).toEqual({});
   });
 });
+
+describe('providerCommand endpoint misconfiguration', () => {
+  afterEach(() => {
+    delete process.env.OPENSWARM_DAEMON_HOST;
+    delete process.env.OPENSWARM_DAEMON_TOKEN;
+  });
+
+  // daemonBaseUrl throws for a bad host or a token it will not send in the
+  // clear. Reading that as "no daemon" would persist an override describing a
+  // provider the live daemon is not running.
+  it('does not report a misconfigured endpoint as an absent daemon', async () => {
+    process.env.OPENSWARM_DAEMON_HOST = 'http://vela';
+    fetchMock.mockReset();
+
+    const { getProviderStatus } = await import('./providerCommand.js');
+
+    await expect(getProviderStatus()).rejects.toThrow(/is not a bare host/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not silently persist an override when the endpoint is misconfigured', async () => {
+    process.env.OPENSWARM_DAEMON_HOST = 'http://vela';
+    fetchMock.mockReset();
+    writeProviderOverrideMock.mockReset();
+
+    const { applyProvider } = await import('./providerCommand.js');
+
+    await expect(applyProvider('claude')).rejects.toThrow(/is not a bare host/);
+    expect(writeProviderOverrideMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/providerCommand.test.ts
+++ b/src/cli/providerCommand.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const readProviderOverrideMock = vi.hoisted(() => vi.fn());
 const writeProviderOverrideMock = vi.hoisted(() => vi.fn());
@@ -259,5 +259,52 @@ describe('provider command helpers', () => {
       expect(writeProviderOverrideMock).not.toHaveBeenCalled();
       log.mockRestore();
     });
+  });
+});
+
+// A secured remote daemon rejects an unauthenticated read, which this command
+// swallows into "no daemon" — so it would misreport the live provider and
+// refuse a switch while OPENSWARM_DAEMON_TOKEN was correctly set. Every other
+// CLI daemon call got the token; this one was missed until the PR-level review
+// saw the whole diff.
+describe('providerCommand daemon auth', () => {
+  afterEach(() => {
+    delete process.env.OPENSWARM_DAEMON_TOKEN;
+  });
+
+  it('presents the daemon token when reading the live provider', async () => {
+    process.env.OPENSWARM_DAEMON_TOKEN = 's3cret';
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(statsResponse({ defaultAdapter: 'claude' }));
+
+    const { getProviderStatus } = await import('./providerCommand.js');
+    await getProviderStatus();
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(fetchMock.mock.calls[0][1].headers).toMatchObject({ 'x-openswarm-token': 's3cret' });
+  });
+
+  it('presents the daemon token when switching the live provider', async () => {
+    process.env.OPENSWARM_DAEMON_TOKEN = 's3cret';
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(statsResponse({ defaultAdapter: 'claude' }));
+
+    const { applyProvider } = await import('./providerCommand.js');
+    await applyProvider('claude');
+
+    expect(fetchMock).toHaveBeenCalled();
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(init.headers).toMatchObject({ 'x-openswarm-token': 's3cret' });
+    }
+  });
+
+  it('sends no token header when none is configured', async () => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(statsResponse({ defaultAdapter: 'claude' }));
+
+    const { getProviderStatus } = await import('./providerCommand.js');
+    await getProviderStatus();
+
+    expect(fetchMock.mock.calls[0][1].headers).toEqual({});
   });
 });

--- a/src/cli/providerCommand.ts
+++ b/src/cli/providerCommand.ts
@@ -64,8 +64,13 @@ interface StatsAdapters {
 
 /** Ask the running daemon which adapter it is actually using right now. */
 async function fetchDaemonAdapters(port: number, timeoutMs = 1500): Promise<StatsAdapters | null> {
+  // Resolved outside the catch on purpose: daemonBaseUrl throws for a bad
+  // OPENSWARM_DAEMON_HOST or a token it refuses to send in the clear, and
+  // reading that as "no daemon" would silently persist a local override while
+  // the live daemon kept running something else (caught by openswarm pr review).
+  const url = `${baseUrl(port)}/api/stats`;
   try {
-    const res = await fetch(`${baseUrl(port)}/api/stats`, { headers: daemonAuthHeaders(), signal: AbortSignal.timeout(timeoutMs) });
+    const res = await fetch(url, { headers: daemonAuthHeaders(), signal: AbortSignal.timeout(timeoutMs) });
     if (!res.ok) return null;
     const stats = await res.json() as { adapters?: StatsAdapters };
     return stats.adapters ?? null;
@@ -124,8 +129,11 @@ export interface ApplyResult {
  */
 export async function applyProvider(next: AdapterName, port = DAEMON_PORT): Promise<ApplyResult> {
   let reachable = false;
+  // Same reason as fetchDaemonAdapters: a configuration error must not read as
+  // an absent daemon, or the override file silently disagrees with the daemon.
+  const url = `${baseUrl(port)}/api/provider`;
   try {
-    const res = await fetch(`${baseUrl(port)}/api/provider`, {
+    const res = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...daemonAuthHeaders() },
       body: JSON.stringify({ provider: next }),

--- a/src/cli/providerCommand.ts
+++ b/src/cli/providerCommand.ts
@@ -19,6 +19,7 @@ import { isKnownAdapter, listAdapterNames } from '../adapters/index.js';
 import type { AdapterName } from '../adapters/types.js';
 import { readProviderOverride, writeProviderOverride } from '../core/providerOverride.js';
 import { loadConfig } from '../core/config.js';
+import { daemonBaseUrl as baseUrl } from './daemonEndpoint.js';
 import { DAEMON_PORT } from './daemon.js';
 
 /**
@@ -60,9 +61,6 @@ interface StatsAdapters {
   [role: string]: unknown;
 }
 
-function baseUrl(port: number): string {
-  return `http://127.0.0.1:${port}`;
-}
 
 /** Ask the running daemon which adapter it is actually using right now. */
 async function fetchDaemonAdapters(port: number, timeoutMs = 1500): Promise<StatsAdapters | null> {

--- a/src/cli/providerCommand.ts
+++ b/src/cli/providerCommand.ts
@@ -19,7 +19,7 @@ import { isKnownAdapter, listAdapterNames } from '../adapters/index.js';
 import type { AdapterName } from '../adapters/types.js';
 import { readProviderOverride, writeProviderOverride } from '../core/providerOverride.js';
 import { loadConfig } from '../core/config.js';
-import { daemonBaseUrl as baseUrl } from './daemonEndpoint.js';
+import { daemonAuthHeaders, daemonBaseUrl as baseUrl } from './daemonEndpoint.js';
 import { DAEMON_PORT } from './daemon.js';
 
 /**
@@ -65,7 +65,7 @@ interface StatsAdapters {
 /** Ask the running daemon which adapter it is actually using right now. */
 async function fetchDaemonAdapters(port: number, timeoutMs = 1500): Promise<StatsAdapters | null> {
   try {
-    const res = await fetch(`${baseUrl(port)}/api/stats`, { signal: AbortSignal.timeout(timeoutMs) });
+    const res = await fetch(`${baseUrl(port)}/api/stats`, { headers: daemonAuthHeaders(), signal: AbortSignal.timeout(timeoutMs) });
     if (!res.ok) return null;
     const stats = await res.json() as { adapters?: StatsAdapters };
     return stats.adapters ?? null;
@@ -127,7 +127,7 @@ export async function applyProvider(next: AdapterName, port = DAEMON_PORT): Prom
   try {
     const res = await fetch(`${baseUrl(port)}/api/provider`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...daemonAuthHeaders() },
       body: JSON.stringify({ provider: next }),
       signal: AbortSignal.timeout(5000),
     });

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -215,10 +215,10 @@ const ALLOWED_EVENTS = new Set(['invoke', 'complete', 'error', 'start', 'stop', 
  * failing test rather than a blind spot discovered months later.
  */
 const ALLOWED_COMMANDS = new Set([
-  'add', 'annotate', 'attach', 'auth', 'chat', 'check', 'dash', 'design-pipeline', 'doctor',
-  'exec', 'fix', 'init', 'login', 'logout', 'mcp', 'memory', 'models', 'openswarm',
+  'add', 'annotate', 'attach', 'auth', 'board', 'chat', 'check', 'dash', 'design-pipeline',
+  'doctor', 'exec', 'fix', 'init', 'login', 'logout', 'mcp', 'memory', 'models', 'openswarm',
   'pr', 'projects', 'provider', 'remove', 'resume', 'review', 'run', 'schedule', 'start',
-  'status', 'stop', 'upgrade', 'validate', 'version', 'work',
+  'status', 'stop', 'threads', 'upgrade', 'validate', 'version', 'work',
 ]);
 
 /**


### PR DESCRIPTION
## What

The dashboard's orchestration, chat and threads pages drive four coordination endpoints. `attach` (AGT-4058) covered the two writes, so an operator could answer a parked question but had no way to *see* that one was waiting — the board was readable only in a browser.

| Endpoint | CLI before | CLI after |
| --- | --- | --- |
| `POST /api/coordination/message` | `attach` (file mandatory) | `attach` (file optional) |
| `POST /api/coordination/attachment` | `attach` | `attach` |
| `GET /api/coordination` | — | `openswarm board` |
| `GET /api/coordination/threads` | — | `openswarm threads` |

- **`openswarm board`** leads with the questions waiting on an operator and prints each `correlationId`, because that is what `attach` needs to answer the right exchange.
- **`openswarm threads`** defaults the repository the route requires to the working directory.
- **`attach` no longer requires a file.** Answering a question usually means sending text and nothing else, which the command could not do.
- **`OPENSWARM_DAEMON_HOST`** points any of this at a daemon on another machine. Three call sites had grown their own `http://127.0.0.1:${port}`; they now share `daemonEndpoint.ts`, which validates the host instead of pasting it into a template literal. Loopback stays the default — a remote host sends operator answers and attachment bytes off the machine, so it is opt-in.

## Verification

Run against a live remote daemon, not just mocked:

- `board` and `threads` both render; `board --json | jq` pipes cleanly (config logging goes to stderr).
- A bad host, an unreachable daemon and a nonsense `--limit` each fail the way they claim to; exit codes 1 / 1 / 0.
- Gate: typecheck, oxlint, build clean. Full suite at baseline parity with `origin/main` — 9 pre-existing failures (7 TUI ANSI assertions, `coordinationTools`), zero new.

## Defects the review gate caught, not the tests

1. **`exec` would have auto-started the wrong daemon.** `startServiceAuto()` only ever starts a daemon on *this* machine. With a remote host configured, a failed health check would have spawned a local daemon nobody asked for and then polled the remote for 30s anyway. It now reports the unreachable remote instead.
2. **`--limit` was unvalidated before slicing.** It reaches `formatBoard` straight from `Number.parseInt`, and `slice(-limit)` mishandles both `NaN` (returns the whole board) and a negative count (slices from the wrong end).

A third came from following up on a reviewer aside: `localhost` and `[::1]` were classified as remote, which would refuse an auto-start that was perfectly valid.

`telemetry.ts`'s command allowlist is itself a guard test — adding a command without listing it there is a red test, and it caught both new commands.