### PR TITLE
feat(cost): record every model API call in a usage ledger with the provider's metered price

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,13 @@ openswarm start --foreground  # run attached (logs stream to the terminal)
 openswarm status              # pid, uptime, log path
 openswarm stop                # stop the daemon
 openswarm dash                # open the web dashboard (:3847)
+openswarm cost --since 24h    # LLM spend by model (--by stage|task|project|adapter|day, --json)
 ```
+
+Every model API call is appended to `~/.openswarm/usage/<UTC date>.jsonl` with the
+provider's own metered price when it reports one (OpenRouter prices every response;
+subscription and local providers are recorded as unmetered). The same aggregate is
+served at `GET /api/usage?since=24h&by=model`.
 
 > **From source / development** (contributors): clone the repo and use the `npm run …` scripts (`npm run dev`, `npm start`, `npm run service:install` for a macOS launchd service, `docker compose up -d`). See [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/src/adapters/agenticLoop.test.ts
+++ b/src/adapters/agenticLoop.test.ts
@@ -820,6 +820,8 @@ describe('loopResultToCliResult costInfo (INT-2508)', () => {
       inputTokens: 10000,
       outputTokens: 2000,
       cachedTokens: 8000,
+      costUsd: 0,
+      meteredCalls: 0,
       durationMs: 45200,
       executedCommands: ['npm test'],
     };
@@ -960,5 +962,72 @@ describe('checking an inbox is not a stall', () => {
     const { allToolCallsSeen } = await import('./agenticLoop.js');
     const mixed = [call('read_file', '{"path":"a.ts"}'), call('coordination_read')];
     expect(allToolCallsSeen(mixed, new Set(['read_file:{"path":"a.ts"}', 'coordination_read:{}']))).toBe(false);
+  });
+});
+
+describe('runAgenticLoop usage ledger (AGT-4178)', () => {
+  it('records every priced response before the loop throws, and sums cost into the result', async () => {
+    const { readUsage } = await import('../support/usageLedger.js');
+    const startedAt = Date.now();
+    const usage = (cost: number | undefined) => ({
+      prompt_tokens: 500, completion_tokens: 20, total_tokens: 520, cached_tokens: 100, ...(cost === undefined ? {} : { cost }),
+    });
+    let calls = 0;
+    const ok = await runAgenticLoop({
+      prompt: 'x', cwd: '/work/demo', model: 'z-ai/glm-5.3', webTools: false, maxTurns: 1,
+      usageAttribution: { adapter: 'openrouter', taskId: 'AGT-77', stage: 'worker' },
+      callApi: async () => {
+        calls++;
+        return { ...finalResp('done'), usage: usage(0.01) };
+      },
+    });
+    expect(calls).toBe(1);
+    expect(ok.costUsd).toBeCloseTo(0.01);
+    expect(ok.meteredCalls).toBe(1);
+    expect(loopResultToCliResult(ok).costInfo?.costUsd).toBeCloseTo(0.01);
+
+    await expect(runAgenticLoop({
+      prompt: 'x', cwd: '/work/demo', model: 'z-ai/glm-5.3', webTools: false, maxTurns: 3,
+      usageAttribution: { adapter: 'openrouter', taskId: 'AGT-78', stage: 'worker' },
+      callApi: async (messages) => {
+        // First response: a tool call so the loop comes back for a second call,
+        // which then fails as an infra error. The first call's spend must survive.
+        if (!messages.some((m) => m.role === 'tool')) {
+          return {
+            choices: [{
+              message: {
+                role: 'assistant',
+                content: null,
+                tool_calls: [{ id: 't1', type: 'function', function: { name: 'read_file', arguments: '{"path":"nope.txt"}' } }],
+              },
+              finish_reason: 'tool_calls',
+            }],
+            usage: usage(0.02),
+          };
+        }
+        throw new Error('connect ECONNREFUSED 127.0.0.1:443');
+      },
+    })).rejects.toThrow(/ECONNREFUSED/);
+
+    const rows = readUsage({ since: startedAt - 1000 }).filter((r) => r.taskId === 'AGT-77' || r.taskId === 'AGT-78');
+    expect(rows.map((r) => [r.taskId, r.costUsd, r.cachedTokens, r.model, r.stage, r.cwd])).toEqual([
+      ['AGT-77', 0.01, 100, 'z-ai/glm-5.3', 'worker', '/work/demo'],
+      ['AGT-78', 0.02, 100, 'z-ai/glm-5.3', 'worker', '/work/demo'],
+    ]);
+  });
+
+  it('records an unpriced response as unmetered (null cost) and keeps costUsd at 0', async () => {
+    const { readUsage } = await import('../support/usageLedger.js');
+    const startedAt = Date.now();
+    const res = await runAgenticLoop({
+      prompt: 'x', cwd: '/work/demo', model: 'local-model', webTools: false, maxTurns: 1,
+      usageAttribution: { adapter: 'local', taskId: 'AGT-79' },
+      callApi: async () => ({ ...finalResp('done'), usage: { prompt_tokens: 5, completion_tokens: 1, total_tokens: 6 } }),
+    });
+    expect(res.costUsd).toBe(0);
+    expect(res.meteredCalls).toBe(0);
+    const row = readUsage({ since: startedAt - 1000 }).find((r) => r.taskId === 'AGT-79');
+    expect(row).toMatchObject({ adapter: 'local', costUsd: null, promptTokens: 5 });
+    expect(row?.stage).toBeUndefined();
   });
 });

--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -13,6 +13,8 @@ import { detectRateLimit, RateLimitError } from './rateLimitError.js';
 import { isInfraError } from './errorClassification.js';
 import { parseSearchReplaceBlocks, applyEditBlock, type EditFormat } from '../support/editParser.js';
 import type { CliRunResult } from './types.js';
+import type { ChatUsage } from './chatStream.js';
+import { recordUsage, type UsageAttribution } from '../support/usageLedger.js';
 import { COORDINATION_TOOL_DEFINITIONS, type CoordinationToolContext } from '../coordination/coordinationTools.js';
 import { filterHumanSurfaceMcpTools, isHumanSurfaceReadOnlyEnabled } from '../mcp/humanSurfacePolicy.js';
 import { SandboxExecutorClient } from '../sandboxExecutor/client.js';
@@ -94,13 +96,7 @@ interface ChatCompletionResponse {
     };
     finish_reason: string;
   }>;
-  usage?: {
-    prompt_tokens: number;
-    completion_tokens: number;
-    total_tokens: number;
-    /** Cached input tokens (prompt-cache hits). Subset of prompt_tokens. */
-    cached_tokens?: number;
-  };
+  usage?: ChatUsage;
 }
 
 /** 에이전틱 루프 설정 */
@@ -177,6 +173,12 @@ export interface AgenticLoopOptions {
    * - 'whole-file': hide edit_file / apply_patch; the model rewrites via write_file.
    */
   editFormat?: EditFormat;
+  /**
+   * Who is spending: stamped on the usage-ledger record written for EVERY
+   * API response, before any of the loop's throw paths. Adapter name is the
+   * minimum; task/stage come from CliRunOptions.processContext. (AGT-4178)
+   */
+  usageAttribution?: UsageAttribution;
 }
 
 /** 루프 실행 결과 */
@@ -195,6 +197,10 @@ export interface AgenticLoopResult {
   outputTokens: number;
   /** 캐시 적중 입력 토큰 누적 (totalTokens의 부분집합) — prompt-cache 효율 측정용 */
   cachedTokens: number;
+  /** Sum of the provider's metered charges (USD) across calls that reported one. */
+  costUsd: number;
+  /** Calls that carried a metered price; 0 means the provider is unmetered. */
+  meteredCalls: number;
   /** A blocking ask_human ended the run; the operator now owns the next step. */
   blockedOnOperator?: boolean;
   /** Exact correlation IDs returned by the blocking ask_human tool call. */
@@ -249,6 +255,7 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
     coordinationContext,
     signal,
     editFormat = 'json',
+    usageAttribution,
   } = options;
 
   // Strict mode exposes bash only after a separate companion has attested its
@@ -372,7 +379,42 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
   let inputTokens = 0;
   let outputTokens = 0;
   let cachedTokens = 0;
+  let costUsd = 0;
+  let meteredCalls = 0;
   let finalText = '';
+
+  // Account for one response: accumulate the run totals AND write the ledger
+  // line immediately. The ledger write comes first because everything after a
+  // response — rate-limit re-throw, infra re-throw, the empty-final-answer
+  // throw, or the process being killed — would otherwise erase the spend of
+  // every call that already completed. (AGT-4178)
+  const accountUsage = (usage: ChatUsage | undefined, callStartedAt: number): void => {
+    if (!usage) return;
+    const metered = typeof usage.cost === 'number';
+    recordUsage({
+      ts: new Date().toISOString(),
+      adapter: usageAttribution?.adapter ?? 'unknown',
+      model: options.model,
+      taskId: usageAttribution?.taskId,
+      stage: usageAttribution?.stage,
+      cwd,
+      promptTokens: usage.prompt_tokens,
+      completionTokens: usage.completion_tokens,
+      cachedTokens: usage.cached_tokens ?? 0,
+      reasoningTokens: usage.reasoning_tokens ?? 0,
+      costUsd: metered ? usage.cost! : null,
+      ...(typeof usage.upstream_cost === 'number' ? { upstreamCostUsd: usage.upstream_cost } : {}),
+      durationMs: Date.now() - callStartedAt,
+    });
+    totalTokens += usage.prompt_tokens + usage.completion_tokens;
+    inputTokens += usage.prompt_tokens;
+    outputTokens += usage.completion_tokens;
+    cachedTokens += usage.cached_tokens ?? 0;
+    if (metered) {
+      costUsd += usage.cost!;
+      meteredCalls += 1;
+    }
+  };
 
   for (let turn = 0; turn < maxTurns + 1; turn++) {
     // 사용자 중단 (Esc/Ctrl+C) — 현재 텍스트가 있으면 유지, 없으면 표시만.
@@ -412,6 +454,7 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
     onLog?.(`▸ API call #${apiCallCount}${turn > 0 ? ` (tool turn ${turn})` : ''}`);
 
     let response: ChatCompletionResponse;
