### PR TITLE
fix(worktree): keep Python test-run output out of preserved WIP and PRs

### DIFF
--- a/src/support/worktreeEphemeral.test.ts
+++ b/src/support/worktreeEphemeral.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { ephemeralPathspecRoots, isEphemeralWorktreeArtifact } from './worktreeEphemeral.js';
+
+describe('isEphemeralWorktreeArtifact', () => {
+  // cgf-portal#207 (2026-09-02) shipped `apps/pipelines/.coverage`: the repo
+  // ignores only `coverage/`, so pytest-cov's data file was trackable and the
+  // WIP preserve committed it.
+  it('drops Python test-run output at any depth', () => {
+    for (const file of [
+      '.coverage',
+      'apps/pipelines/.coverage',
+      'apps/pipelines/.coverage.runner.12345.XyZ',
+      'apps/pipelines/.full-pytest.status',
+      '.pytest_cache/v/cache/nodeids',
+      'src/pkg/__pycache__/mod.cpython-312.pyc',
+      'htmlcov/index.html',
+      '.hypothesis/examples/abc',
+    ]) {
+      expect(isEphemeralWorktreeArtifact(file), file).toBe(true);
+    }
+  });
+
+  it('keeps source that merely resembles test output', () => {
+    for (const file of [
+      'src/coverage.ts',
+      'docs/coverage-report.md',
+      'tests/test_loader.py',
+      'apps/pipelines/src/cgf_pipelines/a3_messaging.py',
+      'coverage/README.md',
+    ]) {
+      expect(isEphemeralWorktreeArtifact(file), file).toBe(false);
+    }
+  });
+
+  it('still recognises the worktree-level scratch it always did', () => {
+    expect(isEphemeralWorktreeArtifact('.venv')).toBe(true);
+    expect(isEphemeralWorktreeArtifact('pytest-of-openswarm/pytest-3/x')).toBe(true);
+    expect(isEphemeralWorktreeArtifact('.trash/AX-1/pytest-a3/out')).toBe(true);
+  });
+});
+
+describe('ephemeralPathspecRoots', () => {
+  it('collapses pytest basetemp paths to their root and keeps single files', () => {
+    expect(ephemeralPathspecRoots([
+      'pytest-of-openswarm/pytest-3/a', 'pytest-of-openswarm/pytest-3/b', 'apps/pipelines/.coverage',
+    ])).toEqual(['apps/pipelines/.coverage', 'pytest-of-openswarm']);
+  });
+});

--- a/src/support/worktreeEphemeral.ts
+++ b/src/support/worktreeEphemeral.ts
@@ -21,7 +21,14 @@ export function isEphemeralWorktreeArtifact(file: string): boolean {
     || /^\.test-tmp(?:-[^/]+)?(?:\/|$)/.test(file)
     || /^\.pytest-lathe(?:\/|$)/.test(file)
     || /^int\d+_[a-z0-9_]{8,}(?:\/|$)/i.test(file)
-    || /^tmp[a-z0-9]{8,}(?:\/|$)/i.test(file);
+    || /^tmp[a-z0-9]{8,}(?:\/|$)/i.test(file)
+    // Python test-run output at any depth. A repository that ignores only
+    // `coverage/` still leaves `.coverage` (and pytest-xdist's
+    // `.coverage.<host>.<pid>.<n>`) trackable, so a worker's `pytest --cov`
+    // reached the PR: cgf-portal#207 shipped `apps/pipelines/.coverage`.
+    || /(?:^|\/)\.coverage(?:\.[^/]+)?$/.test(file)
+    || /(?:^|\/)\.full-pytest\.status$/.test(file)
+    || /(?:^|\/)(?:\.pytest_cache|\.hypothesis|\.mypy_cache|\.ruff_cache|__pycache__|htmlcov)(?:\/|$)/.test(file);
 }
 
 /** Collapse file paths to the shallowest directory (or file) git can rm -r. */


### PR DESCRIPTION
## Problem

[cgf-portal#207](https://github.com/Intrect-io/cgf-portal/pull/207), the first PR the
daemon published this morning, carried `apps/pipelines/.coverage` — pytest-cov's data
file. The repository ignores only `coverage/`, so the file was trackable, and the WIP
preserve committed whatever the worker's `pytest --cov` left behind. `.full-pytest.status`
reached a publication-scope rejection the same way earlier today.

## Change

`isEphemeralWorktreeArtifact` now also drops, at any depth:

- `.coverage` and pytest-xdist's `.coverage.<host>.<pid>.<n>`
- `.full-pytest.status`
- `.pytest_cache/`, `.hypothesis/`, `.mypy_cache/`, `.ruff_cache/`, `__pycache__/`, `htmlcov/`

Every consumer — worker git authority, WIP preserve/purge, the pipeline guards (#508) and
the publication fence (#508) — reads that one predicate, so the fix lands in all of them.
Source that merely resembles test output (`src/coverage.ts`, `coverage/README.md`,
`tests/test_loader.py`) is unaffected.

## Test plan

- [x] `npm run typecheck` — clean; `npm run lint` — 0 errors
- [x] New `worktreeEphemeral.test.ts` (the module had none): 8 artifact paths dropped,
      5 look-alike source paths kept, legacy scratch still recognised, pathspec roots
- [x] `publicationScopeFence.test.ts`, `worker.gitAuthority.test.ts`, `worktreeManager.test.ts` — 74 passed