### PR TITLE
fix(verify): wire the sandbox companion whenever it is enabled (AGT-4172)

### DIFF
--- a/src/agents/deterministicTester.test.ts
+++ b/src/agents/deterministicTester.test.ts
@@ -95,4 +95,28 @@ describe('deterministic verification trust inputs', () => {
       [{ name: 'strict-check', run: 'printf host-fallback-would-pass', kind: 'test', timeoutMs: 1_000 }],
     )).rejects.toThrow(/verify-security:.*strict-check.*sandbox unavailable/);
   });
+
+  it('uses the companion for verify-security even when humanSurfaceReadOnly is off', async () => {
+    root = await mkdtemp(join(tmpdir(), 'openswarm-verify-companion-no-hsr-'));
+    const repo = join(root, 'repo');
+    await mkdir(repo);
+    execFileSync('git', ['init', '-b', 'main', repo], { stdio: 'pipe' });
+    execFileSync('git', ['-C', repo, 'config', 'user.email', 'test@example.com']);
+    execFileSync('git', ['-C', repo, 'config', 'user.name', 'Test']);
+    await writeFile(join(repo, 'README.md'), 'base\n');
+    execFileSync('git', ['-C', repo, 'add', 'README.md']);
+    execFileSync('git', ['-C', repo, 'commit', '-m', 'base'], { stdio: 'pipe' });
+    configureSandboxExecutor({
+      ...DEFAULT_SANDBOX_EXECUTOR_LIMITS,
+      socketPath: join(root, 'missing.sock'),
+      allowedRoots: [root],
+      connectTimeoutMs: 50,
+    });
+
+    await expect(runDeterministicTester(
+      repo,
+      { enabled: true, blockOnNewFailures: false, maxCommands: 1 },
+      [{ name: 'typecheck', run: 'printf host-bwrap-would-fail', kind: 'lint', timeoutMs: 1_000 }],
+    )).rejects.toThrow(/verify-security: typecheck could not run inside the attested companion/);
+  });
 });