+    const callStartedAt = Date.now();
     try {
       response = await callApi(messages, tools);
     } catch (err) {
@@ -458,12 +501,7 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
       break;
     }
 
-    if (response.usage) {
-      totalTokens += response.usage.prompt_tokens + response.usage.completion_tokens;
-      inputTokens += response.usage.prompt_tokens;
-      outputTokens += response.usage.completion_tokens;
-      cachedTokens += response.usage.cached_tokens ?? 0;
-    }
+    accountUsage(response.usage, callStartedAt);
 
     const choice = response.choices?.[0];
     if (!choice) {
@@ -752,13 +790,9 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
       }
 
       try {
+        const salvageStartedAt = Date.now();
         const response = await callApi(messages, []);
-        if (response.usage) {
-          totalTokens += response.usage.prompt_tokens + response.usage.completion_tokens;
-          inputTokens += response.usage.prompt_tokens;
-          outputTokens += response.usage.completion_tokens;
-          cachedTokens += response.usage.cached_tokens ?? 0;
-        }
+        accountUsage(response.usage, salvageStartedAt);
         apiCallCount++;
         const content = response.choices?.[0]?.message?.content;
         finalText = typeof content === 'string' && content.trim() ? content : '';
@@ -790,6 +824,8 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
     inputTokens,
     outputTokens,
     cachedTokens,
+    costUsd,
+    meteredCalls,
     durationMs: Date.now() - startTime,
     executedCommands,
     blockedOnOperator,
@@ -803,10 +839,11 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
 /**
  * AgenticLoopResult → CliRunResult 변환
  *
- * costUsd is 0 by design: the loop cannot price tokens itself — codex-responses
- * bills through a ChatGPT subscription (no per-token marginal cost) and a
- * hardcoded price table would go stale. Adapters with real metering (openrouter)
- * can overwrite costUsd downstream. Tokens and duration are real measurements. (INT-2508)
+ * costUsd is the provider's own metered charge summed over the run (OpenRouter
+ * prices every response); it stays 0 for unmetered providers — codex-responses
+ * bills through a ChatGPT subscription and local models have no marginal cost —
+ * because the loop keeps no price table (it would go stale). Tokens and
+ * duration are real measurements either way. (INT-2508, AGT-4178)
  */
 export function loopResultToCliResult(result: AgenticLoopResult): CliRunResult {
   return {
@@ -819,7 +856,7 @@ export function loopResultToCliResult(result: AgenticLoopResult): CliRunResult {
     executionOutcomeUnknown: result.executionOutcomeUnknown,
     operatorQuestionCorrelationIds: result.operatorQuestionCorrelationIds,
     costInfo: {
-      costUsd: 0,
+      costUsd: result.costUsd,
       inputTokens: result.inputTokens,
       outputTokens: result.outputTokens,
       cacheReadTokens: result.cachedTokens,

--- a/src/adapters/atlascloud.ts
+++ b/src/adapters/atlascloud.ts
@@ -161,6 +161,7 @@ export class AtlasCloudCliAdapter implements CliAdapter {
       coordinationContext: options.coordinationContext,
       signal: options.signal,
       editFormat: options.editFormat,
+      usageAttribution: { adapter: 'atlascloud', taskId: options.processContext?.taskId, stage: options.processContext?.stage },
     };
 
     try {
@@ -168,7 +169,9 @@ export class AtlasCloudCliAdapter implements CliAdapter {
       options.onLog?.(
         `[Atlas Cloud] ${result.apiCallCount} API calls, ${result.toolCallCount} tool uses, ${result.totalTokens} tokens`,
       );
-      return loopResultToCliResult(result);
+      const cli = loopResultToCliResult(result);
+      if (cli.costInfo) cli.costInfo.model = model;
+      return cli;
     } catch (err) {
       if (err instanceof RateLimitError) throw err;
       if (isInfraError(err)) throw err;

--- a/src/adapters/chatStream.test.ts
+++ b/src/adapters/chatStream.test.ts
@@ -48,3 +48,40 @@ describe('reduceChatChunks', () => {
     expect(res.choices[0].message.tool_calls!.map((t) => t.function.name)).toEqual(['f0', 'f1']);
   });
 });
+
+describe('reduceChatChunks usage accounting (AGT-4178)', () => {
+  it('keeps the metered cost, cached and reasoning tokens from the final chunk', () => {
+    const out = reduceChatChunks([
+      { choices: [{ delta: { content: 'hi' } }] },
+      {
+        choices: [],
+        usage: {
+          prompt_tokens: 1200,
+          completion_tokens: 40,
+          total_tokens: 1240,
+          cost: 0.00312,
+          cost_details: { upstream_inference_cost: 0.003 },
+          prompt_tokens_details: { cached_tokens: 900 },
+          completion_tokens_details: { reasoning_tokens: 12 },
+        },
+      },
+    ]);
+    expect(out.usage).toEqual({
+      prompt_tokens: 1200,
+      completion_tokens: 40,
+      total_tokens: 1240,
+      cost: 0.00312,
+      upstream_cost: 0.003,
+      cached_tokens: 900,
+      reasoning_tokens: 12,
+    });
+  });
+
+  it('leaves cost absent — not zero — when the server does not price the call', () => {
+    const out = reduceChatChunks([
+      { choices: [], usage: { prompt_tokens: 10, completion_tokens: 2, cost: null, prompt_tokens_details: null } },
+    ]);
+    expect(out.usage).toEqual({ prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 });
+    expect(out.usage && 'cost' in out.usage).toBe(false);
+  });
+});

--- a/src/adapters/chatStream.ts
+++ b/src/adapters/chatStream.ts
@@ -21,7 +21,24 @@ export interface ChatCompletionLike {
     message: { role: string; content: string | null; tool_calls?: StreamToolCall[] };
     finish_reason: string;
   }>;
-  usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+  usage?: ChatUsage;
+}
+
+/**
+ * Usage as the agentic loop consumes it. `cost` / `upstream_cost` are the
+ * metered charge in USD (OpenRouter attaches them to the final chunk of every
+ * response; other chat-completions servers omit them, so the loop records the
+ * call as unmetered rather than $0). `cached_tokens` is a subset of
+ * prompt_tokens; `reasoning_tokens` a subset of completion_tokens. (AGT-4178)
+ */
+export interface ChatUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  cached_tokens?: number;
+  reasoning_tokens?: number;
+  cost?: number;
+  upstream_cost?: number;
 }
 
 interface StreamChunk {
@@ -32,7 +49,33 @@ interface StreamChunk {
     };
     finish_reason?: string | null;
   }>;
-  usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number } | null;
+  usage?: RawChatUsage | null;
+}
+
+/** The wire shape (OpenRouter's usage-accounting fields are optional extras). */
+export interface RawChatUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  cost?: number | null;
+  cost_details?: { upstream_inference_cost?: number | null } | null;
+  prompt_tokens_details?: { cached_tokens?: number | null } | null;
+  completion_tokens_details?: { reasoning_tokens?: number | null } | null;
+}
+
+/** Normalise a wire usage object; `usage.cost` survives only when it is a finite number. */
+export function normalizeChatUsage(raw: RawChatUsage): ChatUsage {
+  const pt = raw.prompt_tokens ?? 0;
+  const ct = raw.completion_tokens ?? 0;
+  const usage: ChatUsage = { prompt_tokens: pt, completion_tokens: ct, total_tokens: raw.total_tokens ?? pt + ct };
+  const cached = raw.prompt_tokens_details?.cached_tokens;
+  if (typeof cached === 'number') usage.cached_tokens = cached;
+  const reasoning = raw.completion_tokens_details?.reasoning_tokens;
+  if (typeof reasoning === 'number') usage.reasoning_tokens = reasoning;
+  if (typeof raw.cost === 'number' && Number.isFinite(raw.cost)) usage.cost = raw.cost;
+  const upstream = raw.cost_details?.upstream_inference_cost;
+  if (typeof upstream === 'number' && Number.isFinite(upstream)) usage.upstream_cost = upstream;
+  return usage;
 }
 
 /**
@@ -49,11 +92,7 @@ export function reduceChatChunks(chunks: StreamChunk[], onToken?: (delta: string
   const calls = new Map<number, { id: string; name: string; args: string }>();
 
   for (const chunk of chunks) {
-    if (chunk.usage) {
-      const pt = chunk.usage.prompt_tokens ?? 0;
-      const ct = chunk.usage.completion_tokens ?? 0;
-      usage = { prompt_tokens: pt, completion_tokens: ct, total_tokens: chunk.usage.total_tokens ?? pt + ct };
-    }
+    if (chunk.usage) usage = normalizeChatUsage(chunk.usage);
     const choice = chunk.choices?.[0];
     if (!choice) continue;
     const delta = choice.delta ?? {};

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -408,6 +408,7 @@ export class CodexResponsesAdapter implements CliAdapter {
       applyPatch: true,
       signal: options.signal,
       editFormat: options.editFormat,
+      usageAttribution: { adapter: 'codex-responses', taskId: options.processContext?.taskId, stage: options.processContext?.stage },
     };
 
     try {

--- a/src/adapters/gpt.ts
+++ b/src/adapters/gpt.ts
@@ -164,6 +164,7 @@ export class GptCliAdapter implements CliAdapter {
       coordinationContext: options.coordinationContext,
       signal: options.signal,
       editFormat: options.editFormat,
+      usageAttribution: { adapter: 'gpt', taskId: options.processContext?.taskId, stage: options.processContext?.stage },
     };
 
     try {
@@ -171,7 +172,9 @@ export class GptCliAdapter implements CliAdapter {
       if (options.onLog) {
         options.onLog(`[GPT] ${result.apiCallCount} API calls, ${result.toolCallCount} tool uses, ${result.totalTokens} tokens`);
       }
-      return loopResultToCliResult(result);
+      const cli = loopResultToCliResult(result);
+      if (cli.costInfo) cli.costInfo.model = model;
+      return cli;
     } catch (err) {
       // Rate-limit AND infra/capacity errors must propagate so the pipeline
       // classifies them (pause / infra_error backoff) instead of burying them in a

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -199,6 +199,7 @@ export class LocalModelAdapter implements CliAdapter {
       coordinationContext: options.coordinationContext,
       signal: options.signal,
       editFormat: options.editFormat,
+      usageAttribution: { adapter: 'local', taskId: options.processContext?.taskId, stage: options.processContext?.stage },
     };
 
     try {
@@ -207,7 +208,9 @@ export class LocalModelAdapter implements CliAdapter {
         const toolInfo = supportsTools ? `${result.toolCallCount} tool uses` : 'no tools';
         options.onLog(`[${this.logPrefix}] ${result.apiCallCount} API calls, ${toolInfo}, ${result.totalTokens} tokens`);
       }
-      return loopResultToCliResult(result);
+      const cli = loopResultToCliResult(result);
+      if (cli.costInfo) cli.costInfo.model = model;
+      return cli;
     } catch (err) {
       // Rate-limit AND infra/capacity errors (connection refused, 5xx, model not
       // loaded, socket drop) must propagate so the pipeline classifies them

--- a/src/adapters/openrouter.ts
+++ b/src/adapters/openrouter.ts
@@ -193,6 +193,7 @@ export class OpenRouterCliAdapter implements CliAdapter {
       coordinationContext: options.coordinationContext,
       signal: options.signal,
       editFormat: options.editFormat,
+      usageAttribution: { adapter: 'openrouter', taskId: options.processContext?.taskId, stage: options.processContext?.stage },
     };
 
     try {
@@ -200,7 +201,9 @@ export class OpenRouterCliAdapter implements CliAdapter {
       options.onLog?.(
         `[OpenRouter] ${result.apiCallCount} API calls, ${result.toolCallCount} tool uses, ${result.totalTokens} tokens`,
       );
-      return loopResultToCliResult(result);
+      const cli = loopResultToCliResult(result);
+      if (cli.costInfo) cli.costInfo.model = model;
+      return cli;
     } catch (err) {
       // Rate-limit AND infra/capacity errors must propagate (pause / infra_error),
       // not be buried in a fake failed result the worker reads as an empty success. (INT-1906, INT-2520)

--- a/src/agents/draftAnalyzer.ts
+++ b/src/agents/draftAnalyzer.ts
@@ -184,6 +184,8 @@ export interface DraftAnalyzerOptions {
   authoritativeOperatorFeedback?: string;
   projectPath: string;
   projectId?: string;
+  /** Task identity stamped on the usage ledger (issue identifier or scheduler id). */
+  taskId?: string;
   /** Fast model for draft analysis (default: gpt-5-codex) */
   model?: string;
   /** 타임아웃 (기본: 30초 — drafter는 빠름) */
