### PR TITLE
fix(worktree): treat any virtualenv directory as an ephemeral artifact, not just the bare .venv link

### DIFF
--- a/src/support/worktreeEphemeral.test.ts
+++ b/src/support/worktreeEphemeral.test.ts
@@ -37,6 +37,29 @@ describe('isEphemeralWorktreeArtifact', () => {
     expect(isEphemeralWorktreeArtifact('pytest-of-openswarm/pytest-3/x')).toBe(true);
     expect(isEphemeralWorktreeArtifact('.trash/AX-1/pytest-a3/out')).toBe(true);
   });
+
+  // cgf-portal AX-868 (2026-09-02): a worker ran `uv venv .venv_test` and the
+  // publication commit tracked 11,026 files under it. The purge commit that
+  // followed removed nothing because only the bare `.venv` link was known, so
+  // every later attempt died on the publication fence.
+  it('drops any virtualenv directory by name, at any depth', () => {
+    for (const file of [
+      '.venv_test/bin/activate',
+      '.venv_test/pyvenv.cfg',
+      '.venv/lib/python3.12/site-packages/x.py',
+      '.venv-verify/bin/ruff',
+      '.venv.bak/bin/python',
+      'venv/bin/python',
+      'apps/pipelines/.venv/pyvenv.cfg',
+      '.venv',
+      'venv',
+    ]) {
+      expect(isEphemeralWorktreeArtifact(file), file).toBe(true);
+    }
+    for (const file of ['src/venv_tools.py', 'docs/venv.md', 'convenv/x.py', 'src/env/config.py']) {
+      expect(isEphemeralWorktreeArtifact(file), file).toBe(false);
+    }
+  });
 });
 
 describe('ephemeralPathspecRoots', () => {
@@ -44,5 +67,11 @@ describe('ephemeralPathspecRoots', () => {
     expect(ephemeralPathspecRoots([
       'pytest-of-openswarm/pytest-3/a', 'pytest-of-openswarm/pytest-3/b', 'apps/pipelines/.coverage',
     ])).toEqual(['apps/pipelines/.coverage', 'pytest-of-openswarm']);
+  });
+
+  it('collapses a virtualenv to its directory so the purge is one rm -r', () => {
+    expect(ephemeralPathspecRoots([
+      '.venv_test/bin/activate', '.venv_test/lib/python3.12/site-packages/a.py', 'apps/x/.venv/pyvenv.cfg', '.venv',
+    ])).toEqual(['.venv', '.venv_test', 'apps/x/.venv']);
   });
 });

--- a/src/support/worktreeEphemeral.ts
+++ b/src/support/worktreeEphemeral.ts
@@ -1,11 +1,21 @@
 /** Ephemeral paths under agent worktrees — never task source / never verify input. */
 
 /** Test/runtime outputs are never task source, including on a resumed WIP branch. */
+/**
+ * A Python virtualenv directory by name, at any depth: `.venv`, `venv`,
+ * `.venv-verify`, `.venv.bak`, `.venv_test`, … The old list named the
+ * worktree-level `.venv` link and two known siblings by exact string, so a
+ * worker's `uv venv .venv_test` (cgf-portal AX-868, 2026-09-02) committed
+ * 11,026 interpreter files that the purge then could not see, and the branch
+ * failed the publication fence on every attempt after that.
+ */
+const VENV_DIR = /(?:^|\/)\.?venv[\w.-]*\//;
+/** The worktree-level link/dir entry itself (`.venv`, `venv`, `.venv-verify`, `.venv.bak`) — never `venv_tools.py`. */
+const VENV_ENTRY = /^\.?venv(?:[\w-]*|\.bak)$/;
+
 export function isEphemeralWorktreeArtifact(file: string): boolean {
-  return file === '.venv'
-    || file === '.venv-verify'
-    || file === '.venv.bak'
-    || file.startsWith('.venv.bak/')
+  return VENV_DIR.test(file)
+    || VENV_ENTRY.test(file)
     || file === 'pytest-local'
     // pytest's basetemp (`pytest-of-<user>/…`) anywhere in the tree, and the
     // whole worktree-local `.trash/` quarantine (cgf-portal ships secrets under
@@ -46,7 +56,8 @@ export function ephemeralPathspecRoots(files: string[]): string[] {
     if (/^\.trash(?:\/|$)/.test(file) || /^\.test-tmp(?:-[^/]+)?(?:\/|$)/.test(file) || /^\.pytest-lathe(?:\/|$)/.test(file)) {
       pathspec = root;
     } else {
-      const m = file.match(/^(.*(?:^|\/)pytest-of-[^/]+)/);
+      // One `git rm -r` per virtualenv or pytest basetemp, not one per file.
+      const m = file.match(/^(.*(?:^|\/)pytest-of-[^/]+)/) ?? file.match(/^(.*?(?:^|\/)\.?venv[\w.-]*)\//);
       if (m) pathspec = m[1];
     }
     if (roots.some((r) => pathspec === r || pathspec.startsWith(`${r}/`))) continue;


### PR DESCRIPTION
## Why

`isEphemeralWorktreeArtifact` named the worktree-level `.venv` link and two siblings (`.venv-verify`, `.venv.bak`) by exact string, so paths **under** a virtualenv never matched. On cgf-portal AX-868 (vela, 2026-09-02) a worker ran `uv venv .venv_test`; the publication commit (pre-#520) tracked 11,026 interpreter files, the `wip: remove ephemeral runtime artifacts (auto)` commit that followed removed nothing, and every attempt since (22 so far) died on the publication fence with `branch contains files outside reserved write scope: .venv_test/bin/Activate.ps1, …`.

## What

- `VENV_DIR` matches `.venv*` / `venv*` as a directory component at any depth; `VENV_ENTRY` keeps the bare entry names (`.venv`, `venv`, `.venv-verify`, `.venv.bak`). `venv_tools.py`, `docs/venv.md`, `src/env/` stay source.
- `ephemeralPathspecRoots` collapses a virtualenv to its directory so the purge is one `git rm -r`, not 11k pathspecs.

## Verified

- New unit tests (positive/negative names, root collapse); fence/worktree/guard suites pass; full `LC_ALL=C vitest` 5373 pass; typecheck clean.
- Effect on the live branch: the next AX-868 attempt's purge removes `.venv_test/` in one commit and the fence sees only the task files.