### PR TITLE
feat(durability): park a run whose infrastructure failure repeats with one fingerprint

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -79,6 +79,11 @@ autonomous:
   # (default) fails closed; admit relies on isolated worktrees and post-merge
   # integration requeue to surface a branch conflict at PR time instead.
   # unknownScopeAdmission: serialize
+  # An infrastructure failure is not the task's fault and is never counted
+  # toward STUCK — but the same infrastructure failure on this many consecutive
+  # attempts is not a blip. Park the run for the operator with the cause named
+  # instead of backing off forever (`openswarm work` redispatches it). 0 disables.
+  # infraFailureCircuit: 6
   # maxConcurrentPerProject: 64  # Optional hard cap; omit for weighted, work-conserving project fairness
   automationLedgerMode: primary  # off | shadow | primary (durable fail-closed execution truth)
   automationLeaseMs: 600000      # Renewed every ~3m; stale callbacks are fenced

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -556,6 +556,7 @@ export class AutonomousRunner {
       dbPath: config.automationDbPath,
       leaseMs: config.automationLeaseMs,
       maxActiveForProject: effectiveProjectConcurrency(config),
+      infraFailureCircuit: config.infraFailureCircuit,
     });
 
     // Set up scheduler event handling

--- a/src/automation/durableRunCoordinator.test.ts
+++ b/src/automation/durableRunCoordinator.test.ts
@@ -1249,6 +1249,62 @@ describe('DurableRunCoordinator dead marker owners', () => {
   });
 });
 
