### PR TITLE
fix(worktree): retire a consumed worktree directly — the lease, not marker pids, decides

### DIFF
--- a/src/support/branchLineage.test.ts
+++ b/src/support/branchLineage.test.ts
@@ -1,8 +1,9 @@
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { prepareAttemptBranch, resolveAttemptBranchName } from './branchLineage.js';
+import { prepareAttemptBranch, resolveAttemptBranchName, retireConsumedWorktree } from './branchLineage.js';
 
 // vela cgf-portal 2026-09-02: AX-863's PR #179 merged on 08-30, the card came
 // back to In Progress, and 44 attempts pushed the merged branch name again.
@@ -57,8 +58,37 @@ describe('prepareAttemptBranch', () => {
     await expect(prepareAttemptBranch(root, 'issue-1', 'swarm/X-1-t', {
       lookup: async (_r, name) => (name === 'swarm/X-1-t' ? { url: 'u/9', state: 'MERGED' } : null), retire,
     })).resolves.toBe('swarm/X-1-t-r2');
-    expect(retire).toHaveBeenCalledWith(stale);
+    expect(retire).toHaveBeenCalledWith(root, 'issue-1', stale);
     expect(log).toHaveBeenCalledWith(expect.stringContaining('consumed by u/9'));
+    log.mockRestore();
+  });
+
+  // vela AX-863 attempt 45: the ownership-aware removal kept the tree because a
+  // 2026-08-28 marker named a pid that is alive again in this container, and
+  // createWorktree threw "requires reconciliation". The lease already fences
+  // every other executor, so the retirement must not consult markers at all.
+  it('retires the tree and every marker under the issue regardless of who wrote them', async () => {
+    root = mkdtempSync(join(tmpdir(), 'openswarm-lineage-git-'));
+    const repo = join(root, 'repo');
+    const g = (...args: string[]) => execFileSync('git', ['-C', repo, ...args], { encoding: 'utf8' });
+    execFileSync('git', ['init', '-q', '-b', 'main', repo]);
+    g('config', 'user.email', 't@example.com'); g('config', 'user.name', 'T');
+    writeFileSync(join(repo, 'a.txt'), 'a\n'); g('add', '.'); g('commit', '-qm', 'init');
+    const stale = join(repo, 'worktree', 'issue-9');
+    g('worktree', 'add', '-q', '-b', 'swarm/X-9-t', stale);
+    writeFileSync(join(stale, 'wip.txt'), 'wip\n');
+    const markers = join(repo, '.git', 'openswarm', 'active-worktrees', 'issue-9');
+    mkdirSync(markers, { recursive: true });
+    writeFileSync(join(markers, 'legacy.json'), JSON.stringify({ ownerPid: 1, branchName: 'swarm/X-9-t' }));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await retireConsumedWorktree(repo, 'issue-9', stale);
+
+    expect(existsSync(stale)).toBe(false);
+    expect(existsSync(markers)).toBe(false);
+    expect(g('worktree', 'list')).not.toContain('issue-9');
+    // The consumed branch itself is left for the record.
+    expect(g('branch', '--list', 'swarm/X-9-t').trim()).toContain('swarm/X-9-t');
     log.mockRestore();
   });
 });

--- a/src/support/branchLineage.ts
+++ b/src/support/branchLineage.ts
@@ -12,12 +12,53 @@
 // this way (2026-09-02), each attempt paying for a full worker run.
 //
 // Follow-up work therefore starts on a fresh branch name, cut from the base
