### PR TITLE
fix(security-audit): keep CodeQL out of the default autonomous loop (v0.21.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.21.5 — 2026-09-01
+
+### Changed
+
+- **CodeQL is no longer part of the default autonomous loop.** The baseline-diff security gate (`autonomous.securityAudit`) defaults to off. A full CodeQL run is minutes to tens of minutes per language and was parking worker PRs (AGT-4160). Opt in with `securityAudit.enabled: true` when CodeQL is installed and that latency is acceptable.
+
+
 ## 0.21.4 — 2026-09-01
 
 ### Fixed

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -184,10 +184,12 @@ autonomous:
     blockOnNewFailures: true
     maxCommands: 4
 
-  # CodeQL security baseline-diff gate. This also applies to PR auto-remediation.
-  # CodeQL must be preinstalled on an absolute PATH; tool absence blocks an edit.
+  # CodeQL security baseline-diff gate. Off by default: a full audit is minutes
+  # to tens of minutes per language and parked autonomous PRs (AGT-4160).
+  # Set enabled: true only when CodeQL is installed and latency is acceptable.
+  # Tool absence still blocks an edit when this is on.
   securityAudit:
-    enabled: true
+    enabled: false
     maxThreads: 2
     # Memory target passed to each CodeQL run, in MB. Best-effort by CodeQL's
     # own account — a large database can still exceed it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.21.4",
+      "version": "0.21.5",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "description": "Autonomous AI agent orchestrator \u2014 Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",

--- a/src/automation/prProcessor.test.ts
+++ b/src/automation/prProcessor.test.ts
@@ -227,11 +227,11 @@ describe('PRProcessor.fixOne (INT-3282)', () => {
     expect(args?.[9]).toBe(securityAudit);
   });
 
-  it('enables the default CodeQL policy when no autonomous configuration exists', async () => {
+  it('leaves CodeQL off when no autonomous configuration exists', async () => {
     await newProcessor().fixOne(pr, '/tmp/proj');
 
     const args = createPipelineFromConfigImpl.mock.calls.at(-1);
-    expect(args?.[9]).toEqual({ enabled: true, maxThreads: 2, maxRamMb: 4096 });
+    expect(args?.[9]).toEqual({ enabled: false, maxThreads: 2, maxRamMb: 4096 });
   });
 
   it('succeeds when there are no conflicts, the pipeline succeeds, and CI passes', async () => {

--- a/src/cli/prCommand.test.ts
+++ b/src/cli/prCommand.test.ts
@@ -204,7 +204,7 @@ describe('loadRolesBestEffort / buildProcessorConfig (INT-3282)', () => {
   });
 
   it('defaults PR remediation to the enabled CodeQL policy', () => {
-    expect(loadSecurityAuditBestEffort()).toEqual({ enabled: true, maxThreads: 2, maxRamMb: 4096 });
+    expect(loadSecurityAuditBestEffort()).toEqual({ enabled: false, maxThreads: 2, maxRamMb: 4096 });
   });
 
   it('enables the conflict resolver by default', () => {

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -219,7 +219,7 @@ agents:
         maxCommands: 4,
       });
       expect(config.autonomous?.securityAudit).toEqual({
-        enabled: true,
+        enabled: false,
         maxThreads: 2,
         maxRamMb: 4096,
       });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -285,10 +285,10 @@ const VerifyConfigSchema = z.object({
 }).default({ enabled: true, blockOnNewFailures: true, maxCommands: 4 });
 
 const SecurityAuditConfigSchema = z.object({
-  enabled: z.boolean().default(true),
+  enabled: z.boolean().default(false),
   maxThreads: z.number().int().min(1).max(16).default(2),
   maxRamMb: z.number().int().min(512).max(65536).default(4096),
-}).default({ enabled: true, maxThreads: 2, maxRamMb: 4096 });
+}).default({ enabled: false, maxThreads: 2, maxRamMb: 4096 });
 
 const AutonomousConfigSchema = z.object({
   /** Auto-enable on service start */
@@ -340,7 +340,7 @@ const AutonomousConfigSchema = z.object({
   guards: PipelineGuardsConfigSchema,
   /** Deterministic baseline-diff verification (default ON). */
   verify: VerifyConfigSchema,
-  /** CodeQL baseline-diff gate for autonomous code edits (default ON). */
+  /** CodeQL baseline-diff gate for autonomous code edits (default OFF — too slow to gate PRs). */
   securityAudit: SecurityAuditConfigSchema,
   /** Max objective self-repair attempts (lint/bs/test) before giving up */
   maxReflections: z.number().min(1).max(10).default(3),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -609,7 +609,7 @@ export type AutonomousStartupConfig = {
   guards?: Partial<PipelineGuardsConfig>;
   /** Deterministic baseline-diff verification, enabled by default. */
   verify?: VerifyConfig;
-  /** CodeQL baseline-diff gate for autonomous worker edits, enabled by default. */
+  /** CodeQL baseline-diff gate for autonomous worker edits, disabled by default (AGT-4160). */
   securityAudit?: SecurityAuditConfig;
   /**
    * Max objective self-repair attempts (lint/bs/test failures) tolerated before

--- a/src/verify/securityAudit.test.ts
+++ b/src/verify/securityAudit.test.ts
@@ -35,6 +35,8 @@ import {
   selectSecuritySourceFiles,
 } from './securityAudit.js';
 
+const ENABLED_AUDIT = { enabled: true, maxThreads: 2, maxRamMb: 4096 } as const;
+
 beforeEach(() => {
   vi.stubEnv('PATH', '/tools');
   vi.clearAllMocks();
@@ -121,10 +123,15 @@ describe('security audit primitives', () => {
 });
 
 describe('runSecurityAudit', () => {
+  it('stays off unless a caller opts in', async () => {
+    expect(DEFAULT_SECURITY_AUDIT_CONFIG.enabled).toBe(false);
+    await expect(runSecurityAudit('/repo', ['src/a.ts'])).resolves.toMatchObject({ status: 'disabled' });
+  });
+
   it('does not require CodeQL for a disabled or source-free audit', async () => {
     await expect(runSecurityAudit('/repo', ['src/a.ts'], { enabled: false, maxThreads: 2 }))
       .resolves.toEqual({ status: 'disabled', codeqlLanguages: [], skippedCodeqlLanguages: [], findings: [] });
-    await expect(runSecurityAudit('/repo', ['README.md'], DEFAULT_SECURITY_AUDIT_CONFIG))
+    await expect(runSecurityAudit('/repo', ['README.md'], ENABLED_AUDIT))
       .resolves.toEqual({ status: 'passed', codeqlLanguages: [], skippedCodeqlLanguages: [], findings: [] });
     expect(execFileMock).not.toHaveBeenCalled();
   });
@@ -132,7 +139,7 @@ describe('runSecurityAudit', () => {
   it('fails closed when CodeQL cannot be found on an absolute PATH entry', async () => {
     fsMock.access.mockRejectedValue(new Error('ENOENT'));
 
-    const audit = await runSecurityAudit('/repo', ['src/a.ts']);
+    const audit = await runSecurityAudit('/repo', ['src/a.ts'], ENABLED_AUDIT);
 
     expect(audit).toMatchObject({ status: 'unavailable', codeqlLanguages: ['javascript'] });
     expect(audit.findings[0]?.ruleId).toBe('openswarm/security-codeql-unavailable');
@@ -153,7 +160,7 @@ describe('runSecurityAudit', () => {
     fsMock.rm.mockResolvedValue(undefined);
     fsMock.readFile.mockResolvedValue(JSON.stringify({ version: '2.1.0', runs: [{ results: [] }] }));
 
-    const audit = await runSecurityAudit('/repo', ['src/a.ts']);
+    const audit = await runSecurityAudit('/repo', ['src/a.ts'], ENABLED_AUDIT);
 
     expect(audit.status).not.toBe('unavailable');
     expect(execFileMock.mock.calls[0]?.[0]).toBe('/custom/codeql');
@@ -162,7 +169,7 @@ describe('runSecurityAudit', () => {
   it('reports a query-pack preparation failure and cleans its isolated snapshot', async () => {
     execFileMock.mockRejectedValueOnce(Object.assign(new Error('pack failed'), { code: 1, stderr: 'network unavailable' }));
 
-    const audit = await runSecurityAudit('/repo', ['src/a.ts']);
+    const audit = await runSecurityAudit('/repo', ['src/a.ts'], ENABLED_AUDIT);
 
     expect(audit).toMatchObject({ status: 'failed', codeqlLanguages: ['javascript'] });
     expect(audit.findings[0]?.ruleId).toBe('openswarm/security-codeql-query-pack');
@@ -181,7 +188,7 @@ describe('runSecurityAudit', () => {
       }] }],
     }));
 
-    const audit = await runSecurityAudit('/repo', ['src/a.ts']);
+    const audit = await runSecurityAudit('/repo', ['src/a.ts'], ENABLED_AUDIT);
 
     expect(audit).toMatchObject({
       status: 'findings',
@@ -218,7 +225,7 @@ describe('runSecurityAudit', () => {
       ] }],
     }));
 
-    const audit = await runSecurityAudit('/repo', ['web/main.js']);
+    const audit = await runSecurityAudit('/repo', ['web/main.js'], ENABLED_AUDIT);
 
     expect(audit.findings).toEqual([
       expect.objectContaining({ filePath: 'web/main.js', line: 85 }),
@@ -242,7 +249,7 @@ describe('runSecurityAudit', () => {
       }] }],
     }));
 
-    const audit = await runSecurityAudit('/repo', ['web/local_provider.py']);
+    const audit = await runSecurityAudit('/repo', ['web/local_provider.py'], ENABLED_AUDIT);
 
     expect(audit.findings).toEqual([
       expect.objectContaining({
@@ -261,7 +268,7 @@ describe('runSecurityAudit', () => {
         stderr: 'Swift does not support the none build mode. Please try using one of the following build modes instead: autobuild, manual.',
       }));
 
-    const audit = await runSecurityAudit('/repo', ['host/App.swift']);
+    const audit = await runSecurityAudit('/repo', ['host/App.swift'], ENABLED_AUDIT);
 
     expect(audit).toMatchObject({
       status: 'partial',
@@ -280,7 +287,7 @@ describe('runSecurityAudit', () => {
         stderr: 'extractor crashed while importing source',
       }));
 
-    const audit = await runSecurityAudit('/repo', ['host/App.swift']);
+    const audit = await runSecurityAudit('/repo', ['host/App.swift'], ENABLED_AUDIT);
 
     expect(audit).toMatchObject({
       status: 'failed',
@@ -306,7 +313,7 @@ describe('runSecurityAudit', () => {
         stderr: 'Swift does not support the none build mode. Please try using one of the following build modes instead: autobuild, manual.',
       }));
 
-    const audit = await runSecurityAudit('/repo', ['web/main.js', 'host/App.swift']);
+    const audit = await runSecurityAudit('/repo', ['web/main.js', 'host/App.swift'], ENABLED_AUDIT);
 
     expect(audit).toMatchObject({
       status: 'partial',
@@ -319,7 +326,7 @@ describe('runSecurityAudit', () => {
   it('fails closed when SARIF cannot be parsed', async () => {
     fsMock.readFile.mockResolvedValue('{not json');
 
-    const audit = await runSecurityAudit('/repo', ['src/a.ts']);
+    const audit = await runSecurityAudit('/repo', ['src/a.ts'], ENABLED_AUDIT);
 
     expect(audit).toMatchObject({ status: 'failed' });
     expect(audit.findings[0]?.ruleId).toBe('openswarm/security-codeql-javascript-sarif');
@@ -328,7 +335,7 @@ describe('runSecurityAudit', () => {
   it('refuses a symbolic-link source before CodeQL can inspect it', async () => {
     fsMock.lstat.mockResolvedValue({ isFile: () => true, isSymbolicLink: () => true });
 
-    const audit = await runSecurityAudit('/repo', ['src/a.ts']);
+    const audit = await runSecurityAudit('/repo', ['src/a.ts'], ENABLED_AUDIT);
 
     expect(audit).toMatchObject({ status: 'failed' });
     expect(audit.findings[0]?.message).toContain('refuses non-regular source');
@@ -448,9 +455,9 @@ describe('runSecurityAudit resource bounds (AGT-4062)', () => {
     });
 
     const audits = [
-      runSecurityAudit('/repo', ['src/a.ts']),
-      runSecurityAudit('/repo', ['src/b.ts']),
-      runSecurityAudit('/repo', ['src/c.ts']),
+      runSecurityAudit('/repo', ['src/a.ts'], ENABLED_AUDIT),
+      runSecurityAudit('/repo', ['src/b.ts'], ENABLED_AUDIT),
+      runSecurityAudit('/repo', ['src/c.ts'], ENABLED_AUDIT),
     ];
     await firstCallStarted;
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -467,7 +474,7 @@ describe('runSecurityAudit resource bounds (AGT-4062)', () => {
 
   it('caps the memory each CodeQL invocation may take', async () => {
     fsMock.readFile.mockResolvedValue(EMPTY_SARIF);
-    await runSecurityAudit('/repo', ['src/a.ts']);
+    await runSecurityAudit('/repo', ['src/a.ts'], ENABLED_AUDIT);
 
     const codeql = execFileMock.mock.calls
       .map((call) => call[1] as string[])
@@ -492,7 +499,7 @@ describe('runSecurityAudit resource bounds (AGT-4062)', () => {
     });
     fsMock.readFile.mockResolvedValue(EMPTY_SARIF);
 
-    await Promise.all(['a', 'b', 'c', 'd'].map((n) => runSecurityAudit('/repo', [`src/${n}.ts`])));
+    await Promise.all(['a', 'b', 'c', 'd'].map((n) => runSecurityAudit('/repo', [`src/${n}.ts`], ENABLED_AUDIT)));
     expect(peak).toBe(1);
   });
 });
@@ -506,11 +513,11 @@ describe('the gate survives a failing snapshot cleanup (AGT-4062)', () => {
     fsMock.readFile.mockResolvedValue(EMPTY_SARIF);
     fsMock.rm.mockRejectedValueOnce(Object.assign(new Error('EACCES'), { code: 'EACCES' }));
 
-    await expect(runSecurityAudit('/repo', ['src/a.ts'])).rejects.toThrow('EACCES');
+    await expect(runSecurityAudit('/repo', ['src/a.ts'], ENABLED_AUDIT)).rejects.toThrow('EACCES');
     expect(codeqlGate.activeCount).toBe(0);
 
     // The next audit must still be able to start.
     fsMock.rm.mockResolvedValue(undefined);
-    await expect(runSecurityAudit('/repo', ['src/b.ts'])).resolves.toMatchObject({ status: 'passed' });
+    await expect(runSecurityAudit('/repo', ['src/b.ts'], ENABLED_AUDIT)).resolves.toMatchObject({ status: 'passed' });
   });
 });

--- a/src/verify/securityAudit.ts
+++ b/src/verify/securityAudit.ts
@@ -111,7 +111,7 @@ export const codeqlGate = new ConcurrencyGate(
 );
 
 export const DEFAULT_SECURITY_AUDIT_CONFIG: SecurityAuditConfig = {
-  enabled: true,
+  enabled: false,
   maxThreads: 2,
   maxRamMb: 4096,
 };


### PR DESCRIPTION
## Summary
- Autonomous `securityAudit` (CodeQL baseline-diff) now defaults to **off**. A full run is minutes to tens of minutes per language and was parking worker PRs.
- Opt in with `autonomous.securityAudit.enabled: true` when that latency is acceptable.
- vela is already running with `securityAudit.enabled: false` on the 0.21.4 image; this change makes the product default match.

## Test plan
- [x] vitest on securityAudit/config/prCommand/prProcessor/pairPipeline/securityAuditGate (237 passed)
- [x] `npm run typecheck`
- [x] vela: after restart the only CodeQL log line is the hotfix PATH echo