### PR TITLE
feat(admission): let an operator admit unknown-scope runs beside live same-repo work

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -74,6 +74,11 @@ autonomous:
   stalledInProgressHours: 6
   worktreeMode: true  # Required for same-project parallel tasks
   allowSameProjectConcurrent: true
+  # What durable admission does with a task whose write scope could not be
+  # resolved while another run in the same repository is live. serialize
+  # (default) fails closed; admit relies on isolated worktrees and post-merge
+  # integration requeue to surface a branch conflict at PR time instead.
+  # unknownScopeAdmission: serialize
   # maxConcurrentPerProject: 64  # Optional hard cap; omit for weighted, work-conserving project fairness
   automationLedgerMode: primary  # off | shadow | primary (durable fail-closed execution truth)
   automationLeaseMs: 600000      # Renewed every ~3m; stale callbacks are fenced

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -1387,6 +1387,7 @@ export class AutonomousRunner {
         // this heartbeat's in-memory conflict check. An empty scope fails
         // closed while another same-repository run is active.
         conflictScope: task.fileScope ?? [],
+        unknownScopeAdmission: this.config.unknownScopeAdmission,
         // A fixed default attempt budget of 12 made a 32-slot daemon trip its
         // repository circuit before the first pool could even fill. Treat this
         // as an explicit repository policy; failure and cost circuits remain

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -62,6 +62,8 @@ export interface RepositoryAdmissionPolicy {
   maxConcurrent?: number;
   /** Predicted repository-relative write set used for atomic conflict admission. */
   conflictScope?: string[];
+  /** Whether an unknown scope serializes against live same-repo runs (default) or is admitted. */
+  unknownScopeAdmission?: 'serialize' | 'admit';
   maxAttemptsPerHour?: number;
   maxFailuresPerHour?: number;
   maxCostUsdPerDay?: number;
@@ -479,6 +481,7 @@ export class DurableRunCoordinator {
       leaseMs: this.leaseMs,
       maxActiveForProject: options.admission?.maxConcurrent ?? this.maxActiveForProject,
       conflictScope: options.admission?.conflictScope,
+      unknownScopeAdmission: options.admission?.unknownScopeAdmission,
       maxAttemptsPerHour: options.admission?.maxAttemptsPerHour,
       maxFailuresPerHour: options.admission?.maxFailuresPerHour,
       maxCostUsdPerDay: options.admission?.maxCostUsdPerDay,

--- a/src/automation/runLedger.test.ts
+++ b/src/automation/runLedger.test.ts
@@ -463,6 +463,28 @@ describe('RunLedger claim and fencing races', () => {
     ledger.close();
   });
 
+  // vela 2026-09-02: 9 of 12 slots idle because every repository serialized
+  // to one unscoped run. The operator can now choose to rely on isolated
+  // worktrees and post-merge integration requeue instead.
+  it('admits unknown scopes on either side under unknownScopeAdmission=admit, still refusing a known overlap', () => {
+    const ledger = new RunLedger(createDbPath());
+    register(ledger, 'UNKNOWN-1', '/same-repo');
+    register(ledger, 'UNKNOWN-2', '/same-repo');
+    register(ledger, 'KNOWN-A', '/same-repo', ['src/a.ts']);
+    register(ledger, 'KNOWN-A2', '/same-repo', ['src/a.ts']);
+    const admit = { leaseMs: 1_000, maxActiveForProject: 4, unknownScopeAdmission: 'admit' as const };
+
+    expect(ledger.claimRun('UNKNOWN-1', { ...admit, ownerInstanceId: 'u1', now: 2_000, conflictScope: [] })).not.toBeNull();
+    // Unknown next to unknown.
+    expect(ledger.claimRun('UNKNOWN-2', { ...admit, ownerInstanceId: 'u2', now: 2_001, conflictScope: [] })).not.toBeNull();
+    // Known next to unknown actives.
+    expect(ledger.claimRun('KNOWN-A', { ...admit, ownerInstanceId: 'a', now: 2_002, conflictScope: ['src/a.ts'] })).not.toBeNull();
+    // Known overlap is still a conflict.
+    expect(ledger.claimRun('KNOWN-A2', { ...admit, ownerInstanceId: 'a2', now: 2_003, conflictScope: ['src/a.ts'] })).toBeNull();
+    expect(ledger.listRuns(['CLAIMED'])).toHaveLength(3);
+    ledger.close();
+  });
+
   it('rejects a late callback after lease expiry and replacement', () => {
     const dbPath = createDbPath();
     const oldDaemon = new RunLedger(dbPath);

--- a/src/automation/runLedger.ts
+++ b/src/automation/runLedger.ts
@@ -530,7 +530,7 @@ export class RunLedger {
         const activeScopes = activeRows
           .filter(active => ACTIVE_LEASE_STATES.includes(active.state as RunState))
           .map(active => parseJson(active.metadata_json));
-        if (!admitsConflictScope(options.conflictScope, activeScopes)) return null;
+        if (!admitsConflictScope(options.conflictScope, activeScopes, options.unknownScopeAdmission)) return null;
       }
 
       const epoch = row.lease_epoch + 1;

--- a/src/automation/runLedgerScope.ts
+++ b/src/automation/runLedgerScope.ts
@@ -35,16 +35,29 @@ export function scopesOverlap(left: Set<string>, right: Set<string>): boolean {
  * Unknown scope on either side fails closed — worktrees isolate filesystem
  * writes, but they do not make two unknown write sets safe to merge.
  */
+export type UnknownScopeAdmission = 'serialize' | 'admit';
+
 export function admitsConflictScope(
   requested: unknown,
   activeScopes: readonly unknown[],
+  unknownScope: UnknownScopeAdmission = 'serialize',
 ): boolean {
   if (activeScopes.length === 0) return true;
   const requestedScope = normalizeConflictScope(requested);
-  if (requestedScope.size === 0) return false;
+  // 'admit': an unknown scope on either side is not evidence of a conflict.
+  // Two known scopes that overlap are still refused. Measured on vela,
+  // 2026-09-02: runs with no resolvable scope were the most successful
+  // class (20 of 117 finished with a PR) yet serialized every repository
+  // to one of them at a time, leaving 9 of 12 slots idle all morning.
+  const admitUnknown = unknownScope === 'admit';
+  if (requestedScope.size === 0) return admitUnknown;
   for (const active of activeScopes) {
     const activeScope = metadataConflictScope(active);
-    if (activeScope.size === 0 || scopesOverlap(requestedScope, activeScope)) return false;
+    if (activeScope.size === 0) {
+      if (admitUnknown) continue;
+      return false;
+    }
+    if (scopesOverlap(requestedScope, activeScope)) return false;
   }
   return true;
 }

--- a/src/automation/runLedgerTypes.ts
+++ b/src/automation/runLedgerTypes.ts
@@ -148,6 +148,8 @@ export interface ClaimOptions {
   maxActiveForProject?: number;
   /** Normalized predicted write set. Unknown scope serializes against live same-repo claims. */
   conflictScope?: string[];
+  /** How an unknown scope (empty on either side) is admitted. Default 'serialize'. */
+  unknownScopeAdmission?: 'serialize' | 'admit';
   maxAttemptsPerHour?: number;
   maxFailuresPerHour?: number;
   maxCostUsdPerDay?: number;

--- a/src/automation/runnerTypes.ts
+++ b/src/automation/runnerTypes.ts
@@ -47,6 +47,13 @@ export interface AutonomousConfig {
   worktreeMode?: boolean;
   /** Allow concurrent tasks on the same repo (requires worktreeMode). Default true. (INT-1975) */
   allowSameProjectConcurrent?: boolean;
+  /**
+   * Durable admission for a task whose write scope could not be resolved
+   * while another run in the same repository is live. 'serialize' (default)
+   * fails closed; 'admit' relies on isolated worktrees plus post-merge
+   * integration requeue to surface any branch conflict at PR time instead.
+   */
+  unknownScopeAdmission?: 'serialize' | 'admit';
   guards?: Partial<import('../core/types.js').PipelineGuardsConfig>;
   verify?: VerifyConfig;
   securityAudit?: SecurityAuditConfig;

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -257,6 +257,27 @@ agents:
       });
     });
 
+    it('defaults unknownScopeAdmission to serialize and carries an explicit admit through', () => {
+      const base = {
+        language: 'en',
+        linear: { apiKey: 'k', teamId: 't' },
+        agents: [{ name: 'main', projectPath: '/p', enabled: true, paused: false }],
+      };
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ ...base, autonomous: { enabled: true } }));
+      expect(loadConfig('/tmp/config.json').autonomous?.unknownScopeAdmission).toBe('serialize');
+
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        ...base, autonomous: { enabled: true, unknownScopeAdmission: 'admit' },
+      }));
+      expect(loadConfig('/tmp/config.json').autonomous?.unknownScopeAdmission).toBe('admit');
+
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        ...base, autonomous: { enabled: true, unknownScopeAdmission: 'yolo' },
+      }));
+      expect(() => loadConfig('/tmp/config.json')).toThrow();
+    });
+
     it('should accept jobProfiles with partial role overrides', () => {
       // Regression: roles used z.record(enum, string), which under Zod v4 requires
       // EVERY pipeline stage as a key — so a profile naming only worker+reviewer

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -334,6 +334,12 @@ const AutonomousConfigSchema = z.object({
   worktreeMode: z.boolean().default(false),
   /** Allow concurrent tasks on the same repo (requires worktreeMode). (INT-1975) */
   allowSameProjectConcurrent: z.boolean().default(true),
+  /**
+   * 'serialize' (default) refuses a claim with no resolvable write scope while
+   * another same-repo run is live. 'admit' lets it through and leaves branch
+   * conflicts to post-merge integration requeue.
+   */
+  unknownScopeAdmission: z.enum(['serialize', 'admit']).default('serialize'),
   /** Dynamic job profiles for model selection */
   jobProfiles: z.array(JobProfileSchema).optional(),
   /** Pipeline quality guards (bad-edit lint gate, BS detector, etc.) */
@@ -735,6 +741,7 @@ function transformConfig(raw: RawConfig): SwarmConfig {
       } : undefined,
       worktreeMode: raw.autonomous.worktreeMode,
       allowSameProjectConcurrent: raw.autonomous.allowSameProjectConcurrent,
+      unknownScopeAdmission: raw.autonomous.unknownScopeAdmission,
       guards: raw.autonomous.guards,
       verify: raw.autonomous.verify,
       securityAudit: raw.autonomous.securityAudit,

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -297,6 +297,7 @@ async function startServiceLocked(config: SwarmConfig): Promise<void> {
       automationLeaseMs: config.autonomous.automationLeaseMs,
       shutdownGraceMs: config.autonomous.shutdownGraceMs,
       allowSameProjectConcurrent: config.autonomous.allowSameProjectConcurrent,
+      unknownScopeAdmission: config.autonomous.unknownScopeAdmission,
       defaultRoles: config.autonomous.defaultRoles,
       projectAgents: config.autonomous.projectAgents,
       // Task decomposition (Planner) configuration. The whole object is passed,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -605,6 +605,8 @@ export type AutonomousStartupConfig = {
    * blockedBy dependency graph. Default: true. (INT-1975)
    */
   allowSameProjectConcurrent?: boolean;
+  /** Admission for a task with no resolvable write scope next to a live same-repo run. */
+  unknownScopeAdmission?: 'serialize' | 'admit';
   /** Pipeline guards configuration */
   guards?: Partial<PipelineGuardsConfig>;
   /** Deterministic baseline-diff verification, enabled by default. */


### PR DESCRIPTION
## Problem

Durable admission refuses a claim whose write scope could not be resolved whenever
another run in the same repository is live — and refuses *any* claim while an unscoped
run is live. That is a deliberate fail-closed guard against branch conflicts at merge time.

Measured on vela, 2026-09-02, it is also why **9 of 12 worker slots sat idle all morning**:

- Runs with no resolvable scope are the most successful class in the ledger
  (20 of 117 finished with a PR, vs 1 of 43 for mention-derived scopes — see #517).
- Yet one such run serializes its whole repository. Six redispatched runs came back
  `claim_deferred: Durable claim unavailable` within seconds of a single peer starting.
- `allowSameProjectConcurrent: true` reads as "run same-repo work in parallel" and the
  scheduler honours it (`perProject=unlimited`), but the ledger's scope rule overrode it
  for every unscoped task.

## Change

`autonomous.unknownScopeAdmission: serialize | admit` makes the trade-off an explicit
operator choice. **The default stays `serialize`** — no deployment changes behaviour
without opting in.

Under `admit`:
- an unknown scope on either side is not treated as a conflict;
- two **known** scopes that overlap are still refused;
- branch conflicts between admitted unscoped runs surface at PR time and go through
  post-merge integration requeue, which already exists for exactly that.

Plumbed config → `AutonomousConfig` → `RepositoryAdmissionPolicy` → `ClaimOptions` →
`admitsConflictScope`.

## Test plan

- [x] `npm run typecheck` — clean; `npm run lint` — 0 errors
- [x] `npx vitest run src/automation/ src/core/` — 964 passed
- [x] `runLedger.test.ts`: under `admit`, unknown-next-to-unknown, known-next-to-unknown
      admitted; known overlap still refused; existing `serialize` cases unchanged
- [x] `config.test.ts`: default `serialize`, explicit `admit` carried through, invalid
      value rejected