### PR TITLE
fix(verify): skip a subproject pytest whose virtualenv cannot run pytest

### DIFF
--- a/src/verify/discover.test.ts
+++ b/src/verify/discover.test.ts
@@ -100,6 +100,7 @@ describe('discoverVerifyCommands', () => {
       'apps/web/package.json': '{}',
       'packages/shared/pyproject.toml': '[project]\nname = "shared"\n',
       '.venv/bin/python': '#!/bin/sh\n',
+      '.venv/bin/pytest': '#!/bin/sh\n',
       '.venv/bin/ruff': '#!/bin/sh\n',
     });
     expect(await discoverVerifyCommands(root)).toEqual([
@@ -112,6 +113,7 @@ describe('discoverVerifyCommands', () => {
     const nested = await fixture({
       'apps/api/pytest.ini': '[pytest]\n',
       'apps/api/.venv/bin/python': '#!/bin/sh\n',
+      'apps/api/.venv/bin/pytest': '#!/bin/sh\n',
     });
     expect(await discoverVerifyCommands(nested)).toEqual([
       { name: 'pytest:apps/api', run: './.venv/bin/python -m pytest -x -q', kind: 'test', timeoutMs: 300_000, cwd: 'apps/api' },
@@ -122,6 +124,18 @@ describe('discoverVerifyCommands', () => {
       'apps/api/pytest.ini': '[pytest]\n',
     });
     expect((await discoverVerifyCommands(rootProject)).map((c) => c.name)).toEqual(['pytest']);
+  });
+
+  // cgf-portal's root .venv holds only an interpreter; running `python -m pytest`
+  // with it fails identically on base and head, which the runner treats as a
+  // pre-existing environment failure — a green tester with zero tests run.
+  it('emits no subproject pytest when the chosen virtualenv cannot run pytest', async () => {
+    const root = await fixture({
+      'apps/pipelines/pyproject.toml': '[tool.pytest.ini_options]\n',
+      '.venv/bin/python': '#!/bin/sh\n',
+      '.venv/bin/ruff': '#!/bin/sh\n',
+    });
+    expect(await discoverVerifyCommands(root)).toEqual([]);
   });
 
   it('serializes an explicitly configured xdist pytest run for stable base comparison', async () => {

--- a/src/verify/discover.ts
+++ b/src/verify/discover.ts
@@ -1,5 +1,5 @@
 import { access, readdir, readFile } from 'node:fs/promises';
-import { join, relative, sep } from 'node:path';
+import { dirname, join, relative, sep } from 'node:path';
 import type { VerifyCommand } from './manifest.js';
 
 const DEFAULT_TIMEOUT_MS = 300_000;
@@ -33,6 +33,23 @@ async function pythonCommand(projectPath: string, subdir = ''): Promise<string> 
     ? ['.venv-verify/Scripts/python.exe', '.venv/Scripts/python.exe', 'venv/Scripts/python.exe']
     : ['.venv-verify/bin/python', '.venv/bin/python', 'venv/bin/python'];
   return (await toolFromVenv(projectPath, subdir, candidates)) ?? 'python';
+}
+
+/**
+ * Whether the interpreter `pythonCommand` chose can actually run pytest. A
+ * virtualenv without pytest makes BOTH the base and the head run fail with
+ * the same ModuleNotFoundError, which the runner rightly reads as a
+ * pre-existing environment failure — and the tester then passes without a
+ * single test having run. cgf-portal's root `.venv` holds only an
+ * interpreter (its packages live in apps/pipelines/.venv), so the monorepo
+ * command from #534 would have gone green that way. Unknown for a PATH
+ * interpreter, which keeps the root behaviour unchanged.
+ */
+async function interpreterHasPytest(projectPath: string, subdir: string, python: string): Promise<boolean> {
+  if (!python.startsWith('.')) return true;
+  const bin = dirname(join(projectPath, subdir, python));
+  return exists(join(bin, process.platform === 'win32' ? 'pytest.exe' : 'pytest'))
+    || exists(join(bin, process.platform === 'win32' ? 'py.test.exe' : 'py.test'));
 }
 
 async function toolFromVenv(projectPath: string, subdir: string, candidates: string[]): Promise<string | undefined> {
@@ -77,7 +94,10 @@ async function discoverPythonCommands(projectPath: string, subdir: string): Prom
       setupCfg,
     ].filter((value): value is string => value !== null).join('\n');
     const serialXdist = /(?:^|\s)-n(?:\s|=)/m.test(pytestConfig) ? ' -n 0' : '';
-    commands.push({ ...command(`pytest${label}`, `${await pythonCommand(projectPath, subdir)} -m pytest${serialXdist} -x -q`, 'test'), ...cwd });
+    const python = await pythonCommand(projectPath, subdir);
+    if (!subdir || await interpreterHasPytest(projectPath, subdir, python)) {
+      commands.push({ ...command(`pytest${label}`, `${python} -m pytest${serialXdist} -x -q`, 'test'), ...cwd });
+    }
   }
 
   // Python lint: only a repository-installed ruff, so an unknown tool is never


### PR DESCRIPTION
## Summary
- #534 taught discovery to look one level into `apps/|packages/|services/|libs/` and fall back to the root virtualenv. On cgf-portal that root `.venv` holds only an interpreter (packages live in `apps/pipelines/.venv`), so `../../.venv/bin/python -m pytest` fails with `No module named pytest` on **both** base and head.
- `runner.ts` classifies that as a pre-existing environment failure (`newFailure: false`), and `deterministicTester` then reports success — a green verify with zero tests run.
- Discovery now checks that the chosen venv actually has a `pytest` entry point before emitting a subproject pytest command (and, transitively, its ruff). Root-project behaviour and the PATH-interpreter fallback are unchanged.

## Test plan
- [x] `src/verify/discover.test.ts`: new case — root `.venv` with python+ruff but no pytest ⇒ `[]`; existing monorepo fixtures gained `.venv/bin/pytest`
- [x] `npm run typecheck`, `npm run lint`, `LC_ALL=C npx vitest run src/verify/` (139 passed)