### PR TITLE
fix(automation): an operator park must not return the card to Todo — the heartbeat reads that as a reopen

### DIFF
--- a/src/automation/autonomousRunner.coverage.test.ts
+++ b/src/automation/autonomousRunner.coverage.test.ts
@@ -802,6 +802,33 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
     });
   });
 
+  // vela 2026-09-02 13:09–13:35: the coordinator parked a publication-scope
+  // rejection, the failure budget below returned the card to Todo, the next
+  // heartbeat read Todo as an operator reopen and resumed it — a park/resume
+  // cycle every ~4 minutes, each waking the orchestrator sweep.
+  describe('scheduler "failed" event — operatorPark branch', () => {
+    it('parks the card in Backlog like STUCK and never returns it to Todo', async () => {
+      const source = mockTaskSource();
+      runnerExecution.setTaskSource(source);
+      const r = new AutonomousRunner(cfg());
+      const internal = r as unknown as Internal & { completedTaskIds: Set<string>; failedTaskCounts: Map<string, number> };
+      const scheduler = internal.scheduler as unknown as TaskScheduler;
+
+      const reason = 'publication-scope: branch contains files outside reserved write scope: uv.lock';
+      scheduler.startTask(task(), '/repo', async () => pipelineResult('failed', {
+        failureDetail: `publication: ${reason}`,
+        operatorPark: { code: 'publication_scope_mismatch', reason },
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 15));
+
+      expect(source.logStuck).toHaveBeenCalledWith('ISSUE-1', 'autonomous-runner', expect.stringContaining('publication_scope_mismatch'));
+      expect(source.updateState).not.toHaveBeenCalledWith('ISSUE-1', 'Todo');
+      expect(source.logBlocked).not.toHaveBeenCalled();
+      expect(internal.completedTaskIds.has('ISSUE-1')).toBe(true);
+      expect(internal.failedTaskCounts.get('ISSUE-1') ?? 0).toBe(0);
+    });
+  });
+
   describe('pickPipelineFailureDetail', () => {
     it('prefers deterministic verification output over an earlier reviewer approval', () => {
       const result = pipelineResult('failed', {

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -845,6 +845,31 @@ export class AutonomousRunner {
       broadcastEvent({ type: 'task:completed', data: { taskId: taskEventKey(task), success: false, duration: result.totalDuration } });
       await reportToDiscord(formatPipelineResultEmbed(result));
 
+      // A deterministic, operator-owned failure (the publication-scope fence).
+      // The coordinator has already parked the durable row under
+      // `operatorPark.code`; the failure budget below must NOT run: its retry
+      // branch returns the card to Todo, and the heartbeat reads Todo as an
+      // operator reopen — so the park resumed on the next tick and re-parked
+      // four minutes later, every cycle waking the orchestrator sweep (vela
+      // 13:09–13:31, 2026-09-02). Park the card the way STUCK does: comment
+      // the cause, move it to Backlog, and wait for a human to move it back.
+      if (result.operatorPark && task.issueId) {
+        const { code, reason } = result.operatorPark;
+        this.completedTaskIds.add(task.issueId); // no retry changes what the fence saw
+        clearRetryTime(task.issueId, this.failedTaskRetryTimes);
+        recordLastFailureDetail(this.taskStateRef, task.issueId, reason);
+        this.saveTaskState();
+        console.warn(`[Scheduler] ${taskCtx} parked for the operator (${code}): ${reason}`);
+        try {
+          await getTaskSource()?.logStuck(task.issueId, 'autonomous-runner',
+            `Parked for the operator — \`${code}\`. The daemon will not retry this on its own.\n\n**Reason:**\n${reason}`);
+        } catch (err) {
+          console.error('[Scheduler] Failed to record the operator park on the tracker:', err);
+        }
+        this.scheduleNextHeartbeat();
+        return;
+      }
+
       // Structural infeasibility (⑦, INT-2521): the failure text says the DoD can't
       // be met in this sandbox — it needs a human, a manual step, or an absent
       // environment resource (real DB / live network / production access). The


### PR DESCRIPTION
## Why

#526 parks a publication-scope rejection as `NEEDS_HUMAN`, but the result still flowed into the scheduler's `failed` handler and its retry branch (`syncFailureState(..., 'Todo')`) moved the Linear card to **Todo**. The heartbeat treats Todo as the operator-reopen surface (AGT-4155) and resumed the park on its next tick → re-run → re-park 4 min later → Todo again.

vela 13:09–13:35 KST today: AGT-3844 and AGT-4118 cycled park/resume every ~4 minutes (ledger: `operator_parked` → `operator_resumed` 8 s later, ×5), and every park woke the orchestrator sweep — `z-ai/glm-5.3` 153 calls / **$1.44 in 25 minutes**, 80% of all spend in that window (measured with the new usage ledger, #524).

## What

In the `failed` handler, before the failure budget: if `result.operatorPark` is set, handle it like STUCK — `logStuck` (comment with the code/reason, card → **Backlog**), clear the retry clock, mark the task completed in-memory, and stop. The human moves the card back to Todo to retry, which is the existing contract.

## Verified

- Unit: operatorPark result → `logStuck` called with the code, `updateState(…, 'Todo')` never called, failure count not incremented.
- publishOnPark / coordinator operatorPark suites still pass; typecheck clean.