### PR TITLE
fix(ledger): record the failed stage when no typed sub-result names the error

### DIFF
--- a/src/automation/runnerState.coverage.test.ts
+++ b/src/automation/runnerState.coverage.test.ts
@@ -300,6 +300,48 @@ describe('pickFailureDetail (INT-2504)', () => {
   });
 });
 
+describe('pickPipelineFailureDetail stage fallback', () => {
+  const base = { success: false, sessionId: 's', iterations: 1, totalDuration: 10 } as const;
+
+  it('names the failed stage when no typed sub-result carries the error', () => {
+    // vela 2026-09-01: guards, security audit and publication all fail through
+    // stages[], and 57% of that day's ledger rows had no error message.
+    const detail = mod.pickPipelineFailureDetail({
+      ...base,
+      finalStatus: 'failed',
+      stages: [
+        { stage: 'worker', success: true, result: { success: true }, duration: 1, startedAt: 0, completedAt: 1 },
+        { stage: 'security-audit', success: false, result: { success: false, error: 'CodeQL extractor missing for go' }, duration: 1, startedAt: 1, completedAt: 2 },
+      ],
+    } as never);
+    expect(detail).toBe('security-audit: CodeQL extractor missing for go');
+  });
+
+  it('still prefers the typed tester/reviewer/worker detail over the stage error', () => {
+    const detail = mod.pickPipelineFailureDetail({
+      ...base,
+      finalStatus: 'failed',
+      workerResult: { success: false, summary: '', filesChanged: [], commands: [], output: '', error: 'worker-scope: outside fileScope' },
+      stages: [
+        { stage: 'worker', success: false, result: { success: false, error: 'stage copy' }, duration: 1, startedAt: 0, completedAt: 1 },
+      ],
+    } as never);
+    expect(detail).toBe('worker-scope: outside fileScope');
+  });
+
+  it('falls back to stuckReason when stages carry no error text', () => {
+    const detail = mod.pickPipelineFailureDetail({
+      ...base,
+      finalStatus: 'failed',
+      stuckReason: 'self-repair stagnated: identical test errors repeated',
+      stages: [
+        { stage: 'tester', success: false, result: { success: false }, duration: 1, startedAt: 0, completedAt: 1 },
+      ],
+    } as never);
+    expect(detail).toBe('self-repair stagnated: identical test errors repeated');
+  });
+});
+
 it('pickFailureDetail skips locale noSummary fallbacks (INT-2504 follow-up)', () => {
   expect(mod.pickFailureDetail(['(no summary)', 'real feedback here'])).toBe('real feedback here');
   expect(mod.pickFailureDetail(['(요약 없음)'])).toBeUndefined();

--- a/src/automation/runnerState.ts
+++ b/src/automation/runnerState.ts
@@ -227,11 +227,23 @@ export function pickPipelineFailureDetail(result: PipelineResult): string | unde
     ])
     : undefined;
 
+  // Guards, security audit, verification, worktree setup and publication
+  // report through `stages[]` rather than a typed sub-result. Without this
+  // fallback the ledger recorded 57% of one day's failures with no message
+  // at all (vela, 2026-09-01), and the reason was unrecoverable once the
+  // container's log was gone.
+  const failedStage = [...result.stages].reverse().find((stage) => !stage.success);
+  const stageError = failedStage && 'error' in failedStage.result && typeof failedStage.result.error === 'string'
+    ? `${failedStage.stage}: ${failedStage.result.error}`
+    : undefined;
+
   return pickFailureDetail([
     testerFailure,
     result.lastReviewFeedback,
     result.reviewResult?.feedback,
     result.workerResult?.error,
+    stageError,
+    result.stuckReason,
   ]);
 }
 


### PR DESCRIPTION
## Problem

vela's ledger for 2026-09-01 held 446 attempts; **256 of them (57%) had no error
message**. `result_json` carried only `{sessionId, totalDuration, iterations}`.

`pickPipelineFailureDetail` read only the tester, reviewer and worker sub-results — but
guards, the security audit, verification, worktree setup and publication all report
through `stages[]`. Once the container was recreated and its log gone, there was no way
to say why most of the day failed. That blindness is also why the operator loop that day
patched by guessing and restarted 15 times.

## Change

The detail now falls back to the last failed stage, prefixed with its name
(`security-audit: CodeQL extractor missing for go`), and then to `stuckReason`. Typed
sub-results still take precedence, so the existing tester-over-reviewer ordering is
unchanged.

## Test plan

- [x] `npm run typecheck` — clean; `npm run lint` — 0 errors
- [x] `npx vitest run src/automation/runnerState.coverage.test.ts src/automation/autonomousRunner.coverage.test.ts` — 75 passed
- [x] New cases: stage fallback names the stage; typed detail still wins; `stuckReason` used
      when the stage carries no text