### PR TITLE
fix(scope): stop enforcing knowledge-graph mention scopes as the worker's write boundary

### DIFF
--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -4,11 +4,13 @@
 // ============================================
 import { EventEmitter } from 'node:events';
 import { taskEventKey, type TaskItem } from '../orchestration/decisionEngine.js';
+import { enforcedFileScope } from '../orchestration/writeScope.js';
 import type { WorkerResult, ReviewResult } from './agentPair.js';
 import type { TesterResult } from './tester.js';
 import type { DocumenterResult } from './documenter.js';
 import type { AuditorResult } from './auditor.js';
 import type { SkillDocumenterResult } from './skillDocumenter.js';
+import { summarizeStageResult } from './stageSummary.js';
 import type { PipelineStage, PipelineGuardsConfig, JobProfile } from '../core/types.js';
 import { type CostInfo, aggregateCosts, formatCost } from '../support/costTracker.js';
 import { broadcastEvent } from '../core/eventHub.js';
@@ -402,12 +404,9 @@ export class PairPipeline extends EventEmitter {
             // codex spark AND gpt-5.5 both read 30-37× and shipped 0 edits. Push the
             // worker to actually edit before concluding.
             nudgeMaxOnNoEdit: 3,
-            // Legacy raw KG inference is advisory. Declared, existing-direct,
-            // and sufficient-draft scopes are trusted reservations and enforce
-            // the same boundary the scheduler/ledger admitted.
-            fileScope: context.task.fileScopeSource === 'inferred'
-              ? undefined
-              : context.task.fileScope,
+            // Only a scope meant as the edit target is enforced; see
+            // enforcedFileScope for which provenances qualify and why.
+            fileScope: enforcedFileScope(context.task),
             resumedTaskFiles: this.config.resumedTaskFiles,
             issueIdentifier: context.task.issueIdentifier || context.task.issueId,
             projectName: context.task.linearProject?.name,
@@ -1398,106 +1397,6 @@ export function createPipelineFromConfig(
     roleMcpTools,
     adapterRouting,
   });
-}
-
-// Helpers
-
-/**
- * Extract a worker-readable summary of what the agent did during a stage so
- * the dashboard can display "wrote 4 files / approved / reviewed N issues"
- * instead of just "stage=worker status=complete".
- *
- * Returns a plain object suitable for inclusion in the SSE `pipeline:stage`
- * broadcast payload. Fields are optional — missing ones are simply omitted.
- */
-function summarizeStageResult(
-  stage: PipelineStage,
-  result: WorkerResult | ReviewResult | TesterResult | DocumenterResult | AuditorResult | SkillDocumenterResult,
-): Record<string, unknown> {
-  // Cap arrays/strings before broadcasting so a chatty agent cannot blow up
-  // the SSE channel with a 10MB stage event.
-  const MAX_FILES = 12;
-  const MAX_COMMANDS = 8;
-  const SUMMARY_CAP = 240;
-  const FEEDBACK_CAP = 480;
-  const cap = (s: string | undefined, n: number): string | undefined =>
-    s == null ? undefined : (s.length > n ? `${s.slice(0, n - 1)}…` : s);
-
-  switch (stage) {
-    case 'worker': {
-      const r = result as WorkerResult;
-      return {
-        summary: cap(r.summary, SUMMARY_CAP),
-        filesChanged: Array.isArray(r.filesChanged) ? r.filesChanged.slice(0, MAX_FILES) : undefined,
-        filesChangedCount: r.filesChanged?.length ?? 0,
-        commands: Array.isArray(r.commands) ? r.commands.slice(0, MAX_COMMANDS) : undefined,
-        commandsCount: r.commands?.length ?? 0,
-        confidencePercent: r.confidencePercent,
-        haltReason: r.haltReason,
-        error: r.error ? cap(r.error, FEEDBACK_CAP) : undefined,
-      };
-    }
-
-    case 'reviewer': {
-      const r = result as ReviewResult;
-      return {
-        decision: r.decision,
-        feedback: cap(r.feedback, FEEDBACK_CAP),
-        issuesCount: r.issues?.length ?? 0,
-        issues: Array.isArray(r.issues) ? r.issues.slice(0, MAX_COMMANDS) : undefined,
-        suggestionsCount: r.suggestions?.length ?? 0,
-      };
-    }
-
-    case 'tester': {
-      const r = result as TesterResult;
-      return {
-        passed: r.testsPassed,
-        failed: r.testsFailed,
-        coverage: r.coverage,
-        failedTests: Array.isArray(r.failedTests) ? r.failedTests.slice(0, MAX_FILES) : undefined,
-        deterministic: r.deterministic,
-        error: r.error ? cap(r.error, FEEDBACK_CAP) : undefined,
-      };
-    }
-
-    case 'documenter': {
-      const r = result as DocumenterResult;
-      return {
-        summary: cap(r.summary, SUMMARY_CAP),
-        filesChanged: Array.isArray(r.updatedFiles) ? r.updatedFiles.slice(0, MAX_FILES) : undefined,
-        filesChangedCount: r.updatedFiles?.length ?? 0,
-        changelogEntry: cap(r.changelogEntry, SUMMARY_CAP),
-        error: r.error ? cap(r.error, FEEDBACK_CAP) : undefined,
-      };
-    }
-
-    case 'auditor': {
-      const r = result as AuditorResult;
-      return {
-        summary: cap(r.summary, SUMMARY_CAP),
-        bsScore: r.bsScore,
-        criticalCount: r.criticalCount,
-        warningCount: r.warningCount,
-        issues: Array.isArray(r.issues) ? r.issues.slice(0, MAX_COMMANDS) : undefined,
-        issuesCount: r.issues?.length ?? 0,
-        error: r.error ? cap(r.error, FEEDBACK_CAP) : undefined,
-      };
-    }
-
-    case 'skill-documenter': {
-      const r = result as SkillDocumenterResult;
-      return {
-        summary: cap(r.summary, SUMMARY_CAP),
-        filesChanged: Array.isArray(r.updatedFiles) ? r.updatedFiles.slice(0, MAX_FILES) : undefined,
-        filesChangedCount: r.updatedFiles?.length ?? 0,
-        error: r.error ? cap(r.error, FEEDBACK_CAP) : undefined,
-      };
-    }
-
-    default:
-      return {};
-  }
 }
 
 // Re-export formatting functions (extracted to pipelineFormat.ts)

