### PR TITLE
fix(worktree): a reopened issue whose PR already merged continues on a fresh branch

### DIFF
--- a/src/automation/runnerExecution.coverage.test.ts
+++ b/src/automation/runnerExecution.coverage.test.ts
@@ -88,6 +88,7 @@ vi.mock('../support/worktreeManager.js', () => ({
   preserveWorktree,
   removeWorktree,
   WorktreeCoordinationError,
+  findPullRequestForBranch: async () => null, removePreservedWorktreeAt: async () => {}, // branch lineage: nothing consumed
 }));
 
 vi.mock('../core/eventHub.js', () => ({ broadcastEvent }));

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -34,6 +34,7 @@ import type { WorktreeInfo } from '../support/worktreeManager.js';
 import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
 import { publishApprovedWork, publishParkedWork, shouldPublishParkedWork } from './publishOnPark.js';
 import { loadPublicationFreshReview, loadRepoMetadata } from '../support/repoMetadata.js';
+import { prepareAttemptBranch } from '../support/branchLineage.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
 import { applyDraftGates, projectDraftPeers } from './draftGrooming.js';
 import { plannedNewChildren, refuseForChildCap } from './decompositionLimits.js';
@@ -893,7 +894,7 @@ export async function executePipeline(
   let keepWorktree = true;
 
   if (ctx.worktreeMode && task.issueId && task.issueIdentifier) {
-    const branchName = buildBranchName(task.issueIdentifier, task.title);
+    const branchName = await prepareAttemptBranch(projectPath, task.issueId, buildBranchName(task.issueIdentifier, task.title));
     try {
       worktreeInfo = await createWorktree(projectPath, task.issueId, branchName);
       actualPath = worktreeInfo.worktreePath;

--- a/src/support/branchLineage.test.ts
+++ b/src/support/branchLineage.test.ts
@@ -1,0 +1,64 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { prepareAttemptBranch, resolveAttemptBranchName } from './branchLineage.js';
+
+// vela cgf-portal 2026-09-02: AX-863's PR #179 merged on 08-30, the card came
+// back to In Progress, and 44 attempts pushed the merged branch name again.
+describe('resolveAttemptBranchName', () => {
+  const base = 'swarm/AX-863-a2-4';
+
+  it('keeps the base name when no pull request exists or the existing one is open', async () => {
+    await expect(resolveAttemptBranchName('/repo', base, async () => null))
+      .resolves.toEqual({ branchName: base, consumedPullRequests: [] });
+    await expect(resolveAttemptBranchName('/repo', base, async () => ({ url: 'u/1', state: 'OPEN' })))
+      .resolves.toEqual({ branchName: base, consumedPullRequests: [] });
+  });
+
+  it('moves past every merged or closed pull request to the first free name', async () => {
+    const seen = new Map<string, { url: string; state: string }>([
+      [base, { url: 'https://github.com/o/r/pull/179', state: 'MERGED' }],
+      [`${base}-r2`, { url: 'https://github.com/o/r/pull/190', state: 'CLOSED' }],
+    ]);
+    const lookup = vi.fn(async (_repo: string, name: string) => seen.get(name) ?? null);
+    await expect(resolveAttemptBranchName('/repo', base, lookup)).resolves.toEqual({
+      branchName: `${base}-r3`,
+      consumedPullRequests: ['https://github.com/o/r/pull/179', 'https://github.com/o/r/pull/190'],
+    });
+    expect(lookup.mock.calls.map((c) => c[1])).toEqual([base, `${base}-r2`, `${base}-r3`]);
+  });
+
+  it('fails open on a GitHub error, keeping the name it could not check', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await expect(resolveAttemptBranchName('/repo', base, async () => { throw new Error('gh: 502'); }))
+      .resolves.toEqual({ branchName: base, consumedPullRequests: [] });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('gh: 502'));
+    warn.mockRestore();
+  });
+});
+
+describe('prepareAttemptBranch', () => {
+  let root = '';
+  afterEach(() => { if (root) rmSync(root, { recursive: true, force: true }); });
+
+  it('retires the preserved worktree only when the name was consumed', async () => {
+    root = mkdtempSync(join(tmpdir(), 'openswarm-lineage-'));
+    const stale = join(root, 'worktree', 'issue-1');
+    mkdirSync(stale, { recursive: true });
+    const retire = vi.fn(async () => {});
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(prepareAttemptBranch(root, 'issue-1', 'swarm/X-1-t', {
+      lookup: async () => null, retire,
+    })).resolves.toBe('swarm/X-1-t');
+    expect(retire).not.toHaveBeenCalled();
+
+    await expect(prepareAttemptBranch(root, 'issue-1', 'swarm/X-1-t', {
+      lookup: async (_r, name) => (name === 'swarm/X-1-t' ? { url: 'u/9', state: 'MERGED' } : null), retire,
+    })).resolves.toBe('swarm/X-1-t-r2');
+    expect(retire).toHaveBeenCalledWith(stale);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('consumed by u/9'));
+    log.mockRestore();
+  });
+});

