### PR TITLE
feat(automation): per-repository fresh review after the swarm publishes a PR

### DIFF
--- a/docs/DURABLE_AUTONOMY.md
+++ b/docs/DURABLE_AUTONOMY.md
@@ -121,6 +121,24 @@ An optional `automation` block in `openswarm.json` controls admission:
 Unreadable or invalid policy is an infrastructure failure, not permission to
 run with guessed defaults.
 
+A separate `publication` block decides what happens to the pull requests the
+swarm publishes from this repository. Worker attempts run only deterministic
+guards and verification; the agentic fresh review (`openswarm pr review
+--fresh`) runs once, right after the PR is published, and only where the
+repository opts in:
+
+```json
+{
+  "publication": {
+    "freshReview": true
+  }
+}
+```
+
+It lives outside `automation` so opting in does not pull that block's admission
+defaults in with it. A review failure is logged on the run but never undoes the
+publication or re-publishes the PR.
+
 ## Operations
 
 Relevant service settings are:

--- a/openswarm.json
+++ b/openswarm.json
@@ -6,5 +6,8 @@
     "teamKey": "INT",
     "projectId": "74a9d092-7b3c-4d4d-a998-a2c9a8f08e83",
     "projectName": "OpenSwarm"
+  },
+  "publication": {
+    "freshReview": true
   }
 }

--- a/src/automation/prPublicationReview.test.ts
+++ b/src/automation/prPublicationReview.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const freshReview = vi.hoisted(() => vi.fn());
+vi.mock('./prProcessor.js', () => ({
+  PRProcessor: class { freshReview = freshReview; },
+}));
+
+import { parsePublishedPullRequest, reviewPublishedPullRequest } from './prPublicationReview.js';
+
+describe('PR-time publication review', () => {
+  it('accepts only canonical GitHub pull-request URLs', () => {
+    expect(parsePublishedPullRequest('https://github.com/acme/repo/pull/42')).toEqual({
+      repo: 'acme/repo', number: 42, url: 'https://github.com/acme/repo/pull/42',
+    });
+    expect(parsePublishedPullRequest('https://github.com/acme/repo/issues/42')).toBeNull();
+    expect(parsePublishedPullRequest('https://example.test/acme/repo/pull/42')).toBeNull();
+  });
+
+  it('reviews the published PR once from the repository root', async () => {
+    freshReview.mockResolvedValue({ success: true, iterations: 0, gateRan: true });
+    await expect(reviewPublishedPullRequest({
+      prUrl: 'https://github.com/acme/repo/pull/42', projectPath: '/work/repo',
+    })).resolves.toEqual({ success: true, error: undefined, gateRan: true });
+    expect(freshReview).toHaveBeenCalledWith(
+      expect.objectContaining({ repo: 'acme/repo', number: 42 }),
+      '/work/repo',
+    );
+  });
+});