--- a/src/agents/stageSummary.ts
+++ b/src/agents/stageSummary.ts
@@ -1,0 +1,108 @@
+// ============================================
+// OpenSwarm - Stage result summaries for the pipeline event stream
+// ============================================
+
+import type { WorkerResult, ReviewResult } from './agentPair.js';
+import type { TesterResult } from './tester.js';
+import type { DocumenterResult } from './documenter.js';
+import type { AuditorResult } from './auditor.js';
+import type { SkillDocumenterResult } from './skillDocumenter.js';
+import type { PipelineStage } from '../core/types.js';
+
+/**
+ * Extract a worker-readable summary of what the agent did during a stage so
+ * the dashboard can display "wrote 4 files / approved / reviewed N issues"
+ * instead of just "stage=worker status=complete".
+ *
+ * Returns a plain object suitable for inclusion in the SSE `pipeline:stage`
+ * broadcast payload. Fields are optional — missing ones are simply omitted.
+ */
+export function summarizeStageResult(
+  stage: PipelineStage,
+  result: WorkerResult | ReviewResult | TesterResult | DocumenterResult | AuditorResult | SkillDocumenterResult,
+): Record<string, unknown> {
+  // Cap arrays/strings before broadcasting so a chatty agent cannot blow up
+  // the SSE channel with a 10MB stage event.
+  const MAX_FILES = 12;
+  const MAX_COMMANDS = 8;
+  const SUMMARY_CAP = 240;
+  const FEEDBACK_CAP = 480;
+  const cap = (s: string | undefined, n: number): string | undefined =>
+    s == null ? undefined : (s.length > n ? `${s.slice(0, n - 1)}…` : s);
+
+  switch (stage) {
+    case 'worker': {
+      const r = result as WorkerResult;
+      return {
+        summary: cap(r.summary, SUMMARY_CAP),
+        filesChanged: Array.isArray(r.filesChanged) ? r.filesChanged.slice(0, MAX_FILES) : undefined,
+        filesChangedCount: r.filesChanged?.length ?? 0,
+        commands: Array.isArray(r.commands) ? r.commands.slice(0, MAX_COMMANDS) : undefined,
+        commandsCount: r.commands?.length ?? 0,
+        confidencePercent: r.confidencePercent,
+        haltReason: r.haltReason,
+        error: r.error ? cap(r.error, FEEDBACK_CAP) : undefined,
+      };
+    }
+
+    case 'reviewer': {
+      const r = result as ReviewResult;
+      return {
+        decision: r.decision,
+        feedback: cap(r.feedback, FEEDBACK_CAP),
+        issuesCount: r.issues?.length ?? 0,
+        issues: Array.isArray(r.issues) ? r.issues.slice(0, MAX_COMMANDS) : undefined,
+        suggestionsCount: r.suggestions?.length ?? 0,
+      };
+    }
+
+    case 'tester': {
+      const r = result as TesterResult;
+      return {
+        passed: r.testsPassed,
+        failed: r.testsFailed,
+        coverage: r.coverage,
+        failedTests: Array.isArray(r.failedTests) ? r.failedTests.slice(0, MAX_FILES) : undefined,
+        deterministic: r.deterministic,
+        error: r.error ? cap(r.error, FEEDBACK_CAP) : undefined,
+      };
+    }
+
+    case 'documenter': {
+      const r = result as DocumenterResult;
+      return {
+        summary: cap(r.summary, SUMMARY_CAP),
+        filesChanged: Array.isArray(r.updatedFiles) ? r.updatedFiles.slice(0, MAX_FILES) : undefined,
+        filesChangedCount: r.updatedFiles?.length ?? 0,
+        changelogEntry: cap(r.changelogEntry, SUMMARY_CAP),
+        error: r.error ? cap(r.error, FEEDBACK_CAP) : undefined,
+      };
+    }
+
+    case 'auditor': {
+      const r = result as AuditorResult;
+      return {
+        summary: cap(r.summary, SUMMARY_CAP),
+        bsScore: r.bsScore,
+        criticalCount: r.criticalCount,
+        warningCount: r.warningCount,
+        issues: Array.isArray(r.issues) ? r.issues.slice(0, MAX_COMMANDS) : undefined,
+        issuesCount: r.issues?.length ?? 0,
+        error: r.error ? cap(r.error, FEEDBACK_CAP) : undefined,
+      };
+    }
+
+    case 'skill-documenter': {
+      const r = result as SkillDocumenterResult;
+      return {
+        summary: cap(r.summary, SUMMARY_CAP),
+        filesChanged: Array.isArray(r.updatedFiles) ? r.updatedFiles.slice(0, MAX_FILES) : undefined,
+        filesChangedCount: r.updatedFiles?.length ?? 0,
+        error: r.error ? cap(r.error, FEEDBACK_CAP) : undefined,
+      };
+    }
+
+    default:
+      return {};
+  }
+}

