### PR TITLE
fix(throughput): ephemeral worktree filter + verify sandbox (v0.21.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.21.3 — 2026-09-01
+
+### Fixed
+
+- **Throughput: stop treating pytest/.venv scratch as task source.** Worker change detection, worktree WIP preserve, and verify head sandboxes now ignore ephemeral paths (`pytest-of-*`, `.venv`, `.trash`, `.openswarm` snapshots, etc.). Measured on vela: workers completed but PRs never opened because tester failed in 1–4s on polluted worktrees and scope fences blocked retries.
+- **Verify head checkout no longer copies harness garbage** into the disposable sandbox (same ephemeral filter on `cp` + symlink validation).
+
 ## 0.21.2 — 2026-09-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.21.2",
+      "version": "0.21.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "Autonomous AI agent orchestrator \u2014 Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",

--- a/src/agents/worker.test.ts
+++ b/src/agents/worker.test.ts
@@ -7,7 +7,7 @@ import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { WorkerResult } from './agentPair.js';
-import { formatWorkReport, formatWorkerGitChangeStatus, reconcileWorkerFiles, resolveWorkerBashTimeoutMs, loadWorkerRepoRules, WORKER_BASH_TIMEOUT_DEFAULT_MS, type WorkerOptions } from './worker.js';
+import { formatWorkReport, formatWorkerGitChangeStatus, isEphemeralWorkerArtifact, reconcileWorkerFiles, resolveWorkerBashTimeoutMs, loadWorkerRepoRules, WORKER_BASH_TIMEOUT_DEFAULT_MS, type WorkerOptions } from './worker.js';
 
 describe('worker', () => {
   beforeEach(() => {
@@ -61,6 +61,25 @@ describe('worker', () => {
     it('formats the no-change status', () => {
       expect(formatWorkerGitChangeStatus([])).toBe('[Worker] No file changes detected by Git');
     });
+  });
+
+  it('excludes pytest per-run output but not source tests', () => {
+    expect(isEphemeralWorkerArtifact('.venv')).toBe(true);
+    expect(isEphemeralWorkerArtifact('pytest-of-openswarm/pytest-1/test_case0/result.json')).toBe(true);
+    expect(isEphemeralWorkerArtifact('.openswarm-trash/AGT-3533-pytest-1788171300/pytest-1/test_case0/result.json')).toBe(true);
+    expect(isEphemeralWorkerArtifact('int3301_5736n7bf/fixture.json')).toBe(true);
+    expect(isEphemeralWorkerArtifact('tmp3gnhgw1i/output.txt')).toBe(true);
+    expect(isEphemeralWorkerArtifact('.venv-verify')).toBe(true);
+    expect(isEphemeralWorkerArtifact('.openswarm/repo-snapshot.json')).toBe(true);
+    expect(isEphemeralWorkerArtifact('.test-tmp-2/test_case/current')).toBe(true);
+    expect(isEphemeralWorkerArtifact('.test-tmp-verify/test_case/current')).toBe(true);
+    expect(isEphemeralWorkerArtifact('.trash/AX-855/.test-tmp-verify/test_case/current')).toBe(true);
+    expect(isEphemeralWorkerArtifact('.pytest-lathe/test_case/current')).toBe(true);
+    expect(isEphemeralWorkerArtifact('apps/pipelines/pytest-of-openswarm/garbage/test_case/current')).toBe(true);
+    expect(isEphemeralWorkerArtifact('tests/test_case.py')).toBe(false);
+    expect(isEphemeralWorkerArtifact('src/pytest-of-openswarm-helper.ts')).toBe(false);
+    expect(isEphemeralWorkerArtifact('.venv/bin/python')).toBe(true);
+    expect(isEphemeralWorkerArtifact('.openswarm-trash/AGT-3533-user-backup/notes.txt')).toBe(false);
   });
 
   describe('reconcileWorkerFiles (INT-2609)', () => {

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -263,6 +263,29 @@ export function formatWorkerGitChangeStatus(files: string[]): string {
   return `[Worker] Git detected ${files.length} changed file(s): ${shown}${more}`;
 }
 
+/** Test-run quarantine is not a worker-owned source edit. */
+export function isEphemeralWorkerArtifact(file: string): boolean {
+  return file === '.venv'
+    || file === '.venv-verify'
+    || file === 'pytest-local'
+    || file.startsWith('.venv/')
+    || file.startsWith('.venv-verify/')
+    || file.startsWith('pytest-local/')
+    || /(?:^|\/)pytest-of-[^/]+\//.test(file)
+    || /^pytest-of-[^/]+$/.test(file)
+    || /^\.openswarm-trash\/[^/]*-(?:pytest|verify)(?:-|\/|$)/.test(file)
+    || file === '.vega/google_heartbeat_sync.lock'
+    || /^\.openswarm\/(?:repo-snapshot\.json|repo\.graphql)$/.test(file)
+    || /^\.test-tmp(?:-[^/]+)?(?:\/|$)/.test(file)
+    || /^\.trash(?:\/|$)/.test(file)
+    || /^\.pytest-lathe(?:\/|$)/.test(file)
+    // pytest fixtures in VEGA-style repositories use tempfile prefixes such
+    // as int3301_<random> and tmp<random>; they are harness scratch, never a
+    // task-owned source directory.
+    || /^int\d+_[a-z0-9_]{8,}(?:\/|$)/i.test(file)
+    || /^tmp[a-z0-9]{8,}(?:\/|$)/i.test(file);
+}
+
 // Worker Execution
 
 /**
@@ -409,8 +432,16 @@ export async function runWorker(options: WorkerOptions): Promise<WorkerResult> {
     // signal over self-report).
     if (isGitRepo && snapshotHash) {
       const freshChangedFiles = (await gitTracker.getChangedFilesSinceSnapshot(cwd, snapshotHash))
-        .filter((file) => file !== '.openswarm-preserved');
-      const gitChangedFiles = [...new Set([...(options.resumedTaskFiles ?? []), ...freshChangedFiles])];
+        .filter((file) => file !== '.openswarm-preserved' && !isEphemeralWorkerArtifact(file));
+      // Preserved worktree state predates this invocation and may include
+      // test-run byproducts from an older worker. Apply the same quarantine to
+      // both sources before presenting the authoritative change set to guards,
+      // tester, or publication. Otherwise a resumed task can repeatedly claim
+      // `.venv`/pytest scratch files as source edits even though fresh diffs
+      // correctly filter them.
+      const resumedTaskFiles = (options.resumedTaskFiles ?? [])
+        .filter((file) => file !== '.openswarm-preserved' && !isEphemeralWorkerArtifact(file));
+      const gitChangedFiles = [...new Set([...resumedTaskFiles, ...freshChangedFiles])];
 
       // Scope is an execution-time write boundary. Enforce it against edits made
       // by THIS invocation. Task-owned WIP was already preserved after a prior

--- a/src/support/worktreeEphemeral.ts
+++ b/src/support/worktreeEphemeral.ts
@@ -1,0 +1,50 @@
+/** Ephemeral paths under agent worktrees — never task source / never verify input. */
+
+/** Test/runtime outputs are never task source, including on a resumed WIP branch. */
+export function isEphemeralWorktreeArtifact(file: string): boolean {
+  return file === '.venv'
+    || file === '.venv-verify'
+    || file === 'pytest-local'
+    // pytest's basetemp (`pytest-of-<user>/…`) anywhere in the tree, and the
+    // whole worktree-local `.trash/` quarantine (cgf-portal ships secrets under
+    // `.trash/<issue>/pytest-a3/…` which is not named pytest-of-*).
+    || /(?:^|\/)pytest-of-[^/]+\//.test(file)
+    || /^pytest-of-[^/]+$/.test(file)
+    || /^\.trash(?:\/|$)/.test(file)
+    || /^\.openswarm-trash\/[^/]*-(?:pytest|verify)(?:-|\/|$)/.test(file)
+    // The VEGA heartbeat takes this worktree-local process lock while syncing.
+    // It is never task source and must not be carried into a WIP/PR branch.
+    || file === '.vega/google_heartbeat_sync.lock'
+    || /^\.openswarm\/(?:repo-snapshot\.json|repo\.graphql)$/.test(file)
+    || /^\.test-tmp(?:-[^/]+)?(?:\/|$)/.test(file)
+    || /^\.pytest-lathe(?:\/|$)/.test(file)
+    || /^int\d+_[a-z0-9_]{8,}(?:\/|$)/i.test(file)
+    || /^tmp[a-z0-9]{8,}(?:\/|$)/i.test(file);
+}
+
+/** Collapse file paths to the shallowest directory (or file) git can rm -r. */
+export function ephemeralPathspecRoots(files: string[]): string[] {
+  const roots: string[] = [];
+  const sorted = [...new Set(files)].sort();
+  for (const file of sorted) {
+    const slash = file.indexOf('/');
+    const root = slash === -1 ? file : file.slice(0, slash);
+    // Prefer a stable directory root when the match is under a known quarantine
+    // or pytest basetemp prefix; otherwise keep the full relative path.
+    let pathspec = file;
+    if (/^\.trash(?:\/|$)/.test(file) || /^\.test-tmp(?:-[^/]+)?(?:\/|$)/.test(file) || /^\.pytest-lathe(?:\/|$)/.test(file)) {
+      pathspec = root;
+    } else {
+      const m = file.match(/^(.*(?:^|\/)pytest-of-[^/]+)/);
+      if (m) pathspec = m[1];
+    }
+    if (roots.some((r) => pathspec === r || pathspec.startsWith(`${r}/`))) continue;
+    // Drop any prior root that this one supersedes.
+    for (let i = roots.length - 1; i >= 0; i -= 1) {
+      if (roots[i].startsWith(`${pathspec}/`)) roots.splice(i, 1);
+    }
+    roots.push(pathspec);
+  }
+  return roots;
+}
+

--- a/src/support/worktreeEphemeralOps.ts
+++ b/src/support/worktreeEphemeralOps.ts
@@ -1,0 +1,96 @@
+/** Git index ops for ephemeral worktree artifact purge. */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { isEphemeralWorktreeArtifact, ephemeralPathspecRoots } from './worktreeEphemeral.js';
+
+const execFileAsync = promisify(execFile);
+const GIT_TIMEOUT_MS = 30_000;
+const PRESERVE_MARKER = '.openswarm-preserved';
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', ['-C', cwd, ...args], { timeout: GIT_TIMEOUT_MS });
+  return stdout;
+}
+
+async function stripRuntimeMarkerFromGit(worktreePath: string): Promise<void> {
+  const markerPath = join(worktreePath, PRESERVE_MARKER);
+  try { rmSync(markerPath, { force: true }); } catch { /* git cleanup below still runs */ }
+  await git(worktreePath, 'rm', '--cached', '--ignore-unmatch', '--', PRESERVE_MARKER).catch(() => '');
+}
+
+export async function forceRemoveFromIndex(worktreePath: string, files: string[]): Promise<void> {
+  if (files.length === 0) return;
+  // Directory pathspecs beat hundreds of long unicode paths: on cgf-portal
+  // AX-855, `update-index --force-remove -- <245 files>` left the index
+  // unchanged while `git rm -r --cached -- .trash/pytest-of-…` removed them.
+  const roots = ephemeralPathspecRoots(files);
+  for (const root of roots) {
+    await git(worktreePath, 'rm', '-r', '--cached', '--ignore-unmatch', '-q', '--', root).catch(async () => {
+      await git(worktreePath, 'update-index', '--force-remove', '--', root).catch(() => '');
+    });
+  }
+}
+
+/**
+ * Stage only recoverable source edits for the automatic WIP checkpoint.
+ *
+ * `git add -A` can otherwise commit a linked virtualenv and pytest's per-run
+ * directory. Artifacts from an older WIP commit get an index-only removal, so
+ * the branch is repaired without deleting shared/test files from disk.
+ */
+export async function stagePreservableWorktreeChanges(worktreePath: string): Promise<void> {
+  await stripRuntimeMarkerFromGit(worktreePath);
+  await git(worktreePath, 'add', '-A');
+  const staged = (await git(worktreePath, 'diff', '--cached', '--name-only'))
+    .split('\n').filter(Boolean);
+  const artifacts = staged.filter(isEphemeralWorktreeArtifact);
+  if (artifacts.length === 0) return;
+
+  // reset pathspecs in root batches — same ARG/encoding hazard as update-index.
+  for (const root of ephemeralPathspecRoots(artifacts)) {
+    await git(worktreePath, 'reset', '-q', '--', root).catch(() => '');
+  }
+  const trackedInHead: string[] = [];
+  for (const file of artifacts) {
+    if (await git(worktreePath, 'cat-file', '-e', `HEAD:${file}`).then(() => true).catch(() => false)) {
+      trackedInHead.push(file);
+    }
+  }
+  await forceRemoveFromIndex(worktreePath, trackedInHead);
+}
+
+/** Remove legacy runtime artifacts from a previously preserved branch before it can publish. */
+export async function purgeTrackedEphemeralArtifacts(worktreePath: string): Promise<void> {
+  const tracked = (await git(worktreePath, 'ls-tree', '-r', '--name-only', 'HEAD'))
+    .split('\n').filter(isEphemeralWorktreeArtifact);
+  if (tracked.length === 0) return;
+
+  // Index-only removal leaves shared virtualenvs and pytest scratch output on
+  // disk for the active process, but records the deletion on the task branch.
+  // Preserve any unrelated staged source edit for the normal WIP checkpoint;
+  // `git commit -- <path>` re-reads an existing worktree path and cannot commit
+  // this index-only deletion when that path is now intentionally untracked.
+  const stagedSource = (await git(worktreePath, 'diff', '--cached', '--name-only'))
+    .split('\n').filter((file) => file && !isEphemeralWorktreeArtifact(file));
+  if (stagedSource.length > 0) await git(worktreePath, 'restore', '--staged', '--', ...stagedSource);
+  await forceRemoveFromIndex(worktreePath, tracked);
+  const stagedAfter = (await git(worktreePath, 'diff', '--cached', '--name-only'))
+    .split('\n').filter(Boolean);
+  if (stagedAfter.length === 0) return;
+  try {
+    await git(
+      worktreePath,
+      '-c', 'user.email=swarm@openswarm.local', '-c', 'user.name=OpenSwarm',
+      'commit', '--no-verify', '-m', 'wip: remove ephemeral runtime artifacts (auto)',
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // Empty commit after a concurrent cleaner is not an infra failure.
+    if (/nothing to commit|nothing added to commit/i.test(msg)) return;
+    throw err;
+  }
+  console.log(`[Worktree] Removed ${tracked.length} legacy runtime artifact(s) from WIP branch: ${worktreePath}`);
+}

--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -361,6 +361,40 @@ describe('preserveWorktree → createWorktree resume roundtrip (INT-2503)', () =
     expect(() => git(repo, 'show', 'swarm/INT-9-test:.openswarm-preserved')).toThrow();
   });
 
+  it('keeps linked environments and pytest scratch files out of preserved WIP', async () => {
+    const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+    writeFileSync(join(info.worktreePath, 'app.py'), 'base\npartial-impl\n');
+    writeFileSync(join(info.worktreePath, '.venv'), 'runtime-link-placeholder\n');
+    mkdirSync(join(info.worktreePath, 'pytest-of-openswarm', 'pytest-1'), { recursive: true });
+    writeFileSync(join(info.worktreePath, 'pytest-of-openswarm', 'pytest-1', 'current'), 'scratch\n');
+
+    expect(await preserveWorktree(info, 'test failure')).toBe(true);
+    const resumed = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+
+    expect(resumed.resumedTaskFiles).toEqual(['app.py']);
+    expect(() => git(repo, 'show', 'swarm/INT-9-test:.venv')).toThrow();
+    expect(() => git(repo, 'show', 'swarm/INT-9-test:pytest-of-openswarm/pytest-1/current')).toThrow();
+  });
+
+  it('purges runtime artifacts that a legacy WIP commit already tracked on resume', async () => {
+    const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+    writeFileSync(join(info.worktreePath, 'app.py'), 'base\nlegacy-partial\n');
+    writeFileSync(join(info.worktreePath, '.venv'), 'legacy-runtime-link\n');
+    mkdirSync(join(info.worktreePath, 'pytest-of-openswarm', 'pytest-1'), { recursive: true });
+    writeFileSync(join(info.worktreePath, 'pytest-of-openswarm', 'pytest-1', 'current'), 'legacy-scratch\n');
+    git(info.worktreePath, 'add', '-A');
+    git(info.worktreePath, 'commit', '--no-verify', '-m', 'wip: preserved partial work (auto, legacy)');
+    writeFileSync(join(info.worktreePath, '.openswarm-preserved'), '{}\n');
+
+    const resumed = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
+
+    expect(resumed.resumedTaskFiles).toEqual(['app.py']);
+    expect(() => git(repo, 'show', 'swarm/INT-9-test:.venv')).toThrow();
+    expect(() => git(repo, 'show', 'swarm/INT-9-test:pytest-of-openswarm/pytest-1/current')).toThrow();
+    expect(git(repo, 'log', '--format=%s', '-1', 'swarm/INT-9-test').toString())
+      .toContain('wip: remove ephemeral runtime artifacts (auto)');
+  });
+
   it('removes a clean worktree instead of preserving it', async () => {
     const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
     expect(await preserveWorktree(info, 'test failure')).toBe(false);

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -7,6 +7,8 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
+import { isEphemeralWorktreeArtifact } from './worktreeEphemeral.js';
+import { stagePreservableWorktreeChanges, purgeTrackedEphemeralArtifacts } from './worktreeEphemeralOps.js';
 import { getInstanceId } from './healthEndpoint.js';
 import { readyReusedPullRequest } from './pullRequestReady.js';
 import { isProofCapableSpace, processAppearsAlive, processNamespaceId, sameProcessNamespace, writerProvablyGone } from './processLiveness.js';
@@ -85,8 +87,14 @@ async function getPreservedTaskFiles(worktreePath: string): Promise<string[]> {
     const tab = line.indexOf('\t');
     return { hash: line.slice(0, tab), subject: line.slice(tab + 1) };
   });
+  // Artifact-purge commits are an internal continuation of the same WIP
+  // checkpoint. Treating them as a new base would make the actual source diff
+  // disappear on the next resume.
+  const isPreservedWip = (subject: string): boolean =>
+    subject.startsWith('wip: preserved partial work')
+    || subject === 'wip: remove ephemeral runtime artifacts (auto)';
   let preservedCount = 0;
-  while (commits[preservedCount]?.subject.startsWith('wip: preserved partial work')) preservedCount += 1;
+  while (commits[preservedCount] && isPreservedWip(commits[preservedCount].subject)) preservedCount += 1;
   if (preservedCount === 0) return [];
 
   const base = commits[preservedCount]?.hash;
@@ -94,7 +102,9 @@ async function getPreservedTaskFiles(worktreePath: string): Promise<string[]> {
     ? ['diff', '--name-only', base, 'HEAD']
     : ['diff-tree', '--root', '--no-commit-id', '--name-only', '-r', 'HEAD'];
   const files = await git(worktreePath, ...diffArgs);
-  return [...new Set(files.split('\n').filter((file) => file && file !== PRESERVE_MARKER))];
+  return [...new Set(files.split('\n').filter((file) =>
+    file && file !== PRESERVE_MARKER && !isEphemeralWorktreeArtifact(file)
+  ))];
 }
 
 /** Runtime ownership metadata must never be published in a task branch/PR. */
@@ -103,6 +113,7 @@ async function stripRuntimeMarkerFromGit(worktreePath: string): Promise<void> {
   try { rmSync(markerPath, { force: true }); } catch { /* git cleanup below still runs */ }
   await git(worktreePath, 'rm', '--cached', '--ignore-unmatch', '--', PRESERVE_MARKER).catch(() => '');
 }
+
 
 // Branch & Path Utilities
 
@@ -619,8 +630,7 @@ async function removePreservedWorktreeAtUnlocked(
   if (!m || !existsSync(worktreePath)) return;
   const repoRoot = m[1];
   try {
-    await stripRuntimeMarkerFromGit(worktreePath);
-    await git(worktreePath, 'add', '-A');
+    await stagePreservableWorktreeChanges(worktreePath);
     await git(
       worktreePath,
       '-c', 'user.email=swarm@openswarm.local', '-c', 'user.name=OpenSwarm',
@@ -739,7 +749,7 @@ export async function preserveWorktree(info: WorktreeInfo, reason: string): Prom
   // Only meaningful when git status actually reported dirty files.
   if (dirty !== null && fileCount > 0) {
     try {
-      await git(worktreePath, 'add', '-A');
+      await stagePreservableWorktreeChanges(worktreePath);
       await git(
         worktreePath,
         '-c', 'user.email=swarm@openswarm.local', '-c', 'user.name=OpenSwarm',
@@ -796,6 +806,7 @@ export async function createWorktree(
     const valid = await git(worktreePath, 'status', '--porcelain').then(() => true).catch(() => false);
     const branch = await git(worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD').then((b) => b.trim()).catch(() => '');
     if (valid && branch === branchName) {
+      await purgeTrackedEphemeralArtifacts(worktreePath);
       const resumed: WorktreeInfo = {
         worktreePath, branchName, originalPath: repoPath, issueId,
         resumedTaskFiles: await getPreservedTaskFiles(worktreePath),
@@ -830,6 +841,7 @@ export async function createWorktree(
     if (!valid || branch !== branchName) {
       throw new WorktreeCoordinationError(`Existing worktree requires reconciliation (valid=${valid}, branch=${branch}): ${worktreePath}`);
     }
+    await purgeTrackedEphemeralArtifacts(worktreePath);
     const resumed: WorktreeInfo = {
       worktreePath, branchName, originalPath: repoPath, issueId,
       resumedTaskFiles: await getPreservedTaskFiles(worktreePath),
@@ -868,6 +880,7 @@ export async function createWorktree(
     worktreePath, branchName, originalPath: repoPath, issueId,
     resumedTaskFiles: branchExists ? await getPreservedTaskFiles(worktreePath) : undefined,
   };
+  if (branchExists) await purgeTrackedEphemeralArtifacts(worktreePath);
   // Written before dependency setup or worker invocation. A crash anywhere after
   // `git worktree add` is therefore recoverable.
   info.activeMarkerToken = await writeActiveWorktreeMarker(info);
@@ -1116,6 +1129,13 @@ export async function commitAndCreatePRWithHead(
   options: { draft?: boolean; committedOnly?: boolean; fileScope?: string[] } = {},
 ): Promise<PublishedPullRequest> {
   const { worktreePath, branchName } = info;
+
+  // A parked/stuck branch can be published without a subsequent resume, so the
+  // resume-time cleanup above is not sufficient. Repair legacy generated
+  // artifacts at the publication boundary as well; otherwise a harmless
+  // pytest quarantine or heartbeat lock makes the write-scope fence reject a
+  // branch that otherwise contains valid task work.
+  await purgeTrackedEphemeralArtifacts(worktreePath);
 
   // Check for uncommitted changes and commit them.
   //

--- a/src/verify/discover.test.ts
+++ b/src/verify/discover.test.ts
@@ -73,6 +73,15 @@ describe('discoverVerifyCommands', () => {
     ]);
   });
 
+  it('serializes an explicitly configured xdist pytest run for stable base comparison', async () => {
+    const root = await fixture({
+      'pytest.ini': '[pytest]\naddopts = --tb=short -n auto --dist loadgroup\n',
+    });
+    expect(await discoverVerifyCommands(root)).toEqual([
+      { name: 'pytest', run: 'python -m pytest -n 0 -x -q', kind: 'test', timeoutMs: 300_000 },
+    ]);
+  });
+
   it('discovers Rust tests', async () => {
     const root = await fixture({ 'Cargo.toml': '[package]\nname = "demo"\nversion = "0.1.0"\n' });
     expect(await discoverVerifyCommands(root)).toEqual([

--- a/src/verify/discover.ts
+++ b/src/verify/discover.ts
@@ -75,7 +75,18 @@ export async function discoverVerifyCommands(projectPath: string): Promise<Verif
   const pyproject = await readText(join(projectPath, 'pyproject.toml'));
   const setupCfg = await readText(join(projectPath, 'setup.cfg'));
   if (pytestIni || pyproject?.includes('[tool.pytest.ini_options]') || setupCfg?.includes('[tool:pytest]')) {
-    commands.push(command('pytest', `${await pythonCommand(projectPath)} -m pytest -x -q`, 'test'));
+    // Baseline comparison uses -x. If a repository's config enables xdist,
+    // parallel scheduling can make base and HEAD stop at different *existing*
+    // failures and turn deterministic verification into a false regression.
+    // Override only an explicitly configured xdist worker count; generic pytest
+    // environments that do not install xdist must not receive an unknown -n flag.
+    const pytestConfig = [
+      pytestIni ? await readText(join(projectPath, 'pytest.ini')) : null,
+      pyproject,
+      setupCfg,
+    ].filter((value): value is string => value !== null).join('\n');
+    const serialXdist = /(?:^|\s)-n(?:\s|=)/m.test(pytestConfig) ? ' -n 0' : '';
+    commands.push(command('pytest', `${await pythonCommand(projectPath)} -m pytest${serialXdist} -x -q`, 'test'));
   }
 
   // Rust repositories use Cargo's native test runner.

--- a/src/verify/fingerprintStability.test.ts
+++ b/src/verify/fingerprintStability.test.ts
@@ -113,6 +113,35 @@ describe('normalizeFailureOutput', () => {
     expect(out).not.toContain('2.5s');
   });
 
+  it('normalizes pytest-xdist worker assignment and failure completion order', () => {
+    const a = [
+      '============================= FAILURES =============================',
+      '____________________ test_a ____________________',
+      '[gw1] linux',
+      'E   AssertionError: old failure',
+      '____________________ test_b ____________________',
+      '[gw2] linux',
+      'E   AssertionError: other old failure',
+      '=========================== short test summary info ============================',
+      'FAILED tests/test_b.py::test_b',
+      'FAILED tests/test_a.py::test_a',
+    ].join('\n');
+    const b = [
+      '============================= FAILURES =============================',
+      '____________________ test_b ____________________',
+      '[gw7] linux',
+      'E   AssertionError: other old failure',
+      '____________________ test_a ____________________',
+      '[gw3] linux',
+      'E   AssertionError: old failure',
+      '=========================== short test summary info ============================',
+      'FAILED tests/test_a.py::test_a',
+      'FAILED tests/test_b.py::test_b',
+    ].join('\n');
+
+    expect(normalizeFailureOutput(a, [])).toBe(normalizeFailureOutput(b, []));
+  });
+
   it('is stable for output that mixes stdout and stderr content', () => {
     // The fingerprint is now built stdout-then-stderr rather than in arrival
     // order, so the two streams' relative timing cannot change the hash input.

--- a/src/verify/runner.test.ts
+++ b/src/verify/runner.test.ts
@@ -99,6 +99,21 @@ describe('runVerify', () => {
     }
   });
 
+  it('permits VEGA test fixtures only within the disposable verification checkout', async () => {
+    await mkdir(join(repo, 'pipeline'), { recursive: true });
+    await writeFile(join(repo, 'pipeline', 'path_guard.py'), '# VEGA path policy marker\n');
+    git('add', 'pipeline/path_guard.py');
+    git('commit', '-m', 'VEGA path policy marker');
+
+    const [evidence] = await runVerify({
+      projectPath: repo,
+      commands: [verify('test "$VEGA_EXTRA_PATHS" = "$VEGA_CWD"; test "$VEGA_HEADLESS" = 1; test -d "$VEGA_EXTRA_PATHS"')],
+      baseRef: 'HEAD',
+    });
+
+    expect(evidence).toMatchObject({ headStatus: 'pass', baseStatus: 'skipped', newFailure: false });
+  });
+
   it('runs each verification command from a fresh HEAD sandbox', async () => {
     const evidence = await runVerify({
       projectPath: repo,
@@ -150,6 +165,55 @@ describe('runVerify', () => {
     expect(evidence).toMatchObject({ headStatus: 'fail', baseStatus: 'skipped', newFailure: true });
     expect(evidence.rawOutputTail).toContain('rejects escaping symlink');
     expect(await readFile(outside, 'utf8')).toBe('original\n');
+  });
+
+  it('ignores pytest temporary links left by a preserved worker worktree', async () => {
+    const outside = join(root, 'pytest-output');
+    await mkdir(join(repo, 'pytest-of-openswarm', 'pytest-10'), { recursive: true });
+    await writeFile(outside, 'not a verification input\n');
+    await symlink(outside, join(repo, 'pytest-of-openswarm', 'pytest-current'));
+
+    const [evidence] = await runVerify({
+      projectPath: repo,
+      commands: [verify('printf verified')],
+      baseRef: 'HEAD',
+    });
+
+    expect(evidence).toMatchObject({ headStatus: 'pass', baseStatus: 'skipped', newFailure: false });
+    expect(evidence.rawOutputTail).toContain('verified');
+  });
+
+  it('ignores root-level pytest fixture symlinks while retaining normal link containment', async () => {
+    const outside = join(root, 'fixture-output');
+    await mkdir(join(repo, 'int3304_sortsym__p1mb7w0'), { recursive: true });
+    await writeFile(outside, 'not a verification input\n');
+    await symlink(outside, join(repo, 'int3304_sortsym__p1mb7w0', 'mlink_to_dir'));
+
+    const [evidence] = await runVerify({
+      projectPath: repo,
+      commands: [verify('printf verified')],
+      baseRef: 'HEAD',
+    });
+
+    expect(evidence).toMatchObject({ headStatus: 'pass', baseStatus: 'skipped', newFailure: false });
+    expect(evidence.rawOutputTail).toContain('verified');
+  });
+
+  it('ignores task-scoped OpenSwarm pytest quarantine links', async () => {
+    const outside = join(root, 'pytest-output');
+    const quarantine = join(repo, '.openswarm-trash', 'AGT-3533-pytest-123');
+    await mkdir(quarantine, { recursive: true });
+    await writeFile(outside, 'not a verification input\n');
+    await symlink(outside, join(quarantine, 'test-current'));
+
+    const [evidence] = await runVerify({
+      projectPath: repo,
+      commands: [verify('printf verified')],
+      baseRef: 'HEAD',
+    });
+
+    expect(evidence).toMatchObject({ headStatus: 'pass', baseStatus: 'skipped', newFailure: false });
+    expect(evidence.rawOutputTail).toContain('verified');
   });
 
   it('allows a relative symlink whose target remains inside the repository sandbox', async () => {

--- a/src/verify/runner.ts
+++ b/src/verify/runner.ts
@@ -78,6 +78,33 @@ function pathCoveredBy(path: string, roots: string[]): boolean {
   return roots.some((root) => path === root || path.startsWith(`${root}${sep}`));
 }
 
+/**
+ * Worker retries can leave pytest's numbered temporary directory in a preserved
+ * worktree. Its `*-current` convenience link intentionally points outside that
+ * worktree, but it is neither source nor an input to verification. Do not turn
+ * that known test byproduct into a blanket exception for escaping symlinks.
+ */
+function isEphemeralVerificationArtifact(path: string): boolean {
+  const segments = path.split(sep);
+  const root = segments[0] ?? '';
+  // Root-scoped scratch that must never enter the verification checkout or
+  // count as a worker source edit. Measured on vela: preserved worktrees carried
+  // hundreds of pytest-of-* / .venv paths, so head verify failed in 1–4s and PR
+  // publication never ran.
+  return root === '.venv'
+    || root === '.venv-verify'
+    || root === 'pytest-local'
+    || root === '.pytest-lathe'
+    || root === '.trash'
+    || /^pytest-of-[^/]+$/.test(root)
+    || /^int\d+_[a-z0-9_]{8,}$/i.test(root)
+    || /^tmp[a-z0-9]{8,}$/i.test(root)
+    || /^\.openswarm-trash\/[^/]*-(?:pytest|verify)(?:-|\/|$)/.test(path)
+    || /^\.openswarm\/(?:repo-snapshot\.json|repo\.graphql)$/.test(path)
+    || /^\.trash\/(?:atomic-verify-[^/]+|pytest-of-[^/]+)(?:\/|$)/.test(path)
+    || /(?:^|\/)pytest-of-[^/]+\//.test(path);
+}
+
 function hasSameFailure(base: CommandResult, head: CommandResult): boolean {
   // A shared non-zero exit code is not enough to prove that the failure is
   // pre-existing: HEAD may contain the old failure plus a new regression.
@@ -114,11 +141,37 @@ export function normalizeFailureOutput(output: string, paths: Array<[string, str
   for (const [path, label] of ordered) {
     normalized = normalized.replace(new RegExp(escapeForRegExp(path), 'g'), label);
   }
-  return normalized
+  normalized = normalized
     .replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'), '')
     .replace(/(=+ .*? in )\d+(?:\.\d+)?s( =+)/g, '$1<DURATION>$2')
     .replace(/(Ran \d+ tests? in )\d+(?:\.\d+)?s/g, '$1<DURATION>')
-    .replace(/(finished in )\d+(?:\.\d+)?s/gi, '$1<DURATION>');
+    .replace(/(finished in )\d+(?:\.\d+)?s/gi, '$1<DURATION>')
+    // pytest-xdist assigns the same failure to different workers on base and
+    // head.  A worker number is scheduler noise, not failure evidence.
+    .replace(/\[gw\d+\]/g, '[gw<WORKER>]');
+
+  // xdist also completes failing workers in nondeterministic order.  Preserve
+  // every traceback (so a changed assertion still differs), but compare their
+  // order-insensitive set.  The short summary is normalized for the same reason.
+  const failureMatch = /^(={3,} FAILURES ={3,})\n/m.exec(normalized);
+  if (failureMatch?.index !== undefined) {
+    const bodyStart = failureMatch.index + failureMatch[0].length;
+    const nextHeading = /^(={3,} (?:warnings summary|short test summary info) ={3,})$/m
+      .exec(normalized.slice(bodyStart));
+    const bodyEnd = nextHeading?.index === undefined ? normalized.length : bodyStart + nextHeading.index;
+    const body = normalized.slice(bodyStart, bodyEnd);
+    const blocks = body.split(/(?=^_{8,}.*$)/m).filter(Boolean);
+    normalized = normalized.slice(0, bodyStart) + blocks.sort().join('') + normalized.slice(bodyEnd);
+  }
+  const summaryMatch = /^(={3,} short test summary info ={3,})\n/m.exec(normalized);
+  if (summaryMatch?.index !== undefined) {
+    const bodyStart = summaryMatch.index + summaryMatch[0].length;
+    const nextHeading = /^(={3,} .* ={3,})$/m.exec(normalized.slice(bodyStart));
+    const bodyEnd = nextHeading?.index === undefined ? normalized.length : bodyStart + nextHeading.index;
+    const lines = normalized.slice(bodyStart, bodyEnd).split('\n').filter(Boolean).sort();
+    normalized = normalized.slice(0, bodyStart) + lines.join('\n') + (lines.length ? '\n' : '') + normalized.slice(bodyEnd);
+  }
+  return normalized;
 }
 
 function isEnvironmentFailure(output: string): boolean {
@@ -159,6 +212,18 @@ function shellQuote(value: string): string {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
+/**
+ * VEGA's file-tool policy deliberately permits only its home, OS temp paths,
+ * and explicit user roots.  Verification, however, runs a disposable checkout
+ * beneath the companion's /work root; pytest's cwd-relative tmp paths therefore
+ * are neither home nor /tmp.  Permit precisely that disposable checkout for
+ * VEGA's own tests.  This is not inherited from the supervisor environment and
+ * is never a parent sandbox directory.
+ */
+function vegaVerifyWorkspaceRoot(root: string): string | undefined {
+  return existsSync(join(root, 'pipeline', 'path_guard.py')) ? root : undefined;
+}
+
 async function runWithSandboxExecutor(
   command: VerifyCommand,
   root: string,
@@ -173,9 +238,15 @@ async function runWithSandboxExecutor(
     const cwdBin = join(cwd, 'node_modules', '.bin');
     const rootBin = join(root, 'node_modules', '.bin');
     const relativeCwd = relative(root, cwd) || '.';
+    const vegaWorkspace = vegaVerifyWorkspaceRoot(root);
     const result = await session.execute([
       `cd -- ${shellQuote(relativeCwd)}`,
       `export PATH=${shellQuote(`${cwdBin}${delimiter}${rootBin}`)}:"$PATH"`,
+      ...(vegaWorkspace ? [`export VEGA_EXTRA_PATHS=${shellQuote(vegaWorkspace)}`] : []),
+      // Bundled VEGA toolsets intentionally use the narrower headless-workspace
+      // contract instead of VEGA_EXTRA_PATHS.  Both settings name this same
+      // disposable checkout; neither admits its parent /work directory.
+      ...(vegaWorkspace ? ['export VEGA_HEADLESS=1', `export VEGA_CWD=${shellQuote(vegaWorkspace)}`] : []),
       command.run,
     ].join(' && '), timeoutMs);
     let status: CommandResult['status'];
@@ -254,6 +325,12 @@ async function runCommand(
   };
   for (const key of ['LANG', 'LC_ALL', 'LC_CTYPE', 'TERM', 'COLORTERM', 'NO_COLOR', 'FORCE_COLOR', 'CI', 'TZ', 'SystemRoot', 'ComSpec', 'PATHEXT']) {
     if (env[key] !== undefined) safeEnv[key] = env[key];
+  }
+  const vegaWorkspace = vegaVerifyWorkspaceRoot(root);
+  if (vegaWorkspace) {
+    safeEnv.VEGA_EXTRA_PATHS = vegaWorkspace;
+    safeEnv.VEGA_HEADLESS = '1';
+    safeEnv.VEGA_CWD = vegaWorkspace;
   }
   if (sandboxExecutorSessionFactory) {
     return await runWithSandboxExecutor(
@@ -451,7 +528,11 @@ async function validateSandboxSymlinks(projectPath: string, sharedPaths: string[
     for (const entry of await readdir(directory, { withFileTypes: true })) {
       const source = join(directory, entry.name);
       const path = relative(projectRoot, source);
-      if (path.split(sep).some((segment) => segment === '.git' || segment === 'node_modules') || pathCoveredBy(path, sharedPaths)) continue;
+      if (
+        path.split(sep).some((segment) => segment === '.git' || segment === 'node_modules')
+        || isEphemeralVerificationArtifact(path)
+        || pathCoveredBy(path, sharedPaths)
+      ) continue;
       if (entry.isSymbolicLink()) {
         const target = await readlink(source);
         const resolvedTarget = resolve(dirname(source), target);
@@ -514,7 +595,12 @@ async function createHeadSandbox(
       filter: (source) => {
         const path = relative(projectPath, source);
         return path === '' || (
-          !path.split(sep).some((segment) => segment === '.git' || segment === 'node_modules')
+          !path.split(sep).some((segment) =>
+            segment === '.git'
+            || segment === 'node_modules'
+            || segment === '.venv'
+            || segment === '.venv-verify')
+          && !isEphemeralVerificationArtifact(path)
           && !pathCoveredBy(path, sharedPaths)
         );
       },


### PR DESCRIPTION
## Summary
- **Root cause of low PR throughput on vela:** workers finish, then tester fails in 1–4s / scope fence retries forever because preserved worktrees treat pytest-of-*, `.venv`, `.trash`, `.openswarm` snapshots as source changes (often 100–370 “changed files”).
- Filter ephemeral paths in worker change detection, worktree WIP preserve/purge, and verify head sandbox `cp` + symlink validation.
- Version **0.21.3** (auto-release on merge).

## Ops companion (deploy, not in this PR)
- Point all roles at **openrouter** (orchestrator still on exhausted Codex quota).
- Prefer clean worktrees over polluted preserved resumes where possible.

## Test plan
- [x] worker / worktreeManager / verify runner tests
- [x] typecheck
- [ ] CI green
- [ ] After merge: npm 0.21.3 + rebuild vela image