--- a/src/automation/prPublicationReview.ts
+++ b/src/automation/prPublicationReview.ts
@@ -1,0 +1,53 @@
+// ============================================
+// OpenSwarm — fresh review immediately after PR publication
+// ============================================
+
+import type { DefaultRolesConfig, SecurityAuditConfig } from '../core/types.js';
+import type { PRInfo } from '../github/index.js';
+import { PRProcessor } from './prProcessor.js';
+
+export type PublishedPullRequest = Pick<PRInfo, 'repo' | 'number' | 'url'>;
+
+/** Parse only canonical GitHub pull-request URLs emitted by the publisher. */
+export function parsePublishedPullRequest(prUrl: string): PublishedPullRequest | null {
+  try {
+    const url = new URL(prUrl);
+    if (url.protocol !== 'https:' || url.hostname !== 'github.com') return null;
+    const match = url.pathname.match(/^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/?$/);
+    if (!match) return null;
+    return {
+      repo: `${match[1]}/${match[2]}`,
+      number: Number(match[3]),
+      url: prUrl,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run the expensive agentic review once the diff is a remotely addressable PR.
+ * Worker execution intentionally uses only deterministic guards and verification;
+ * this hook is the PR-time replacement for its former per-attempt LLM reviewer.
+ */
+export async function reviewPublishedPullRequest(input: {
+  prUrl: string;
+  projectPath: string;
+  roles?: DefaultRolesConfig;
+  securityAudit?: SecurityAuditConfig;
+}): Promise<{ success: boolean; error?: string; gateRan?: boolean }> {
+  const pr = parsePublishedPullRequest(input.prUrl);
+  if (!pr) {
+    return { success: false, error: `Unsupported published PR URL: ${input.prUrl}`, gateRan: false };
+  }
+
+  const processor = new PRProcessor({
+    repos: [pr.repo],
+    schedule: '0 0 1 1 *', // This instance is one-shot; its scheduler is never started.
+    maxIterations: 1,
+    roles: input.roles,
+    securityAudit: input.securityAudit,
+  });
+  const result = await processor.freshReview(pr as PRInfo, input.projectPath);
+  return { success: result.success, error: result.error, gateRan: result.gateRan };
+}

--- a/src/automation/publishOnPark.test.ts
+++ b/src/automation/publishOnPark.test.ts
@@ -79,6 +79,36 @@ describe('publication identity (AGT-4145)', () => {
 // vela 2026-09-02: AGT-3844 (48 attempts), AX-868 (23), AGT-4158 (15) — every
 // one a publication-scope rejection of files an EARLIER attempt had already
 // committed, turned into a 15-minute infra retry with a blank ledger message.
+describe('afterPublication hook (per-repository fresh review)', () => {
+  const info = { worktreePath: '/tmp/w', originalPath: '/tmp/r', branchName: 'swarm/AGT-1', issueId: 'AGT-1' };
+  const publishable = { id: 'task-1', issueIdentifier: 'AGT-1', title: 'Hooked' };
+
+  it('runs once, after the publication is durably recorded, with the PR identity', async () => {
+    commitAndCreatePRWithHead.mockResolvedValue({ prUrl: 'https://github.com/o/r/pull/9', headSha: 'head-9' });
+    const calls: string[] = [];
+    const durability = {
+      beforePublish: vi.fn(async () => true),
+      onPublication: vi.fn(async () => { calls.push('recorded'); return true; }),
+    } as unknown as ExecutionDurabilityHooks;
+    const hook = vi.fn(async (p: { prUrl: string; headSha: string }) => { calls.push(`hook:${p.prUrl}:${p.headSha}`); });
+    const result: { success: boolean; finalStatus: string; prUrl?: string } = { success: true, finalStatus: 'approved' };
+
+    await publishApprovedWork(info, publishable, result, durability, hook);
+
+    expect(calls).toEqual(['recorded', 'hook:https://github.com/o/r/pull/9:head-9']);
+    expect(result).toMatchObject({ success: true, finalStatus: 'approved', prUrl: 'https://github.com/o/r/pull/9' });
+  });
+
+  it('keeps the publication a success when the review itself fails', async () => {
+    commitAndCreatePRWithHead.mockResolvedValue({ prUrl: 'https://github.com/o/r/pull/10', headSha: 'head-10' });
+    const result: { success: boolean; finalStatus: string; prUrl?: string } = { success: true, finalStatus: 'approved' };
+
+    await publishApprovedWork(info, publishable, result, undefined, async () => { throw new Error('reviewer adapter down'); });
+
+    expect(result).toMatchObject({ success: true, finalStatus: 'approved', prUrl: 'https://github.com/o/r/pull/10' });
+  });
+});
+
 describe('publication failure classification', () => {
   const info = { worktreePath: '/tmp/w', originalPath: '/tmp/r', branchName: 'swarm/AGT-4158', issueId: 'AGT-4158' };
   const publishable = { id: 'task-1', issueIdentifier: 'AGT-4158', title: 'Artifact cohort producer', fileScope: ['src/vega_plugins/eval/'], fileScopeSource: 'drafted' as const };

--- a/src/automation/publishOnPark.ts
+++ b/src/automation/publishOnPark.ts
@@ -19,6 +19,13 @@ import { commitAndCreatePRWithHead, type WorktreeInfo } from '../support/worktre
 import type { PipelineResult } from '../agents/pairPipelineTypes.js';
 import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
 
+/** Runs once after a reviewed publication succeeded and was durably recorded. */
+export type ApprovedPublicationHook = (publication: {
+  prUrl: string;
+  headSha: string;
+  worktreeInfo: WorktreeInfo;
+}) => Promise<void>;
+
 /** NEEDS_HUMAN code for a branch the publication-scope fence refused. */
 export const PUBLICATION_SCOPE_PARK_REASON = 'publication_scope_mismatch';
 
@@ -222,6 +229,7 @@ export async function publishApprovedWork(
   task: PublishableTask,
   result: PublishableResult & Pick<PipelineResult, 'failureDetail' | 'operatorPark'> & { success?: boolean; finalStatus?: string; prUrl?: string },
   durability: ExecutionDurabilityHooks | undefined,
+  afterPublication?: ApprovedPublicationHook,
 ): Promise<void> {
   // Create PR (worktree mode + pipeline success = finalStatus 'approved')
   if (worktreeInfo && result.success && result.finalStatus === 'approved') {
@@ -254,6 +262,21 @@ export async function publishApprovedWork(
           },
         });
         console.log(`[Runner] PR created for ${task.issueIdentifier}: ${prUrl}`);
+        if (afterPublication) {
+          try {
+            await afterPublication({ prUrl, headSha, worktreeInfo });
+          } catch (reviewError) {
+            // The PR and durable publication record are already real. A review
+            // infrastructure failure must be visible but cannot pretend the
+            // publication never happened or trigger a duplicate PR on retry.
+            const detail = reviewError instanceof Error ? reviewError.message : String(reviewError);
+            console.error(`[Runner] PR-time review failed for ${task.issueIdentifier}:`, reviewError);
+            broadcastEvent({
+              type: 'log',
+              data: { taskId: task.issueId || task.id, stage: 'pr-review', line: `PR-time review failed: ${detail}` },
+            });
+          }
+        }
       } catch (err) {
         console.error('[Worktree] PR creation failed:', err);
         const message = err instanceof Error ? err.message : String(err);

--- a/src/automation/runnerExecution.coverage.test.ts
+++ b/src/automation/runnerExecution.coverage.test.ts
@@ -127,7 +127,7 @@ vi.mock('./runnerState.js', () => ({
 
 // resolveProjectPath / isValidProjectPath dependencies (real versions all read
 // the real filesystem — openswarm.json lookups, directory scans).
-vi.mock('../support/repoMetadata.js', () => ({ loadRepoMetadata }));
+vi.mock('../support/repoMetadata.js', () => ({ loadRepoMetadata, loadPublicationFreshReview: async () => false }));
 vi.mock('../support/projectMapper.js', () => ({ mapLinearProject }));
 vi.mock('fs/promises', () => ({ stat: fsStat }));
 

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -34,7 +34,6 @@ import type { WorktreeInfo } from '../support/worktreeManager.js';
 import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
 import { publishApprovedWork, publishParkedWork, shouldPublishParkedWork } from './publishOnPark.js';
 import { loadPublicationFreshReview, loadRepoMetadata } from '../support/repoMetadata.js';
-import { reviewPublishedPullRequest } from './prPublicationReview.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
 import { applyDraftGates, projectDraftPeers } from './draftGrooming.js';
 import { plannedNewChildren, refuseForChildCap } from './decompositionLimits.js';
@@ -1222,6 +1221,9 @@ export async function executePipeline(
     const freshReview = worktreeInfo ? await loadPublicationFreshReview(worktreeInfo.originalPath) : false;
     await publishApprovedWork(worktreeInfo, task, result, ctx.durability,
       freshReview ? async ({ prUrl, worktreeInfo: publishedWorktree }) => {
+        // Loaded on demand: the review pulls in the whole PR processor, which
+        // only an opted-in repository ever needs.
+        const { reviewPublishedPullRequest } = await import('./prPublicationReview.js');
         const review = await reviewPublishedPullRequest({
           prUrl,
           projectPath: publishedWorktree.originalPath,

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -33,7 +33,8 @@ import {createWorktree, hasRecoverableWorktree, preserveWorktree, removeWorktree
 import type { WorktreeInfo } from '../support/worktreeManager.js';
 import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
 import { publishApprovedWork, publishParkedWork, shouldPublishParkedWork } from './publishOnPark.js';
-import { loadRepoMetadata } from '../support/repoMetadata.js';
+import { loadPublicationFreshReview, loadRepoMetadata } from '../support/repoMetadata.js';
+import { reviewPublishedPullRequest } from './prPublicationReview.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
 import { applyDraftGates, projectDraftPeers } from './draftGrooming.js';
 import { plannedNewChildren, refuseForChildCap } from './decompositionLimits.js';
@@ -1216,7 +1217,24 @@ export async function executePipeline(
       await publishParkedWork(worktreeInfo, task, ctx.durability);
     }
 
-    await publishApprovedWork(worktreeInfo, task, result, ctx.durability);
+    // The repository, not the daemon, decides whether its published PRs get
+    // the agentic fresh review (openswarm.json `publication.freshReview`).
+    const freshReview = worktreeInfo ? await loadPublicationFreshReview(worktreeInfo.originalPath) : false;
+    await publishApprovedWork(worktreeInfo, task, result, ctx.durability,
+      freshReview ? async ({ prUrl, worktreeInfo: publishedWorktree }) => {
+        const review = await reviewPublishedPullRequest({
+          prUrl,
+          projectPath: publishedWorktree.originalPath,
+          roles,
+          securityAudit: ctx.securityAudit,
+        });
+        const status = review.success ? 'approved' : review.gateRan ? 'changes requested' : 'did not run';
+        broadcastEvent({
+          type: 'log',
+          data: { taskId: task.issueId || task.id, stage: 'pr-review', line: `PR-time fresh review ${status}${review.error ? `: ${review.error}` : ''}` },
+        });
+      } : undefined,
+    );
 
     keepWorktree = !(result.success && result.finalStatus === 'approved');
     return result;

--- a/src/support/repoMetadata.test.ts
+++ b/src/support/repoMetadata.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { loadRepoMetadata, saveRepoMetadata, REPO_METADATA_FILENAME, RepoMetadataError } from './repoMetadata.js';
+import { loadPublicationFreshReview, loadRepoMetadata, saveRepoMetadata, REPO_METADATA_FILENAME, RepoMetadataError } from './repoMetadata.js';
 
 describe('loadRepoMetadata', () => {
   let dir: string;
@@ -71,6 +71,25 @@ describe('loadRepoMetadata', () => {
       maxCostUsdPerDay: 5,
       circuitCooldownMinutes: 60,
     });
+  });
+
+  // The PR-time fresh review is a per-repository opt-in (operator decision
+  // 2026-09-02: OpenSwarm itself yes, its target repositories no), and opting
+  // in must not drag the `automation` block's admission defaults along.
+  it('reads the publication fresh-review opt-in without touching automation defaults', async () => {
+    await expect(loadPublicationFreshReview(dir)).resolves.toBe(false);
+
+    writeFileSync(join(dir, REPO_METADATA_FILENAME), JSON.stringify({ schemaVersion: 1, publication: { freshReview: true } }));
+    await expect(loadPublicationFreshReview(dir)).resolves.toBe(true);
+    const meta = await loadRepoMetadata(dir);
+    expect(meta?.publication).toEqual({ freshReview: true });
+    expect(meta?.automation).toBeUndefined();
+
+    writeFileSync(join(dir, REPO_METADATA_FILENAME), JSON.stringify({ schemaVersion: 1, publication: {} }));
+    await expect(loadPublicationFreshReview(dir)).resolves.toBe(false);
+
+    writeFileSync(join(dir, REPO_METADATA_FILENAME), '{ not json');
+    await expect(loadPublicationFreshReview(dir)).resolves.toBe(false);
   });
 
   it('throws RepoMetadataError on invalid JSON', async () => {

--- a/src/support/repoMetadata.ts
+++ b/src/support/repoMetadata.ts
@@ -76,6 +76,21 @@ const RepoMetadataSchema = z.object({
     /** How long an admission circuit remains open before reevaluation. */
     circuitCooldownMinutes: z.number().int().min(1).max(24 * 60).default(60),
   }).optional(),
+  /**
+   * What happens to a pull request the swarm publishes from this repository.
+   * Kept outside `automation` so opting in does not pull that block's
+   * admission defaults (maxConcurrent 1, …) in with it.
+   */
+  publication: z.object({
+    /**
+     * Run the agentic fresh review (`openswarm pr review --fresh`) once, right
+     * after the PR is published. Worker attempts stay on deterministic guards
+     * and verification; this is the only LLM review in the autonomous loop,
+     * and it is per repository — OpenSwarm itself opts in, its target
+     * repositories do not (operator decision, 2026-09-02).
+     */
+    freshReview: z.boolean().default(false),
+  }).optional(),
   /** Free-form notes the swarm should keep in mind. */
   notes: z.string().optional(),
 });
@@ -155,6 +170,17 @@ export async function saveRepoMetadata(repoPath: string, meta: RepoMetadata): Pr
  * a missing/malformed file yields `undefined` (the caller then falls back to an
  * effort-derived or default timeout). Never throws. (INT-2415)
  */
+/** Whether this repository asked for a fresh review after each published PR. */
+export async function loadPublicationFreshReview(repoPath: string): Promise<boolean> {
+  try {
+    return (await loadRepoMetadata(repoPath))?.publication?.freshReview === true;
+  } catch {
+    // An unreadable openswarm.json already warns elsewhere; a review is an
+    // opt-in extra, so an unparseable file means "not opted in".
+    return false;
+  }
+}
+
 export async function loadSandboxBashTimeoutMs(repoPath: string): Promise<number | undefined> {
   try {
     const meta = await loadRepoMetadata(repoPath);


### PR DESCRIPTION
## Why

Worker attempts run only deterministic guards and verification; the one agentic review left in the autonomous loop belongs at PR time, once the diff is a remotely addressable pull request. Which repositories get it is a policy question: the operator decided (2026-09-02) that **OpenSwarm itself** does and its target repositories (vega-*, cgf-portal) do not — so the switch has to be per repository, not the daemon-wide `reviewOnPublication` that vela's config has carried as an unknown key.

## What

- `openswarm.json` gains `publication.freshReview` (default false). Kept **outside** `automation` so opting in does not pull that block's zod defaults (`maxConcurrent: 1`, …) in with it — which would have throttled the repository as a side effect.
- `src/automation/prPublicationReview.ts`: parses the canonical GitHub PR URL and runs `PRProcessor.freshReview` once from the repository root.
- `publishApprovedWork` takes an `afterPublication` hook, invoked only after the publication is durably recorded; a hook failure is logged on the run and never undoes the publication or re-publishes.
- `executePipeline` reads the repo's opt-in at publication time and installs the hook.
- This repository's own `openswarm.json` opts in.
- `docs/DURABLE_AUTONOMY.md` documents the block.

## Verified

- Unit: opt-in read (absent / true / empty block / corrupt file → false), hook ordering (`recorded` → `hook`) and hook failure tolerance, PR URL parsing and one-shot review.
- Full `LC_ALL=C vitest` 5394 pass, typecheck and lint clean. `runnerExecution.ts` 1491 lines.