### PR TITLE
fix(publish): stage the publication commit through the ephemeral filter

### DIFF
--- a/src/support/publicationScopeFence.test.ts
+++ b/src/support/publicationScopeFence.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -70,6 +70,42 @@ describe('pre-publication write-scope fence', () => {
     )).rejects.toThrow(/publication-scope.*src\/outside\.ts/);
 
     expect(remoteBranch(origin, branchName)).toBe('');
+  });
+
+  // vega-plugins#36 (2026-09-02): after three "remove ephemeral runtime
+  // artifacts" commits the publication commit did a raw `git add -A` and
+  // shipped `.venv`, `.openswarm/*` and two `tmp*/whatsapp.db` alongside two
+  // source files. Publication must stage through the same filter the WIP
+  // checkpoint uses.
+  it('publishes without the runtime artifacts still on disk', async () => {
+    const branchName = 'swarm/AGT-SCOPE-publish-clean';
+    const { repo, origin, info } = repository(branchName);
+    writeFileSync(join(repo, 'src/allowed.ts'), 'real work\n');
+    writeFileSync(join(repo, '.venv'), '/tmp/venv-link\n');
+    mkdirSync(join(repo, '.openswarm'));
+    writeFileSync(join(repo, '.openswarm', 'repo-snapshot.json'), '{}\n');
+    mkdirSync(join(repo, 'tmppcd_d3bf'));
+    writeFileSync(join(repo, 'tmppcd_d3bf', 'whatsapp.db'), 'sqlite\n');
+    mkdirSync(join(repo, 'apps'));
+    writeFileSync(join(repo, 'apps', '.coverage'), 'cov\n');
+
+    const bin = join(root, 'bin');
+    mkdirSync(bin, { recursive: true });
+    writeFileSync(join(bin, 'gh'), '#!/bin/sh\ncase "$*" in *"pr create"*) echo "https://example.test/clean";; esac\n');
+    chmodSync(join(bin, 'gh'), 0o755);
+    const prevPath = process.env.PATH;
+    process.env.PATH = `${bin}:${prevPath}`;
+    try {
+      await expect(commitAndCreatePRWithHead(
+        info, 'Clean publish', 'AGT-SCOPE', '', { fileScope: ['src/allowed.ts'] },
+      )).resolves.toMatchObject({ prUrl: 'https://example.test/clean' });
+    } finally {
+      process.env.PATH = prevPath;
+    }
+
+    const published = git(repo, 'ls-tree', '-r', '--name-only', `origin/${branchName}`).split('\n').filter(Boolean).sort();
+    expect(published).toEqual(['src/allowed.ts', 'src/outside.ts']);
+    expect(remoteBranch(origin, branchName)).not.toBe('');
   });
 
   it('ignores generated OpenSwarm repository snapshots in a preserved branch', async () => {

--- a/src/support/worktreeEphemeral.ts
+++ b/src/support/worktreeEphemeral.ts
@@ -21,7 +21,9 @@ export function isEphemeralWorktreeArtifact(file: string): boolean {
     || /^\.test-tmp(?:-[^/]+)?(?:\/|$)/.test(file)
     || /^\.pytest-lathe(?:\/|$)/.test(file)
     || /^int\d+_[a-z0-9_]{8,}(?:\/|$)/i.test(file)
-    || /^tmp[a-z0-9]{8,}(?:\/|$)/i.test(file)
+    // Python's tempfile.mkdtemp() draws its 8-character suffix from
+    // [a-z0-9_], so `tmppcd_d3bf/` must match too (vega-plugins#36).
+    || /^tmp[a-z0-9_]{8,}(?:\/|$)/i.test(file)
     // Python test-run output at any depth. A repository that ignores only
     // `coverage/` still leaves `.coverage` (and pytest-xdist's
     // `.coverage.<host>.<pid>.<n>`) trackable, so a worker's `pytest --cov`

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -1152,7 +1152,11 @@ export async function commitAndCreatePRWithHead(
     const status = await git(worktreePath, 'status', '--porcelain');
 
     if (status.trim()) {
-      await git(worktreePath, 'add', '-A');
+      // Same filtered staging as the WIP checkpoint. The purge above only
+      // cleans HEAD; a raw `add -A` here re-adds every runtime artifact still
+      // on disk, which is how vega-plugins#36 shipped `.venv`, `.openswarm/*`
+      // and two `tmp*/whatsapp.db` after three purge commits.
+      await stagePreservableWorktreeChanges(worktreePath);
       await guardUnsafeBinaryStaging(worktreePath); // INT-2430
 
       const stillStaged = await git(worktreePath, 'diff', '--cached', '--name-only');
@@ -1330,7 +1334,7 @@ export async function commitAndCreateAuditPR(info: WorktreeInfo, req: AuditPRReq
 
   const dirty = await git(worktreePath, 'status', '--porcelain');
   if (dirty.trim()) {
-    await git(worktreePath, 'add', '-A');
+    await stagePreservableWorktreeChanges(worktreePath);
     await guardUnsafeBinaryStaging(worktreePath); // INT-2430
     const staged = await git(worktreePath, 'diff', '--cached', '--name-only');
     if (staged.trim()) {

--- a/src/verify/runner.ts
+++ b/src/verify/runner.ts
@@ -99,7 +99,7 @@ function isEphemeralVerificationArtifact(path: string): boolean {
     || root === '.trash'
     || /^pytest-of-[^/]+$/.test(root)
     || /^int\d+_[a-z0-9_]{8,}$/i.test(root)
-    || /^tmp[a-z0-9]{8,}$/i.test(root)
+    || /^tmp[a-z0-9_]{8,}$/i.test(root)
     || /^\.openswarm-trash\/[^/]*-(?:pytest|verify)(?:-|\/|$)/.test(path)
     || /^\.openswarm\/(?:repo-snapshot\.json|repo\.graphql)$/.test(path)
     || /^\.trash\/(?:atomic-verify-[^/]+|pytest-of-[^/]+)(?:\/|$)/.test(path)


### PR DESCRIPTION
## Problem

[vega-plugins#36](https://github.com/Intrect-io/vega-plugins/pull/36), published this
morning after 25 attempts, has 8 files: two source files and

```
.venv  .venv-verify  .openswarm/repo-snapshot.json  .openswarm/repo.graphql
tmppcd_d3bf/whatsapp.db  tmprb_i3p58/whatsapp.db
```

— 1,842 added lines, lint red.

The branch history shows **three** `wip: remove ephemeral runtime artifacts (auto)`
commits. Each purge cleaned HEAD's tree; the next publication then ran a raw
`git add -A` and put everything still on disk straight back. #504 gave the WIP checkpoint
`stagePreservableWorktreeChanges` for exactly this, but neither publication path
(`commitAndCreatePRWithHead`, `commitAndCreateAuditPR`) used it.

## Change

- Both publication paths stage through `stagePreservableWorktreeChanges`.
- The `tmp*` scratch pattern accepts an underscore: Python's `tempfile.mkdtemp()` draws its
  8-char suffix from `[a-z0-9_]`, so `tmppcd_d3bf/` never matched. `verify/runner.ts`'s
  copy of the pattern is aligned.

## Test plan

- [x] `npm run typecheck` — clean; `npm run lint` — 0 errors
- [x] New case in `publicationScopeFence.test.ts` publishes a tree carrying `.venv`,
      `.openswarm/*`, `tmp*/` and `.coverage` through a stubbed `gh` and asserts the pushed
      tree is only the two source files. **Without the change it fails listing exactly
      those four paths** (verified by reverting `worktreeManager.ts` and re-running).
- [x] `npx vitest run src/support/ src/verify/` — 764 passed