--- a/src/support/branchLineage.ts
+++ b/src/support/branchLineage.ts
@@ -1,0 +1,85 @@
+// ============================================
+// OpenSwarm - Branch lineage across reopened issues
+// ============================================
+//
+// An issue whose pull request already merged can come back: the operator
+// moves the card to Todo for follow-up work, or redispatches it. The runner
+// used to resume the preserved worktree and push the SAME branch name again —
+// but that branch is consumed. Its commits are already in the base (squashed,
+// under new hashes), the remote branch still exists at the merged head, and
+// `push --force-with-lease` with no lease information is rejected as "stale
+// info". On vela cgf-portal AX-855 reached attempt 64 and AX-863 attempt 44
+// this way (2026-09-02), each attempt paying for a full worker run.
+//
+// Follow-up work therefore starts on a fresh branch name, cut from the base
+// like a first attempt: `<name>-r2`, `-r3`, … The stale preserved worktree is
+// removed (it is reachable from the merged PR); its local branch is left alone.
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { findPullRequestForBranch, removePreservedWorktreeAt } from './worktreeManager.js';
+
+/** Highest follow-up suffix tried before giving up and reusing the last name. */
+const MAX_LINEAGE = 20;
+
+export interface AttemptBranch {
+  branchName: string;
+  /** Pull requests, oldest first, that consumed the earlier names. */
+  consumedPullRequests: string[];
+}
+
+type PullRequestLookup = (repoPath: string, branchName: string) => Promise<{ url: string; state: string } | null>;
+
+/**
+ * Pick the branch this attempt may publish from. A name whose pull request is
+ * MERGED or CLOSED is consumed and the next `-rN` name is tried; an OPEN pull
+ * request (or none) keeps the name, which is the normal resume path. A GitHub
+ * lookup failure keeps the base name — the same fail-open the file-overlap
+ * check uses, and no worse than the previous behaviour.
+ */
+export async function resolveAttemptBranchName(
+  repoPath: string,
+  baseName: string,
+  lookup: PullRequestLookup = findPullRequestForBranch,
+): Promise<AttemptBranch> {
+  const consumed: string[] = [];
+  for (let n = 1; n <= MAX_LINEAGE; n += 1) {
+    const candidate = n === 1 ? baseName : `${baseName}-r${n}`;
+    let pr: { url: string; state: string } | null;
+    try {
+      pr = await lookup(repoPath, candidate);
+    } catch (error) {
+      console.warn(`[Worktree] Could not check pull requests for ${candidate}; keeping it: ${error instanceof Error ? error.message : String(error)}`);
+      return { branchName: candidate, consumedPullRequests: consumed };
+    }
+    if (pr && (pr.state === 'MERGED' || pr.state === 'CLOSED')) {
+      consumed.push(pr.url);
+      continue;
+    }
+    return { branchName: candidate, consumedPullRequests: consumed };
+  }
+  return { branchName: `${baseName}-r${MAX_LINEAGE}`, consumedPullRequests: consumed };
+}
+
+/**
+ * Resolve the branch for an attempt and retire a preserved worktree that still
+ * sits on a consumed name, so `createWorktree` cuts the new branch from the
+ * base instead of throwing "requires reconciliation" over the old tree.
+ */
+export async function prepareAttemptBranch(
+  repoPath: string,
+  issueId: string,
+  baseName: string,
+  deps: { lookup?: PullRequestLookup; retire?: (worktreePath: string) => Promise<void> } = {},
+): Promise<string> {
+  const lineage = await resolveAttemptBranchName(repoPath, baseName, deps.lookup);
+  if (lineage.consumedPullRequests.length > 0) {
+    console.log(
+      `[Worktree] ${baseName} is consumed by ${lineage.consumedPullRequests.join(', ')}; `
+      + `follow-up work continues on ${lineage.branchName}`,
+    );
+    const stale = join(repoPath, 'worktree', issueId);
+    if (existsSync(stale)) await (deps.retire ?? removePreservedWorktreeAt)(stale);
+  }
+  return lineage.branchName;
+}


### PR DESCRIPTION
## Why

An issue can come back after its pull request merged — the operator moves the card to Todo for follow-up work, or redispatches it. The runner resumed the preserved worktree and pushed the **same branch name** again, but that branch is consumed: its commits are already in the base under new squash hashes, the remote branch still sits at the merged head, and `push --force-with-lease` with no lease information is rejected as `stale info`.

vela cgf-portal today: five issues whose PRs merged (#170 #177 #178 #179 #184) sat in exactly this loop — **AX-855 attempt 64, AX-863 attempt 44**, AX-879 16, AX-864 15, AX-854 11 — the five largest attempt counts in the ledger, each attempt a full worker run that produced nothing.

## What

`src/support/branchLineage.ts`: before `createWorktree`, ask GitHub (`findPullRequestForBranch`) whether the branch name's PR is MERGED or CLOSED. If so, retire the stale preserved worktree (`removePreservedWorktreeAt`, ownership-aware; the local branch is left alone) and continue on `<name>-r2` (then `-r3`, …) cut from the base like a first attempt. An OPEN PR or none keeps the name — the normal resume path. A GitHub lookup error keeps the name too (fail-open, same as the file-overlap check).

`runnerExecution.ts` (+3 lines, 1494/1500): `buildBranchName(...)` → `prepareAttemptBranch(projectPath, issueId, buildBranchName(...))`.

## Verified

- Unit: base kept for none/OPEN; walks past MERGED and CLOSED to the first free `-rN`; fails open on a lookup error; retires the stale worktree only when a name was consumed.
- Full `LC_ALL=C vitest` 5400 pass, typecheck and lint clean.