### PR TITLE
fix(agentic-loop): keep the ENOENT path tail in LIVE LOG tool errors (AGT-4175)

### DIFF
--- a/src/adapters/agenticLoop.test.ts
+++ b/src/adapters/agenticLoop.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { compactPriorTurns, toolCallKey, allToolCallsSeen, shouldNudgeReadLoop, READ_LOOP_NUDGE_AT, shouldNudgeCoordinationCheck, COORDINATION_CHECK_NUDGE_EVERY, COORDINATION_CHECK_NUDGE_PROMPT, runAgenticLoop, loopResultToCliResult, type ChatMessage, type AgenticLoopResult } from './agenticLoop.js';
+import { compactPriorTurns, toolCallKey, allToolCallsSeen, shouldNudgeReadLoop, READ_LOOP_NUDGE_AT, shouldNudgeCoordinationCheck, COORDINATION_CHECK_NUDGE_EVERY, COORDINATION_CHECK_NUDGE_PROMPT, runAgenticLoop, loopResultToCliResult, formatToolErrorLog, type ChatMessage, type AgenticLoopResult } from './agenticLoop.js';
 import type { ToolCall } from './tools.js';
 import { enableHumanSurfaceReadOnly, resetHumanSurfaceReadOnlyForTests } from '../mcp/humanSurfacePolicy.js';
 import { SandboxOutcomeUnknownError } from '../sandboxExecutor/protocol.js';
@@ -41,6 +41,21 @@ const multiToolCallResp = (calls: Array<{ id: string; name: string; args: object
 /** Scripted API response with no tool calls (model tries to finish). */
 const finalResp = (content: string) => ({
   choices: [{ message: { role: 'assistant', content }, finish_reason: 'stop' }],
+});
+
+describe('formatToolErrorLog', () => {
+  it('keeps short errors whole', () => {
+    expect(formatToolErrorLog('Tool error: missing')).toBe('Tool error: missing');
+  });
+
+  it('keeps the ENOENT path tail instead of cutting the worktree UUID', () => {
+    const content = "Tool error: ENOENT: no such file or directory, open '/work/cgf-portal/worktree/6627815b-7e6b-455e-af72-9a6b6bdfc7be/docs/CGF_data/0821.xls'";
+    const logged = formatToolErrorLog(content);
+    expect(logged.length).toBeLessThanOrEqual(240);
+    expect(logged).toContain('ENOENT');
+    expect(logged).toContain('0821.xls');
+    expect(logged).not.toMatch(/455e-af$/);
+  });
 });
 
 describe('progress-based stop helpers', () => {

--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -54,6 +54,19 @@ function truncateToolResult(content: string, maxLen = 2500): string {
   return `${head}\n...[${content.length - 2200} chars truncated]...\n${tail}`;
 }
 
+/**
+ * One LIVE LOG line for a failed tool call. The previous `slice(0, 100)` cut an
+ * ENOENT path off inside `/work/.../worktree/<uuid-prefix>`, which read as a
+ * missing worktree rather than a missing file. Keep the error kind (head) and
+ * the path/filename that identifies it (tail).
+ */
+export function formatToolErrorLog(content: string, maxLen = 240): string {
+  if (content.length <= maxLen) return content;
+  const head = 90;
+  const tail = Math.max(40, maxLen - head - 1);
+  return `${content.slice(0, head)}…${content.slice(-tail)}`;
+}
+
 // ============ 타입 ============
 
 /** OpenAI Chat Completions API 메시지 포맷 */
@@ -630,7 +643,7 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
         content,
       });
       if (result.is_error) {
-        onLog?.(`  ✖ ${content.slice(0, 100)}`);
+        onLog?.(`  ✖ ${formatToolErrorLog(content)}`);
       }
     }
 


### PR DESCRIPTION
## Problem

A failed tool call was logged as `content.slice(0, 100)`. For an ENOENT that is exactly
long enough to end inside the worktree UUID:

```
✖ Tool error: ENOENT: no such file or directory, open '/work/cgf-portal/worktree/6627815b-7e6b-455e-af
```

That reads as a *missing worktree*, and the operator went looking for one. The file
that was actually absent (`docs/CGF_data/0821.xls`) was in the part cut off.

## Change

`formatToolErrorLog` keeps the error kind at the head (90 chars) and the path/filename
at the tail within the same one-line budget (240), so the log answers "what failed"
and "on which file" without opening the transcript.

## Test plan

- [x] `npx vitest run src/adapters/agenticLoop.test.ts` — 54 passed
- [x] New cases: short errors are untouched; a real vela ENOENT keeps `ENOENT` and
      `0821.xls` and no longer ends mid-UUID