-// like a first attempt: `<name>-r2`, `-r3`, … The stale preserved worktree is
-// removed (it is reachable from the merged PR); its local branch is left alone.
+// like a first attempt: `<name>-r2`, `-r3`, … The stale preserved worktree and
+// its markers are removed (the work is reachable from the merged PR); the
+// local branch is left alone.
 
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
-import { findPullRequestForBranch, removePreservedWorktreeAt } from './worktreeManager.js';
+import { execFile } from 'node:child_process';
+import { existsSync, rmSync } from 'node:fs';
+import { isAbsolute, join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { findPullRequestForBranch } from './worktreeManager.js';
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', ['-C', cwd, ...args], { timeout: 5 * 60_000 });
+  return stdout;
+}
+
+/**
+ * Remove a preserved worktree that sits on a consumed branch, plus every
+ * active-worktree marker filed under the issue.
+ *
+ * This deliberately does NOT go through the ownership-aware
+ * `removePreservedWorktreeAt`: that path keeps a tree whenever a marker's pid
+ * looks alive, and markers left by earlier container generations name pids
+ * that are alive again in this one — on vela the 2026-08-28 marker for
+ * AX-863 (ownerPid 7) kept the stale tree, `createWorktree` then threw
+ * "requires reconciliation", and attempt 45 was lost. The caller runs after
+ * the durable claim, so every other executor of this issue is already fenced
+ * out by the lease; the tree's commits live on its local branch and in the
+ * merged PR. Nothing recoverable is at stake.
+ */
+export async function retireConsumedWorktree(repoPath: string, issueId: string, worktreePath: string): Promise<void> {
+  try {
+    await git(repoPath, 'worktree', 'remove', '--force', worktreePath);
+  } catch {
+    rmSync(worktreePath, { recursive: true, force: true });
+  }
+  await git(repoPath, 'worktree', 'prune').catch(() => {});
+  try {
+    const commonRaw = (await git(repoPath, 'rev-parse', '--git-common-dir')).trim();
+    const commonDir = isAbsolute(commonRaw) ? commonRaw : resolve(repoPath, commonRaw);
+    rmSync(join(commonDir, 'openswarm', 'active-worktrees', issueId), { recursive: true, force: true });
+  } catch (error) {
+    console.warn(`[Worktree] Could not clear stale markers for ${issueId}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  console.log(`[Worktree] Retired consumed worktree: ${worktreePath}`);
+}
 
 /** Highest follow-up suffix tried before giving up and reusing the last name. */
 const MAX_LINEAGE = 20;
@@ -70,7 +111,7 @@ export async function prepareAttemptBranch(
   repoPath: string,
   issueId: string,
   baseName: string,
-  deps: { lookup?: PullRequestLookup; retire?: (worktreePath: string) => Promise<void> } = {},
+  deps: { lookup?: PullRequestLookup; retire?: (repoPath: string, issueId: string, worktreePath: string) => Promise<void> } = {},
 ): Promise<string> {
   const lineage = await resolveAttemptBranchName(repoPath, baseName, deps.lookup);
   if (lineage.consumedPullRequests.length > 0) {
@@ -79,7 +120,15 @@ export async function prepareAttemptBranch(
       + `follow-up work continues on ${lineage.branchName}`,
     );
     const stale = join(repoPath, 'worktree', issueId);
-    if (existsSync(stale)) await (deps.retire ?? removePreservedWorktreeAt)(stale);
+    if (existsSync(stale)) {
+      try {
+        await (deps.retire ?? retireConsumedWorktree)(repoPath, issueId, stale);
+      } catch (error) {
+        // createWorktree will refuse the stale tree and the run retries as
+        // infra_error — the same outcome as before, now with the cause logged.
+        console.warn(`[Worktree] Could not retire ${stale}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
   }
   return lineage.branchName;
 }


### PR DESCRIPTION
## Why

#531 picked the fresh `-r2` branch correctly (vela 14:47: `swarm/AX-863-a2-4 is consumed by #179; follow-up work continues on swarm/AX-863-a2-4-r2`) but handed the stale tree to the ownership-aware `removePreservedWorktreeAt`, which keeps a tree whenever a marker's pid looks alive. Markers left by earlier container generations name pids that are alive again in this container (AX-863: a 2026-08-28 marker with `ownerPid: 7`), so the tree stayed, `createWorktree` threw `Preserved worktree requires reconciliation`, and attempt 45 ended as `infra_error`.

## What

`retireConsumedWorktree(repoPath, issueId, worktreePath)`: `git worktree remove --force` (rmSync fallback), `git worktree prune`, and delete `<git-common-dir>/openswarm/active-worktrees/<issueId>` outright. Justification: `prepareAttemptBranch` runs after the durable claim, so every other executor of this issue is fenced out by the lease, and the tree's commits live on its local branch (left alone) and in the merged PR. A retirement failure is logged and falls through to the previous behaviour.

## Verified

- Unit (real git repo): tree gone, marker dir gone, `worktree list` clean, consumed branch kept; existing lineage tests unchanged. runnerExecution coverage suite passes; typecheck/lint clean.