@@ -687,6 +689,7 @@ export async function runDraftAnalysis(options: DraftAnalyzerOptions): Promise<D
           timeoutMs: draftTimeoutMs, // size-adaptive: 30s timed out on large repos → type=unknown (INT-2485)
           model: resolvedModel,
           maxTurns: budget.maxTurns, // size-adaptive: 3 ran out reading a real repo before emitting the brief (INT-2485)
+          processContext: { taskId: options.taskId ?? options.taskTitle, stage: 'draft' },
         });
 
         haikuResult = parseDraftResponse(raw.stdout);

--- a/src/automation/backlogGrooming.ts
+++ b/src/automation/backlogGrooming.ts
@@ -1,6 +1,6 @@
 // OpenSwarm - whole-backlog grooming planner (INT-1609)
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { getAdapter, spawnCli } from '../adapters/index.js';
 import type { AdapterName } from '../adapters/types.js';
 import { expandPath } from '../core/config.js';
@@ -172,6 +172,7 @@ export async function runBacklogGroomingPlanner(options: RunBacklogGroomingOptio
       onLog: options.onLog,
       readOnly: true,
       reasoningEffort: 'high',
+      processContext: { taskId: `groom:${options.projectName ?? basename(cwd)}`, stage: 'groom' },
     });
     if (raw.exitCode !== 0 && !raw.stdout.trim()) {
       return { success: false, decisions: [], error: raw.stderr.slice(0, 500) || `Planner adapter exited with code ${raw.exitCode}` };

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -209,6 +209,7 @@ export async function runPreAdmissionDraft(
     taskDescription: task.description || '',
     authoritativeOperatorFeedback: task.authoritativeOperatorFeedback,
     projectPath,
+    taskId: task.issueIdentifier ?? taskId,
     model: ctx.draftModel,
     peerIssues: projectDraftPeers(task, ctx.peerIssues),
     onLog: (line) => {
@@ -666,6 +667,7 @@ export async function decomposeTask(
       authoritativeOperatorFeedback: task.authoritativeOperatorFeedback,
       projectPath,
       projectName: task.linearProject?.name,
+      taskId: task.issueIdentifier ?? taskId,
       targetMinutes,
       // Planner runs through the configured adapter loop now (not claude -p);
       // leave model unset to use the adapter default when no planner model is configured.
@@ -800,6 +802,7 @@ export async function executePipeline(
           taskDescription: task.description || '',
           authoritativeOperatorFeedback: task.authoritativeOperatorFeedback,
           projectPath,
+          taskId: task.issueIdentifier ?? taskId,
           model: ctx.draftModel,
           peerIssues: projectDraftPeers(task, ctx.peerIssues),
           // No fixed timeout: the draft scales its own read/analyze budget to the

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -711,6 +711,19 @@ program
     console.log(`  logs:   ${status.logFile}`);
   });
 
+// openswarm cost
+
+program
+  .command('cost')
+  .description('Show LLM spend from the usage ledger (per API call, metered by the provider)')
+  .option('--since <window>', 'Duration back from now (90m, 24h, 7d) or an ISO date', '24h')
+  .option('--by <key>', 'Group by model | stage | task | project | adapter | day', 'model')
+  .option('--json', 'Print the aggregate as JSON')
+  .action(async (opts: { since: string; by: string; json?: boolean }) => {
+    const { runCostCommand } = await import('./cli/costCommand.js');
+    await runCostCommand(opts);
+  });
+
 // openswarm provider
 
 program

--- a/src/cli/costCommand.test.ts
+++ b/src/cli/costCommand.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { recordUsage } from '../support/usageLedger.js';
+import { formatCostTable, queryUsage } from './costCommand.js';
+
+describe('openswarm cost', () => {
+  let dir = '';
+  let prevDir: string | undefined;
+  const now = Date.parse('2026-09-02T12:00:00.000Z');
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'openswarm-cost-'));
+    prevDir = process.env.OPENSWARM_USAGE_DIR;
+    process.env.OPENSWARM_USAGE_DIR = dir;
+    recordUsage({ ts: '2026-09-02T11:00:00.000Z', adapter: 'openrouter', model: 'z-ai/glm-5.3', stage: 'decompose', promptTokens: 400_000, completionTokens: 3_000, cachedTokens: 0, reasoningTokens: 800, costUsd: 0.57 });
+    recordUsage({ ts: '2026-09-02T11:30:00.000Z', adapter: 'openrouter', model: 'deepseek/deepseek-v4-flash', stage: 'worker', promptTokens: 700_000, completionTokens: 4_000, cachedTokens: 500_000, reasoningTokens: 0, costUsd: 0.06 });
+    recordUsage({ ts: '2026-09-02T11:40:00.000Z', adapter: 'codex-responses', model: 'gpt-5.6-sol', stage: 'worker', promptTokens: 10_000, completionTokens: 200, cachedTokens: 0, reasoningTokens: 0, costUsd: null });
+    recordUsage({ ts: '2026-09-02T11:45:00.000Z', adapter: 'openrouter', model: 'qwen/qwen3-235b-a22b-2507', stage: 'draft', promptTokens: 117, completionTokens: 2, cachedTokens: 0, reasoningTokens: 0, costUsd: 0.0000082803 });
+    recordUsage({ ts: '2026-09-01T11:40:00.000Z', adapter: 'openrouter', model: 'z-ai/glm-5.3', stage: 'orchestrator', promptTokens: 1, completionTokens: 1, cachedTokens: 0, reasoningTokens: 0, costUsd: 9 });
+  });
+
+  afterEach(() => {
+    if (prevDir === undefined) delete process.env.OPENSWARM_USAGE_DIR;
+    else process.env.OPENSWARM_USAGE_DIR = prevDir;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('rejects an unknown window or group key', () => {
+    expect(queryUsage({ since: 'soon', by: 'model', now })).toMatchObject({ ok: false, error: expect.stringContaining("--since 'soon'") });
+    expect(queryUsage({ since: '1h', by: 'colour', now })).toMatchObject({ ok: false, error: expect.stringContaining("--by 'colour'") });
+  });
+
+  it('renders the window as a table with an unmetered footnote', () => {
+    const result = queryUsage({ since: '2h', by: 'model', now });
+    if (!result.ok) throw new Error(result.error);
+    const table = formatCostTable(result);
+    const lines = table.split('\n');
+    expect(lines[0]).toContain('Usage since 2026-09-02T10:00:00.000Z');
+    expect(lines[1].trim().split(/\s+/)).toEqual(['model', 'calls', 'in', 'out', 'cached', 'cost']);
+    expect(lines[3].trim().split(/\s+/)).toEqual(['z-ai/glm-5.3', '1', '400.0k', '3.0k', '0', '$0.5700']);
+    expect(lines[4].trim().split(/\s+/)).toEqual(['deepseek/deepseek-v4-flash', '1', '700.0k', '4.0k', '500.0k', '$0.0600']);
+    expect(lines[5].trim().split(/\s+/)).toEqual(['qwen/qwen3-235b-a22b-2507', '1', '117', '2', '0', '$0.000008']);
+    expect(lines[6].trim().split(/\s+/)).toEqual(['gpt-5.6-sol', '1', '10.0k', '200', '0', '—']);
+    expect(lines[8].trim().split(/\s+/)).toEqual(['total', '4', '1.11M', '7.2k', '500.0k', '$0.6300*']);
+    expect(lines[9]).toContain('1 call(s) reported no price');
+    expect(table).not.toContain('orchestrator');
+  });
+
+  it('groups by stage for the API payload', () => {
+    const result = queryUsage({ since: '24h', by: 'stage', now });
+    if (!result.ok) throw new Error(result.error);
+    expect(result.aggregate.rows.map((r) => [r.key, r.calls])).toEqual([['decompose', 1], ['worker', 2], ['draft', 1]]);
+  });
+});

--- a/src/cli/costCommand.ts
+++ b/src/cli/costCommand.ts
@@ -1,0 +1,66 @@
+// ============================================
+// OpenSwarm - `openswarm cost`
+// ============================================
+//
+// Reads the usage ledger and prints spend grouped by model / stage / task /
+// project / adapter / day. The same aggregate backs GET /api/usage so the
+// CLI and the dashboard never disagree. (AGT-4178)
+
+import { queryUsage, type UsageAggregateRow, type UsageQueryResult } from '../support/usageLedger.js';
+
+export { queryUsage };
+
+function tokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+function usd(row: UsageAggregateRow): string {
+  if (row.meteredCalls === 0) return '—';
+  // Sub-cent rows (one cheap call) would all print as $0.0000 at four places.
+  const value = `$${row.costUsd.toFixed(row.costUsd < 0.01 ? 6 : 4)}`;
+  return row.meteredCalls < row.calls ? `${value}*` : value;
+}
+
+/** Render the aggregate as a fixed-width table. Pure so it can be asserted on. */
+export function formatCostTable(result: Extract<UsageQueryResult, { ok: true }>): string {
+  const { aggregate } = result;
+  const rows = aggregate.rows;
+  const keyWidth = Math.max(aggregate.by.length, 5, ...rows.map((r) => r.key.length), 5);
+  const header = [
+    aggregate.by.padEnd(keyWidth), 'calls'.padStart(6), 'in'.padStart(9), 'out'.padStart(8),
+    'cached'.padStart(9), 'cost'.padStart(11),
+  ].join('  ');
+  const line = (r: UsageAggregateRow, label = r.key) => [
+    label.padEnd(keyWidth), String(r.calls).padStart(6), tokens(r.promptTokens).padStart(9),
+    tokens(r.completionTokens).padStart(8), tokens(r.cachedTokens).padStart(9), usd(r).padStart(11),
+  ].join('  ');
+  const out: string[] = [
+    `Usage since ${new Date(result.since).toISOString()} (${result.dir})`,
+    header,
+    '-'.repeat(header.length),
+    ...rows.map((r) => line(r)),
+  ];
+  if (rows.length === 0) out.push('(no calls recorded in this window)');
+  out.push('-'.repeat(header.length), line(aggregate.total, 'total'));
+  const unmetered = aggregate.total.calls - aggregate.total.meteredCalls;
+  if (unmetered > 0) {
+    out.push(`* ${unmetered} call(s) reported no price (subscription or local provider) and are excluded from cost.`);
+  }
+  return out.join('\n');
+}
+
+export async function runCostCommand(opts: { since?: string; by?: string; json?: boolean }): Promise<void> {
+  const result = queryUsage({ since: opts.since ?? '24h', by: opts.by ?? 'model' });
+  if (!result.ok) {
+    console.error(result.error);
+    process.exitCode = 1;
+    return;
+  }
+  if (opts.json) {
+    console.log(JSON.stringify({ since: new Date(result.since).toISOString(), until: new Date(result.until).toISOString(), ...result.aggregate }, null, 2));
+    return;
+  }
+  console.log(formatCostTable(result));
+}

--- a/src/coordination/orchestratorAgent.ts
+++ b/src/coordination/orchestratorAgent.ts
@@ -12,6 +12,7 @@
 // once, so scratch cwd alone is not a security boundary.
 
 import { randomUUID } from 'node:crypto';
+import { basename } from 'node:path';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -245,6 +246,9 @@ export async function runOrchestrator(options: OrchestratorRunOptions): Promise<
       shellTools: false,
       filesystemTools: false,
       signal: options.signal,
+      // cwd is a scratch dir, so the ledger's project column would be noise;
+      // the repository is carried by the task id instead. (AGT-4178)
+      processContext: { taskId: `${basename(options.repository)}:${options.taskId}`, stage: 'orchestrator' },
     });
     await store.publish({
       repository: options.repository,

--- a/src/support/planner.ts
+++ b/src/support/planner.ts
@@ -22,6 +22,8 @@ export interface PlannerOptions {
   authoritativeOperatorFeedback?: string;
   projectPath: string;
   projectName?: string;
+  /** Task identity stamped on the usage ledger (issue identifier or scheduler id). */
+  taskId?: string;
   timeoutMs?: number;
   model?: string;
   adapterName?: AdapterName;  // CLI adapter (default: configured default)
@@ -165,6 +167,7 @@ export async function runPlanner(options: PlannerOptions): Promise<PlannerResult
       systemPrompt: getPrompts().systemPrompt,
       readOnly: true,
       // Planner is a judgment role — keep reasoning ON (unlike the worker).
+      processContext: { taskId: options.taskId ?? options.taskTitle, stage: 'decompose' },
     });
 
     if (raw.exitCode !== 0 && !raw.stdout.trim()) {

--- a/src/support/usageLedger.test.ts
+++ b/src/support/usageLedger.test.ts
@@ -1,0 +1,115 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  aggregateUsage,
+  parseUsageSince,
+  readUsage,
+  recordUsage,
+  resetUsageLedgerWarning,
+  usageDayKey,
+  type UsageRecord,
+} from './usageLedger.js';
+
+function record(overrides: Partial<UsageRecord> = {}): UsageRecord {
+  return {
+    ts: '2026-09-02T03:00:00.000Z',
+    adapter: 'openrouter',
+    model: 'deepseek/deepseek-v4-flash',
+    taskId: 'AGT-1',
+    stage: 'worker',
+    cwd: '/work/vega-agent',
+    promptTokens: 1000,
+    completionTokens: 100,
+    cachedTokens: 400,
+    reasoningTokens: 0,
+    costUsd: 0.0012,
+    durationMs: 900,
+    ...overrides,
+  };
+}
+
+describe('usage ledger', () => {
+  let dir = '';
+  let prevDir: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'openswarm-usage-'));
+    prevDir = process.env.OPENSWARM_USAGE_DIR;
+    process.env.OPENSWARM_USAGE_DIR = dir;
+    resetUsageLedgerWarning();
+  });
+
+  afterEach(() => {
+    if (prevDir === undefined) delete process.env.OPENSWARM_USAGE_DIR;
+    else process.env.OPENSWARM_USAGE_DIR = prevDir;
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('appends one JSON line per call into the UTC day file of its timestamp', () => {
+    recordUsage(record({ ts: '2026-09-01T23:59:59.000Z' }));
+    recordUsage(record({ ts: '2026-09-02T00:00:00.000Z', model: 'z-ai/glm-5.3' }));
+    expect(readdirSync(dir).sort()).toEqual(['2026-09-01.jsonl', '2026-09-02.jsonl']);
+    const lines = readFileSync(join(dir, '2026-09-02.jsonl'), 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).model).toBe('z-ai/glm-5.3');
+  });
+
+  it('reads back only the window, spanning day files and skipping corrupt lines', () => {
+    recordUsage(record({ ts: '2026-09-01T22:00:00.000Z', taskId: 'old' }));
+    recordUsage(record({ ts: '2026-09-01T23:30:00.000Z', taskId: 'in-1' }));
+    recordUsage(record({ ts: '2026-09-02T00:30:00.000Z', taskId: 'in-2' }));
+    recordUsage(record({ ts: '2026-09-02T02:00:00.000Z', taskId: 'future' }));
+    writeFileSync(join(dir, '2026-09-02.jsonl'), '{"truncated": tru\n', { flag: 'a' });
+
+    const since = Date.parse('2026-09-01T23:00:00.000Z');
+    const until = Date.parse('2026-09-02T01:00:00.000Z');
+    expect(readUsage({ since, until }).map((r) => r.taskId)).toEqual(['in-1', 'in-2']);
+  });
+
+  it('never throws on a write failure and warns exactly once', () => {
+    process.env.OPENSWARM_USAGE_DIR = join(dir, 'not-a-dir');
+    writeFileSync(join(dir, 'not-a-dir'), 'file, not a directory');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(() => recordUsage(record())).not.toThrow();
+    expect(() => recordUsage(record())).not.toThrow();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('[UsageLedger] write failed');
+  });
+
+  it('aggregates by model, ordering by cost and counting unmetered calls separately', () => {
+    const rows = aggregateUsage([
+      record({ model: 'cheap', costUsd: 0.001 }),
+      record({ model: 'cheap', costUsd: 0.002, cachedTokens: 0 }),
+      record({ model: 'pricey', costUsd: 0.5, promptTokens: 50 }),
+      record({ model: 'local', costUsd: null, promptTokens: 9999 }),
+    ], 'model');
+    expect(rows.rows.map((r) => r.key)).toEqual(['pricey', 'cheap', 'local']);
+    expect(rows.rows[1]).toMatchObject({ calls: 2, meteredCalls: 2, promptTokens: 2000, cachedTokens: 400, costUsd: 0.003 });
+    expect(rows.rows[2]).toMatchObject({ calls: 1, meteredCalls: 0, costUsd: 0 });
+    expect(rows.total).toMatchObject({ calls: 4, meteredCalls: 3, costUsd: 0.503 });
+  });
+
+  it('groups by stage, task, project basename and UTC day', () => {
+    const records = [
+      record({ stage: undefined, taskId: undefined, cwd: undefined }),
+      record({ ts: '2026-09-03T01:00:00.000Z', cwd: '/work/cgf-portal' }),
+    ];
+    expect(aggregateUsage(records, 'stage').rows.map((r) => r.key).sort()).toEqual(['(unattributed)', 'worker']);
+    expect(aggregateUsage(records, 'task').rows.map((r) => r.key).sort()).toEqual(['(unattributed)', 'AGT-1']);
+    expect(aggregateUsage(records, 'project').rows.map((r) => r.key).sort()).toEqual(['(unknown)', 'cgf-portal']);
+    expect(aggregateUsage(records, 'day').rows.map((r) => r.key).sort()).toEqual(['2026-09-02', '2026-09-03']);
+  });
+
+  it('parses durations back from now and ISO dates', () => {
+    const now = Date.parse('2026-09-02T12:00:00.000Z');
+    expect(parseUsageSince('90m', now)).toBe(now - 90 * 60_000);
+    expect(parseUsageSince('24h', now)).toBe(now - 24 * 3_600_000);
+    expect(parseUsageSince('7d', now)).toBe(now - 7 * 86_400_000);
+    expect(parseUsageSince('2026-09-01', now)).toBe(Date.parse('2026-09-01'));
+    expect(parseUsageSince('yesterday', now)).toBeNull();
+    expect(usageDayKey(new Date('2026-09-02T23:59:59.999Z'))).toBe('2026-09-02');
+  });
+});