--- a/src/agents/deterministicTester.ts
+++ b/src/agents/deterministicTester.ts
@@ -27,14 +27,19 @@ async function strictVerifySandbox(projectPath: string): Promise<{
   sessionFactory?: (workspace: string) => Promise<SandboxExecutorSession>;
   scratchRoot?: string;
 }> {
-  if (!isHumanSurfaceReadOnlyEnabled()) return {};
   const config = getSandboxExecutorConfig();
   if (!config) {
-    return {
-      sessionFactory: async () => {
-        throw new Error('strict sandbox executor is not configured');
-      },
-    };
+    // Companion is optional unless humanSurfaceReadOnly demanded it.
+    // Cursor-on-vela keeps HSR off but still ships sandboxExecutor.enabled
+    // so verify can leave the credentialed daemon. (AGT-4172)
+    if (isHumanSurfaceReadOnlyEnabled()) {
+      return {
+        sessionFactory: async () => {
+          throw new Error('strict sandbox executor is not configured');
+        },
+      };
+    }
+    return {};
   }
   let project: string;
   let roots: string[];
@@ -137,7 +142,10 @@ export async function runDeterministicTester(
   });
   const security = evidence.find((item) => item.securityFailure);
   if (security) {
-    throw new VerifySecurityError(`${security.command.name} could not run inside the attested companion: ${security.rawOutputTail}`);
+    const where = strictSandbox.sessionFactory
+      ? 'inside the attested companion'
+      : 'in the OS verification sandbox';
+    throw new VerifySecurityError(`${security.command.name} could not run ${where}: ${security.rawOutputTail}`);
   }
   const infra = evidence.find((item) => item.headStatus === 'infra'
     || (item.headStatus === 'fail' && item.baseStatus === 'infra'));

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -11,7 +11,7 @@ import type { SwarmConfig, AgentSession, LongRunningMonitorConfig, ConflictResol
 import { setTimeWindowConfig, DEFAULT_TIME_WINDOW } from '../support/timeWindow.js';
 import { c, status } from '../support/colors.js';
 import { enableHumanSurfaceReadOnly } from '../mcp/humanSurfacePolicy.js';
-import { configureSandboxExecutor } from '../sandboxExecutor/runtime.js';
+import { wireSandboxExecutorIfEnabled } from '../sandboxExecutor/runtime.js';
 
 // Constants
 
@@ -831,10 +831,7 @@ export function loadConfig(customPath?: string): SwarmConfig {
   // different/default file must never silently downgrade an active boundary.
   // Disabling therefore requires a process restart with enabled:false.
   if (config.humanSurfaceReadOnly?.enabled === true) enableHumanSurfaceReadOnly();
-  if (config.humanSurfaceReadOnly?.enabled === true
-      && config.humanSurfaceReadOnly.sandboxExecutor?.enabled === true) {
-    configureSandboxExecutor(config.humanSurfaceReadOnly.sandboxExecutor);
-  }
+  wireSandboxExecutorIfEnabled(config.humanSurfaceReadOnly?.sandboxExecutor);
 
   // 6. Apply time window config
   if (config.timeWindow) {
@@ -930,7 +927,8 @@ notifications:
 # Fail closed on writes to human-facing collaboration surfaces. Delegated CLIs
 # and diagnostics remain disabled. Native bash requires the separately deployed
 # network-none companion and exact health/contract attestation; any failure
-# leaves bash hidden. Approved typed DevOps/data MCP writes remain available.
+# leaves bash hidden. Verify-security uses the same companion whenever
+# sandboxExecutor.enabled is true, even if this flag is off. (AGT-4172)
 humanSurfaceReadOnly:
   enabled: false
   sandboxExecutor:

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -33,7 +33,7 @@ import {
   enableHumanSurfaceReadOnly,
   isHumanSurfaceReadOnlyEnabled,
 } from '../mcp/humanSurfacePolicy.js';
-import { configureSandboxExecutor } from '../sandboxExecutor/runtime.js';
+import { wireSandboxExecutorIfEnabled } from '../sandboxExecutor/runtime.js';
 
 let state: ServiceState = {
   running: false,
@@ -79,10 +79,7 @@ export async function startService(config: SwarmConfig): Promise<void> {
 
 async function startServiceLocked(config: SwarmConfig): Promise<void> {
   if (config.humanSurfaceReadOnly?.enabled === true) enableHumanSurfaceReadOnly();
-  if (config.humanSurfaceReadOnly?.enabled === true
-      && config.humanSurfaceReadOnly.sandboxExecutor?.enabled === true) {
-    configureSandboxExecutor(config.humanSurfaceReadOnly.sandboxExecutor);
-  }
+  wireSandboxExecutorIfEnabled(config.humanSurfaceReadOnly?.sandboxExecutor);
   let postMergeIntegration: PRProcessorConfig['postMergeIntegration'];
   // The lifetime SQLite lock above is the atomic single-instance authority.
   // Keep the port probe as a diagnostic for older daemons or unrelated

--- a/src/sandboxExecutor/runtime.test.ts
+++ b/src/sandboxExecutor/runtime.test.ts
@@ -3,6 +3,7 @@ import {
   configureSandboxExecutor,
   getSandboxExecutorConfig,
   resetSandboxExecutorForTests,
+  wireSandboxExecutorIfEnabled,
 } from './runtime.js';
 
 const config = {
@@ -36,5 +37,13 @@ describe('sandbox executor process capability', () => {
     expect(getSandboxExecutorConfig()?.allowedRoots).toEqual(['/work']);
     expect(() => getSandboxExecutorConfig()!.allowedRoots.push('/work/attacker')).toThrow();
     expect(getSandboxExecutorConfig()?.allowedRoots).toEqual(['/work']);
+  });
+
+  it('ignores a disabled executor block and wires an enabled one without humanSurfaceReadOnly', () => {
+    wireSandboxExecutorIfEnabled({ ...config, enabled: false });
+    expect(getSandboxExecutorConfig()).toBeUndefined();
+
+    wireSandboxExecutorIfEnabled({ ...config, enabled: true });
+    expect(getSandboxExecutorConfig()).toEqual(config);
   });
 });

--- a/src/sandboxExecutor/runtime.ts
+++ b/src/sandboxExecutor/runtime.ts
@@ -31,6 +31,18 @@ export function configureSandboxExecutor(config: SandboxExecutorClientConfig): v
   }
 }
 
+/**
+ * Wire the network-none companion whenever its block is enabled.
+ * Verify-security needs that socket even if humanSurfaceReadOnly is off
+ * (Cursor CLI workers still run typecheck in the daemon process). (AGT-4172)
+ */
+export function wireSandboxExecutorIfEnabled(
+  executor: (SandboxExecutorClientConfig & { enabled?: boolean }) | undefined,
+): void {
+  if (executor?.enabled !== true) return;
+  configureSandboxExecutor(executor);
+}
+
 export function getSandboxExecutorConfig(): Readonly<SandboxExecutorClientConfig> | undefined {
   return configuredClient;
 }


### PR DESCRIPTION
## Problem

`configureSandboxExecutor` was called only when `humanSurfaceReadOnly.enabled` was
*also* true:

```ts
if (config.humanSurfaceReadOnly?.enabled === true
    && config.humanSurfaceReadOnly.sandboxExecutor?.enabled === true) {
  configureSandboxExecutor(config.humanSurfaceReadOnly.sandboxExecutor);
}
```

So a deployment that ships the network-none companion but keeps HSR off never
registered it. `strictVerifySandbox` then took the HSR-off early return and ran
verification in the credentialed daemon process instead.

That is exactly the vela Cursor-CLI configuration — HSR off, `sandboxExecutor.enabled`
true — and verify-security needs that socket regardless of HSR, because the worker
still runs typecheck inside the daemon.

## Change

- `wireSandboxExecutorIfEnabled` keys the wiring off the executor block alone; both
  call sites (`loadConfig`, `startServiceLocked`) share it.
- `strictVerifySandbox` treats a missing companion config as fatal **only** when HSR
  demanded it; otherwise it falls back to the OS verification sandbox rather than
  throwing `strict sandbox executor is not configured`.
- The security-failure message names where the command actually ran, so
  "could not run inside the attested companion" no longer appears for a run that
  never had one.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run src/sandboxExecutor/runtime.test.ts src/agents/deterministicTester.test.ts` — 9 passed
- [x] `npx vitest run src/core/config.test.ts` — 50 passed (no regression from the
      rewired call site)