### PR TITLE
fix(pipeline): keep ephemeral worktree output out of guards and the scope fence

### DIFF
--- a/src/agents/pipelineGuards.coverage.test.ts
+++ b/src/agents/pipelineGuards.coverage.test.ts
@@ -270,6 +270,13 @@ describe('pipelineGuards — additional coverage', () => {
       expect(issues.length).toBe(0);
       expect(res.allPassed).toBe(true);
     });
+
+    it('does not scan a worktree-local virtual-environment pointer', async () => {
+      writeFileSync(join(repo, '.venv'), 'debugger; // generated environment link\n');
+      const res = await runGuards(mockWorker(['.venv']), repo, { bsDetector: true });
+      expect(guardIssues(res, 'bsDetector')).toEqual([]);
+      expect(res.allPassed).toBe(true);
+    });
   });
 
   // --------------------------------------------------------------

--- a/src/agents/pipelineGuards.ts
+++ b/src/agents/pipelineGuards.ts
@@ -12,6 +12,7 @@ import type { PipelineGuardsConfig } from '../core/types.js';
 import { getRegistryStore } from '../registry/sqliteStore.js';
 import { scanFile as scanFileForBs } from '../registry/bsDetector.js';
 import { getWorkingDiffDetail } from '../support/gitTracker.js';
