### PR TITLE
fix(coordination): stop mirroring to Linear once the board issue hits its comment cap

### DIFF
--- a/src/coordination/linearBoard.test.ts
+++ b/src/coordination/linearBoard.test.ts
@@ -50,4 +50,15 @@ describe('TrackerCoordinationBoard', () => {
     expect(addComment).toHaveBeenCalledWith('BOARD-1', expect.stringContaining('Agent board'), `coordination:${event.fingerprint}`);
     expect(await board.read()).toEqual([event]);
   });
+
+  it('stops retrying after Linear reports its immutable comment quota', async () => {
+    const addComment = vi.fn(async () => { throw new Error('Quota exceeded - An issue can have a maximum of 2000 comments.'); });
+    const board = new TrackerCoordinationBoard({ addComment } as unknown as ITaskSource, 'BOARD-1');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await board.publish(event);
+    await board.publish({ ...event, id: 'e2', fingerprint: 'a'.repeat(64) });
+    expect(addComment).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenCalledTimes(1);
+    error.mockRestore();
+  });
 });

--- a/src/coordination/linearBoard.ts
+++ b/src/coordination/linearBoard.ts
@@ -67,10 +67,26 @@ export function parseCoordinationComment(body: string): CoordinationEvent | null
 }
 
 export class TrackerCoordinationBoard {
+  private commentQuotaExhausted = false;
+
   constructor(private readonly source: ITaskSource, private readonly boardIssueId: string) {}
 
   async publish(event: CoordinationEvent): Promise<void> {
-    await this.source.addComment(this.boardIssueId, formatCoordinationComment(event), `coordination:${event.fingerprint}`);
+    if (this.commentQuotaExhausted) return;
+    try {
+      await this.source.addComment(this.boardIssueId, formatCoordinationComment(event), `coordination:${event.fingerprint}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      // Linear rejects every subsequent comment once an issue reaches its hard
+      // 2,000-comment limit. The local coordination store remains durable, so
+      // retrying each event only creates an unbounded error storm.
+      if (/quota exceeded|maximum of \d+ comments/i.test(message)) {
+        this.commentQuotaExhausted = true;
+        console.error(`[CoordinationBoard] disabled remote mirror for ${this.boardIssueId}: ${message}`);
+        return;
+      }
+      throw error;
+    }
   }
 
   async read(): Promise<CoordinationEvent[]> {


### PR DESCRIPTION
## Problem

Linear rejects every comment on an issue past 2,000:

```
Quota exceeded - An issue can have a maximum of 2000 comments.
```

The cap is per issue and never resets, so once the coordination board issue reaches
it, every subsequent `publish` fails identically. The local SQLite coordination store
is the durable record and the Linear comment is only a mirror — yet each event retried
the mirror and logged the same rejection, an unbounded error storm that buried real
failures.

## Change

`TrackerCoordinationBoard` recognises that rejection, logs it once, and drops the
mirror for the rest of the process. Other errors still propagate.

## Test plan

- [x] `npx vitest run src/coordination/linearBoard.test.ts` — passes; new case asserts a
      second `publish` after the quota error does not call `addComment` again and logs once