### PR TITLE
fix(durability): reclaim a claim whose owner shares this PID but not this generation

### DIFF
--- a/src/automation/durableRunCoordinator.test.ts
+++ b/src/automation/durableRunCoordinator.test.ts
@@ -992,7 +992,7 @@ describe('DurableRunCoordinator', () => {
     ledger.close();
   });
 
-  it('uses the default PID probe to retain live owners and release dead owners', () => {
+  it('uses the default PID probe to reclaim a prior daemon generation and release dead owners', () => {
     const livePath = dbPath();
     const liveLedger = new RunLedger(livePath);
     liveLedger.registerRun({ issueId: 'LIVE-PID', source: 'linear', projectPath: '/live-repo' }, 1_000);
@@ -1007,7 +1007,8 @@ describe('DurableRunCoordinator', () => {
     expect(liveReplacement.reconcile(4_001)).toHaveLength(1);
     expect(liveLedger.getRun('LIVE-PID')).toMatchObject({
       state: 'NEEDS_RECONCILE',
-      ownerInstanceId: `${process.pid}-live-owner`,
+      ownerInstanceId: undefined,
+      leaseToken: undefined,
     });
     liveReplacement.close();
     liveLedger.close();

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -748,7 +748,13 @@ export class DurableRunCoordinator {
     for (const run of this.ledger.listRuns(['CLAIMED', 'EXECUTING', 'VERIFYING', 'PUBLISHING'])) {
       if (!run.ownerInstanceId || !run.leaseToken) continue;
       const pid = ownerProcessId(run.ownerInstanceId);
-      if (pid == null || this.processIsAlive(pid)) continue;
+      // Docker commonly gives a replacement daemon the same container PID.
+      // The PID probe then finds *this* process even though the persisted UUID
+      // belongs to the daemon generation that was just stopped. A PID cannot
+      // belong to two generations, so this exact mismatch proves the recorded
+      // executor exited and avoids idling the repository for a full lease.
+      const samePidDifferentGeneration = pid === process.pid && run.ownerInstanceId !== this.instanceId;
+      if (pid != null && this.processIsAlive(pid) && !samePidDifferentGeneration) continue;
       const ownership = {
         issueId: run.issueId,
         ownerInstanceId: run.ownerInstanceId,
@@ -802,7 +808,8 @@ export class DurableRunCoordinator {
       // renewal (multiple consecutive misses, not one) before this frees the
       // row, purely as a fallback for when the pid probe can't be trusted.
       const abandonedByAge = now - run.updatedAt >= this.reconcileAbandonMs;
-      if (!abandonedByAge && (pid == null || this.processIsAlive(pid))) continue;
+      const samePidDifferentGeneration = pid === process.pid && run.ownerInstanceId !== this.instanceId;
+      if (!abandonedByAge && !samePidDifferentGeneration && (pid == null || this.processIsAlive(pid))) continue;
       this.confirmExitedClaim({
         issueId: run.issueId,
         ownerInstanceId: run.ownerInstanceId,


### PR DESCRIPTION
## Problem

Docker restarts the daemon into a container where the replacement commonly gets the
**same PID** as the generation it replaced. `reconcile` probes the recorded owner PID,
finds this very process alive, and keeps the row claimed:

```
[Reconciler] Keeping AGT-3836 in NEEDS_RECONCILE (active_owner)
[Reconciler] Keeping AGT-4140 in NEEDS_RECONCILE (active_owner)
[Reconciler] Keeping AGT-3226 in NEEDS_RECONCILE (active_owner)
```

Measured on vela: 90 such lines in two hours, each holding a worker slot for a full
lease with no worker behind it.

## Change

A PID cannot belong to two daemon generations at once. When the recorded owner has
*this* process's PID but a **different `instanceId`**, the recorded executor has provably
exited, and the claim is released the same way a dead PID's would be. Owners with a
genuinely different live PID are untouched — that path is unchanged.

The existing test asserting that a same-PID/different-instance owner is *retained*
modelled a sibling coordinator in one process, which does not exist; it now asserts the
reclaim.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run src/automation/durableRunCoordinator.test.ts` — 56 passed