+import { isEphemeralWorktreeArtifact } from '../support/worktreeEphemeral.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -739,14 +740,20 @@ export async function runGuards(
   config: Partial<PipelineGuardsConfig>,
 ): Promise<GuardsRunResult> {
   const results: GuardResult[] = [];
+  // Keep the original result for reporting/publication, but never feed
+  // generated pytest/venv artifacts into guards that open changed files.
+  const guardWorkerResult = {
+    ...workerResult,
+    filesChanged: workerResult.filesChanged.filter((file) => !isEphemeralWorktreeArtifact(file)),
+  };
 
   if (config.qualityGate) {
     console.warn('[Guard:qualityGate] Deprecated: use autonomous.verify baseline-diff verification instead.');
-    results.push(await runQualityGate(workerResult, projectPath));
+    results.push(await runQualityGate(guardWorkerResult, projectPath));
   }
 
   if (config.fakeDataGuard) {
-    results.push(runFakeDataGuard(workerResult));
+    results.push(runFakeDataGuard(guardWorkerResult));
   }
 
   if (config.branchValidation) {
@@ -754,27 +761,27 @@ export async function runGuards(
   }
 
   if (config.uncertaintyDetection) {
-    results.push(runUncertaintyDetection(workerResult));
+    results.push(runUncertaintyDetection(guardWorkerResult));
   }
 
   if (config.registryCheck) {
-    results.push(runRegistryCheck(workerResult));
+    results.push(runRegistryCheck(guardWorkerResult));
   }
 
   if (config.bsDetector) {
-    results.push(await runBsDetectorGuard(workerResult, projectPath));
+    results.push(await runBsDetectorGuard(guardWorkerResult, projectPath));
   }
 
   if (config.dependencyAntiPatternCheck) {
-    results.push(await runDependencyAntiPatternGuard(workerResult, projectPath));
+    results.push(await runDependencyAntiPatternGuard(guardWorkerResult, projectPath));
   }
 
   if (config.contractEvidenceCheck) {
-    results.push(await runContractEvidenceGuard(workerResult, projectPath));
+    results.push(await runContractEvidenceGuard(guardWorkerResult, projectPath));
   }
 
   if (config.verifiedMetricEvidenceCheck) {
-    results.push(await runVerifiedMetricEvidenceGuard(workerResult, projectPath));
+    results.push(await runVerifiedMetricEvidenceGuard(guardWorkerResult, projectPath));
   }
 
   if (config.deadModuleCheck) {

--- a/src/support/publicationScopeFence.test.ts
+++ b/src/support/publicationScopeFence.test.ts
@@ -3,7 +3,9 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import { assertBranchWithinWriteScope } from './publicationScopeFence.js';
 import { commitAndCreatePRWithHead, type WorktreeInfo } from './worktreeManager.js';
+import { purgeTrackedEphemeralArtifacts } from './worktreeEphemeralOps.js';
 
 function git(cwd: string, ...args: string[]): string {
   return execFileSync('git', ['-C', cwd, ...args], { encoding: 'utf8' });
@@ -67,6 +69,83 @@ describe('pre-publication write-scope fence', () => {
       { committedOnly: true, fileScope: ['src/allowed.ts'] },
     )).rejects.toThrow(/publication-scope.*src\/outside\.ts/);
 
+    expect(remoteBranch(origin, branchName)).toBe('');
+  });
+
+  it('ignores generated OpenSwarm repository snapshots in a preserved branch', async () => {
+    const branchName = 'swarm/AGT-SCOPE-bookkeeping';
+    const { repo } = repository(branchName);
+    mkdirSync(join(repo, '.openswarm'));
+    writeFileSync(join(repo, '.openswarm', 'repo-snapshot.json'), '{}\n');
+    writeFileSync(join(repo, '.openswarm', 'repo.graphql'), 'type Query { ok: Boolean }\n');
+    git(repo, 'add', '.openswarm');
+    git(repo, 'commit', '-qm', 'chore: generated repository context');
+
+    await expect(assertBranchWithinWriteScope(
+      repo, 'origin/main', ['src/allowed.ts'],
+    )).resolves.toBeUndefined();
+  });
+
+  it('ignores pytest per-run artifacts but not source test files', async () => {
+    const branchName = 'swarm/AGT-SCOPE-pytest-temp';
+    const { repo } = repository(branchName);
+    mkdirSync(join(repo, 'pytest-of-openswarm', 'pytest-1'), { recursive: true });
+    writeFileSync(join(repo, 'pytest-of-openswarm', 'pytest-1', 'run-marker'), 'generated\n');
+    git(repo, 'add', 'pytest-of-openswarm');
+    git(repo, 'commit', '-qm', 'test: generated pytest worktree output');
+
+    await expect(assertBranchWithinWriteScope(
+      repo, 'origin/main', ['src/allowed.ts'],
+    )).resolves.toBeUndefined();
+
+    writeFileSync(join(repo, 'src/outside.ts'), 'still source\n');
+    git(repo, 'add', 'src/outside.ts');
+    git(repo, 'commit', '-qm', 'test: out of scope source');
+    await expect(assertBranchWithinWriteScope(
+      repo, 'origin/main', ['src/allowed.ts'],
+    )).rejects.toThrow(/publication-scope.*src\/outside\.ts/);
+  });
+
+  it('ignores the worktree-local virtual-environment link', async () => {
+    const branchName = 'swarm/AGT-SCOPE-venv';
+    const { repo } = repository(branchName);
+    writeFileSync(join(repo, '.venv'), '/private/var/tmp/venv-link\n');
+    git(repo, 'add', '.venv');
+    git(repo, 'commit', '-qm', 'test: generated virtual environment pointer');
+
+    await expect(assertBranchWithinWriteScope(
+      repo, 'origin/main', ['src/allowed.ts'],
+    )).resolves.toBeUndefined();
+  });
+
+  it('ignores quarantined pytest output', async () => {
+    const branchName = 'swarm/AGT-SCOPE-pytest-quarantine';
+    const { repo } = repository(branchName);
+    mkdirSync(join(repo, '.openswarm-trash', 'AGT-SCOPE-pytest-1', 'pytest-1'), { recursive: true });
+    writeFileSync(join(repo, '.openswarm-trash', 'AGT-SCOPE-pytest-1', 'pytest-1', 'run-marker'), 'generated\n');
+    git(repo, 'add', '.openswarm-trash');
+    git(repo, 'commit', '-qm', 'test: quarantined generated pytest output');
+
+    await expect(assertBranchWithinWriteScope(
+      repo, 'origin/main', ['src/allowed.ts'],
+    )).resolves.toBeUndefined();
+  });
+
+  it('ignores and removes legacy verify quarantine and heartbeat locks before publication', async () => {
+    const branchName = 'swarm/AGT-SCOPE-verify-quarantine';
+    const { repo, origin } = repository(branchName);
+    mkdirSync(join(repo, '.openswarm-trash', 'AGT-SCOPE-verify-1', 'pytest-1'), { recursive: true });
+    mkdirSync(join(repo, '.vega'), { recursive: true });
+    writeFileSync(join(repo, '.openswarm-trash', 'AGT-SCOPE-verify-1', 'pytest-1', 'run-marker'), 'generated\n');
+    writeFileSync(join(repo, '.vega', 'google_heartbeat_sync.lock'), 'runtime\n');
+    writeFileSync(join(repo, 'src', 'allowed.ts'), 'task source\n');
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-qm', 'wip: includes legacy runtime output');
+
+    await purgeTrackedEphemeralArtifacts(repo);
+
+    const changed = git(repo, 'diff', '--name-only', 'origin/main...HEAD').trim().split('\n').filter(Boolean);
+    expect(changed).toEqual(['src/allowed.ts']);
     expect(remoteBranch(origin, branchName)).toBe('');
   });
 });