+describe('DurableRunCoordinator infra failure circuit', () => {
+  function infraResult(detail: string): PipelineResult {
+    return {
+      success: false, sessionId: 's', stages: [
+        { stage: 'tester', success: false, result: { success: false, error: detail }, duration: 1, startedAt: 0, completedAt: 1 },
+      ], finalStatus: 'infra_error', totalDuration: 1, iterations: 1,
+    } as PipelineResult;
+  }
+
+  // vela 2026-09-01: 140 infra_error attempts, none counted toward STUCK,
+  // the same CodeQL / socket failure on every one of them.
+  it('parks a run once the identical infrastructure failure has repeated across the circuit', async () => {
+    const ledger = new RunLedger(dbPath());
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', ledger, infraFailureCircuit: 3 });
+    const t = task('infra');
+    const detail = (n: number) => `verify-security: pytest could not run: ENOENT lstat '/run/openswarm-sandbox' (took ${n}.${n}s)`;
+
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+      await coordinator.execute(t, '/repo', async () => infraResult(detail(attempt)));
+      expect(ledger.getRun('infra')).toMatchObject({ state: 'RETRY_AT', lastErrorCode: 'infra_error' });
+      // Bring the backoff forward so the next execute can claim it.
+      expect(ledger.markReady('infra')).toBe(true);
+    }
+    await coordinator.execute(t, '/repo', async () => infraResult(detail(3)));
+    expect(ledger.getRun('infra')).toMatchObject({
+      state: 'NEEDS_HUMAN',
+      lastErrorCode: 'infra_circuit_open',
+      lastErrorMessage: expect.stringContaining('3 consecutive attempts'),
+    });
+    // The park is an operator park: an explicit redispatch may end it.
+    expect(ledger.resumeNeedsHuman('infra')).toBe('READY');
+    coordinator.close();
+    ledger.close();
+  });
+
+  it('resets on a different failure, and never parks when disabled', async () => {
+    const ledger = new RunLedger(dbPath());
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', ledger, infraFailureCircuit: 2 });
+    const t = task('mixed');
+    await coordinator.execute(t, '/repo', async () => infraResult('tester: openrouter timeout after 360000ms'));
+    ledger.markReady('mixed');
+    await coordinator.execute(t, '/repo', async () => infraResult('security-audit: CodeQL extractor missing'));
+    expect(ledger.getRun('mixed')?.state).toBe('RETRY_AT');
+    coordinator.close();
+
+    const off = new DurableRunCoordinator({ mode: 'primary', ledger, infraFailureCircuit: 0 });
+    for (let i = 0; i < 4; i += 1) {
+      ledger.markReady('mixed');
+      await off.execute(t, '/repo', async () => infraResult('tester: openrouter timeout after 360000ms'));
+    }
+    expect(ledger.getRun('mixed')?.state).toBe('RETRY_AT');
+    off.close();
+    ledger.close();
+  });
+});
+
 describe('runRecordToTask', () => {
   // AGT-4094: reconciliation has to finish a published run whose tracker card
   // already went Done, and a Done card is never in the fetch — so the run

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -1,4 +1,5 @@
 import { getInstanceId } from '../support/healthEndpoint.js';
+import { DEFAULT_INFRA_FAILURE_CIRCUIT, INFRA_CIRCUIT_PARK_REASON, infraFailureFingerprint } from './infraFailureCircuit.js';
 import type { PipelineResult } from '../agents/pairPipeline.js';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
 
@@ -41,6 +42,12 @@ export interface DurableRunCoordinatorConfig {
    * already fully expired once, so this is a second, independent wait.
    */
   reconcileAbandonMs?: number;
+  /**
+   * Consecutive infra_error attempts with one failure fingerprint after which
+   * the run parks for the operator instead of backing off again. 0 disables.
+   * Default 6.
+   */
+  infraFailureCircuit?: number;
 }
 
 export interface ExecutionDurabilityHooks {
@@ -217,6 +224,7 @@ export class DurableRunCoordinator {
   private readonly ownsLedger: boolean;
   private readonly leaseMs: number;
   private readonly maxActiveForProject: number;
+  private readonly infraFailureCircuit: number;
   private readonly processIsAlive: (pid: number) => boolean;
   private readonly reconcileAbandonMs: number;
   private readonly exitedClaims = new Map<string, RunClaim>();
@@ -229,6 +237,7 @@ export class DurableRunCoordinator {
     this.instanceId = config.instanceId ?? `${process.pid}-${getInstanceId()}`;
     this.leaseMs = config.leaseMs ?? 10 * 60_000;
     this.maxActiveForProject = Math.max(1, Math.floor(config.maxActiveForProject ?? 1));
+    this.infraFailureCircuit = Math.max(0, Math.floor(config.infraFailureCircuit ?? DEFAULT_INFRA_FAILURE_CIRCUIT));
     this.processIsAlive = config.processIsAlive ?? processIsAlive;
     this.reconcileAbandonMs = config.reconcileAbandonMs ?? this.leaseMs;
     if (this.leaseMs < 3_000) throw new Error('Durable run lease must be at least 3000ms');
@@ -728,6 +737,30 @@ export class DurableRunCoordinator {
       // default RETRY_AT below is the fail-closed compatibility path.
     }
 
+    const detail = pickPipelineFailureDetail(result);
+
+    // An infrastructure failure is not counted toward STUCK, and rightly so:
+    // a provider blip is not the task's fault. But the same infrastructure
+    // failure on every attempt is not a blip, and retrying it forever is how
+    // vela spent 140 attempts on 2026-09-01 — CodeQL extractor missing, a
+    // sandbox socket not mounted — and produced nothing. Once the identical
+    // fingerprint has repeated across the configured number of attempts, the
+    // cause is durable and an operator has to change something; park with
+    // the cause named, where `openswarm work` can redispatch it afterwards.
+    if (result.finalStatus === 'infra_error' && this.infraFailureCircuit > 0) {
+      const fingerprint = infraFailureFingerprint(detail);
+      const prior = fingerprint ? this.ledger.consecutiveIdenticalInfraFailures(issueId, fingerprint) : 0;
+      if (prior + 1 >= this.infraFailureCircuit) {
+        const reason = `Identical infrastructure failure on ${prior + 1} consecutive attempts: ${detail ?? 'no detail'}`;
+        return this.ledger.transition(claim, 'NEEDS_HUMAN', {
+          errorCode: INFRA_CIRCUIT_PARK_REASON,
+          errorMessage: reason,
+          eventKind: 'infra_circuit_parked',
+          eventData: { sessionId: result.sessionId, fingerprint, attempts: prior + 1 },
+        }, now) ? result : fencedResult(result);
+      }
+    }
+
     let target: RunState;
     switch (result.finalStatus) {
       case 'rate_limited':
@@ -739,7 +772,7 @@ export class DurableRunCoordinator {
     const transitioned = this.ledger.transition(claim, target, {
       retryAt: target === 'RETRY_AT' ? retryAtFor(result, now) : null,
       errorCode: result.finalStatus,
-      errorMessage: pickPipelineFailureDetail(result),
+      errorMessage: detail,
       eventData: { sessionId: result.sessionId, finalStatus: result.finalStatus },
     }, now);
     return transitioned ? result : fencedResult(result);

--- a/src/automation/infraFailureCircuit.test.ts
+++ b/src/automation/infraFailureCircuit.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { infraFailureFingerprint } from './infraFailureCircuit.js';
+
+describe('infraFailureFingerprint', () => {
+  it('ignores what changes between attempts and keeps what identifies the cause', () => {
+    const a = infraFailureFingerprint(
+      "verify-security: pytest could not run inside the attested companion: [security] strict verification sandbox unavailable: ENOENT: no such file or directory, lstat '/run/openswarm-sandbox' (took 1.93s)",
+    );
+    const b = infraFailureFingerprint(
+      "verify-security: pytest could not run inside the attested companion: [security] strict verification sandbox unavailable: ENOENT: no such file or directory, lstat '/run/openswarm-sandbox' (took 2.41s)",
+    );
+    expect(a).toBe(b);
+    expect(a).toContain("lstat '/run/openswarm-sandbox'");
+  });
+
+  it('collapses sandbox roots and worktree ids', () => {
+    const a = infraFailureFingerprint('tester: pytest infrastructure failure in /work/.openswarm-verify-base-3zSAeP/worktree/ (worktree/fa265da7-a479-45f5-8ee3-d603465d98d6)');
+    const b = infraFailureFingerprint('tester: pytest infrastructure failure in /work/.openswarm-verify-base-UY8fMU/worktree/ (worktree/9241f3b4-01c5-44a1-9d3f-77ea8037df3d)');
+    expect(a).toBe(b);
+  });
+
+  it('keeps different causes apart and is empty for no detail', () => {
+    expect(infraFailureFingerprint('tester: openrouter timeout after 360000ms'))
+      .not.toBe(infraFailureFingerprint('security-audit: CodeQL extractor missing for go'));
+    expect(infraFailureFingerprint(undefined)).toBe('');
+  });
+});

--- a/src/automation/infraFailureCircuit.ts
+++ b/src/automation/infraFailureCircuit.ts
@@ -1,0 +1,55 @@
+// ============================================
+// OpenSwarm - Same-fingerprint infrastructure failure circuit
+// ============================================
+
+import type Database from 'better-sqlite3';
+
+/** Default number of consecutive identical infrastructure failures that parks a run. */
+export const DEFAULT_INFRA_FAILURE_CIRCUIT = 6;
+
+export const INFRA_CIRCUIT_PARK_REASON = 'infra_circuit_open';
+
+/**
+ * Reduce an infrastructure failure message to what identifies its cause.
+ *
+ * Sandbox roots, worktree ids, timings and byte counts change on every
+ * attempt; the tool, the command and the error class do not. Two attempts
+ * that agree on this string failed for the same reason.
+ */
+export function infraFailureFingerprint(message: string | undefined): string {
+  return (message ?? '')
+    .replace(/\/work\/\.openswarm-verify-(?:base|head)-[A-Za-z0-9]+/g, '<SANDBOX>')
+    .replace(/worktree\/[0-9a-f]{8}[0-9a-f-]*/g, 'worktree/<ID>')
+    .replace(/\b\d+(?:\.\d+)?\s?(?:ms|s|MB|KB|bytes?)\b/g, '<N>')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 240);
+}
+
+/**
+ * How many of the most recent finished attempts, walking back from the
+ * newest, ended as `infra_error` with this same fingerprint. Stops at the
+ * first attempt that differs, so an intervening success or a different
+ * failure resets the count.
+ */
+export function consecutiveIdenticalInfraFailuresInDb(
+  db: Database.Database,
+  issueId: string,
+  fingerprint: string,
+  limit = 32,
+): number {
+  if (!fingerprint) return 0;
+  const rows = db.prepare(`
+    SELECT result_status, error_message FROM automation_attempts
+    WHERE issue_id = ? AND finished_at IS NOT NULL
+    ORDER BY attempt_no DESC, lease_epoch DESC
+    LIMIT ?
+  `).all(issueId, limit) as Array<{ result_status: string | null; error_message: string | null }>;
+  let streak = 0;
+  for (const row of rows) {
+    if (row.result_status !== 'infra_error') break;
+    if (infraFailureFingerprint(row.error_message ?? undefined) !== fingerprint) break;
+    streak += 1;
+  }
+  return streak;
+}

--- a/src/automation/runLedger.ts
+++ b/src/automation/runLedger.ts
@@ -15,6 +15,7 @@ import { admitsConflictScope } from './runLedgerScope.js';
 import { migrateAutomationSchema } from './runLedgerSchema.js';
 import { queueIntegrationRequeueInDb } from './runLedgerIntegration.js';
 import { listClaimOwnersInDb } from './runLedgerOwners.js';
+import { consecutiveIdenticalInfraFailuresInDb } from './infraFailureCircuit.js';
 import {
   markNeedsHumanForQuestionsInDb,
   resumeNeedsHumanForQuestionsInDb,
@@ -262,6 +263,11 @@ export class RunLedger {
   /** Every executor that ever claimed this run, newest first. */
   listClaimOwners(issueId: string): string[] {
     return listClaimOwnersInDb(this.db, issueId);
+  }
+
+  /** Finished attempts, newest first, that ended as infra_error with this fingerprint before anything else. */
+  consecutiveIdenticalInfraFailures(issueId: string, fingerprint: string): number {
+    return consecutiveIdenticalInfraFailuresInDb(this.db, issueId, fingerprint);
   }
 
   queueIntegrationRequeue(issueId: string, expectedStateVersion: number, effect: EffectInput, now = Date.now()): boolean {

--- a/src/automation/runnerTypes.ts
+++ b/src/automation/runnerTypes.ts
@@ -54,6 +54,8 @@ export interface AutonomousConfig {
    * integration requeue to surface any branch conflict at PR time instead.
    */
   unknownScopeAdmission?: 'serialize' | 'admit';
+  /** Identical-fingerprint infra_error attempts that park a run for the operator (0 disables, default 6). */
+  infraFailureCircuit?: number;
   guards?: Partial<import('../core/types.js').PipelineGuardsConfig>;
   verify?: VerifyConfig;
   securityAudit?: SecurityAuditConfig;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -340,6 +340,11 @@ const AutonomousConfigSchema = z.object({
    * conflicts to post-merge integration requeue.
    */
   unknownScopeAdmission: z.enum(['serialize', 'admit']).default('serialize'),
+  /**
+   * Consecutive infra_error attempts with one failure fingerprint after which a
+   * run parks for the operator instead of backing off again. 0 disables.
+   */
+  infraFailureCircuit: z.number().int().min(0).max(100).default(6),
   /** Dynamic job profiles for model selection */
   jobProfiles: z.array(JobProfileSchema).optional(),
   /** Pipeline quality guards (bad-edit lint gate, BS detector, etc.) */
@@ -742,6 +747,7 @@ function transformConfig(raw: RawConfig): SwarmConfig {
       worktreeMode: raw.autonomous.worktreeMode,
       allowSameProjectConcurrent: raw.autonomous.allowSameProjectConcurrent,
       unknownScopeAdmission: raw.autonomous.unknownScopeAdmission,
+      infraFailureCircuit: raw.autonomous.infraFailureCircuit,
       guards: raw.autonomous.guards,
       verify: raw.autonomous.verify,
       securityAudit: raw.autonomous.securityAudit,

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -298,6 +298,7 @@ async function startServiceLocked(config: SwarmConfig): Promise<void> {
       shutdownGraceMs: config.autonomous.shutdownGraceMs,
       allowSameProjectConcurrent: config.autonomous.allowSameProjectConcurrent,
       unknownScopeAdmission: config.autonomous.unknownScopeAdmission,
+      infraFailureCircuit: config.autonomous.infraFailureCircuit,
       defaultRoles: config.autonomous.defaultRoles,
       projectAgents: config.autonomous.projectAgents,
       // Task decomposition (Planner) configuration. The whole object is passed,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -607,6 +607,8 @@ export type AutonomousStartupConfig = {
   allowSameProjectConcurrent?: boolean;
   /** Admission for a task with no resolvable write scope next to a live same-repo run. */
   unknownScopeAdmission?: 'serialize' | 'admit';
+  /** Identical-fingerprint infra_error attempts that park a run (0 disables, default 6). */
+  infraFailureCircuit?: number;
   /** Pipeline guards configuration */
   guards?: Partial<PipelineGuardsConfig>;
   /** Deterministic baseline-diff verification, enabled by default. */


### PR DESCRIPTION
## Problem

An `infra_error` is not counted toward STUCK — rightly, a provider blip is not the task's
fault. But the same infrastructure failure on every attempt is not a blip.

On 2026-09-01 vela recorded **140 `infra_error` attempts** across the day, each backing
off and retrying the same CodeQL extractor path or the same unmounted sandbox socket,
and produced nothing. The ledger had no bound on it at all. This is the retry treadmill
AGT-4177 describes.

## Change

Once the failure fingerprint has repeated across `autonomous.infraFailureCircuit`
consecutive attempts (**default 6**, `0` disables), the run parks `NEEDS_HUMAN` with the
cause named:

```
Identical infrastructure failure on 6 consecutive attempts: verify-security: pytest could not run …
```

- The park is an ordinary operator park: `openswarm work` / `POST /api/work` redispatches
  it (#516) once the operator has changed whatever the message names.
- The fingerprint strips what varies per attempt — verify sandbox roots, worktree ids,
  timings, byte counts — and keeps the tool, command and error.
- A different failure or a success in between resets the streak.

Depends on #514: before it the ledger held no message for most of these attempts, so
there was nothing to fingerprint.

## Test plan

- [x] `npm run typecheck` — clean; `npm run lint` — 0 errors
- [x] `infraFailureCircuit.test.ts`: timings/sandbox roots/worktree ids collapse, different
      causes stay apart
- [x] `durableRunCoordinator.test.ts`: 3rd identical infra failure parks with
      `infra_circuit_open` and is resumable; a different failure resets; `0` never parks
- [x] `npx vitest run src/automation/ src/core/` — 969 passed