### PR TITLE
fix(automation): park a publication-scope rejection for the operator instead of retrying it forever

### DIFF
--- a/src/agents/pairPipelineTypes.ts
+++ b/src/agents/pairPipelineTypes.ts
@@ -117,6 +117,22 @@ export interface PipelineResult {
   };
   prUrl?: string;
   totalCost?: CostInfo;
+  /**
+   * Cause of a failure that happened outside the staged pipeline — today the
+   * publication step, which runs after every stage succeeded. `stages[]`
+   * cannot carry it (there is no 'pr' stage), and without it the ledger
+   * recorded these attempts with no message at all (vela AGT-3844: 48
+   * attempts, half of them blank).
+   */
+  failureDetail?: string;
+  /**
+   * A deterministic failure that an operator has to resolve. The coordinator
+   * parks the run as NEEDS_HUMAN under `code` instead of scheduling a retry:
+   * the publication-scope fence rejecting files already committed on the
+   * branch cannot be retried into success, and vela spent 23/48/15 attempts
+   * on three such runs on 2026-09-02 before anyone looked.
+   */
+  operatorPark?: { code: string; reason: string };
 }
 
 export interface PipelineContext {

--- a/src/automation/durableRunCoordinator.operatorPark.test.ts
+++ b/src/automation/durableRunCoordinator.operatorPark.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { PipelineResult } from '../agents/pairPipeline.js';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import { DurableRunCoordinator } from './durableRunCoordinator.js';
+import { RunLedger } from './runLedger.js';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function dbPath(): string {
+  const root = mkdtempSync(join(tmpdir(), 'openswarm-coordinator-park-'));
+  roots.push(root);
+  return join(root, 'automation.db');
+}
+
+function task(id: string): TaskItem {
+  return {
+    id,
+    issueId: id,
+    issueIdentifier: id,
+    source: 'linear',
+    title: `Task ${id}`,
+    priority: 2,
+    createdAt: Date.now(),
+    linearState: 'Todo',
+    linearProject: { id: 'project', name: 'Repo' },
+  };
+}
+
+// vela 2026-09-02: AGT-3844 / AX-868 / AGT-4158 retried a publication-scope
+// rejection 48 / 23 / 15 times. The pipeline now names the failure as the
+// operator's; the coordinator must park it rather than schedule it again.
+describe('DurableRunCoordinator operatorPark', () => {
+  it('parks immediately under the pipeline\'s own operator code, before any circuit', async () => {
+    const ledger = new RunLedger(dbPath());
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', ledger, infraFailureCircuit: 6 });
+    const reason = 'publication-scope: branch contains files outside reserved write scope: uv.lock';
+    const parked: PipelineResult = {
+      success: false,
+      sessionId: 's',
+      stages: [],
+      finalStatus: 'failed',
+      totalDuration: 1,
+      iterations: 1,
+      failureDetail: `publication: ${reason}`,
+      operatorPark: { code: 'publication_scope_mismatch', reason },
+    };
+
+    await coordinator.execute(task('scope'), '/repo', async () => parked);
+
+    expect(ledger.getRun('scope')).toMatchObject({
+      state: 'NEEDS_HUMAN',
+      lastErrorCode: 'publication_scope_mismatch',
+      lastErrorMessage: reason,
+    });
+    // An explicit redispatch after the operator widens the scope resumes it.
+    expect(ledger.resumeNeedsHuman('scope')).toBe('READY');
+    coordinator.close();
+    ledger.close();
+  });
+});

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -739,6 +739,18 @@ export class DurableRunCoordinator {
 
     const detail = pickPipelineFailureDetail(result);
 
+    // A deterministic failure the pipeline has already attributed to the
+    // operator (publication-scope fence, …): retrying reproduces it exactly.
+    if (result.operatorPark) {
+      const { code, reason } = result.operatorPark;
+      return this.ledger.transition(claim, 'NEEDS_HUMAN', {
+        errorCode: code,
+        errorMessage: reason,
+        eventKind: 'operator_parked',
+        eventData: { sessionId: result.sessionId, code, reason },
+      }, now) ? result : fencedResult(result);
+    }
+
     // An infrastructure failure is not counted toward STUCK, and rightly so:
     // a provider blip is not the task's fault. But the same infrastructure
     // failure on every attempt is not a blip, and retrying it forever is how

--- a/src/automation/publishOnPark.test.ts
+++ b/src/automation/publishOnPark.test.ts
@@ -5,7 +5,8 @@ const commitAndCreatePRWithHead = vi.hoisted(() => vi.fn());
 vi.mock('../support/worktreeManager.js', () => ({ commitAndCreatePRWithHead }));
 vi.mock('../core/eventHub.js', () => ({ broadcastEvent: vi.fn() }));
 
-import { publishApprovedWork, publishStuckWork, shouldPublishParkedWork } from './publishOnPark.js';
+import { PublicationScopeMismatchError } from '../support/publicationScopeFence.js';
+import { PUBLICATION_SCOPE_PARK_REASON, publishApprovedWork, publishStuckWork, shouldPublishParkedWork } from './publishOnPark.js';
 
 beforeEach(() => {
   commitAndCreatePRWithHead.mockReset();
@@ -72,6 +73,39 @@ describe('publication identity (AGT-4145)', () => {
 
     expect(result.prUrl).toBe('https://github.com/o/r/pull/17');
     expect(onPublication).toHaveBeenCalledWith('https://github.com/o/r/pull/17', 'head-b');
+  });
+});
+
+// vela 2026-09-02: AGT-3844 (48 attempts), AX-868 (23), AGT-4158 (15) — every
+// one a publication-scope rejection of files an EARLIER attempt had already
+// committed, turned into a 15-minute infra retry with a blank ledger message.
+describe('publication failure classification', () => {
+  const info = { worktreePath: '/tmp/w', originalPath: '/tmp/r', branchName: 'swarm/AGT-4158', issueId: 'AGT-4158' };
+  const publishable = { id: 'task-1', issueIdentifier: 'AGT-4158', title: 'Artifact cohort producer', fileScope: ['src/vega_plugins/eval/'], fileScopeSource: 'drafted' as const };
+
+  it('parks a publication-scope rejection for the operator instead of retrying it', async () => {
+    commitAndCreatePRWithHead.mockRejectedValue(new PublicationScopeMismatchError(['benchmarks/artifact_cohort.py', 'uv.lock']));
+    const result: { success: boolean; finalStatus: string; failureDetail?: string; operatorPark?: { code: string; reason: string } } = { success: true, finalStatus: 'approved' };
+
+    await publishApprovedWork(info, publishable, result, undefined);
+
+    expect(result.success).toBe(false);
+    expect(result.finalStatus).toBe('failed');
+    expect(result.operatorPark).toEqual({
+      code: PUBLICATION_SCOPE_PARK_REASON,
+      reason: expect.stringContaining('benchmarks/artifact_cohort.py, uv.lock'),
+    });
+    expect(result.failureDetail).toMatch(/^publication: publication-scope: /);
+  });
+
+  it('keeps every other publication failure a retryable infra error, with the cause recorded', async () => {
+    commitAndCreatePRWithHead.mockRejectedValue(new Error('gh: HTTP 502 Bad Gateway'));
+    const result: { success: boolean; finalStatus: string; failureDetail?: string; operatorPark?: unknown } = { success: true, finalStatus: 'approved' };
+
+    await publishApprovedWork(info, publishable, result, undefined);
+
+    expect(result).toMatchObject({ success: false, finalStatus: 'infra_error', failureDetail: 'publication: gh: HTTP 502 Bad Gateway' });
+    expect(result.operatorPark).toBeUndefined();
   });
 });
 

--- a/src/automation/publishOnPark.ts
+++ b/src/automation/publishOnPark.ts
@@ -14,8 +14,13 @@
 
 import { broadcastEvent } from '../core/eventHub.js';
 import { enforcedFileScope, type FileScopeSource } from '../orchestration/writeScope.js';
+import { PublicationScopeMismatchError } from '../support/publicationScopeFence.js';
 import { commitAndCreatePRWithHead, type WorktreeInfo } from '../support/worktreeManager.js';
+import type { PipelineResult } from '../agents/pairPipelineTypes.js';
 import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
+
+/** NEEDS_HUMAN code for a branch the publication-scope fence refused. */
+export const PUBLICATION_SCOPE_PARK_REASON = 'publication_scope_mismatch';
 
 /** The fields these paths read; narrower than the full pipeline result. */
 interface PublishableResult {
@@ -208,12 +213,14 @@ export async function publishStuckWork(
  *
  * A publication failure is fatal here, unlike the parked path: a worktree-mode
  * run is not deliverable until its branch is remotely reviewable, so the result
- * is turned back into a retryable `infra_error` with the worktree preserved.
+ * is turned back into a retryable `infra_error` with the worktree preserved —
+ * except a publication-scope rejection, which no retry can change and which
+ * therefore parks for the operator (`operatorPark`).
  */
 export async function publishApprovedWork(
   worktreeInfo: WorktreeInfo | null | undefined,
   task: PublishableTask,
-  result: PublishableResult & { success?: boolean; finalStatus?: string; prUrl?: string },
+  result: PublishableResult & Pick<PipelineResult, 'failureDetail' | 'operatorPark'> & { success?: boolean; finalStatus?: string; prUrl?: string },
   durability: ExecutionDurabilityHooks | undefined,
 ): Promise<void> {
   // Create PR (worktree mode + pipeline success = finalStatus 'approved')
@@ -249,17 +256,28 @@ export async function publishApprovedWork(
         console.log(`[Runner] PR created for ${task.issueIdentifier}: ${prUrl}`);
       } catch (err) {
         console.error('[Worktree] PR creation failed:', err);
+        const message = err instanceof Error ? err.message : String(err);
         // A worktree-mode run is not deliverable until the branch is published.
-        // Keep it retryable and preserved instead of marking the issue Done with
-        // no remotely reviewable artifact.
+        // Keep it preserved instead of marking the issue Done with no remotely
+        // reviewable artifact — and record WHY, or the ledger row is blank.
         result.success = false;
-        result.finalStatus = 'infra_error';
+        result.failureDetail = `publication: ${message}`;
+        if (err instanceof PublicationScopeMismatchError) {
+          // The branch already holds commits outside the reserved write scope.
+          // No retry changes that history; the worker just re-runs, finds the
+          // work done, and the fence rejects the same files again — 15-min
+          // backoff forever. Park it for the operator with the file list.
+          result.finalStatus = 'failed';
+          result.operatorPark = { code: PUBLICATION_SCOPE_PARK_REASON, reason: message };
+        } else {
+          result.finalStatus = 'infra_error';
+        }
         broadcastEvent({
           type: 'log',
           data: {
             taskId: task.issueId || task.id,
             stage: 'pr',
-            line: `PR creation failed: ${err instanceof Error ? err.message : String(err)}`,
+            line: `PR creation failed: ${message}`,
           },
         });
       }

--- a/src/automation/runnerState.ts
+++ b/src/automation/runnerState.ts
@@ -238,6 +238,8 @@ export function pickPipelineFailureDetail(result: PipelineResult): string | unde
     : undefined;
 
   return pickFailureDetail([
+    // Publication failed after every stage passed: nothing below describes it.
+    result.failureDetail,
     testerFailure,
     result.lastReviewFeedback,
     result.reviewResult?.feedback,


### PR DESCRIPTION
## Why

`publishApprovedWork` turned **every** PR-creation failure into a retryable `infra_error` and set no message on the result, so (a) the ledger row was blank and (b) the retry reproduced the failure exactly. A `PublicationScopeMismatchError` is deterministic — the branch already holds commits outside the reserved write scope from an earlier attempt; the worker re-runs, finds the work done ("no changed files"), and the fence rejects the same files again.

vela, 2026-09-02: AGT-3844 48 attempts, AX-868 23, AGT-4158 15 — all this loop, a `feat(...)` commit per attempt, no PR, half the ledger rows without a message. Because the message was blank, the infra circuit from #522 had no fingerprint to trip on either.

## What

- `PipelineResult.failureDetail` — the publication failure's cause, picked first by `pickPipelineFailureDetail` (there is no `'pr'` stage to carry it in `stages[]`).
- `PipelineResult.operatorPark { code, reason }` — a deterministic, operator-owned failure. `DurableRunCoordinator` parks it `NEEDS_HUMAN` under that code before the infra circuit; `resumeNeedsHuman` → READY still works, so an explicit redispatch after widening the scope resumes it.
- The fence rejection sets `operatorPark` with `publication_scope_mismatch` and the offending file list; every other publication failure stays a retryable `infra_error`, now with `failureDetail` recorded.

## Verified

- Unit: fence error → park code + detail; other error → infra_error + detail; coordinator parks under the pipeline's code and resumes to READY (new file — `durableRunCoordinator.test.ts` sits at the 1500-line cap).
- Full `LC_ALL=C vitest` 5389 pass, typecheck clean.
- Effect on the live rows: the next attempt of each of the three runs parks with the file list instead of retrying at 15 min.