--- a/src/support/publicationScopeFence.ts
+++ b/src/support/publicationScopeFence.ts
@@ -4,7 +4,9 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { withoutBookkeeping } from '../agents/siblingWorkFormat.js';
 import { filesOutsideWriteScope } from '../orchestration/writeScope.js';
+import { isEphemeralWorktreeArtifact } from './worktreeEphemeral.js';
 
 const execFileAsync = promisify(execFile);
 const GIT_TIMEOUT_MS = 5 * 60_000;
@@ -35,7 +37,11 @@ export async function assertBranchWithinWriteScope(
     ['-C', worktreePath, 'diff', '--name-only', `${baseRef}...HEAD`],
     { timeout: GIT_TIMEOUT_MS },
   );
-  const changed = stdout.split('\n').map((line) => line.trim()).filter(Boolean);
+  // The graph exporter writes these managed files into every worktree. They
+  // are not task-owned source edits and are already ignored by the sibling
+  // overlap advisory; apply the same rule before rejecting a branch publish.
+  const changed = withoutBookkeeping(stdout.split('\n').map((line) => line.trim()).filter(Boolean))
+    .filter((file) => !isEphemeralWorktreeArtifact(file));
   const outsideScope = filesOutsideWriteScope(changed, fileScope);
   if (outsideScope.length > 0) throw new PublicationScopeMismatchError(outsideScope);
 }


### PR DESCRIPTION
## Problem

#504 taught worker git authority, WIP preserve/purge and the verify sandbox to ignore
`pytest-of-*`, `.venv` and `.openswarm` scratch. Two consumers of the same changed-file
list were left behind, and both fail closed.

Observed on the vela daemon:

```
[Worktree] PR creation failed: PublicationScopeMismatchError: publication-scope:
  branch contains files outside reserved write scope: ...
    at assertBranchWithinWriteScope (dist/support/publicationScopeFence.js:29:15)
```

- **`runGuards`** opens every changed file. A preserved WIP commit can still list a
  pytest basetemp whose directory was since cleaned, so a static-analysis guard reports
  an error for a file that is neither source nor present.
- **`assertBranchWithinWriteScope`** compares the whole `base..HEAD` list against the
  reservation, so the same scratch aborts publication.

## Change

Both filter through `isEphemeralWorktreeArtifact` from #504's `worktreeEphemeral.ts`
instead of carrying their own narrower copy (the local copies covered 4 patterns; the
shared one covers `.venv.bak`, `pytest-local`, `.trash/`, `.test-tmp` and more).

The guard filter applies **only** to the list handed to guards — `workerResult.filesChanged`
is still reported and published unchanged.

The fence additionally drops bookkeeping paths via `withoutBookkeeping`, which the
sibling-overlap advisory already ignores: the graph exporter writes those into every
worktree and they are not task-owned edits.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run src/agents/pipelineGuards.coverage.test.ts src/support/publicationScopeFence.test.ts` — 27 passed
- [x] New fence cases cover legacy verify quarantine, heartbeat locks, and that a real
      source test (`tests/test_loader.py`) is still scoped