### PR TITLE
fix(recovery): release a prior generation's worktree marker once the ledger has released its lease

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -1503,7 +1503,7 @@ export class AutonomousRunner {
       // Never overlap a replacement with an executor that lost its lease but
       // still owns the filesystem. Missing/ambiguous markers stay parked;
       // preserved work or a dead owner is safe for createWorktree to resume.
-      const recovery = await inspectWorktreeRecovery(run.projectPath, run.issueId, run.worktreePath)
+      const recovery = await inspectWorktreeRecovery(run.projectPath, run.issueId, run.worktreePath, this.durableRuns.deadMarkerOwners(run.issueId))
         .catch((error) => {
           console.warn(`[Reconciler] Worktree evidence unreadable for ${run.identifier ?? run.issueId}:`, error);
           return null;

--- a/src/automation/durableRunCoordinator.test.ts
+++ b/src/automation/durableRunCoordinator.test.ts
@@ -1216,6 +1216,39 @@ describe('DurableRunCoordinator', () => {
   });
 });
 
+describe('DurableRunCoordinator dead marker owners', () => {
+  it('derives its instance id from the per-process id the worktree markers carry', async () => {
+    const { getInstanceId } = await import('../support/healthEndpoint.js');
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', ledger: new RunLedger(dbPath()) });
+    expect(coordinator.instanceId).toBe(`${process.pid}-${getInstanceId()}`);
+    coordinator.close();
+  });
+
+  it('names released prior-generation owners by marker id and never itself or the live owner', async () => {
+    const { getInstanceId } = await import('../support/healthEndpoint.js');
+    const ledger = new RunLedger(dbPath());
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', ledger });
+    ledger.registerRun({ issueId: 'GEN-1', source: 'linear', projectPath: '/repo' }, 1_000);
+
+    // A prior generation claimed, went silent, and the ledger released it.
+    const prior = ledger.claimRun('GEN-1', { ownerInstanceId: '7-prior-generation-uuid', leaseMs: 1_000, now: 2_000 })!;
+    expect(ledger.transition(prior, 'RETRY_AT', { retryAt: 2_500 }, 2_100)).toBe(true);
+    // Our own generation claimed it afterwards.
+    const ours = ledger.claimRun('GEN-1', { ownerInstanceId: coordinator.instanceId, leaseMs: 1_000, now: 3_000 })!;
+
+    // Our own id is filtered by both the live-owner rule and the self rule.
+    expect(coordinator.deadMarkerOwners('GEN-1')).toEqual(['prior-generation-uuid']);
+    expect(coordinator.deadMarkerOwners('GEN-1')).not.toContain(getInstanceId());
+
+    // Once ours is released too, it is still never reported as dead to itself.
+    expect(ledger.transition(ours, 'RETRY_AT', { retryAt: 3_500 }, 3_100)).toBe(true);
+    expect(coordinator.deadMarkerOwners('GEN-1')).toEqual(['prior-generation-uuid']);
+    expect(coordinator.deadMarkerOwners('unknown')).toEqual([]);
+    coordinator.close();
+    ledger.close();
+  });
+});
+
 describe('runRecordToTask', () => {
   // AGT-4094: reconciliation has to finish a published run whose tracker card
   // already went Done, and a Done card is never in the fetch — so the run

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { getInstanceId } from '../support/healthEndpoint.js';
 import type { PipelineResult } from '../agents/pairPipeline.js';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
 
@@ -222,7 +222,9 @@ export class DurableRunCoordinator {
 
   constructor(config: DurableRunCoordinatorConfig) {
     this.mode = config.mode;
-    this.instanceId = config.instanceId ?? `${process.pid}-${randomUUID()}`;
+    // Share the per-process id the worktree markers are stamped with, so a
+    // ledger owner id names the same generation as the marker it wrote.
+    this.instanceId = config.instanceId ?? `${process.pid}-${getInstanceId()}`;
     this.leaseMs = config.leaseMs ?? 10 * 60_000;
     this.maxActiveForProject = Math.max(1, Math.floor(config.maxActiveForProject ?? 1));
     this.processIsAlive = config.processIsAlive ?? processIsAlive;
@@ -820,6 +822,28 @@ export class DurableRunCoordinator {
       }, now);
     }
     return reconciled;
+  }
+
+  /**
+   * Marker owner ids (`getInstanceId()` values) of every executor that once
+   * claimed this run and no longer holds its lease.
+   *
+   * A worktree marker from another pid namespace cannot be judged by pid, so
+   * the marker code trusts it for a full day. But an owner our own ledger has
+   * already released is not "another container": it is a previous generation
+   * of this daemon, and the ledger has proven its claim dead by a full lease
+   * of silence. Naming those ids lets recovery release their markers now
+   * rather than after the 24h window — which otherwise parks every in-flight
+   * run for a day on each container recreate.
+   */
+  deadMarkerOwners(issueId: string): string[] {
+    if (!this.ledger) return [];
+    const run = this.ledger.getRun(issueId);
+    const live = run?.ownerInstanceId;
+    return this.ledger.listClaimOwners(issueId)
+      .filter((owner) => owner !== live && owner !== this.instanceId)
+      .map((owner) => owner.replace(/^\d+-/, ''))
+      .filter((owner) => owner !== getInstanceId());
   }
 
   getProtectedWorktreePaths(projectPath?: string): Set<string> {

--- a/src/automation/runLedger.test.ts
+++ b/src/automation/runLedger.test.ts
@@ -107,6 +107,22 @@ describe('RunLedger state machine', () => {
   });
 });
 
+describe('RunLedger claim-owner history', () => {
+  it('lists every executor that ever claimed the run, newest first, without duplicates', () => {
+    const ledger = new RunLedger(createDbPath());
+    register(ledger, 'OWNERS-1');
+    const first = claim(ledger, 'OWNERS-1', '7-first-generation', 2_000);
+    expect(ledger.transition(first, 'RETRY_AT', { retryAt: 2_500 }, 2_100)).toBe(true);
+    const second = claim(ledger, 'OWNERS-1', '7-second-generation', 3_000);
+    expect(ledger.transition(second, 'RETRY_AT', { retryAt: 3_500 }, 3_100)).toBe(true);
+    claim(ledger, 'OWNERS-1', '7-second-generation', 4_000);
+
+    expect(ledger.listClaimOwners('OWNERS-1')).toEqual(['7-second-generation', '7-first-generation']);
+    expect(ledger.listClaimOwners('never-registered')).toEqual([]);
+    ledger.close();
+  });
+});
+
 describe('RunLedger tracker observation cache (AGT-4127)', () => {
   it('preserves the row and recovery fields while closing a stale run from tracker truth', () => {
     const ledger = new RunLedger(createDbPath());

--- a/src/automation/runLedger.ts
+++ b/src/automation/runLedger.ts
@@ -14,6 +14,7 @@ import {
 import { admitsConflictScope } from './runLedgerScope.js';
 import { migrateAutomationSchema } from './runLedgerSchema.js';
 import { queueIntegrationRequeueInDb } from './runLedgerIntegration.js';
+import { listClaimOwnersInDb } from './runLedgerOwners.js';
 import {
   markNeedsHumanForQuestionsInDb,
   resumeNeedsHumanForQuestionsInDb,
@@ -256,6 +257,11 @@ export class RunLedger {
       'NEEDS_HUMAN', 'NEEDS_RECONCILE', 'DONE', 'DECOMPOSED', 'CANCELLED',
     ];
     return this.unfencedTransition(issueId, eligible, 'READY', {}, now);
+  }
+
+  /** Every executor that ever claimed this run, newest first. */
+  listClaimOwners(issueId: string): string[] {
+    return listClaimOwnersInDb(this.db, issueId);
   }
 
   queueIntegrationRequeue(issueId: string, expectedStateVersion: number, effect: EffectInput, now = Date.now()): boolean {

--- a/src/automation/runLedgerOwners.ts
+++ b/src/automation/runLedgerOwners.ts
@@ -1,0 +1,31 @@
+// ============================================
+// OpenSwarm - Claim-owner history for a durable run
+// ============================================
+
+import type Database from 'better-sqlite3';
+
+/**
+ * Every executor instance that ever claimed this run, newest first.
+ *
+ * Read from the `claimed` events rather than the run row: once a lease is
+ * released or expires the row's `owner_instance_id` is cleared, and it is
+ * exactly that released owner the caller wants to name.
+ */
+export function listClaimOwnersInDb(db: Database.Database, issueId: string): string[] {
+  const rows = db.prepare(`
+    SELECT data_json FROM automation_events
+    WHERE issue_id = ? AND kind = 'claimed'
+    ORDER BY sequence DESC
+  `).all(issueId) as Array<{ data_json: string | null }>;
+  const owners: string[] = [];
+  for (const row of rows) {
+    let owner: unknown;
+    try {
+      owner = row.data_json ? (JSON.parse(row.data_json) as { ownerInstanceId?: unknown }).ownerInstanceId : undefined;
+    } catch {
+      continue;
+    }
+    if (typeof owner === 'string' && owner && !owners.includes(owner)) owners.push(owner);
+  }
+  return owners;
+}

--- a/src/support/worktreeManager.coverage.test.ts
+++ b/src/support/worktreeManager.coverage.test.ts
@@ -308,6 +308,33 @@ describe('createWorktree retry/resume error paths', () => {
     });
   });
 
+  // vela 2026-09-02: a container recreate gives the daemon a new pid namespace,
+  // so every in-flight marker reads as "another pid space" and is trusted for
+  // the full 24h window. The ledger, however, knows that owner as a released
+  // lease of a prior generation. Naming it releases the tree now; an owner the
+  // ledger never claimed stays protected exactly as before.
+  it('treats a foreign-namespace marker as orphaned when the ledger names its owner dead', async () => {
+    const info = await createWorktree(repo, 'INT-1', 'swarm/INT-1-prior-generation');
+    const markerPath = join(
+      repo, '.git', 'openswarm', 'active-worktrees', 'INT-1', `${info.activeMarkerToken}.json`,
+    );
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
+    marker.ownerInstanceId = 'prior-generation-00000000-0000-4000-8000-000000000000';
+    marker.ownerNamespace = 'some-other-host:pid:[4026531999]';
+    marker.createdAt = new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString();
+    writeFileSync(markerPath, JSON.stringify(marker));
+
+    await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath)).resolves.toMatchObject({
+      state: 'active_owner',
+    });
+    await expect(inspectWorktreeRecovery(repo, 'INT-1', info.worktreePath, ['unrelated-owner'])).resolves.toMatchObject({
+      state: 'active_owner',
+    });
+    await expect(inspectWorktreeRecovery(
+      repo, 'INT-1', info.worktreePath, ['prior-generation-00000000-0000-4000-8000-000000000000'],
+    )).resolves.toMatchObject({ state: 'orphaned' });
+  });
+
   // The live incident this was written for: the markers already on disk were
   // written before `ownerInstanceId` existed, so the boot comparison cannot
   // reach them. A pid is unique among live processes, which is proof enough —

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -583,13 +583,16 @@ export async function inspectWorktreeRecovery(
   repoPath: string,
   issueId: string,
   recordedPath?: string,
+  // Marker owners the ledger has already proven dead (a released lease of a
+  // prior daemon generation). Only the ledger can say this across pid spaces.
+  deadOwners: readonly string[] = [],
 ): Promise<WorktreeRecoveryStatus> {
   const worktreePath = recordedPath
     ? assertManagedWorktreePath(repoPath, recordedPath)
     : resolveWorktreePath(repoPath, issueId);
   if (!existsSync(worktreePath)) return { state: 'missing', worktreePath };
   const active = await readActiveWorktreeMarkers(repoPath, worktreePath);
-  const liveMarker = active.markers.find(markerLooksLive);
+  const liveMarker = active.markers.find((marker) => !(marker.ownerInstanceId && deadOwners.includes(marker.ownerInstanceId)) && markerLooksLive(marker));
   if (liveMarker) return { state: 'active_owner', worktreePath, marker: liveMarker };
   if (existsSync(join(worktreePath, PRESERVE_MARKER))) {
     return preserveMarkerAgeMs(worktreePath) === null


### PR DESCRIPTION
## Problem

Recreating the container (new image via compose) gives the daemon a new pid namespace.
Every in-flight worktree marker then reads as "another pid space", which the marker code
deliberately cannot judge by pid, so it is trusted for the full **24h** abandon window:

```
[Reconciler] Keeping AGT-3836 in NEEDS_RECONCILE (active_owner)
```

Measured on vela after this morning's deploy: 4 runs parked that way, each holding an
admission slot until 13:17 tomorrow. That is one day of a slot per in-flight run, per
deploy — and #513 only fixed the *ledger* half of the same restart problem.

## Why the ledger can decide this

Those markers were written by a previous generation of this daemon while it held the
ledger claim, and the ledger has since proven that claim dead by a full lease of silence.
That proof was never handed to the marker check, and it *could not* be: the ledger owner
id (`${pid}-${randomUUID()}`) and the marker owner id (`getInstanceId()`) were two
unrelated per-process ids.

## Change

- Coordinator instance id becomes `${pid}-${getInstanceId()}` — the same per-process id
  the markers are stamped with.
- `RunLedger.listClaimOwners(issueId)` reads claim history from the events table (the run
  row clears its owner on release). Lives in `runLedgerOwners.ts`; `runLedger.ts` is at
  the LOC cap.
- `DurableRunCoordinator.deadMarkerOwners(issueId)` names every *released* owner's marker
  id — never the live owner, never this process.
- `inspectWorktreeRecovery` takes that list; a marker whose owner is on it is `orphaned`
  regardless of pid space. **An owner the ledger never claimed — a genuinely different
  container on the same checkout — is judged exactly as before.**

Markers written before this change carry an unrelated id and still fall back to the 24h
window; the four currently parked runs free by age today.

## Test plan

- [x] `npm run typecheck` — clean; `npm run lint` — 0 errors
- [x] `npx vitest run src/automation/` — 41 files, 741 passed
- [x] `worktreeManager.coverage.test.ts` — foreign-namespace marker: `active_owner` with no
      list, `active_owner` with an unrelated owner, `orphaned` when the ledger names it
- [x] `durableRunCoordinator.test.ts` — id derivation; dead owners exclude live owner and self
- [x] `runLedger.test.ts` — owner history newest-first, deduplicated