### PR TITLE
feat(verify): discover Python projects one level below a monorepo root

### DIFF
--- a/src/verify/discover.test.ts
+++ b/src/verify/discover.test.ts
@@ -91,6 +91,39 @@ describe('discoverVerifyCommands', () => {
     expect((await discoverVerifyCommands(withoutRuff)).map((c) => c.name)).toEqual(['pytest']);
   });
 
+  // cgf-portal (2026-09-02): pyproject with pytest config at apps/pipelines,
+  // nothing at the root. Discovery found nothing, the deterministic tester never
+  // ran, and all 113 attempts that day fell through to the LLM tester.
+  it('looks one level into workspace directories when the root has no Python project', async () => {
+    const root = await fixture({
+      'apps/pipelines/pyproject.toml': '[tool.pytest.ini_options]\ntestpaths = ["tests"]\n',
+      'apps/web/package.json': '{}',
+      'packages/shared/pyproject.toml': '[project]\nname = "shared"\n',
+      '.venv/bin/python': '#!/bin/sh\n',
+      '.venv/bin/ruff': '#!/bin/sh\n',
+    });
+    expect(await discoverVerifyCommands(root)).toEqual([
+      { name: 'pytest:apps/pipelines', run: '../../.venv/bin/python -m pytest -x -q', kind: 'test', timeoutMs: 300_000, cwd: 'apps/pipelines' },
+      { name: 'ruff:apps/pipelines', run: '../../.venv/bin/ruff check .', kind: 'lint', timeoutMs: 300_000, cwd: 'apps/pipelines' },
+    ]);
+  });
+
+  it('prefers a subproject virtualenv and stays at the root when the root is a Python project', async () => {
+    const nested = await fixture({
+      'apps/api/pytest.ini': '[pytest]\n',
+      'apps/api/.venv/bin/python': '#!/bin/sh\n',
+    });
+    expect(await discoverVerifyCommands(nested)).toEqual([
+      { name: 'pytest:apps/api', run: './.venv/bin/python -m pytest -x -q', kind: 'test', timeoutMs: 300_000, cwd: 'apps/api' },
+    ]);
+
+    const rootProject = await fixture({
+      'pytest.ini': '[pytest]\n',
+      'apps/api/pytest.ini': '[pytest]\n',
+    });
+    expect((await discoverVerifyCommands(rootProject)).map((c) => c.name)).toEqual(['pytest']);
+  });
+
   it('serializes an explicitly configured xdist pytest run for stable base comparison', async () => {
     const root = await fixture({
       'pytest.ini': '[pytest]\naddopts = --tb=short -n auto --dist loadgroup\n',

--- a/src/verify/discover.ts
+++ b/src/verify/discover.ts
@@ -1,5 +1,5 @@
-import { access, readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { access, readdir, readFile } from 'node:fs/promises';
+import { join, relative, sep } from 'node:path';
 import type { VerifyCommand } from './manifest.js';
 
 const DEFAULT_TIMEOUT_MS = 300_000;
@@ -23,24 +23,74 @@ async function readText(path: string): Promise<string | null> {
   }
 }
 
-async function pythonCommand(projectPath: string): Promise<string> {
+/**
+ * The interpreter a command run from `subdir` should use: the subproject's own
+ * virtualenv first, else the repository's (reached by a relative path, so the
+ * command stays valid inside the companion sandbox), else PATH.
+ */
+async function pythonCommand(projectPath: string, subdir = ''): Promise<string> {
   const candidates = process.platform === 'win32'
     ? ['.venv-verify/Scripts/python.exe', '.venv/Scripts/python.exe', 'venv/Scripts/python.exe']
     : ['.venv-verify/bin/python', '.venv/bin/python', 'venv/bin/python'];
-  for (const candidate of candidates) {
-    if (await exists(join(projectPath, candidate))) return `./${candidate}`;
-  }
-  return 'python';
+  return (await toolFromVenv(projectPath, subdir, candidates)) ?? 'python';
 }
 
-async function ruffCommand(projectPath: string): Promise<string | undefined> {
+async function toolFromVenv(projectPath: string, subdir: string, candidates: string[]): Promise<string | undefined> {
+  for (const base of subdir ? [subdir, ''] : ['']) {
+    for (const candidate of candidates) {
+      if (await exists(join(projectPath, base, candidate))) {
+        const fromCwd = relative(join(projectPath, subdir), join(projectPath, base, candidate)).split(sep).join('/');
+        return fromCwd.startsWith('../') ? fromCwd : `./${fromCwd}`;
+      }
+    }
+  }
+  return undefined;
+}
+
+async function ruffCommand(projectPath: string, subdir = ''): Promise<string | undefined> {
   const candidates = process.platform === 'win32'
     ? ['.venv-verify/Scripts/ruff.exe', '.venv/Scripts/ruff.exe', 'venv/Scripts/ruff.exe']
     : ['.venv-verify/bin/ruff', '.venv/bin/ruff', 'venv/bin/ruff'];
-  for (const candidate of candidates) {
-    if (await exists(join(projectPath, candidate))) return `./${candidate}`;
+  return toolFromVenv(projectPath, subdir, candidates);
+}
+
+/** pytest (and a repository-installed ruff) for one Python project at `subdir` ('' = repository root). */
+async function discoverPythonCommands(projectPath: string, subdir: string): Promise<VerifyCommand[]> {
+  const dir = join(projectPath, subdir);
+  const commands: VerifyCommand[] = [];
+  const label = subdir ? `:${subdir.split(sep).join('/')}` : '';
+  const cwd = subdir ? { cwd: subdir.split(sep).join('/') } : {};
+
+  // Python: require an explicit pytest configuration signal.
+  const pytestIni = await exists(join(dir, 'pytest.ini'));
+  const pyproject = await readText(join(dir, 'pyproject.toml'));
+  const setupCfg = await readText(join(dir, 'setup.cfg'));
+  if (pytestIni || pyproject?.includes('[tool.pytest.ini_options]') || setupCfg?.includes('[tool:pytest]')) {
+    // Baseline comparison uses -x. If a repository's config enables xdist,
+    // parallel scheduling can make base and HEAD stop at different *existing*
+    // failures and turn deterministic verification into a false regression.
+    // Override only an explicitly configured xdist worker count; generic pytest
+    // environments that do not install xdist must not receive an unknown -n flag.
+    const pytestConfig = [
+      pytestIni ? await readText(join(dir, 'pytest.ini')) : null,
+      pyproject,
+      setupCfg,
+    ].filter((value): value is string => value !== null).join('\n');
+    const serialXdist = /(?:^|\s)-n(?:\s|=)/m.test(pytestConfig) ? ' -n 0' : '';
+    commands.push({ ...command(`pytest${label}`, `${await pythonCommand(projectPath, subdir)} -m pytest${serialXdist} -x -q`, 'test'), ...cwd });
   }
-  return undefined;
+
+  // Python lint: only a repository-installed ruff, so an unknown tool is never
+  // introduced and the repository's own ruff config (or ruff's default rule
+  // set, which includes pyflakes F-rules) applies. vega-agent#608 shipped an
+  // undefined name (F821) and 63 pyflakes errors past a green pytest run;
+  // the repository's CI runs `ruff check` and rejected it on arrival.
+  // Only alongside a pytest project: a bare virtualenv with ruff in it (a
+  // monorepo root, say) is not a Python project of its own.
+  if (commands.length === 0) return commands;
+  const ruff = await ruffCommand(projectPath, subdir);
+  if (ruff) commands.push({ ...command(`ruff${label}`, `${ruff} check .`, 'lint'), ...cwd });
+  return commands;
 }
 
 function command(name: string, run: string, kind: VerifyCommand['kind']): VerifyCommand {
@@ -80,32 +130,30 @@ export async function discoverVerifyCommands(projectPath: string): Promise<Verif
     commands.push(command('test', 'npm run test', 'test'));
   }
 
-  // Python: require an explicit pytest configuration signal.
-  const pytestIni = await exists(join(projectPath, 'pytest.ini'));
-  const pyproject = await readText(join(projectPath, 'pyproject.toml'));
-  const setupCfg = await readText(join(projectPath, 'setup.cfg'));
-  if (pytestIni || pyproject?.includes('[tool.pytest.ini_options]') || setupCfg?.includes('[tool:pytest]')) {
-    // Baseline comparison uses -x. If a repository's config enables xdist,
-    // parallel scheduling can make base and HEAD stop at different *existing*
-    // failures and turn deterministic verification into a false regression.
-    // Override only an explicitly configured xdist worker count; generic pytest
-    // environments that do not install xdist must not receive an unknown -n flag.
-    const pytestConfig = [
-      pytestIni ? await readText(join(projectPath, 'pytest.ini')) : null,
-      pyproject,
-      setupCfg,
-    ].filter((value): value is string => value !== null).join('\n');
-    const serialXdist = /(?:^|\s)-n(?:\s|=)/m.test(pytestConfig) ? ' -n 0' : '';
-    commands.push(command('pytest', `${await pythonCommand(projectPath)} -m pytest${serialXdist} -x -q`, 'test'));
-  }
+  const python = await discoverPythonCommands(projectPath, '');
+  commands.push(...python);
 
-  // Python lint: only a repository-installed ruff, so an unknown tool is never
-  // introduced and the repository's own ruff config (or ruff's default rule
-  // set, which includes pyflakes F-rules) applies. vega-agent#608 shipped an
-  // undefined name (F821) and 63 pyflakes errors past a green pytest run;
-  // the repository's CI runs `ruff check` and rejected it on arrival.
-  const ruff = await ruffCommand(projectPath);
-  if (ruff) commands.push(command('ruff', `${ruff} check .`, 'lint'));
+  // A monorepo keeps its Python packages one level down (cgf-portal:
+  // apps/pipelines/pyproject.toml, nothing at the root). Root-only discovery
+  // found nothing there, so the deterministic tester never ran and every one
+  // of its 113 attempts on 2026-09-02 fell back to the LLM tester — a six
+  // minute timeout at worst, no pytest at best. Look one level into the
+  // conventional workspace directories when the root itself is silent.
+  if (python.length === 0) {
+    for (const parent of ['apps', 'packages', 'services', 'libs']) {
+      let entries: string[];
+      try {
+        entries = (await readdir(join(projectPath, parent), { withFileTypes: true }))
+          .filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        throw error;
+      }
+      for (const name of entries) {
+        commands.push(...await discoverPythonCommands(projectPath, join(parent, name)));
+      }
+    }
+  }
 
   // Rust repositories use Cargo's native test runner.
   if (await exists(join(projectPath, 'Cargo.toml'))) {


### PR DESCRIPTION
## Why

cgf-portal keeps its Python package at `apps/pipelines/pyproject.toml` with nothing at the repository root. Root-only discovery found no command, so the deterministic tester returned nothing and **every one of the repository's 113 attempts today fell through to the LLM tester** — no pytest gate at best, a six-minute OpenRouter timeout at worst (AX-863 attempt 47, 15:52–15:58: `tester: openrouter timeout after 360000ms`).

## What

When the root has no Python project, look one level into `apps/`, `packages/`, `services/`, `libs/` for a pytest signal (pytest.ini / `[tool.pytest.ini_options]` / `[tool:pytest]`) and emit the commands with that subdirectory as `cwd` (already supported by `VerifyCommand` and the runner). The interpreter and ruff resolve from the subproject's own virtualenv first, else the repository's by a relative path (`../../.venv/bin/python`) so the command stays valid inside the companion sandbox. ruff is added only next to a pytest project — a bare root virtualenv with ruff in it is not a project of its own (this also makes the existing "after pytest, and only then" test literally true).

Root Python projects are unchanged: a root pytest signal keeps discovery at the root.

## Verified

- Unit: monorepo fixture → `pytest:apps/pipelines` + `ruff:apps/pipelines` with `cwd`, relative venv paths; subproject venv preferred; root project unchanged; existing discover/runner/deterministicTester suites pass.
- Full `LC_ALL=C vitest` pass, typecheck/lint clean.