### PR TITLE
fix(automation): stop re-admitting a parked run from its own footprint

### DIFF
--- a/src/automation/autonomousRunner.operatorQuestionPark.test.ts
+++ b/src/automation/autonomousRunner.operatorQuestionPark.test.ts
@@ -323,17 +323,39 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
     internal.durableRuns.close();
   });
 
-  it('still resumes an unrelated NEEDS_HUMAN park once Linear reopens it', async () => {
-    // The other half of the mutual-exclusivity fix: making the ask_human path
-    // ignore linearState must not cost the OTHER park types their own
-    // resume condition.
+  it('leaves an unrelated NEEDS_HUMAN park alone while its card sits In Progress (AGT-4155)', async () => {
+    // 'In Progress' is where THIS run put the card when it claimed the task,
+    // and parking does not move it back. Treating that level as "the operator
+    // reopened it" re-admitted the park on the very next heartbeat: it
+    // re-claimed, re-executed, re-published and re-parked, once per cycle,
+    // holding a slot the whole time. Observed in production at attempt 20.
     const internal = await makeRunner();
     internal.durableRuns.markNeedsHuman('AGT-1', 'Reviewer rejected 4 attempts: still failing lint');
-    const reopened: TaskItem = { ...TASK, linearState: 'In Progress' };
+    const stillParked: TaskItem = { ...TASK, linearState: 'In Progress' };
+    // The slot the park was holding has to go somewhere: an unrelated task in
+    // the same cycle must still be admitted.
+    const sibling: TaskItem = {
+      ...TASK, id: 'AGT-2', issueId: 'AGT-2', issueIdentifier: 'AGT-2', title: 'unrelated work',
+    };
 
-    const selected = internal.filterAlreadyProcessed([reopened]);
+    const selected = internal.filterAlreadyProcessed([stillParked, sibling]);
 
-    expect(selected).toEqual([reopened]);
+    expect(selected).toEqual([sibling]);
+    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('NEEDS_HUMAN');
+    internal.durableRuns.close();
+  });
+
+  it('resumes an unrelated NEEDS_HUMAN park when the operator dispatches it again (AGT-4155)', async () => {
+    // The park stays terminal for the autonomous loop but must remain
+    // recoverable by an operator ACT — the issue board or `work` CLI saying
+    // "run this", which the pipeline's own writes cannot forge.
+    const internal = await makeRunner();
+    internal.durableRuns.markNeedsHuman('AGT-1', 'Reviewer rejected 4 attempts: still failing lint');
+    const dispatched: TaskItem = { ...TASK, linearState: 'In Progress', explicitDispatch: true };
+
+    const selected = internal.filterAlreadyProcessed([dispatched]);
+
+    expect(selected).toEqual([dispatched]);
     expect(internal.durableRuns.getRun('AGT-1')?.state).not.toBe('NEEDS_HUMAN');
     internal.durableRuns.close();
   });

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -1114,29 +1114,38 @@ export class AutonomousRunner {
           if (durableRun?.state === 'NEEDS_HUMAN') return false;
           if (!durableRun) return false;
         }
-        // The two resume conditions are mutually exclusive by why the run was
+        // The resume conditions are mutually exclusive by why the run was
         // parked, not layered as "either one fires it." An ask_human park
-        // (marker prefix) leaves the Linear card exactly where it already was
-        // — the pipeline never touches it — which for an active task is
-        // routinely 'Todo' or 'In Progress' already; the pre-existing
-        // linearState check would then resume it on the very next heartbeat
-        // regardless of an answer, undoing the park before it did anything.
-        // So it resumes ONLY on its own condition — the question got
-        // answered — and the rejection-limit / PR-closed-without-merge parks
-        // elsewhere in this file, which share NEEDS_HUMAN but DO move the
-        // card (a STUCK label / Backlog), keep resuming only on that Linear
-        // change.
+        // (marker prefix) resumes only when its own questions are answered;
+        // every other park resumes only when the operator dispatches it again.
+        // Neither reads the Linear card's state, because an active task's card
+        // is routinely 'Todo' or 'In Progress' for reasons the pipeline itself
+        // created — see the note on `operatorRedispatched` below.
         const isExactOperatorQuestionPark = durableRun.lastErrorCode === OPERATOR_QUESTION_PARK_REASON;
         const isLegacyOperatorQuestionPark = durableRun.lastErrorMessage?.startsWith(OPERATOR_QUESTION_PARK_MARKER) ?? false;
         const isOperatorQuestionPark = isExactOperatorQuestionPark || isLegacyOperatorQuestionPark;
-        const linearReopened = !isOperatorQuestionPark
-          && ['Todo', 'In Progress', 'In Review'].includes(task.linearState ?? '');
+        // A park is terminal for the autonomous loop, so re-admission needs an
+        // operator ACT. 'In Progress' and 'In Review' are not one: this run put
+        // the card there when it claimed the task and parking does not move it
+        // back, so the old `['Todo','In Progress','In Review']` test was true on
+        // the very next heartbeat for every park that leaves the card alone.
+        // Each cycle re-claimed, re-executed, re-published and re-parked while
+        // holding a slot — AX-1030 reached attempt 20, AX-1027 16, AX-873 15,
+        // and 6 parked runs sat in 'In Progress' feeding this loop with none in
+        // 'Todo' (AGT-4155).
+        //
+        // 'Todo' survives because the pipeline never parks a card there — it is
+        // the operator-reopen surface `observeTask` already documents, reached
+        // by moving a STUCK issue back. `explicitDispatch` is the same act via
+        // the issue board or the `work` CLI.
+        const operatorReopened = !isOperatorQuestionPark
+          && (task.explicitDispatch === true || task.linearState === 'Todo');
         // Read from the durable trace, not the live board: a busy task's own
         // traffic can push its unanswered question out of a board window, and
         // `openQuestionCount` would then read that as "no questions open" —
         // resuming a run that is still genuinely waiting.
         const legacyQuestionAnswered = isLegacyOperatorQuestionPark && getCoordinationStore().allQuestionsAnswered(id);
-        if (linearReopened || legacyQuestionAnswered || isExactOperatorQuestionPark) {
+        if (operatorReopened || legacyQuestionAnswered || isExactOperatorQuestionPark) {
           const resumed = isExactOperatorQuestionPark
             ? this.durableRuns.resumeNeedsHumanForQuestions(id)
             : this.durableRuns.resumeNeedsHuman(id);
@@ -1271,7 +1280,14 @@ export class AutonomousRunner {
         console.warn(`[AutonomousRunner] Failed to clear stuck label for ${id}:`, err));
     }
     if (stuckSkipped > 0) {
-      this.syslog(`🛑 Skipped ${stuckSkipped} stuck issue(s) (retries exhausted — remove the \`${STUCK_LABEL}\` label or move to Todo / In Progress to retry)`);
+      // Todo only. 'In Progress' still recovers a purely label-stuck issue via
+      // classifyStuck, but an issue whose durable run is NEEDS_HUMAN is filtered
+      // out above before it ever reaches that check — and it is filtered there
+      // precisely because the pipeline writes 'In Progress' itself when it
+      // claims a task, so a parked card left in that state cannot distinguish an
+      // operator's intent from this run's own footprint (AGT-4155). Naming the
+      // one state that works on both paths beats naming two that disagree.
+      this.syslog(`🛑 Skipped ${stuckSkipped} stuck issue(s) (retries exhausted — remove the \`${STUCK_LABEL}\` label or move to Todo to retry)`);
     }
     if (recovered > 0) {
       this.saveTaskState();

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -1280,14 +1280,16 @@ export class AutonomousRunner {
         console.warn(`[AutonomousRunner] Failed to clear stuck label for ${id}:`, err));
     }
     if (stuckSkipped > 0) {
-      // Todo only. 'In Progress' still recovers a purely label-stuck issue via
-      // classifyStuck, but an issue whose durable run is NEEDS_HUMAN is filtered
-      // out above before it ever reaches that check — and it is filtered there
-      // precisely because the pipeline writes 'In Progress' itself when it
-      // claims a task, so a parked card left in that state cannot distinguish an
-      // operator's intent from this run's own footprint (AGT-4155). Naming the
-      // one state that works on both paths beats naming two that disagree.
-      this.syslog(`🛑 Skipped ${stuckSkipped} stuck issue(s) (retries exhausted — remove the \`${STUCK_LABEL}\` label or move to Todo to retry)`);
+      // Name Todo because it is the one action that works in every mode. Under
+      // the durable ledger (isPrimary) retry exhaustion also parks the run in
+      // NEEDS_HUMAN and this filter returns on that state above, before the
+      // label check below — so there, removing the label does nothing and
+      // 'In Progress' cannot help either, being a state the pipeline writes
+      // itself when it claims a task (AGT-4155). The legacy non-primary path
+      // skips that gate and still recovers a labelled issue from any of
+      // classifyStuck's RECOVERABLE_STATES. Todo recovers on both. The recovery
+      // branch strips the label itself, so the operator only moves the card.
+      this.syslog(`🛑 Skipped ${stuckSkipped} stuck issue(s) (retries exhausted — move to Todo to retry)`);
     }
     if (recovered > 0) {
       this.saveTaskState();

--- a/src/automation/taskSource.ts
+++ b/src/automation/taskSource.ts
@@ -349,7 +349,7 @@ export class SqliteTaskSource implements ITaskSource {
       sections: [
         { label: 'Reason', body: reason },
         { label: 'How to retry', body: [
-          'Move this issue back to Todo / In Progress.',
+          'Move this issue back to Todo.',
           'The agent will not retry on its own until then.',
         ] },
       ],

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -1161,8 +1161,17 @@ export async function removeIssueLabel(issueId: string, labelName: string): Prom
  * heartbeat must NOT re-attempt it. Adds the durable {@link STUCK_LABEL} (survives
  * daemon restarts, unlike the in-memory failure counters) and parks the issue in
  * Backlog — a non-recoverable state, so the heartbeat's recovery branch won't
- * silently un-block it. Removing the label or moving the issue back to an active
- * state (Todo / In Progress) is the explicit signal to retry.
+ * silently un-block it. Moving the issue back to Todo is the explicit signal to
+ * retry, and the heartbeat strips the label itself on that recovery.
+ *
+ * Todo is named because it is the one action that works in every mode. Under the
+ * durable ledger, exhausting retries also parks the run in NEEDS_HUMAN and
+ * `filterAlreadyProcessed` returns on that state before it ever reaches the label
+ * check — so there, removing the label alone does nothing, and 'In Progress' cannot
+ * help either, being a state the pipeline writes itself when it claims a task
+ * (AGT-4155). Only Todo or an explicit dispatch from the issue board / `work` CLI
+ * retry a parked run. The legacy non-primary path still recovers a labelled issue
+ * from any active state, and Todo satisfies that one too.
  */
 export async function logStuck(
   issueId: string,
@@ -1174,7 +1183,7 @@ export async function logStuck(
     sections: [
       { label: 'Reason', body: reason },
       { label: 'How to retry', body: [
-        `Remove the \`${STUCK_LABEL}\` label, or move this issue back to Todo / In Progress.`,
+        'Move this issue back to Todo — the `' + STUCK_LABEL + '` label is cleared automatically on retry.',
         'The agent will not retry on its own until then.',
       ] },
     ],


### PR DESCRIPTION
## Problem

A run parked on `NEEDS_HUMAN` was pulled back to `READY` whenever its Linear card sat in `Todo`, `In Progress` or `In Review`. The pipeline writes `In Progress` itself when it claims a task, and parking does not move the card back — so that test was true on the very next heartbeat for every park that leaves the card alone. Each cycle re-claimed, re-executed, re-published and re-parked, burning an attempt and holding a slot the whole time.

```
20  parked            RETRY_AT     NEEDS_HUMAN  2026-08-30 10:04:15
20  transition        PUBLISHING   RETRY_AT     2026-08-30 10:04:15
20  transition        EXECUTING    PUBLISHING   2026-08-30 10:04:14
20  claimed           RETRY_AT     CLAIMED      2026-08-30 10:00:05
18  operator_resumed  NEEDS_HUMAN  READY        2026-08-30 09:25:00   ← nobody acted
18  parked            RETRY_AT     NEEDS_HUMAN  2026-08-30 06:08:26
```

Counters reached this way: AX-1030 = 20, AX-1027 = 16, AX-873 = 15, AGT-4119 = 9. Four `operator_resumed` events fired on the current build, the most recent an hour before this change.

## Why `Todo` survives and `In Progress` does not

Across the live ledger, every parked run in a state that triggered the resume was in `In Progress`, and none was in `Todo`:

| card state | parked runs | max attempt |
| --- | --- | --- |
| Backlog | 15 | 21 |
| *(none)* | 12 | 19 |
| **In Progress** | **6** | **20** |
| Todo | **0** | — |

So the loop is entirely the pipeline reading its own writes back as an operator signal. `Todo` is the state only an operator puts a parked card in — `durableRunCoordinator` already documents it as "the autonomous operator-reopen surface", and the same file already warns that `In Progress` "may be owned by a human or another daemon".

## Change

Re-admission of a non-question park now requires an operator act: the card in `Todo`, or an explicit dispatch from the issue board / `work` CLI. Both answer-fenced `ask_human` paths are untouched — they read the durable trace, not the ring buffer.

The stuck-issue log line advertised `Todo / In Progress`; it now names `Todo` alone. `In Progress` still recovers a purely label-stuck issue via `classifyStuck`, but an issue with a durable `NEEDS_HUMAN` run is filtered out before reaching that check, so `Todo` is the one state that works on both paths.

## Tests

Replaces the test that asserted the old resume with two guards:

- a park stays parked while its card is `In Progress`, **and an unrelated task takes the freed slot**
- the same park still resumes on explicit dispatch

Mutation-checked: restoring `['Todo','In Progress','In Review']` turns the first guard red. The pre-existing *"resumes durable NEEDS_HUMAN when an operator moves a stuck issue to Todo"* test passes unchanged — the first draft of this fix broke it, which is what led to narrowing to `Todo` rather than removing the card check.

`typecheck` / `lint` clean; the three park suites pass 28/28. Full suite: 8 failing files, all reproduced on unmodified `origin/main` on this machine (7 TUI + `coordinationTools`) and green in CI.

Closes AGT-4155.
