### PR TITLE
fix(dispatch): let an explicit redispatch actually resume the run it was told to resume

### DIFF
--- a/src/automation/autonomousRunner.dispatch.test.ts
+++ b/src/automation/autonomousRunner.dispatch.test.ts
@@ -60,6 +60,64 @@ describe('AutonomousRunner.enqueueIssues (INT-3388)', () => {
     expect(runSpy).toHaveBeenCalledTimes(2); // nothing new queued → no kick
   });
 
+  // vela 2026-09-02: six runs parked "until explicit operator redispatch" were
+  // redispatched through POST /api/work and every one came back "superseded":
+  // the explicit path skipped the heartbeat filter that reopens the ledger
+  // row, so the coordinator found NEEDS_HUMAN and fenced the task.
+  it('reopens a sandbox-outcome quarantine in the ledger when the operator redispatches it', async () => {
+    const dbDir = mkdtempSync(join(tmpdir(), 'osw-dispatch-readmit-'));
+    try {
+      const dbPath = join(dbDir, 'automation.db');
+      const runner = new AutonomousRunner(cfg({ automationLedgerMode: 'primary', automationDbPath: dbPath }));
+      const runSpy = vi.fn(async () => {});
+      (runner as unknown as Internal).runAvailableTasks = runSpy;
+      const internal = runner as unknown as { durableRuns: DurableRunCoordinator };
+
+      internal.durableRuns.observeTask(task('q'), '/x/a');
+      expect(internal.durableRuns.markNeedsHuman('q', 'Sandbox command outcome unknown; inspect the preserved worktree and explicitly redispatch to resume')).toBe(true);
+      // markNeedsHuman records its own code; the quarantine is recognised by
+      // state, so any non-question park must reopen the same way.
+      expect(internal.durableRuns.getRun('q')?.state).toBe('NEEDS_HUMAN');
+
+      const result = await runner.enqueueIssues([{ ...task('q'), explicitDispatch: true }], '/x/a');
+      expect(result.queued).toEqual(['q']);
+      expect(internal.durableRuns.getRun('q')?.state).toBe('READY');
+      expect(runSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      rmSync(dbDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not let a redispatch bypass an unanswered operator question', async () => {
+    const dbDir = mkdtempSync(join(tmpdir(), 'osw-dispatch-question-'));
+    try {
+      const dbPath = join(dbDir, 'automation.db');
+      const runner = new AutonomousRunner(cfg({ automationLedgerMode: 'primary', automationDbPath: dbPath }));
+      const runSpy = vi.fn(async () => {});
+      (runner as unknown as Internal).runAvailableTasks = runSpy;
+      const internal = runner as unknown as { durableRuns: DurableRunCoordinator };
+
+      internal.durableRuns.observeTask(task('ask'), '/x/a');
+      expect(internal.durableRuns.markNeedsHuman('ask', 'parked')).toBe(true);
+      // An exact question park needs a published question and a RETRY_AT row
+      // to create; the decision only reads the row, so present that row.
+      const real = internal.durableRuns.getRun('ask')!;
+      const getRun = vi.spyOn(internal.durableRuns, 'getRun')
+        .mockReturnValue({ ...real, lastErrorCode: 'operator_question' });
+      const resume = vi.spyOn(internal.durableRuns, 'resumeNeedsHuman');
+
+      const result = await runner.enqueueIssues([{ ...task('ask'), explicitDispatch: true }], '/x/a');
+      expect(result.queued).toEqual([]);
+      expect(result.rejected).toEqual([{ id: 'ask', reason: 'duplicate' }]);
+      expect(resume).not.toHaveBeenCalled();
+      expect(runSpy).not.toHaveBeenCalled();
+      getRun.mockRestore();
+      resume.mockRestore();
+    } finally {
+      rmSync(dbDir, { recursive: true, force: true });
+    }
+  });
+
   it('throws loudly on a config whose scheduler never executes (solo mode) instead of stranding the queue (review finding)', async () => {
     const noPair = new AutonomousRunner(cfg({ pairMode: false }));
     await expect(noPair.enqueueIssues([task('1')], '/x/a')).rejects.toThrow(/pairMode/);

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -54,6 +54,7 @@ import * as execution from './runnerExecution.js';
 import { reportToDiscord, fetchLinearTasks, getTaskSource } from './runnerExecution.js';
 import { t } from '../locale/index.js';
 import { SANDBOX_OUTCOME_UNKNOWN_PARK_REASON } from '../sandboxExecutor/protocol.js';
+import { decideExplicitReadmission } from './explicitDispatchReadmission.js';
 import { broadcastEvent, type SwarmStats } from '../core/eventHub.js';
 import { writeProviderOverride } from '../core/providerOverride.js';
 import { getTaskState, updateTaskLinearState, upsertTaskState } from '../taskState/store.js';
@@ -2739,6 +2740,13 @@ export class AutonomousRunner {
         rejected.push({ id: task.id, reason: 'stopping' });
         continue;
       }
+      // The heartbeat filter reopens a parked/terminal ledger row for an
+      // explicitly dispatched task; this path skips that filter, so do the
+      // same here or the coordinator fences the task as superseded.
+      if (task.explicitDispatch === true && !this.readmitForExplicitDispatch(task)) {
+        rejected.push({ id: task.id, reason: 'duplicate' });
+        continue;
+      }
       if (this.enqueueCandidate(task, projectPath)) queued.push(task.id);
       else rejected.push({ id: task.id, reason: 'duplicate' });
     }
@@ -2746,6 +2754,36 @@ export class AutonomousRunner {
       this.trackSchedulerHandler('explicitDispatch', this.runAvailableTasks());
     }
     return { queued, rejected };
+  }
+
+  /**
+   * Apply the operator's redispatch act to the durable row. False only for a
+   * park that dispatching cannot end (an unanswered operator question).
+   */
+  private readmitForExplicitDispatch(task: TaskItem): boolean {
+    if (!this.durableRuns.isPrimary) return true;
+    const id = task.issueId || task.id;
+    const decision = decideExplicitReadmission(this.durableRuns.getRun(id));
+    const label = task.issueIdentifier || id;
+    switch (decision.action) {
+      case 'none': return true;
+      case 'refuse':
+        console.log(`[Scheduler] Explicit dispatch of ${label} refused: ${decision.reason}`);
+        return false;
+      case 'resume-needs-human': {
+        const resumed = this.durableRuns.resumeNeedsHuman(id);
+        if (resumed) console.log(`[Scheduler] Explicit dispatch resumed ${label} from NEEDS_HUMAN (${resumed})`);
+        // A dead external effect resumes through SYNC_PENDING; the heartbeat
+        // drains it, not the scheduler, so make sure one is coming.
+        if (resumed === 'SYNC_PENDING') this.scheduleNextHeartbeat();
+        return resumed !== null;
+      }
+      case 'mark-ready': {
+        const ready = this.durableRuns.markReady(id);
+        if (ready) console.log(`[Scheduler] Explicit dispatch reopened ${label} as READY`);
+        return ready;
+      }
+    }
   }
 
   /** Execute task in pair mode */

--- a/src/automation/explicitDispatchReadmission.test.ts
+++ b/src/automation/explicitDispatchReadmission.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { OPERATOR_QUESTION_PARK_REASON } from '../coordination/operatorAnswers.js';
+import { SANDBOX_OUTCOME_UNKNOWN_PARK_REASON } from '../sandboxExecutor/protocol.js';
+import { decideExplicitReadmission, OPERATOR_QUESTION_PARK_MARKER } from './explicitDispatchReadmission.js';
+import type { RunRecord } from './runLedgerTypes.js';
+
+function run(over: Partial<RunRecord>): RunRecord {
+  return {
+    issueId: 'r', source: 'linear', projectPath: '/repo', state: 'READY', stateVersion: 1,
+    attemptNo: 1, leaseEpoch: 1, createdAt: 0, updatedAt: 0, ...over,
+  } as RunRecord;
+}
+
+describe('decideExplicitReadmission', () => {
+  it('leaves a claimable or unknown row alone', () => {
+    expect(decideExplicitReadmission(undefined)).toEqual({ action: 'none' });
+    expect(decideExplicitReadmission(null)).toEqual({ action: 'none' });
+    expect(decideExplicitReadmission(run({ state: 'READY' }))).toEqual({ action: 'none' });
+    expect(decideExplicitReadmission(run({ state: 'EXECUTING' }))).toEqual({ action: 'none' });
+  });
+
+  // vela 2026-09-02: six runs parked "until explicit operator redispatch" were
+  // redispatched and every one came back "superseded".
+  it('resumes a sandbox-outcome quarantine, which is exactly the park redispatch exists for', () => {
+    expect(decideExplicitReadmission(run({
+      state: 'NEEDS_HUMAN', lastErrorCode: SANDBOX_OUTCOME_UNKNOWN_PARK_REASON,
+    }))).toEqual({ action: 'resume-needs-human' });
+  });
+
+  it('resumes a generic operator park', () => {
+    expect(decideExplicitReadmission(run({ state: 'NEEDS_HUMAN', lastErrorCode: 'needs_human' })))
+      .toEqual({ action: 'resume-needs-human' });
+  });
+
+  it('refuses a park that only its own answers may end', () => {
+    expect(decideExplicitReadmission(run({ state: 'NEEDS_HUMAN', lastErrorCode: OPERATOR_QUESTION_PARK_REASON })).action)
+      .toBe('refuse');
+    expect(decideExplicitReadmission(run({
+      state: 'NEEDS_HUMAN', lastErrorMessage: `${OPERATOR_QUESTION_PARK_MARKER} which file?`,
+    })).action).toBe('refuse');
+  });
+
+  it('overrides a backoff whose time has not come, and ignores one that has', () => {
+    expect(decideExplicitReadmission(run({ state: 'RETRY_AT', retryAt: 2_000 }), 1_000)).toEqual({ action: 'mark-ready' });
+    expect(decideExplicitReadmission(run({ state: 'RETRY_AT', retryAt: 500 }), 1_000)).toEqual({ action: 'none' });
+  });
+
+  it('reopens a terminal record the way the heartbeat does for a Todo card', () => {
+    for (const state of ['DONE', 'DECOMPOSED', 'CANCELLED'] as const) {
+      expect(decideExplicitReadmission(run({ state }))).toEqual({ action: 'mark-ready' });
+    }
+  });
+});

--- a/src/automation/explicitDispatchReadmission.ts
+++ b/src/automation/explicitDispatchReadmission.ts
@@ -1,0 +1,54 @@
+// ============================================
+// OpenSwarm - What an explicit operator dispatch may reopen in the ledger
+// ============================================
+
+import { OPERATOR_QUESTION_PARK_REASON } from '../coordination/operatorAnswers.js';
+import type { RunRecord } from './runLedgerTypes.js';
+
+/** Legacy ask_human parks carried this prefix before the exact park code existed. */
+export const OPERATOR_QUESTION_PARK_MARKER = '[operator-question]';
+
+export type ExplicitReadmission =
+  /** Row is already claimable, or has no durable record: enqueue as-is. */
+  | { action: 'none' }
+  /** A park that an operator act ends: `resumeNeedsHuman`. */
+  | { action: 'resume-needs-human' }
+  /** A terminal record or a live backoff the operator is overriding: `markReady`. */
+  | { action: 'mark-ready' }
+  /** A park only its own answers may end; dispatching it is not that act. */
+  | { action: 'refuse'; reason: string };
+
+/**
+ * `POST /api/work` and `openswarm work` are the operator's redispatch act.
+ * The heartbeat filter honours that act for a parked run, but the explicit
+ * path enqueued straight onto the scheduler, so the coordinator then found a
+ * NEEDS_HUMAN row it cannot claim and fenced the task as superseded — the
+ * very park whose message says "explicitly redispatch to resume" could not be
+ * resumed by redispatching it (vela, 2026-09-02: six infra quarantines).
+ *
+ * Pure so both paths can share one reading of the ledger row.
+ */
+export function decideExplicitReadmission(run: RunRecord | null | undefined, now = Date.now()): ExplicitReadmission {
+  if (!run) return { action: 'none' };
+  switch (run.state) {
+    case 'NEEDS_HUMAN': {
+      const exactQuestionPark = run.lastErrorCode === OPERATOR_QUESTION_PARK_REASON;
+      const legacyQuestionPark = run.lastErrorMessage?.startsWith(OPERATOR_QUESTION_PARK_MARKER) ?? false;
+      if (exactQuestionPark || legacyQuestionPark) {
+        return { action: 'refuse', reason: 'parked on an operator question; answer it instead of redispatching' };
+      }
+      // Sandbox-outcome quarantine and every other operator park resume here.
+      return { action: 'resume-needs-human' };
+    }
+    case 'RETRY_AT':
+      // The ledger refuses to claim a backoff whose time has not come. An
+      // explicit dispatch is the operator overriding that heuristic.
+      return run.retryAt != null && run.retryAt > now ? { action: 'mark-ready' } : { action: 'none' };
+    case 'DONE':
+    case 'DECOMPOSED':
+    case 'CANCELLED':
+      return { action: 'mark-ready' };
+    default:
+      return { action: 'none' };
+  }
+}


### PR DESCRIPTION
## Problem

A sandbox-outcome quarantine parks a run with:

> Sandbox command outcome unknown; inspect the preserved worktree and **explicitly
> redispatch to resume**

Redispatching it through `POST /api/work` (the issue board, `openswarm work`) queued it
and the scheduler started it — then the coordinator found the `NEEDS_HUMAN` row it cannot
claim and fenced the task as `superseded`.

Measured on vela 2026-09-02: six infra-quarantined runs (all parked within seconds of
yesterday's restarts) redispatched → six `Task superseded`, ledger unchanged.

The heartbeat's `filterAlreadyProcessed` knows how to reopen a parked/terminal row for an
`explicitDispatch` task. `enqueueIssues` bypasses that filter by design (INT-3388) and had
no reopen step of its own.

## Change

`decideExplicitReadmission(run)` is that reading of the ledger row as a pure function,
applied by `enqueueIssues` before it enqueues:

| Row state | Decision |
|---|---|
| `NEEDS_HUMAN` (sandbox quarantine, generic park) | `resumeNeedsHuman` (SYNC_PENDING schedules a heartbeat) |
| `NEEDS_HUMAN` operator-question park | **refused** — only its own answers may end it; reported, not dropped silently |
| `RETRY_AT`, retryAt in the future | `markReady` — the operator is overriding the backoff heuristic |
| `DONE` / `DECOMPOSED` / `CANCELLED` | `markReady`, as the heartbeat already does for a Todo card |
| anything else | untouched |

## Test plan

- [x] `npm run typecheck` — clean; `npm run lint` — 0 errors
- [x] `explicitDispatchReadmission.test.ts` — 6 cases over the decision table
- [x] `autonomousRunner.dispatch.test.ts` — a quarantined row goes `NEEDS_HUMAN → READY`
      on `enqueueIssues`; an operator-question park is refused and `resumeNeedsHuman` is
      never called
- [x] `workRunner.test.ts` — unchanged, 36 passed across the three files