### PR TITLE
fix(automation): a branch with nothing to publish is the attempt failing, not the infrastructure

### DIFF
--- a/src/automation/publishOnPark.test.ts
+++ b/src/automation/publishOnPark.test.ts
@@ -128,6 +128,16 @@ describe('publication failure classification', () => {
     expect(result.failureDetail).toMatch(/^publication: publication-scope: /);
   });
 
+  it('counts a branch with nothing to publish as the attempt failing, not the infrastructure', async () => {
+    commitAndCreatePRWithHead.mockRejectedValue(new Error('No commits to create PR from - branch has no changes compared to main'));
+    const result: { success: boolean; finalStatus: string; failureDetail?: string; operatorPark?: unknown } = { success: true, finalStatus: 'approved' };
+
+    await publishApprovedWork(info, publishable, result, undefined);
+
+    expect(result).toMatchObject({ success: false, finalStatus: 'failed', failureDetail: expect.stringContaining('No commits to create PR from') });
+    expect(result.operatorPark).toBeUndefined();
+  });
+
   it('keeps every other publication failure a retryable infra error, with the cause recorded', async () => {
     commitAndCreatePRWithHead.mockRejectedValue(new Error('gh: HTTP 502 Bad Gateway'));
     const result: { success: boolean; finalStatus: string; failureDetail?: string; operatorPark?: unknown } = { success: true, finalStatus: 'approved' };

--- a/src/automation/publishOnPark.ts
+++ b/src/automation/publishOnPark.ts
@@ -26,6 +26,9 @@ export type ApprovedPublicationHook = (publication: {
   worktreeInfo: WorktreeInfo;
 }) => Promise<void>;
 
+/** worktreeManager's refusal to open a PR from a branch with nothing on it. */
+const NO_COMMITS_TO_PUBLISH = /No commits to create PR from/;
+
 /** NEEDS_HUMAN code for a branch the publication-scope fence refused. */
 export const PUBLICATION_SCOPE_PARK_REASON = 'publication_scope_mismatch';
 
@@ -292,6 +295,15 @@ export async function publishApprovedWork(
           // backoff forever. Park it for the operator with the file list.
           result.finalStatus = 'failed';
           result.operatorPark = { code: PUBLICATION_SCOPE_PARK_REASON, reason: message };
+        } else if (NO_COMMITS_TO_PUBLISH.test(message)) {
+          // The worker claimed success but left the branch identical to its
+          // base (its only edits were runtime artifacts the stager drops).
+          // That is the attempt failing at its job, not the infrastructure
+          // failing the attempt: count it against the task's retry budget so
+          // a fresh attempt gets its chance and STUCK ends it — instead of the
+          // 15-minute infra backoff that cgf-portal AX-874 rode twice in an
+          // hour on 2026-09-02 with nothing to show.
+          result.finalStatus = 'failed';
         } else {
           result.finalStatus = 'infra_error';
         }


### PR DESCRIPTION
## Why

The worker claimed success but left the branch identical to its base (its only edits were runtime artifacts the publication stager drops), and `commitAndCreatePRWithHead` refused with `No commits to create PR from`. `publishApprovedWork` classified that as `infra_error`, so the run rode the fixed 15-minute infra backoff — cgf-portal AX-874 did it twice in an hour today with nothing to show — instead of counting against the task's retry budget (4) and reaching STUCK.

## What

In the publication catch, a `No commits to create PR from` refusal becomes `finalStatus: 'failed'` (task failure, budgeted, a fresh attempt still gets its chance). Scope rejections still park (#526); everything else stays a retryable `infra_error`. `failureDetail` is recorded in all three cases.

## Verified

- Unit: the refusal → `failed` with detail and no operator park; existing scope-park and infra cases unchanged. Suite 19/19, typecheck clean.