### PR TITLE
fix(worker): show the write boundary before the worker edits, not after

### DIFF
--- a/src/agents/workerContext.test.ts
+++ b/src/agents/workerContext.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Only the write-boundary decision is under test here; every other context
+// source is stubbed to an empty result so it cannot mask the assertion.
+vi.mock('../knowledge/index.js', () => ({ analyzeIssue: vi.fn(async () => null) }));
+vi.mock('../memory/repoKnowledge.js', () => ({ recallRepoKnowledge: vi.fn(async () => []) }));
+vi.mock('../registry/sqliteStore.js', () => ({ getRegistryStore: vi.fn(() => null) }));
+vi.mock('./siblingWork.js', () => ({ collectSiblingWork: vi.fn(async () => []) }));
+
+import { collectWorkerContext } from './workerContext.js';
+
+function contextWith(fileScope: string[], fileScopeSource?: string): never {
+  return { task: { fileScope, fileScopeSource }, projectPath: '/tmp/does-not-exist' } as never;
+}
+
+describe('collectWorkerContext write boundary', () => {
+  it('announces a declared scope, which the post-run guard also enforces', async () => {
+    const wc = await collectWorkerContext(contextWith(['src/router.ts'], 'declared'), undefined);
+    expect(wc?.fileScope).toEqual(['src/router.ts']);
+  });
+
+  it('stays silent about an inferred scope, which no consumer enforces', async () => {
+    // pairPipeline.ts and publishOnPark.ts both pass `undefined` for an
+    // inferred scope. Rendering it as "binding" would make the worker refuse
+    // edits that would in fact have passed the gate.
+    const wc = await collectWorkerContext(contextWith(['src/router.ts'], 'inferred'), undefined);
+    expect(wc?.fileScope).toBeUndefined();
+  });
+
+  it('copies the scope rather than aliasing the task', async () => {
+    const scope = ['src/router.ts'];
+    const wc = await collectWorkerContext(contextWith(scope, 'declared'), undefined);
+    wc?.fileScope?.push('src/injected.ts');
+    expect(scope).toEqual(['src/router.ts']);
+  });
+});