--- a/src/agents/workerContext.ts
+++ b/src/agents/workerContext.ts
@@ -2,6 +2,7 @@ import { analyzeIssue } from '../knowledge/index.js';
 import { recallRepoKnowledge } from '../memory/repoKnowledge.js';
 import { getRegistryStore } from '../registry/sqliteStore.js';
 import type { WorkerContext } from '../locale/types.js';
+import { enforcedFileScope } from '../orchestration/writeScope.js';
 import { safeConsole } from '../support/safeLog.js';
 import { collectSiblingWork } from './siblingWork.js';
 import type { PipelineContext } from './pairPipelineTypes.js';
@@ -14,11 +15,11 @@ export async function collectWorkerContext(
     const wc: WorkerContext = {};
     // The runner enforces this boundary after the worker finishes. Exposing it
     // before planning prevents otherwise-valid edits being discovered only by
-    // the post-run scope guard. Legacy raw KG inference is advisory and is NOT
-    // enforced by pairPipeline/publishOnPark, so announcing it as binding here
-    // would make the worker refuse edits that would actually have passed.
-    const enforcedScope = context.task.fileScopeSource === 'inferred' ? undefined : context.task.fileScope;
-    if (enforcedScope?.length) wc.fileScope = [...enforcedScope];
+    // the post-run scope guard. Announce exactly what will be enforced: an
+    // advisory scope presented as binding makes the worker refuse edits that
+    // would have passed.
+    const enforcedScope = enforcedFileScope(context.task);
+    if (enforcedScope) wc.fileScope = enforcedScope;
     if (draft) {
       wc.draftAnalysis = { taskType: draft.taskType, intentSummary: draft.intentSummary, relevantFiles: draft.relevantFiles,
         suggestedApproach: draft.suggestedApproach, projectStats: draft.projectStats, completionCriteria: draft.completionCriteria, sufficient: draft.sufficient };

--- a/src/automation/publishOnPark.ts
+++ b/src/automation/publishOnPark.ts
@@ -13,6 +13,7 @@
 // Split out of runnerExecution.ts, which sits on the 1500-line pre-commit cap.
 
 import { broadcastEvent } from '../core/eventHub.js';
+import { enforcedFileScope, type FileScopeSource } from '../orchestration/writeScope.js';
 import { commitAndCreatePRWithHead, type WorktreeInfo } from '../support/worktreeManager.js';
 import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
 
@@ -33,7 +34,7 @@ interface PublishableTask {
   description?: string;
   issueIdentifier?: string;
   fileScope?: string[];
-  fileScopeSource?: 'declared' | 'validated-direct' | 'drafted' | 'inferred';
+  fileScopeSource?: FileScopeSource;
 }
 
 /**
@@ -92,7 +93,7 @@ export async function publishParkedWork(
       // Draft, and committed work only: nothing reviewed this, and the tree
       // must stay exactly as the worker left it so the resume continues.
       { draft: true, committedOnly: true,
-        fileScope: task.fileScopeSource === 'inferred' ? undefined : task.fileScope },
+        fileScope: enforcedFileScope(task) },
     );
     // The ledger records the PR; the pipeline result deliberately does NOT.
     //
@@ -183,7 +184,7 @@ export async function publishStuckWork(
       // no-op (a clean tree skips the whole commit phase) — but that commit
       // swallows its own failures, and this is the second chance.
       { draft: true,
-        fileScope: task.fileScopeSource === 'inferred' ? undefined : task.fileScope },
+        fileScope: enforcedFileScope(task) },
     );
     broadcastEvent({
       type: 'log',
@@ -229,7 +230,7 @@ export async function publishApprovedWork(
           task.title,
           task.issueIdentifier || '',
           task.description || '',
-          { fileScope: task.fileScopeSource === 'inferred' ? undefined : task.fileScope },
+          { fileScope: enforcedFileScope(task) },
         );
         const { prUrl, headSha } = publication;
         result.prUrl = prUrl;

--- a/src/orchestration/writeScope.test.ts
+++ b/src/orchestration/writeScope.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { enforcedFileScope, filesOutsideWriteScope } from './writeScope.js';
+
+describe('enforcedFileScope', () => {
+  const scope = ['src/a.ts', 'src/b.ts'];
+
+  it('binds a declared or drafted reservation', () => {
+    expect(enforcedFileScope({ fileScope: scope, fileScopeSource: 'declared' })).toEqual(scope);
+    expect(enforcedFileScope({ fileScope: scope, fileScopeSource: 'drafted' })).toEqual(scope);
+  });
+
+  // vela 2026-09-02: 3 of 3 scope violations were mention-scopes that were
+  // simply wrong; validated-direct runs finished 1 of 43 at 15 attempts each.
+  it('treats knowledge-graph mention scopes as advisory, whether raw or existence-checked', () => {
+    expect(enforcedFileScope({ fileScope: scope, fileScopeSource: 'inferred' })).toBeUndefined();
+    expect(enforcedFileScope({ fileScope: scope, fileScopeSource: 'validated-direct' })).toBeUndefined();
+  });
+
+  it('enforces nothing when there is no reservation', () => {
+    expect(enforcedFileScope({})).toBeUndefined();
+    expect(enforcedFileScope({ fileScope: [], fileScopeSource: 'declared' })).toBeUndefined();
+  });
+
+  it('returns a copy so a consumer cannot widen the task in place', () => {
+    const task = { fileScope: [...scope], fileScopeSource: 'declared' as const };
+    enforcedFileScope(task)!.push('src/c.ts');
+    expect(task.fileScope).toEqual(scope);
+  });
+});
+
+describe('filesOutsideWriteScope', () => {
+  it('allows a companion test beside a scoped source file', () => {
+    expect(filesOutsideWriteScope(['src/a.ts', 'src/a.test.ts', 'src/z.ts'], ['src/a.ts'])).toEqual(['src/z.ts']);
+  });
+});

--- a/src/orchestration/writeScope.ts
+++ b/src/orchestration/writeScope.ts
@@ -63,6 +63,35 @@ function isTestForScopedFile(file: string, scoped: string): boolean {
   ).test(file);
 }
 
+/** Provenance of a task's reserved write scope; mirrors TaskItem.fileScopeSource. */
+export type FileScopeSource = 'declared' | 'validated-direct' | 'drafted' | 'inferred';
+
+/**
+ * The write scope a worker is held to, or undefined when none is enforced.
+ *
+ * Only a scope somebody meant as the edit target is binding: `declared`
+ * (planner or operator) and `drafted` (an analysis that judged itself
+ * sufficient). `inferred` and `validated-direct` both come from the knowledge
+ * graph matching the issue text — files the issue *mentions*, which is not
+ * the same as files the fix must touch. Measured on vela, 2026-09-02:
+ * validated-direct runs finished 1 of 43 with an average of 15 attempts,
+ * against 20 of 117 at 5 attempts for runs with no reservation at all; 3 of
+ * 3 scope violations that morning were mention-scopes that were simply wrong
+ * ("session list pin" reserved to `auth/superthread.py`). Those scopes still
+ * feed admission conflict checks, where over-caution costs only ordering.
+ *
+ * One function so the worker prompt, the post-run guard and the publication
+ * fence cannot disagree about what is enforced.
+ */
+export function enforcedFileScope(task: {
+  fileScope?: readonly string[];
+  fileScopeSource?: FileScopeSource;
+}): string[] | undefined {
+  if (!task.fileScope?.length) return undefined;
+  if (task.fileScopeSource === 'inferred' || task.fileScopeSource === 'validated-direct') return undefined;
+  return [...task.fileScope];
+}
+
 /** Return original Git paths that fall outside a trusted write reservation. */
 export function filesOutsideWriteScope(
   files: readonly string[],


### PR DESCRIPTION
## Problem

`validated-direct` is the knowledge graph's `directModules` for the issue text, kept only
where the file exists. Existence does not make a *mentioned* file the *edit target*, and
the ledger shows what enforcing it as one costs (vela, 2026-09-02, `/work/*` runs):

| source | runs | done (PR) | parked | avg attempts | scope-violation issues |
|---|---|---|---|---|---|
| (none) | 117 | 20 | 18 | 5 | 20 |
| **validated-direct** | **43** | **1** | 15 | **15** | **15** |
| drafted | 38 | 3 | 17 | 7 | 7 |

Every scope violation this morning — with #507 deployed, so the worker *was* told the
boundary — was a validated-direct reservation that was simply wrong:

| Issue | Reserved | Worker actually edited |
|---|---|---|
| "session list pin" | `pipeline/auth/superthread.py` | `session_store.py`, `routers/sessions.py`, `chat.html` |
| CI suite timing | `auth/github.py`, `routers/cron.py` | `.github/workflows/*.yml` |
| bank statement parser | `connectors/slack.py` | `a2_bank_aggregation.py`, `pyproject.toml` |

One task was held to its wrong scope **46 times**.

## Change

`enforcedFileScope(task)` in `writeScope.ts` is now the single reading of which
provenances bind: `declared` and `drafted`. `inferred` and `validated-direct` are advisory
— they still feed admission conflict checks (`fileScopesConflict`), where over-caution
only costs ordering, not correctness.

The worker prompt (`workerContext`), the post-run guard (`pairPipeline`) and the
publication fence (`publishOnPark`, 3 sites) all call it, replacing three copies of the
inline `fileScopeSource === 'inferred' ? undefined : fileScope` gate.

`summarizeStageResult` moves to `stageSummary.ts` unchanged — `pairPipeline.ts` was
already at 1504 lines, past the 1500-line pre-commit cap, before this change.

## Test plan

- [x] `npm run typecheck` — clean; `npm run lint` — 0 errors
- [x] `npx vitest run src/agents/ src/automation/ src/orchestration/` — 101 files, 1738 passed
- [x] New `writeScope.test.ts`: declared/drafted bind, inferred/validated-direct do not,
      empty scope enforces nothing, result is a copy