--- a/src/support/usageLedger.ts
+++ b/src/support/usageLedger.ts
@@ -1,0 +1,252 @@
+// ============================================
+// OpenSwarm - LLM usage ledger
+// ============================================
+//
+// Append-only record of every model API call the process makes, so spend can
+// be attributed after the fact — by model, by pipeline stage, by task, by day.
+// Nothing else in the daemon keeps this: the run ledger stores outcomes, the
+// logs print per-run token totals, and a run that dies mid-way (infra error,
+// rate limit, lease expiry) used to leave no trace of the tokens it burned.
+//
+// One JSON line per call under `~/.openswarm/usage/<UTC date>.jsonl`. The
+// file is opened O_APPEND and each record is a single write, so concurrent
+// writers on one host never interleave lines. `costUsd` is the provider's own
+// metered charge when the response carried one (OpenRouter attaches it to
+// every response); it is `null` — not 0 — when the provider reports no price,
+// so unmetered spend is visible as a count instead of vanishing into a $0
+// total. No price table lives here: it would go stale. (AGT-4178)
+
+import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
+
+export interface UsageRecord {
+  /** ISO-8601 UTC timestamp of the response. */
+  ts: string;
+  /** Adapter name (openrouter, gpt, local, atlascloud, codex-responses, …). */
+  adapter: string;
+  model: string;
+  /** Pipeline task identity (issue identifier or scheduler task id) when known. */
+  taskId?: string;
+  /** Pipeline stage (worker, reviewer, draft, decompose, groom, orchestrator, chat, …). */
+  stage?: string;
+  /** Working directory the call served; the project is derived from its basename. */
+  cwd?: string;
+  promptTokens: number;
+  completionTokens: number;
+  /** Prompt-cache hits, a subset of promptTokens. */
+  cachedTokens: number;
+  /** Reasoning tokens, a subset of completionTokens. */
+  reasoningTokens: number;
+  /** Metered charge in USD, or null when the provider did not price the call. */
+  costUsd: number | null;
+  /** Upstream provider charge when routed through a proxy (OpenRouter BYOK). */
+  upstreamCostUsd?: number;
+  durationMs?: number;
+}
+
+/** Attribution the agentic loop stamps on every record it writes. */
+export interface UsageAttribution {
+  adapter: string;
+  taskId?: string;
+  stage?: string;
+}
+
+export function usageLedgerDir(): string {
+  return process.env.OPENSWARM_USAGE_DIR ?? join(homedir(), '.openswarm', 'usage');
+}
+
+/** `YYYY-MM-DD` in UTC — the ledger partitions by UTC day, matching the ISO `ts`. */
+export function usageDayKey(at: Date): string {
+  return at.toISOString().slice(0, 10);
+}
+
+let warnedWriteFailure = false;
+
+/**
+ * Append one record. Never throws: losing a ledger line must not fail the
+ * model call that produced it. The first failure is logged once so a
+ * misconfigured directory is noticed without flooding the daemon log.
+ */
+export function recordUsage(record: UsageRecord): void {
+  try {
+    const dir = usageLedgerDir();
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(join(dir, `${usageDayKey(new Date(record.ts))}.jsonl`), `${JSON.stringify(record)}\n`);
+  } catch (error) {
+    if (warnedWriteFailure) return;
+    warnedWriteFailure = true;
+    console.warn(`[UsageLedger] write failed (further failures silent): ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+/** Test seam: reset the one-shot warning latch. */
+export function resetUsageLedgerWarning(): void {
+  warnedWriteFailure = false;
+}
+
+export interface UsageWindow {
+  /** Inclusive lower bound (epoch ms). */
+  since: number;
+  /**
+   * Inclusive upper bound (epoch ms); defaults to now. Inclusive because a
+   * caller reading "up to now" right after a call must see the record that
+   * was written in this same millisecond.
+   */
+  until?: number;
+}
+
+/**
+ * Read every record whose `ts` falls inside the window. Only the day files
+ * that can overlap the window are opened, and a corrupt line (a crash mid
+ * write is the realistic cause) is skipped rather than poisoning the whole
+ * day.
+ */
+export function readUsage(window: UsageWindow, dir: string = usageLedgerDir()): UsageRecord[] {
+  const until = window.until ?? Date.now();
+  if (!existsSync(dir)) return [];
+  const first = usageDayKey(new Date(window.since));
+  const last = usageDayKey(new Date(until));
+  const files = readdirSync(dir)
+    .filter((name) => /^\d{4}-\d{2}-\d{2}\.jsonl$/.test(name))
+    .filter((name) => {
+      const day = name.slice(0, 10);
+      return day >= first && day <= last;
+    })
+    .sort();
+  const records: UsageRecord[] = [];
+  for (const name of files) {
+    for (const line of readFileSync(join(dir, name), 'utf8').split('\n')) {
+      if (!line.trim()) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (!isUsageRecord(parsed)) continue;
+      const at = Date.parse(parsed.ts);
+      if (Number.isNaN(at) || at < window.since || at > until) continue;
+      records.push(parsed);
+    }
+  }
+  return records;
+}
+
+function isUsageRecord(value: unknown): value is UsageRecord {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.ts === 'string'
+    && typeof v.adapter === 'string'
+    && typeof v.model === 'string'
+    && typeof v.promptTokens === 'number'
+    && typeof v.completionTokens === 'number'
+    && (typeof v.costUsd === 'number' || v.costUsd === null);
+}
+
+export const USAGE_GROUP_KEYS = ['model', 'stage', 'task', 'project', 'adapter', 'day'] as const;
+export type UsageGroupKey = (typeof USAGE_GROUP_KEYS)[number];
+
+export interface UsageAggregateRow {
+  key: string;
+  calls: number;
+  /** Calls whose provider reported a price; `costUsd` sums only these. */
+  meteredCalls: number;
+  promptTokens: number;
+  completionTokens: number;
+  cachedTokens: number;
+  reasoningTokens: number;
+  costUsd: number;
+}
+
+export interface UsageAggregate {
+  by: UsageGroupKey;
+  rows: UsageAggregateRow[];
+  total: UsageAggregateRow;
+}
+
+function groupKeyOf(record: UsageRecord, by: UsageGroupKey): string {
+  switch (by) {
+    case 'model': return record.model;
+    case 'adapter': return record.adapter;
+    case 'stage': return record.stage ?? '(unattributed)';
+    case 'task': return record.taskId ?? '(unattributed)';
+    case 'project': return record.cwd ? basename(record.cwd) : '(unknown)';
+    case 'day': return record.ts.slice(0, 10);
+  }
+}
+
+function emptyRow(key: string): UsageAggregateRow {
+  return { key, calls: 0, meteredCalls: 0, promptTokens: 0, completionTokens: 0, cachedTokens: 0, reasoningTokens: 0, costUsd: 0 };
+}
+
+function addTo(row: UsageAggregateRow, record: UsageRecord): void {
+  row.calls += 1;
+  row.promptTokens += record.promptTokens;
+  row.completionTokens += record.completionTokens;
+  row.cachedTokens += record.cachedTokens ?? 0;
+  row.reasoningTokens += record.reasoningTokens ?? 0;
+  if (record.costUsd !== null) {
+    row.meteredCalls += 1;
+    row.costUsd += record.costUsd;
+  }
+}
+
+/** Group and sum. Rows are ordered by cost, then by prompt tokens for unmetered ties. */
+export function aggregateUsage(records: readonly UsageRecord[], by: UsageGroupKey): UsageAggregate {
+  const rows = new Map<string, UsageAggregateRow>();
+  const total = emptyRow('total');
+  for (const record of records) {
+    const key = groupKeyOf(record, by);
+    let row = rows.get(key);
+    if (!row) {
+      row = emptyRow(key);
+      rows.set(key, row);
+    }
+    addTo(row, record);
+    addTo(total, record);
+  }
+  const ordered = [...rows.values()].sort((a, b) => (b.costUsd - a.costUsd) || (b.promptTokens - a.promptTokens));
+  return { by, rows: ordered, total };
+}
+
+/**
+ * Parse a window spec: a duration (`90m`, `24h`, `7d`) measured back from
+ * `now`, or an ISO date/time. Returns null for anything else.
+ */
+export function parseUsageSince(spec: string, now: number = Date.now()): number | null {
+  const duration = /^(\d+)([mhd])$/.exec(spec.trim());
+  if (duration) {
+    const n = Number(duration[1]);
+    const unit = { m: 60_000, h: 3_600_000, d: 86_400_000 }[duration[2] as 'm' | 'h' | 'd'];
+    return now - n * unit;
+  }
+  const at = Date.parse(spec);
+  return Number.isNaN(at) ? null : at;
+}
+
+export interface UsageQuery {
+  /** Window spec accepted by parseUsageSince. */
+  since: string;
+  /** One of USAGE_GROUP_KEYS. */
+  by: string;
+  now?: number;
+}
+
+export type UsageQueryResult =
+  | { ok: true; since: number; until: number; by: UsageGroupKey; aggregate: UsageAggregate; dir: string }
+  | { ok: false; error: string };
+
+export function isUsageGroupKey(value: string): value is UsageGroupKey {
+  return (USAGE_GROUP_KEYS as readonly string[]).includes(value);
+}
+
+/** Validate a window/group query and aggregate the ledger. Shared by `openswarm cost` and GET /api/usage. */
+export function queryUsage(query: UsageQuery): UsageQueryResult {
+  const now = query.now ?? Date.now();
+  const since = parseUsageSince(query.since, now);
+  if (since === null) return { ok: false, error: `invalid --since '${query.since}': use a duration (90m, 24h, 7d) or an ISO date` };
+  if (!isUsageGroupKey(query.by)) return { ok: false, error: `invalid --by '${query.by}': one of ${USAGE_GROUP_KEYS.join(', ')}` };
+  const records = readUsage({ since, until: now });
+  return { ok: true, since, until: now, by: query.by, aggregate: aggregateUsage(records, query.by), dir: usageLedgerDir() };
+}

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -506,6 +506,16 @@ export async function startWebServer(port: number = 3847): Promise<void> {
         res.write(':connected\n\n');
         addSSEClient(res, skipReplay);
 
+      // ---- Usage ledger (AGT-4178) ----
+      } else if (url === '/api/usage' && req.method === 'GET') {
+        const { queryUsage } = await import('./usageLedger.js');
+        const result = queryUsage({
+          since: requestUrl.searchParams.get('since') ?? '24h',
+          by: requestUrl.searchParams.get('by') ?? 'model',
+        });
+        if (!result.ok) { writeJson(res, 400, { error: result.error }); return; }
+        writeJson(res, 200, { since: new Date(result.since).toISOString(), until: new Date(result.until).toISOString(), ...result.aggregate });
+
       // ---- Stats ----
       } else if (url === '/api/stats') {
         const stats = runnerRef?.getStats();

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -215,7 +215,7 @@ const ALLOWED_EVENTS = new Set(['invoke', 'complete', 'error', 'start', 'stop', 
  * failing test rather than a blind spot discovered months later.
  */
 const ALLOWED_COMMANDS = new Set([
-  'add', 'annotate', 'attach', 'auth', 'board', 'chat', 'check', 'dash', 'design-pipeline',
+  'add', 'annotate', 'attach', 'auth', 'board', 'chat', 'check', 'cost', 'dash', 'design-pipeline',
   'doctor', 'exec', 'fix', 'init', 'login', 'logout', 'mcp', 'memory', 'models', 'openswarm',
   'pr', 'projects', 'provider', 'remove', 'resume', 'review', 'run', 'schedule', 'start',
   'status', 'stop', 'threads', 'upgrade', 'validate', 'version', 'work',

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -33,3 +33,9 @@ process.env.OPENSWARM_COORDINATION_FILE = join(tmpdir(), 'openswarm-test-coordin
 // per worker for the same reason as the board: sharing it would reintroduce
 // the contention the line above removes.
 process.env.OPENSWARM_AUTOMATION_DB = join(tmpdir(), 'openswarm-test-automation', workerScope, 'automation.db');
+
+// The agentic loop appends a usage-ledger line for every model response it
+// sees, including the fake responses loop tests feed it. Keep those out of the
+// operator's live ~/.openswarm/usage/. Per worker: ledger tests read the whole
+// directory back. (AGT-4178)
+process.env.OPENSWARM_USAGE_DIR = join(tmpdir(), 'openswarm-test-usage', workerScope);


### PR DESCRIPTION
## Why

Nothing recorded where the money went. The daemon logged per-run token totals with `costUsd` pinned to 0, so "is glm-5.3 the expensive part?" had no answer (OpenRouter's key page shows only the account total: today $11.89, weekly $56.78; the per-model activity endpoint needs a management key). A run that died on an infra error or rate limit left no trace of the tokens it had already burned — yesterday's 428 failed attempts are uncountable.

OpenRouter prices every response (`usage.cost`, `cost_details.upstream_inference_cost`, `prompt_tokens_details.cached_tokens`, `completion_tokens_details.reasoning_tokens`) but `chatStream` read only the three token counts, so even cached tokens were always 0 on that path.

## What

- `chatStream` normalises the usage-accounting fields into `ChatUsage`.
- `runAgenticLoop` writes one ledger line per response **before** any of its throw paths, and sums metered cost into the result; `loopResultToCliResult` passes it through so stage costs → `totalCost` → project pace → Linear rolling cost stop reading 0. Unmetered providers (codex-responses subscription, local) record `costUsd: null`, not 0, so they show as a count instead of vanishing into a $0 total.
- `src/support/usageLedger.ts`: append-only JSONL under `~/.openswarm/usage/<UTC day>.jsonl` (`OPENSWARM_USAGE_DIR` override). O_APPEND single-line writes, never throws (warns once). `readUsage` / `aggregateUsage` / `queryUsage`.
- Attribution: the five loop adapters pass `processContext` through; draft, decompose, groom and orchestrator calls now carry a stage and task id.
- Read surfaces: `openswarm cost --since 24h --by model|stage|task|project|adapter|day [--json]` and `GET /api/usage?since=&by=` — both over the same aggregate.

## Verified

- `npm run typecheck`, `npm run lint`, `LC_ALL=C vitest` full suite 5386 pass.
- Live smoke against OpenRouter (1 call, v4-flash): ledger line `costUsd: 0.0000082803, upstreamCostUsd: 0.0000082803`, `costInfo.costUsd` real, `openswarm cost --by stage` renders it.
- Concurrency: multi-process appends to one day file are single `write()`s on an O_APPEND fd; reads are per-day file scans. Window upper bound is inclusive so a read "up to now" sees the record written in the same millisecond (the exclusive form flaked in the loop test).

AGT-4178