### PR TITLE
fix(verify): normalize the duration on a quiet-mode pytest summary line

### DIFF
--- a/src/verify/fingerprintStability.test.ts
+++ b/src/verify/fingerprintStability.test.ts
@@ -45,6 +45,28 @@ describe('normalizeFailureOutput', () => {
     );
   });
 
+  // vega-agent AGT-4118, 2026-09-02: base and head both failed collection with
+  // the same ModuleNotFoundError, but the discovered command is `pytest -q`,
+  // whose summary line has no `=` decoration, so the timing survived into the
+  // fingerprint and the pre-existing failure was reported as a new regression.
+  it('normalizes the duration on a quiet-mode pytest summary line', () => {
+    const out = (secs: string) => [
+      '==================================== ERRORS ====================================',
+      '______________ ERROR collecting tests/test_codeql_audit_scope.py _______________',
+      'E   ModuleNotFoundError: No module named \'yaml\'',
+      '=========================== short test summary info ============================',
+      'ERROR tests/test_codeql_audit_scope.py',
+      '!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!',
+      `3 skipped, 1 error in ${secs}s`,
+      '',
+    ].join('\n');
+    const a = normalizeFailureOutput(out('1.93'), paths(SANDBOX_A));
+    expect(a).toBe(normalizeFailureOutput(out('1.54'), paths(SANDBOX_B)));
+    expect(a).toContain('3 skipped, 1 error in <DURATION>');
+    // A different count is still a different failure.
+    expect(a).not.toBe(normalizeFailureOutput(out('1.93').replace('1 error', '2 errors'), paths(SANDBOX_A)));
+  });
+
   it('normalizes paths outside the command cwd — the subdirectory-cwd bug', () => {
     // A command with `cwd: packages/api` fails, but the traceback points at a
     // sibling package. Normalizing only the cwd left this line sandbox-specific.

--- a/src/verify/runner.ts
+++ b/src/verify/runner.ts
@@ -145,6 +145,12 @@ export function normalizeFailureOutput(output: string, paths: Array<[string, str
   normalized = normalized
     .replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'), '')
     .replace(/(=+ .*? in )\d+(?:\.\d+)?s( =+)/g, '$1<DURATION>$2')
+    // The discovered pytest command runs with `-q`, whose final summary line
+    // carries no `=` decoration: `3 skipped, 1 error in 1.54s`. Left alone,
+    // base and head fingerprints differed by timing alone, and every
+    // pre-existing failure read as a new regression (vega-agent AGT-4118:
+    // the same ModuleNotFoundError on both sides, 1.93s vs 1.54s).
+    .replace(/^(\d+ [a-z]+(?:, \d+ [a-z]+)* in )\d+(?:\.\d+)?s$/gm, '$1<DURATION>')
     .replace(/(Ran \d+ tests? in )\d+(?:\.\d+)?s/g, '$1<DURATION>')
     .replace(/(finished in )\d+(?:\.\d+)?s/gi, '$1<DURATION>')
     // pytest-xdist assigns the same failure to different workers on base and


### PR DESCRIPTION
## Problem

The discovered pytest command is `pytest -x -q` (`src/verify/discover.ts:89`). In quiet
mode the final summary line has **no `=` decoration**:

```
3 skipped, 1 error in 1.54s
```

The duration normalizer in `normalizeFailureOutput` only matched the decorated form
(`=== ... in 1.54s ===`). The timing therefore survived into the failure fingerprint,
base and head never hashed the same, and `hasSameFailure` reported every pre-existing
pytest failure as a new regression.

vega-agent AGT-4118 today: base and head both failed collection with the identical
`ModuleNotFoundError: No module named 'yaml'` — 1.93s vs 1.54s — and the run was failed
for it. Attempt 49.

## Change

The bare summary line (`N passed, M failed, … in X.XXs`) is normalized to `<DURATION>`
like the decorated one. A different count on that line still fingerprints differently.

## Test plan

- [x] `npm run typecheck` — clean; `npm run lint` — 0 errors
- [x] `fingerprintStability.test.ts`: two quiet-mode outputs differing only in timing
      normalize equal; a different error count does not
- [x] `npx vitest run src/verify/ src/agents/deterministicTester.test.ts` — 141 passed