--- a/src/agents/workerContext.ts
+++ b/src/agents/workerContext.ts
@@ -12,6 +12,13 @@ export async function collectWorkerContext(
 ): Promise<WorkerContext | undefined> {
   try {
     const wc: WorkerContext = {};
+    // The runner enforces this boundary after the worker finishes. Exposing it
+    // before planning prevents otherwise-valid edits being discovered only by
+    // the post-run scope guard. Legacy raw KG inference is advisory and is NOT
+    // enforced by pairPipeline/publishOnPark, so announcing it as binding here
+    // would make the worker refuse edits that would actually have passed.
+    const enforcedScope = context.task.fileScopeSource === 'inferred' ? undefined : context.task.fileScope;
+    if (enforcedScope?.length) wc.fileScope = [...enforcedScope];
     if (draft) {
       wc.draftAnalysis = { taskType: draft.taskType, intentSummary: draft.intentSummary, relevantFiles: draft.relevantFiles,
         suggestedApproach: draft.suggestedApproach, projectStats: draft.projectStats, completionCriteria: draft.completionCriteria, sufficient: draft.sufficient };
@@ -46,6 +53,6 @@ export async function collectWorkerContext(
     // it changes what the worker knows, not what it is allowed to do. (AGT-4088)
     const siblingWork = await collectSiblingWork(context.projectPath);
     if (siblingWork.length) { wc.siblingWork = siblingWork; safeConsole.log(`[Pipeline] ${siblingWork.length} sibling worktree(s) have uncommitted changes`); }
-    return wc.impactAnalysis || wc.registryBriefs || wc.draftAnalysis || wc.repoMemories || wc.siblingWork ? wc : undefined;
+    return wc.fileScope || wc.impactAnalysis || wc.registryBriefs || wc.draftAnalysis || wc.repoMemories || wc.siblingWork ? wc : undefined;
   } catch (error) { safeConsole.warn('[Pipeline] Worker context collection failed (non-blocking):', error); return undefined; }
 }

--- a/src/locale/prompts/en.ts
+++ b/src/locale/prompts/en.ts
@@ -104,8 +104,14 @@ Apply the above feedback and make corrections.
 
     // Code context section (repository + draftAnalysis + impactAnalysis + registryBriefs + repoMemories)
     let contextSection = '';
-    if (context?.repository || context?.draftAnalysis || context?.impactAnalysis || context?.registryBriefs?.length || context?.repoMemories?.length || context?.siblingWork?.length) {
+    if (context?.fileScope?.length || context?.repository || context?.draftAnalysis || context?.impactAnalysis || context?.registryBriefs?.length || context?.repoMemories?.length || context?.siblingWork?.length) {
       const parts: string[] = ['## Code Context (auto-generated)'];
+
+      if (context.fileScope?.length) {
+        parts.push('', '### Allowed Edit Boundary (binding)');
+        parts.push('Only create or modify the following repository-relative paths. A companion test beside a listed source file (`foo.ts` -> `foo.test.ts`) is also allowed; any other test file must be listed. If the task needs another file, report the concrete mismatch instead of editing it.');
+        parts.push(promptDataBlock(context.fileScope.join('\n')));
+      }
 
       if (context.repository) {
         const repo = context.repository;

--- a/src/locale/prompts/ko.ts
+++ b/src/locale/prompts/ko.ts
@@ -104,8 +104,14 @@ ${promptDataBlock(previousFeedback)}
 
     // Code context section (repository + draftAnalysis + impactAnalysis + registryBriefs + repoMemories)
     let contextSection = '';
-    if (context?.repository || context?.draftAnalysis || context?.impactAnalysis || context?.registryBriefs?.length || context?.repoMemories?.length || context?.siblingWork?.length) {
+    if (context?.fileScope?.length || context?.repository || context?.draftAnalysis || context?.impactAnalysis || context?.registryBriefs?.length || context?.repoMemories?.length || context?.siblingWork?.length) {
       const parts: string[] = ['## 코드 컨텍스트 (자동 생성)'];
+
+      if (context.fileScope?.length) {
+        parts.push('', '### 허용 편집 경계 (구속력 있음)');
+        parts.push('아래 저장소 상대 경로만 생성·수정하라. 목록에 있는 소스 파일 옆의 동반 테스트(`foo.ts` -> `foo.test.ts`)는 목록에 없어도 허용되며, 그 밖의 테스트 파일은 목록에 있어야 한다. 작업에 다른 파일이 필요하면 편집하지 말고 구체적인 불일치를 보고하라.');
+        parts.push(promptDataBlock(context.fileScope.join('\n')));
+      }
 
       if (context.repository) {
         const repo = context.repository;

--- a/src/locale/prompts/prompts.test.ts
+++ b/src/locale/prompts/prompts.test.ts
@@ -39,6 +39,16 @@ describe('systemPrompt', () => {
 describe('buildWorkerPrompt', () => {
   const base = { taskTitle: 'Fix login bug', taskDescription: 'Session expires too fast' };
 
+  it('shows the binding file scope before the worker edits', () => {
+    const result = enPrompts.buildWorkerPrompt({
+      ...base,
+      context: { fileScope: ['src/router.ts', 'tests/router.test.ts'] },
+    });
+    expect(result).toContain('Allowed Edit Boundary (binding)');
+    expect(result).toContain('src/router.ts');
+    expect(result).toContain('tests/router.test.ts');
+  });
+
   it('returns string containing task title and description', () => {
     const result = enPrompts.buildWorkerPrompt(base);
     expect(result).toContain('Fix login bug');

--- a/src/locale/types.ts
+++ b/src/locale/types.ts
@@ -458,6 +458,11 @@ export interface LocaleMessages {
 /** Worker에 주입할 코드 컨텍스트 (반복 횟수 감소 목적) */
 export interface WorkerContext {
   /**
+   * Durable task write boundary. This is rendered to the worker so it can plan
+   * inside the same scope the runner will enforce after execution.
+   */
+  fileScope?: string[];
+  /**
    * What the repository's other worktrees are editing right now, so a worker
    * can see an overlap before its branch collides with theirs at integration.
    */


### PR DESCRIPTION
## Problem

Measured on the vela daemon over one hour: **23 worker completions, 0 PRs published.**

The dominant failure was the worker's own scope guard rejecting its work:

```
Worker failed, retrying... (worker-scope: changed files outside declared fileScope:
  docs/A1-A3-DATA-READINESS.md, docs/CGF-DECISIONS-2026-08-02.md)
[FreshContext] Session b41657a8: failure streak = 3
[FreshContext] Session b41657a8: failure streak = 4
[FreshContext] Session b41657a8: failure streak = 5
```

The runner reserves a write scope per task and `worker.ts` enforces it *after*
execution — but nothing told the worker what that scope was. It planned freely,
edited a neighbouring file, and was failed for it, then retried with the same
blind spot.

## Change

`collectWorkerContext` carries the reservation into the worker prompt as an
`### Allowed Edit Boundary (binding)` block, so the worker plans inside the same
boundary the runner will later enforce.

Two things this deliberately does **not** do:

- **Inferred scope stays unannounced.** `fileScopeSource === 'inferred'` is legacy
  raw knowledge-graph inference that `pairPipeline.ts:408` and `publishOnPark.ts`
  pass as `undefined`. Announcing it as binding would make the worker refuse edits
  that would in fact have passed the gate.
- **The wording matches the gate, not a stricter reading of it.** `isTestForScopedFile`
  (`src/orchestration/writeScope.ts:56`) already auto-allows a companion
  `foo.ts` → `foo.test.ts`, so the prompt says so rather than demanding every test
  be pre-listed.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npx vitest run src/agents/workerContext.test.ts src/locale/prompts/prompts.test.ts` — 75 passed
- [x] New `workerContext.test.ts` covers declared (announced), inferred (silent),
      and that the scope array is copied rather than aliased