### PR TITLE
feat(verify): discover a repository-installed ruff alongside pytest

### DIFF
--- a/src/verify/discover.test.ts
+++ b/src/verify/discover.test.ts
@@ -73,6 +73,24 @@ describe('discoverVerifyCommands', () => {
     ]);
   });
 
+  // vega-agent#608, 2026-09-02: a green pytest run published an undefined name
+  // (F821) and 63 pyflakes errors; the repository's own CI runs ruff.
+  it('adds a repository-installed ruff after pytest, and only then', async () => {
+    const withRuff = await fixture({
+      'pytest.ini': '[pytest]\n',
+      '.venv/bin/python': '#!/bin/sh\n',
+      '.venv/bin/ruff': '#!/bin/sh\n',
+    });
+    expect(await discoverVerifyCommands(withRuff)).toEqual([
+      { name: 'pytest', run: './.venv/bin/python -m pytest -x -q', kind: 'test', timeoutMs: 300_000 },
+      { name: 'ruff', run: './.venv/bin/ruff check .', kind: 'lint', timeoutMs: 300_000 },
+    ]);
+
+    // No installed ruff: nothing is invented, even with a ruff config present.
+    const withoutRuff = await fixture({ 'pytest.ini': '[pytest]\n', 'ruff.toml': 'line-length = 100\n' });
+    expect((await discoverVerifyCommands(withoutRuff)).map((c) => c.name)).toEqual(['pytest']);
+  });
+
   it('serializes an explicitly configured xdist pytest run for stable base comparison', async () => {
     const root = await fixture({
       'pytest.ini': '[pytest]\naddopts = --tb=short -n auto --dist loadgroup\n',

--- a/src/verify/discover.ts
+++ b/src/verify/discover.ts
@@ -33,6 +33,16 @@ async function pythonCommand(projectPath: string): Promise<string> {
   return 'python';
 }
 
+async function ruffCommand(projectPath: string): Promise<string | undefined> {
+  const candidates = process.platform === 'win32'
+    ? ['.venv-verify/Scripts/ruff.exe', '.venv/Scripts/ruff.exe', 'venv/Scripts/ruff.exe']
+    : ['.venv-verify/bin/ruff', '.venv/bin/ruff', 'venv/bin/ruff'];
+  for (const candidate of candidates) {
+    if (await exists(join(projectPath, candidate))) return `./${candidate}`;
+  }
+  return undefined;
+}
+
 function command(name: string, run: string, kind: VerifyCommand['kind']): VerifyCommand {
   return { name, run, kind, timeoutMs: DEFAULT_TIMEOUT_MS };
 }
@@ -88,6 +98,14 @@ export async function discoverVerifyCommands(projectPath: string): Promise<Verif
     const serialXdist = /(?:^|\s)-n(?:\s|=)/m.test(pytestConfig) ? ' -n 0' : '';
     commands.push(command('pytest', `${await pythonCommand(projectPath)} -m pytest${serialXdist} -x -q`, 'test'));
   }
+
+  // Python lint: only a repository-installed ruff, so an unknown tool is never
+  // introduced and the repository's own ruff config (or ruff's default rule
+  // set, which includes pyflakes F-rules) applies. vega-agent#608 shipped an
+  // undefined name (F821) and 63 pyflakes errors past a green pytest run;
+  // the repository's CI runs `ruff check` and rejected it on arrival.
+  const ruff = await ruffCommand(projectPath);
+  if (ruff) commands.push(command('ruff', `${ruff} check .`, 'lint'));
 
   // Rust repositories use Cargo's native test runner.
   if (await exists(join(projectPath, 'Cargo.toml'))) {


### PR DESCRIPTION
## Problem

[vega-agent#608](https://github.com/Intrect-io/vega-agent/pull/608), published today with
a **green pytest run**, carries an undefined name (`F821 _GOOGLE_SYNC_MIN_INTERVAL_SEC`)
and 63 pyflakes errors in the two files the worker wrote. The repository's own CI runs
`ruff check . --select F` and rejected it on arrival. Verification never looked: Python
discovery only ever produced the pytest command.

## Change

When the repository's virtualenv has ruff installed (`.venv-verify/bin/ruff`,
`.venv/bin/ruff`, `venv/bin/ruff`), discovery adds `ruff check .` after pytest as a
`lint` command.

- Only an installed binary qualifies — no tool is introduced that the repository does not
  already carry.
- The repository's own ruff configuration applies, or ruff's default rule set (which
  includes the pyflakes F rules) when there is none.
- Baseline comparison waives lint failures that already exist on base; a new one blocks
  like a new test failure (`blockOnNewFailures`, default on; `maxCommands` default 4).

A repository whose virtualenv lacks ruff still gets pytest only.

## Test plan

- [x] `npm run typecheck` — clean; `npm run lint` — 0 errors
- [x] `discover.test.ts`: pytest + ruff when the venv has ruff; pytest only when it does
      not, even with a `ruff.toml` present
- [x] `npx vitest run src/verify/` — all green