### PR TITLE
fix(pr): review a published PR with the daemon's configured reviewer adapter, not the scratch checkout's

### DIFF
--- a/src/automation/prProcessor.test.ts
+++ b/src/automation/prProcessor.test.ts
@@ -581,7 +581,7 @@ describe('PRProcessor.freshReview (INT-3282)', () => {
   });
 
   it('reviews inside a scratch worktree at the merge-base, posts the reviewed SHA as a comment, and reports approve as success', async () => {
-    const processor = newProcessor();
+    const processor = newProcessor({ roles: { reviewer: { adapter: 'openrouter' } } } as never);
     const result = await processor.freshReview(pr, '/tmp/proj');
     // gateRan distinguishes a real verdict from a review that produced none, so
     // the caller can exit 2 rather than reporting a rejection. (INT-3914)
@@ -632,6 +632,9 @@ describe('PRProcessor.freshReview (INT-3282)', () => {
         path: expect.stringMatching(scratchDirPattern),
         base: 'mergebasesha123',
         readOnly: true,
+        // The scratch worktree is the reviewed repository, whose config
+        // discovery would otherwise pick that repository's (or no) adapter.
+        adapter: 'openrouter',
       }),
       expect.objectContaining({ saveHistory: expect.any(Function) }),
     );

--- a/src/automation/prProcessor.ts
+++ b/src/automation/prProcessor.ts
@@ -489,6 +489,10 @@ export class PRProcessor {
       const review = await runReviewCommand({
         path: scratchWorktree,
         base: mergeBase,
+        // The scratch checkout is the reviewed repository, not OpenSwarm, so
+        // config discovery there falls back to the unavailable `codex` CLI.
+        // Preserve the daemon's explicitly configured PR reviewer adapter.
+        adapter: this.config.roles?.reviewer?.adapter,
         // The checked-out content is another PR's diff — untrusted the same
         // way review-gate.yml's CI run is (INT-3189). Denying mutating tools,
         // including bash, keeps a malicious PR from using the reviewer's


### PR DESCRIPTION
## Why

`PRProcessor.freshReview` runs the reviewer inside a detached scratch worktree of the *reviewed* repository. Config discovery from that cwd finds that repository's config — or none — and falls back to the `codex` CLI, which the daemon container does not have. The per-repository fresh review (#528) would therefore never run on vela even where a repo opts in.

## What

Pass `this.config.roles?.reviewer?.adapter` to `runReviewCommand` so the review uses the provider the operator configured for the daemon.

## Verified

- `prProcessor.test.ts` asserts the adapter reaches `runReviewCommand` when the processor is built with a reviewer adapter; suite 74/74, typecheck clean.