### PR TITLE
fix(automation): back off a superseded run on its supersession streak, not its attempt count

### DIFF
--- a/src/automation/durableRunCoordinator.supersession.test.ts
+++ b/src/automation/durableRunCoordinator.supersession.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { PipelineResult } from '../agents/pairPipeline.js';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import { DurableRunCoordinator } from './durableRunCoordinator.js';
+import { RunLedger } from './runLedger.js';
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+
+function dbPath(): string {
+  const root = mkdtempSync(join(tmpdir(), 'openswarm-supersession-'));
+  roots.push(root);
+  return join(root, 'automation.db');
+}
+
+function task(id: string): TaskItem {
+  return {
+    id, issueId: id, issueIdentifier: id, source: 'linear', title: `Task ${id}`,
+    priority: 2, createdAt: Date.now(), linearState: 'Todo', linearProject: { id: 'project', name: 'Repo' },
+  };
+}
+
+function ended(finalStatus: PipelineResult['finalStatus']): PipelineResult {
+  return { success: false, sessionId: 's', stages: [], finalStatus, totalDuration: 1, iterations: 1 };
+}
+
+// vela 2026-09-02: AGT-4168 had eight earlier attempts of every kind; one
+// sibling PR (the operator's own #612) claiming its files then cost it a
+// six-hour wait, and an explicit redispatch that met the same PR pushed the
+// retry to 20:07. The backoff must count supersessions in a row, not history.
+describe('supersession backoff', () => {
+  it('backs off on the streak of supersessions, ignoring earlier failures of other kinds', async () => {
+    const ledger = new RunLedger(dbPath());
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', ledger });
+    const t = task('sib');
+    let now = 1_000_000;
+
+    for (let i = 0; i < 4; i += 1) {
+      await coordinator.execute(t, '/repo', async () => ended('failed'));
+      ledger.markReady('sib');
+    }
+    await coordinator.execute(t, '/repo', async () => ended('superseded'));
+    expect(ledger.getRun('sib')).toMatchObject({ state: 'RETRY_AT', attemptNo: 5 });
+    now = Date.now();
+    // First supersession → the 5-minute floor, not 5 min × 2^4.
+    expect((ledger.getRun('sib')!.retryAt ?? 0) - now).toBeLessThanOrEqual(5 * 60_000 + 5_000);
+
+    ledger.markReady('sib');
+    await coordinator.execute(t, '/repo', async () => ended('superseded'));
+    // Second in a row → 10 minutes.
+    const second = (ledger.getRun('sib')!.retryAt ?? 0) - Date.now();
+    expect(second).toBeGreaterThan(9 * 60_000);
+    expect(second).toBeLessThanOrEqual(10 * 60_000 + 5_000);
+
+    // A failure of another kind resets the streak.
+    ledger.markReady('sib');
+    await coordinator.execute(t, '/repo', async () => ended('failed'));
+    ledger.markReady('sib');
+    await coordinator.execute(t, '/repo', async () => ended('superseded'));
+    expect((ledger.getRun('sib')!.retryAt ?? 0) - Date.now()).toBeLessThanOrEqual(5 * 60_000 + 5_000);
+
+    coordinator.close();
+    ledger.close();
+  });
+});

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -691,8 +691,10 @@ export class DurableRunCoordinator {
     }
 
     if (result.finalStatus === 'superseded') {
+      // Back off on how many times in a row a sibling has claimed the files,
+      // not on how many attempts of any kind the run has behind it.
       return this.ledger.transition(claim, 'RETRY_AT', {
-        retryAt: retryAtFor(result, now, claim.attemptNo),
+        retryAt: retryAtFor(result, now, this.ledger.consecutiveSupersessions(issueId) + 1),
         errorCode: result.finalStatus,
         eventData: { sessionId: result.sessionId, finalStatus: result.finalStatus },
       }, now) ? result : fencedResult(result);

--- a/src/automation/infraFailureCircuit.ts
+++ b/src/automation/infraFailureCircuit.ts
@@ -53,3 +53,26 @@ export function consecutiveIdenticalInfraFailuresInDb(
   }
   return streak;
 }
