### PR TITLE
feat(threads): open the durable board across every repository

### DIFF
--- a/src/coordination/coordinationThreadRoutes.test.ts
+++ b/src/coordination/coordinationThreadRoutes.test.ts
@@ -85,9 +85,17 @@ describe('durable coordination thread HTTP API', () => {
   });
 
   it('returns bounded errors and leaves unrelated paths alone', async () => {
-    expect(await call('GET', '/api/coordination/threads')).toMatchObject({
-      handled: true, status: 400, body: { error: 'Invalid coordination thread request' },
+    const first = await call('POST', '/api/coordination/threads', {
+      repository: '/repo-a', taskId: 'task-a', subject: 'First', idempotencyKey: 'first',
     });
+    const second = await call('POST', '/api/coordination/threads', {
+      repository: '/repo-b', taskId: 'task-b', subject: 'Second', idempotencyKey: 'second',
+    });
+    const all = await call('GET', '/api/coordination/threads?limit=200');
+    expect(all).toMatchObject({ handled: true, status: 200 });
+    expect(all.body.items.map((thread: { id: string }) => thread.id)).toEqual(expect.arrayContaining([
+      first.body.thread.id, second.body.thread.id,
+    ]));
     expect(await call('POST', '/api/coordination/threads', { repository: '/repo' }))
       .toMatchObject({ handled: true, status: 400, body: { error: 'Invalid coordination thread request' } });
     expect((await call('GET', '/api/not-coordination')).handled).toBe(false);

--- a/src/coordination/coordinationThreadRoutes.ts
+++ b/src/coordination/coordinationThreadRoutes.ts
@@ -20,6 +20,10 @@ import { publishCoordinationThreadUpdate } from './coordinationThreadTools.js';
 type BodyReader = (req: IncomingMessage) => Promise<string>;
 
 function threadRepository(path: string): string {
+  // The all-repositories board returns the durable opaque cell key.  Accept it
+  // on subsequent detail reads so the operator can open that thread without
+  // first selecting its original filesystem path.
+  if (/^(?:git|path):[a-f0-9]{32}$/.test(path)) return path;
   return repositoryKey(undefined, path);
 }
 
@@ -103,7 +107,6 @@ export async function tryHandleCoordinationThreadRoutes(
   try {
     if (url === '/api/coordination/threads' && req.method === 'GET') {
       const repository = requestUrl.searchParams.get('repository');
-      if (!repository) throw new Error('repository query parameter is required');
       const statusRaw = requestUrl.searchParams.get('status') ?? undefined;
       if (statusRaw && statusRaw !== 'open' && statusRaw !== 'resolved') {
         throw new Error('status must be open or resolved');
@@ -115,7 +118,7 @@ export async function tryHandleCoordinationThreadRoutes(
       }
       const limit = Number.parseInt(requestUrl.searchParams.get('limit') ?? '', 10);
       writeJson(res, 200, listCoordinationThreads({
-        repository: threadRepository(repository),
+        ...(repository ? { repository: threadRepository(repository) } : {}),
         status: statusRaw as CoordinationThreadStatus | undefined,
         relatedTaskId: requestUrl.searchParams.get('taskId') ?? undefined,
         ...(actor && participantTaskId ? { participant: { actor, taskId: participantTaskId } } : {}),

--- a/src/coordination/coordinationThreads.ts
+++ b/src/coordination/coordinationThreads.ts
@@ -769,7 +769,8 @@ function decodeThreadCursor(cursor: string): [number, string] {
 }
 
 export function listCoordinationThreads(input: {
-  repository: string;
+  /** Omit to read the operator-wide board across repository cells. */
+  repository?: string;
   status?: CoordinationThreadStatus;
   relatedTaskId?: string;
   participant?: { actor: string; taskId: string };
@@ -777,10 +778,14 @@ export function listCoordinationThreads(input: {
   cursor?: string;
 }): ThreadPage<CoordinationThread> {
   const db = database();
-  const repo = repository(input.repository);
   const limit = Math.min(Math.max(Math.trunc(input.limit ?? DEFAULT_LIMIT), 1), MAX_LIMIT);
-  const where = ['t.repository = ?'];
-  const params: Array<string | number> = [repo];
+  const repo = input.repository ? repository(input.repository) : undefined;
+  const where: string[] = [];
+  const params: Array<string | number> = [];
+  if (repo) {
+    where.push('t.repository = ?');
+    params.push(repo);
+  }
   if (input.status) {
     where.push('t.status = ?');
     params.push(input.status);
@@ -822,7 +827,7 @@ export function listCoordinationThreads(input: {
       (SELECT COUNT(*) FROM coordination_thread_subscriptions s WHERE s.thread_id = t.thread_id) AS participant_count
       ${unreadSelect}
     FROM coordination_threads t
-    WHERE ${where.join(' AND ')}
+    ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''}
     ORDER BY t.updated_at DESC, t.thread_id DESC
     LIMIT ?
   `).all(...unreadParams, ...params, limit + 1) as ThreadRow[];

--- a/tests/web/threadBoard.test.ts
+++ b/tests/web/threadBoard.test.ts
@@ -2,7 +2,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 // @ts-expect-error — browser ESM asset without type declarations
-import { renderThreadDetail, renderThreadList, startThreadBoard } from '../../web/static/js/threadBoard.mjs';
+import { renderThreadDetail, renderThreadList, renderThreadMessageBody, startThreadBoard } from '../../web/static/js/threadBoard.mjs';
 
 function shell(): Document {
   document.body.innerHTML = `
@@ -51,6 +51,41 @@ describe('repository thread board', () => {
     expect(doc.querySelector('img')).toBeNull();
     expect(doc.querySelector('svg')).toBeNull();
     expect(doc.querySelector('script')).toBeNull();
+  });
+
+  it('renders fenced code with safe syntax tokens', () => {
+    const doc = shell();
+    const holder = doc.createElement('div');
+    renderThreadMessageBody(doc, holder, 'Use `src/a.ts`.\n```ts\nconst answer = 42; // safe\n```\n<img src=x>');
+    expect(holder.querySelector('pre code')).not.toBeNull();
+    expect(holder.querySelector('.token-keyword')?.textContent).toBe('const');
+    expect(holder.querySelector('.token-number')?.textContent).toBe('42');
+    expect(holder.querySelector('.inline-code')?.textContent).toBe('src/a.ts');
+    expect(holder.querySelector('img')).toBeNull();
+    expect(holder.textContent).toContain('<img src=x>');
+  });
+
+  it('loads every repository thread before a repository is selected', async () => {
+    const doc = shell();
+    const thread = {
+      id: 'thread-all', repository: 'git:0123456789abcdef0123456789abcdef', subject: 'Shared decision',
+      status: 'open', relatedTaskIds: [], relatedFiles: [], messageCount: 1, participantCount: 1, updatedAt: 1,
+    };
+    const fetchImpl = vi.fn(async (path: string) => {
+      if (path === '/api/work/projects') return response([]);
+      if (path.startsWith('/api/coordination/threads?')) return response({ items: [thread] });
+      if (path.startsWith('/api/coordination/threads/thread-all?')) {
+        return response({ thread, participants: [], messages: { items: [] } });
+      }
+      throw new Error(`Unexpected request: ${path}`);
+    });
+    const view = startThreadBoard(doc, { fetchImpl, pollMs: 0 });
+    await vi.waitFor(() => expect(doc.querySelector('[data-thread-id="thread-all"]')).not.toBeNull());
+    expect(fetchImpl).toHaveBeenCalledWith('/api/coordination/threads?limit=200&status=open', expect.any(Object));
+    (doc.querySelector('[data-thread-id="thread-all"]') as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(doc.getElementById('detail-subject')?.textContent).toBe('Shared decision'));
+    expect(fetchImpl).toHaveBeenCalledWith(expect.stringContaining('repository=git%3A0123456789abcdef0123456789abcdef'), expect.any(Object));
+    view.stop();
   });
 
   it('drives create, follow, reply, read, and CAS resolve through the HTTP contract', async () => {

--- a/web/static/js/threadBoard.mjs
+++ b/web/static/js/threadBoard.mjs
@@ -34,6 +34,50 @@ function time(value) {
   return new Date(value).toLocaleString();
 }
 
+function appendCode(doc, holder, source) {
+  const code = doc.createElement('code');
+  // A small DOM-only lexer keeps agent-controlled text inert while making the
+  // common code and log fragments materially easier to scan.
+  const token = /(\/\/[^\n]*|#[^\n]*|\/\*[\s\S]*?\*\/)|((?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'))|(\b(?:async|await|break|case|class|const|def|else|export|false|for|from|function|if|import|in|let|new|null|return|true|try|catch|throw|while)\b)|(\b\d+(?:\.\d+)?\b)|([{}[\]().,;:=])/g;
+  let cursor = 0;
+  for (const match of source.matchAll(token)) {
+    if (match.index > cursor) code.append(doc.createTextNode(source.slice(cursor, match.index)));
+    const className = match[1] ? 'token-comment'
+      : match[2] ? 'token-string'
+        : match[3] ? 'token-keyword'
+          : match[4] ? 'token-number' : 'token-punctuation';
+    code.appendChild(text(doc, 'span', match[0], className));
+    cursor = match.index + match[0].length;
+  }
+  if (cursor < source.length) code.append(doc.createTextNode(source.slice(cursor)));
+  holder.appendChild(code);
+}
+
+/** Render prose, inline code, and fenced code without ever interpreting HTML. */
+export function renderThreadMessageBody(doc, holder, body) {
+  holder.replaceChildren();
+  const appendProse = (value) => {
+    let cursor = 0;
+    for (const match of value.matchAll(/`([^`\n]+)`/g)) {
+      if (match.index > cursor) holder.append(doc.createTextNode(value.slice(cursor, match.index)));
+      holder.appendChild(text(doc, 'code', match[1], 'inline-code'));
+      cursor = match.index + match[0].length;
+    }
+    if (cursor < value.length) holder.append(doc.createTextNode(value.slice(cursor)));
+  };
+  const source = String(body ?? '');
+  const fence = /```[^\n]*\n([\s\S]*?)```/g;
+  let cursor = 0;
+  for (const match of source.matchAll(fence)) {
+    appendProse(source.slice(cursor, match.index));
+    const pre = doc.createElement('pre');
+    appendCode(doc, pre, match[1]);
+    holder.appendChild(pre);
+    cursor = match.index + match[0].length;
+  }
+  appendProse(source.slice(cursor));
+}
+
 export function renderThreadList(doc, holder, threads, selectedId, onSelect) {
   holder.replaceChildren();
   if (threads.length === 0) {
@@ -54,7 +98,7 @@ export function renderThreadList(doc, holder, threads, selectedId, onSelect) {
     card.appendChild(text(
       doc,
       'div',
-      `${tasks} · ${thread.messageCount} messages · ${thread.participantCount} participants · ${time(thread.updatedAt)}`,
+      `${thread.repository} · ${tasks} · ${thread.messageCount} messages · ${thread.participantCount} participants · ${time(thread.updatedAt)}`,
       'meta',
     ));
     card.addEventListener('click', () => onSelect(thread.id));
@@ -67,6 +111,7 @@ export function renderThreadDetail(doc, detail) {
   doc.getElementById('detail').classList.add('visible');
   doc.getElementById('detail-subject').textContent = detail.thread.subject;
   doc.getElementById('detail-meta').textContent = [
+    detail.thread.repository,
     `v${detail.thread.version}`,
     detail.thread.status,
     `tasks ${(detail.thread.relatedTaskIds ?? []).join(', ')}`,
@@ -86,7 +131,9 @@ export function renderThreadDetail(doc, detail) {
       `${message.actorName ?? message.actor} · ${message.actorRole ?? 'agent'} · ${message.taskLabel ?? message.taskId} · ${time(message.createdAt)}`,
       'message-head',
     ));
-    block.appendChild(text(doc, 'div', message.body, 'message-body'));
+    const body = text(doc, 'div', '', 'message-body');
+    renderThreadMessageBody(doc, body, message.body);
+    block.appendChild(body);
     messages.appendChild(block);
   }
 }
@@ -112,12 +159,14 @@ export function startThreadBoard(doc, { fetchImpl = globalThis.fetch, pollMs = 5
     status.className = error ? 'error' : '';
   };
 
-  const repositoryQuery = () => `repository=${encodeURIComponent(state.repository)}`;
+  const repositoryForThread = (threadId = state.selectedId) => state.threads
+    .find((thread) => thread.id === threadId)?.repository ?? state.repository;
+  const repositoryQuery = (threadId) => `repository=${encodeURIComponent(repositoryForThread(threadId))}`;
 
   async function loadDetail(threadId = state.selectedId) {
-    if (!state.repository || !threadId || state.stopped) return;
+    if (!threadId || state.stopped) return;
     try {
-      const detail = await request(fetchImpl, `/api/coordination/threads/${encodeURIComponent(threadId)}?${repositoryQuery()}&messageLimit=200`);
+      const detail = await request(fetchImpl, `/api/coordination/threads/${encodeURIComponent(threadId)}?${repositoryQuery(threadId)}&messageLimit=200`);
       if (state.stopped || threadId !== state.selectedId) return;
       state.detail = detail;
       renderThreadDetail(doc, detail);
@@ -130,7 +179,7 @@ export function startThreadBoard(doc, { fetchImpl = globalThis.fetch, pollMs = 5
       reply.querySelector('textarea').disabled = detail.thread.status !== 'open';
       if (subscribed) {
         await request(fetchImpl, `/api/coordination/threads/${encodeURIComponent(threadId)}/read`, {
-          method: 'POST', body: JSON.stringify({ repository: state.repository }),
+          method: 'POST', body: JSON.stringify({ repository: repositoryForThread(threadId) }),
         });
       }
       say(`${detail.thread.messageCount} durable messages · version ${detail.thread.version}`);
@@ -146,11 +195,12 @@ export function startThreadBoard(doc, { fetchImpl = globalThis.fetch, pollMs = 5
   }
 
   async function loadThreads({ refreshDetail = true } = {}) {
-    if (!state.repository || state.stopped) return;
+    if (state.stopped) return;
     const generation = ++state.generation;
     try {
       const statusValue = statusFilter.value;
-      const query = new URLSearchParams({ repository: state.repository, limit: '200' });
+      const query = new URLSearchParams({ limit: '200' });
+      if (state.repository) query.set('repository', state.repository);
       if (statusValue) query.set('status', statusValue);
       const page = await request(fetchImpl, `/api/coordination/threads?${query}`);
       if (state.stopped || generation !== state.generation) return;
@@ -173,15 +223,11 @@ export function startThreadBoard(doc, { fetchImpl = globalThis.fetch, pollMs = 5
     state.repository = path;
     state.selectedId = null;
     state.detail = null;
-    if (!path) {
-      holder.replaceChildren(text(doc, 'div', 'No repository selected.', 'empty'));
-      say('Choose a repository to open its durable board.');
-      return;
-    }
+    if (!path) say('Loading durable threads across all repositories…');
     try {
-      doc.defaultView?.history?.replaceState({}, '', `/threads?repository=${encodeURIComponent(path)}`);
+      doc.defaultView?.history?.replaceState({}, '', path ? `/threads?repository=${encodeURIComponent(path)}` : '/threads');
     } catch { /* embedded hosts may not expose history */ }
-    say('Loading durable threads…');
+    if (path) say('Loading durable threads…');
     await loadThreads({ refreshDetail: false });
   }
 
@@ -205,10 +251,8 @@ export function startThreadBoard(doc, { fetchImpl = globalThis.fetch, pollMs = 5
         option.textContent = requested;
         repo.appendChild(option);
       }
-      if (requested) {
-        repo.value = requested;
-        await chooseRepository(requested);
-      }
+      repo.value = requested;
+      await chooseRepository(requested);
     } catch (error) {
       say(error instanceof Error ? error.message : String(error), true);
     }
@@ -250,7 +294,7 @@ export function startThreadBoard(doc, { fetchImpl = globalThis.fetch, pollMs = 5
     try {
       await request(fetchImpl, `/api/coordination/threads/${encodeURIComponent(state.selectedId)}/messages`, {
         method: 'POST', body: JSON.stringify({
-          repository: state.repository, body, idempotencyKey: mutationKey('operator-reply'),
+          repository: repositoryForThread(), body, idempotencyKey: mutationKey('operator-reply'),
         }),
       });
       reply.reset();
@@ -265,7 +309,7 @@ export function startThreadBoard(doc, { fetchImpl = globalThis.fetch, pollMs = 5
     const following = follow.dataset.following === 'true';
     try {
       await request(fetchImpl, `/api/coordination/threads/${encodeURIComponent(state.selectedId)}/follow`, {
-        method: following ? 'DELETE' : 'POST', body: JSON.stringify({ repository: state.repository }),
+        method: following ? 'DELETE' : 'POST', body: JSON.stringify({ repository: repositoryForThread() }),
       });
       await loadDetail();
     } catch (error) {
@@ -278,7 +322,7 @@ export function startThreadBoard(doc, { fetchImpl = globalThis.fetch, pollMs = 5
     try {
       await request(fetchImpl, `/api/coordination/threads/${encodeURIComponent(state.selectedId)}/resolve`, {
         method: 'POST', body: JSON.stringify({
-          repository: state.repository, expectedVersion: state.detail.thread.version,
+          repository: repositoryForThread(), expectedVersion: state.detail.thread.version,
         }),
       });
       await loadThreads();

--- a/web/static/threads.html
+++ b/web/static/threads.html
@@ -44,7 +44,16 @@
     #messages { flex:1; overflow:auto; padding:10px 16px; }
     .message { padding:9px 10px; margin:7px 0; border:1px solid var(--border); border-radius:6px; background:var(--panel); }
     .message-head { color:var(--dim); font-size:10px; }
-    .message-body { margin-top:4px; white-space:pre-wrap; overflow-wrap:anywhere; }
+    .message-body { margin-top:6px; color:#d9e2ef; white-space:pre-wrap; overflow-wrap:anywhere; line-height:1.65; }
+    .message-body .inline-code { color:#77d9ff; background:#0a1019; border:1px solid #27364b; border-radius:3px; padding:1px 4px; }
+    .message-body pre { margin:8px 0 2px; padding:10px 12px; overflow:auto; color:#dce7f5; background:#080c12; border:1px solid #26364c; border-radius:5px; line-height:1.55; white-space:pre; }
+    .message-body code { font:12px/1.55 "SF Mono",ui-monospace,Menlo,monospace; }
+    .message-body .token-comment { color:#7f8da3; font-style:italic; }
+    .message-body .token-keyword { color:#c792ea; }
+    .message-body .token-string { color:#c3e88d; }
+    .message-body .token-number { color:#f6c177; }
+    .message-body .token-property { color:#82aaff; }
+    .message-body .token-punctuation { color:#aab7c8; }
     form { display:grid; gap:8px; }
     #reply-form { grid-template-columns:1fr auto; padding:12px 16px; border-top:1px solid var(--border); }
     #reply-form textarea { min-height:54px; resize:vertical; }
@@ -62,7 +71,7 @@
     <a href="/chat">chat</a>
     <select id="repo" aria-label="Repository"><option value="">Select repository…</option></select>
   </header>
-  <div id="status" role="status" aria-live="polite">Choose a repository to open its durable board.</div>
+  <div id="status" role="status" aria-live="polite">Loading durable threads across all repositories…</div>
   <main>
     <aside>
       <div class="toolbar">
@@ -73,7 +82,7 @@
         </select>
         <button id="refresh" type="button">refresh</button>
       </div>
-      <div id="threads"><div class="empty">No repository selected.</div></div>
+      <div id="threads"><div class="empty">Loading all repository threads…</div></div>
       <form id="new-thread">
         <strong>NEW THREAD</strong>
         <input name="taskId" required placeholder="Related task ID (for example AGT-4131)" />


### PR DESCRIPTION
## Problem

The threads page could only show one repository at a time and started empty until the
operator picked one. With workers spread across several repos, the operator has no way
to see "what is waiting for me *anywhere*" without clicking through each cell.

## Change

**Server**
- `GET /api/coordination/threads` no longer requires `repository`; omitting it reads
  across repository cells. `listCoordinationThreads` builds its `WHERE` clause from the
  filters actually present.
- Detail reads accept the opaque `git:<hash>` / `path:<hash>` cell key the
  all-repositories list returns, so a thread can be opened without first re-selecting
  its filesystem path.

**Dashboard**
- Loads the all-repositories board on entry; the repository select narrows it.
- Each card and the detail header name the repository the thread belongs to.
- Detail and read-receipt calls resolve the thread's *own* repository rather than the
  page filter, so opening a thread from the wide view works.
- Message bodies render inline code and fenced blocks through a DOM-only tokenizer.
  Nothing is interpreted as HTML — agent-authored text stays inert.

The CLI's `openswarm threads` (#501) still sends `repository` and is unaffected.

## Test plan

- [x] `npm run typecheck` — clean; `npm run lint` — 0 errors
- [x] `npx vitest run src/coordination/coordinationThreadRoutes.test.ts src/coordination/coordinationThreads.test.ts tests/web/threadBoard.test.ts src/cli/coordinationHandler.test.ts` — 41 passed
- [x] New cases: list without `repository`, detail via opaque cell key, dashboard renders
      fenced code as `<pre>` with no HTML interpretation