### PR TITLE
feat(worker): tell a reopened issue's worker what was already delivered

### DIFF
--- a/src/agents/workerContext.ts
+++ b/src/agents/workerContext.ts
@@ -20,6 +20,9 @@ export async function collectWorkerContext(
     // would have passed.
     const enforcedScope = enforcedFileScope(context.task);
     if (enforcedScope) wc.fileScope = enforcedScope;
+    // cgf-portal#211 (2026-09-02): an issue whose PR had merged came back, the
+    // worker found nothing left to do and "improved" an unrelated dev script.
+    if (context.task.priorDeliveries?.length) wc.priorDeliveries = [...context.task.priorDeliveries];
     if (draft) {
       wc.draftAnalysis = { taskType: draft.taskType, intentSummary: draft.intentSummary, relevantFiles: draft.relevantFiles,
         suggestedApproach: draft.suggestedApproach, projectStats: draft.projectStats, completionCriteria: draft.completionCriteria, sufficient: draft.sufficient };
@@ -54,6 +57,6 @@ export async function collectWorkerContext(
     // it changes what the worker knows, not what it is allowed to do. (AGT-4088)
     const siblingWork = await collectSiblingWork(context.projectPath);
     if (siblingWork.length) { wc.siblingWork = siblingWork; safeConsole.log(`[Pipeline] ${siblingWork.length} sibling worktree(s) have uncommitted changes`); }
-    return wc.fileScope || wc.impactAnalysis || wc.registryBriefs || wc.draftAnalysis || wc.repoMemories || wc.siblingWork ? wc : undefined;
+    return wc.fileScope || wc.priorDeliveries || wc.impactAnalysis || wc.registryBriefs || wc.draftAnalysis || wc.repoMemories || wc.siblingWork ? wc : undefined;
   } catch (error) { safeConsole.warn('[Pipeline] Worker context collection failed (non-blocking):', error); return undefined; }
 }

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -894,7 +894,9 @@ export async function executePipeline(
   let keepWorktree = true;
 
   if (ctx.worktreeMode && task.issueId && task.issueIdentifier) {
-    const branchName = await prepareAttemptBranch(projectPath, task.issueId, buildBranchName(task.issueIdentifier, task.title));
+    const lineage = await prepareAttemptBranch(projectPath, task.issueId, buildBranchName(task.issueIdentifier, task.title));
+    const branchName = lineage.branchName;
+    if (lineage.consumedPullRequests.length > 0) task.priorDeliveries = lineage.consumedPullRequests;
     try {
       worktreeInfo = await createWorktree(projectPath, task.issueId, branchName);
       actualPath = worktreeInfo.worktreePath;

--- a/src/locale/prompts/en.ts
+++ b/src/locale/prompts/en.ts
@@ -104,8 +104,14 @@ Apply the above feedback and make corrections.
 
     // Code context section (repository + draftAnalysis + impactAnalysis + registryBriefs + repoMemories)
     let contextSection = '';
-    if (context?.fileScope?.length || context?.repository || context?.draftAnalysis || context?.impactAnalysis || context?.registryBriefs?.length || context?.repoMemories?.length || context?.siblingWork?.length) {
+    if (context?.fileScope?.length || context?.priorDeliveries?.length || context?.repository || context?.draftAnalysis || context?.impactAnalysis || context?.registryBriefs?.length || context?.repoMemories?.length || context?.siblingWork?.length) {
       const parts: string[] = ['## Code Context (auto-generated)'];
+
+      if (context.priorDeliveries?.length) {
+        parts.push('', '### Prior Deliveries (binding)');
+        parts.push('The following pull request(s) for this issue were already merged or closed before this attempt. This attempt exists only because the issue was reopened. Do only what the issue\'s latest description and comments still ask for; do not re-implement, restyle, or "improve" delivered work. If nothing remains, make no edits and finish with status done and a noChangesReason naming the delivery.');
+        parts.push(promptDataBlock(context.priorDeliveries.join('\n')));
+      }
 
       if (context.fileScope?.length) {
         parts.push('', '### Allowed Edit Boundary (binding)');

--- a/src/locale/prompts/ko.ts
+++ b/src/locale/prompts/ko.ts
@@ -104,8 +104,14 @@ ${promptDataBlock(previousFeedback)}
 
     // Code context section (repository + draftAnalysis + impactAnalysis + registryBriefs + repoMemories)
     let contextSection = '';
-    if (context?.fileScope?.length || context?.repository || context?.draftAnalysis || context?.impactAnalysis || context?.registryBriefs?.length || context?.repoMemories?.length || context?.siblingWork?.length) {
+    if (context?.fileScope?.length || context?.priorDeliveries?.length || context?.repository || context?.draftAnalysis || context?.impactAnalysis || context?.registryBriefs?.length || context?.repoMemories?.length || context?.siblingWork?.length) {
       const parts: string[] = ['## 코드 컨텍스트 (자동 생성)'];
+
+      if (context.priorDeliveries?.length) {
+        parts.push('', '### 이전 납품 (구속력 있음)');
+        parts.push('이 이슈에 대한 아래 PR은 이번 시도 전에 이미 머지되거나 닫혔다. 이번 시도는 이슈가 다시 열렸기 때문에 존재한다. 이슈의 최신 설명과 코멘트가 아직 요구하는 것만 하고, 이미 납품된 작업을 다시 구현하거나 고쳐 쓰거나 "개선"하지 마라. 남은 것이 없으면 아무것도 편집하지 말고 status done과 그 납품을 지목하는 noChangesReason으로 끝내라.');
+        parts.push(promptDataBlock(context.priorDeliveries.join('\n')));
+      }
 
       if (context.fileScope?.length) {
         parts.push('', '### 허용 편집 경계 (구속력 있음)');

--- a/src/locale/prompts/prompts.test.ts
+++ b/src/locale/prompts/prompts.test.ts
@@ -49,6 +49,20 @@ describe('buildWorkerPrompt', () => {
     expect(result).toContain('tests/router.test.ts');
   });
 
+  // cgf-portal#211 (2026-09-02): the issue's PR #179 had merged, the card came
+  // back, and the worker "improved" an unrelated dev script for lack of work.
+  it('names prior deliveries and tells the worker to stop when nothing remains', () => {
+    for (const [prompts, heading] of [[enPrompts, 'Prior Deliveries (binding)'], [koPrompts, '이전 납품 (구속력 있음)']] as const) {
+      const result = prompts.buildWorkerPrompt({
+        ...base,
+        context: { priorDeliveries: ['https://github.com/o/r/pull/179'] },
+      });
+      expect(result).toContain(heading);
+      expect(result).toContain('https://github.com/o/r/pull/179');
+      expect(result).toContain('noChangesReason');
+    }
+  });
+
   it('returns string containing task title and description', () => {
     const result = enPrompts.buildWorkerPrompt(base);
     expect(result).toContain('Fix login bug');

--- a/src/locale/types.ts
+++ b/src/locale/types.ts
@@ -463,6 +463,11 @@ export interface WorkerContext {
    */
   fileScope?: string[];
   /**
+   * Pull requests already merged or closed for this issue. The attempt exists
+   * because the issue was reopened; the worker must not redo delivered work.
+   */
+  priorDeliveries?: string[];
+  /**
    * What the repository's other worktrees are editing right now, so a worker
    * can see an overlap before its branch collides with theirs at integration.
    */

--- a/src/orchestration/decisionEngine.ts
+++ b/src/orchestration/decisionEngine.ts
@@ -66,6 +66,12 @@ export interface TaskItem {
   fileScope?: string[];    // Reserved repository-relative write scope for admission/execution/publication
   /** Provenance of the reserved write boundary (legacy `inferred` stays advisory). */
   fileScopeSource?: 'declared' | 'validated-direct' | 'drafted' | 'inferred';
+  /**
+   * Pull requests already MERGED or CLOSED for this issue before this attempt
+   * (branch lineage). Rendered to the worker so a reopened issue does not
+   * get re-implemented — or worse, "improved" with unrelated edits.
+   */
+  priorDeliveries?: string[];
   /** Sufficient pre-admission draft reused by the execution pipeline. */
   preAdmissionDraft?: import('../agents/draftAnalyzer.js').DraftAnalysis;
   /** Tracker comments already appended before the pre-admission draft. */

--- a/src/support/branchLineage.test.ts
+++ b/src/support/branchLineage.test.ts
@@ -52,12 +52,12 @@ describe('prepareAttemptBranch', () => {
 
     await expect(prepareAttemptBranch(root, 'issue-1', 'swarm/X-1-t', {
       lookup: async () => null, retire,
-    })).resolves.toBe('swarm/X-1-t');
+    })).resolves.toEqual({ branchName: 'swarm/X-1-t', consumedPullRequests: [] });
     expect(retire).not.toHaveBeenCalled();
 
     await expect(prepareAttemptBranch(root, 'issue-1', 'swarm/X-1-t', {
       lookup: async (_r, name) => (name === 'swarm/X-1-t' ? { url: 'u/9', state: 'MERGED' } : null), retire,
-    })).resolves.toBe('swarm/X-1-t-r2');
+    })).resolves.toEqual({ branchName: 'swarm/X-1-t-r2', consumedPullRequests: ['u/9'] });
     expect(retire).toHaveBeenCalledWith(root, 'issue-1', stale);
     expect(log).toHaveBeenCalledWith(expect.stringContaining('consumed by u/9'));
     log.mockRestore();

--- a/src/support/branchLineage.ts
+++ b/src/support/branchLineage.ts
@@ -112,7 +112,7 @@ export async function prepareAttemptBranch(
   issueId: string,
   baseName: string,
   deps: { lookup?: PullRequestLookup; retire?: (repoPath: string, issueId: string, worktreePath: string) => Promise<void> } = {},
-): Promise<string> {
+): Promise<AttemptBranch> {
   const lineage = await resolveAttemptBranchName(repoPath, baseName, deps.lookup);
   if (lineage.consumedPullRequests.length > 0) {
     console.log(
@@ -130,5 +130,5 @@ export async function prepareAttemptBranch(
       }
     }
   }
-  return lineage.branchName;
+  return lineage;
 }


### PR DESCRIPTION
## Why

cgf-portal#211 today: AX-863's PR #179 had merged on 08-30, the card came back, #531/#532 correctly cut the fresh `-r2` branch — and the worker, finding nothing left to do, rewrote `scripts/dev/link-local-assets.sh`: it deleted the "never link `.venv`" warning block and dropped four env links (`apps/pipelines/.env`, `apps/portal/.env`, `.dev.vars`, `infra/n8n/.env`). The daemon even knew (`1 other PR(s) already close AX-863 — opening as draft`), but the worker did not.

## What

- `prepareAttemptBranch` returns the lineage; `executePipeline` stamps `task.priorDeliveries` with the consumed PR URLs (+2 lines, runnerExecution 1496/1500).
- `WorkerContext.priorDeliveries` → a binding **Prior Deliveries** section in the en/ko worker prompts: do only what the issue's latest description and comments still ask for; never re-implement, restyle or "improve" delivered work; if nothing remains, make no edits and finish `done` with a `noChangesReason` naming the delivery (the existing no-changes contract).

## Verified

- Prompt tests (en/ko) assert the section, the PR URL and the `noChangesReason` instruction; lineage tests updated for the richer return; workerContext / runnerExecution suites pass. Full `LC_ALL=C vitest` pass, typecheck/lint clean.