+
+/**
+ * Finished attempts, newest first, that ended `superseded` before anything
+ * else. The supersession backoff is keyed on this streak, not on the run's
+ * total attempt number: a run with eight earlier attempts of any kind used to
+ * wait six hours after ONE sibling PR claimed its files, and an explicit
+ * redispatch that hit the same PR only pushed it further out (vela
+ * AGT-3597/4165/3502 → 19:27–20:07 on 2026-09-02).
+ */
+export function consecutiveSupersessionsInDb(db: Database.Database, issueId: string, limit = 32): number {
+  const rows = db.prepare(`
+    SELECT result_status FROM automation_attempts
+    WHERE issue_id = ? AND finished_at IS NOT NULL
+    ORDER BY attempt_no DESC, lease_epoch DESC
+    LIMIT ?
+  `).all(issueId, limit) as Array<{ result_status: string | null }>;
+  let streak = 0;
+  for (const row of rows) {
+    if (row.result_status !== 'superseded') break;
+    streak += 1;
+  }
+  return streak;
+}

--- a/src/automation/runLedger.ts
+++ b/src/automation/runLedger.ts
@@ -15,7 +15,7 @@ import { admitsConflictScope } from './runLedgerScope.js';
 import { migrateAutomationSchema } from './runLedgerSchema.js';
 import { queueIntegrationRequeueInDb } from './runLedgerIntegration.js';
 import { listClaimOwnersInDb } from './runLedgerOwners.js';
-import { consecutiveIdenticalInfraFailuresInDb } from './infraFailureCircuit.js';
+import { consecutiveIdenticalInfraFailuresInDb, consecutiveSupersessionsInDb } from './infraFailureCircuit.js';
 import {
   markNeedsHumanForQuestionsInDb,
   resumeNeedsHumanForQuestionsInDb,
@@ -268,6 +268,11 @@ export class RunLedger {
   /** Finished attempts, newest first, that ended as infra_error with this fingerprint before anything else. */
   consecutiveIdenticalInfraFailures(issueId: string, fingerprint: string): number {
     return consecutiveIdenticalInfraFailuresInDb(this.db, issueId, fingerprint);
+  }
+
+  /** Finished attempts, newest first, that ended superseded before anything else. */
+  consecutiveSupersessions(issueId: string): number {
+    return consecutiveSupersessionsInDb(this.db, issueId);
   }
 
   queueIntegrationRequeue(issueId: string, expectedStateVersion: number, effect: EffectInput, now = Date.now()): boolean {


### PR DESCRIPTION
## Why

`retryAtFor('superseded')` scaled on the run's **attempt number**, so a run with eight earlier attempts of any kind waited six hours after **one** sibling PR claimed its files — and an explicit redispatch that met the same PR pushed the retry further out. vela today: AGT-3597/4165/3502 all yield (correctly) to the operator's own PRs vega-agent#612 / vega-plugins#35, and after my redispatch their retries moved to 19:27–20:07. When those PRs merge, the follow-up should run within minutes, not hours.

## What

- `consecutiveSupersessionsInDb` (next to the infra-failure streak): finished attempts, newest first, that ended `superseded` before anything else.
- `RunLedger.consecutiveSupersessions`; the coordinator passes `streak + 1` to `retryAtFor` for a superseded result. Backoff: 5 min for the first supersession, doubling while a sibling keeps claiming the files (6 h cap unchanged), reset by any other outcome.

## Verified

- New coordinator test: four `failed` attempts then a supersession → 5-minute floor (was 80 min); second in a row → 10 min; a `failed` in between resets to 5 min. Existing `retryAtFor` unit tests unchanged.
- Full `LC_ALL=C vitest` pass, typecheck/lint clean. `runLedger.ts` 1493/1500.