### PR TITLE
fix(publish): park a worker's explicit no-changes verdict for the operator

### DIFF
--- a/src/agents/worker.gitAuthority.test.ts
+++ b/src/agents/worker.gitAuthority.test.ts
@@ -39,6 +39,24 @@ describe('runWorker Git authority (INT-2609)', () => {
     expect(result.error).toContain('no changed files');
   });
 
+  it('keeps a zero-diff success that carries a noChangesReason, and says so in the log', async () => {
+    getChangedFilesSinceSnapshot.mockResolvedValue([]);
+    parseWorkerOutput.mockReturnValue({
+      success: true, summary: 'Nothing to do', filesChanged: [], commands: [], output: 'looked',
+      noChangesReason: 'ledger.py already splits settlement tags',
+    });
+    const lines: string[] = [];
+
+    const result = await runWorker({
+      taskTitle: 'split settlement tags', taskDescription: 'AX-874',
+      projectPath: '/repo', adapterName: 'gpt', onLog: (line) => { lines.push(line); },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.noChangesReason).toBe('ledger.py already splits settlement tags');
+    expect(lines).toContain('[Worker] Finished without edits: ledger.py already splits settlement tags');
+  });
+
   it('fails when the Git diff escapes planner fileScope', async () => {
     getChangedFilesSinceSnapshot.mockResolvedValue([
       'kyte_cli/core/exec_tools.py', 'worktree/other/web_tools.py',

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -478,9 +478,16 @@ export async function runWorker(options: WorkerOptions): Promise<WorkerResult> {
         emitWorkerStatus(options, formatWorkerGitChangeStatus([]));
       }
 
-      if (parsedResult.success && parsedResult.filesChanged.length === 0 && !parsedResult.noChangesReason?.trim()) {
-        parsedResult.success = false;
-        parsedResult.error = 'Worker reported success with no changed files and no explicit noChangesReason.';
+      if (parsedResult.success && parsedResult.filesChanged.length === 0) {
+        const noChangesReason = parsedResult.noChangesReason?.trim();
+        if (noChangesReason) {
+          // Say it in the log: publication will refuse the empty branch and
+          // the run parks on this sentence, so it must be findable there.
+          emitWorkerStatus(options, `[Worker] Finished without edits: ${noChangesReason.slice(0, 500)}`);
+        } else {
+          parsedResult.success = false;
+          parsedResult.error = 'Worker reported success with no changed files and no explicit noChangesReason.';
+        }
       }
     }
 

--- a/src/automation/publishOnPark.test.ts
+++ b/src/automation/publishOnPark.test.ts
@@ -6,7 +6,7 @@ vi.mock('../support/worktreeManager.js', () => ({ commitAndCreatePRWithHead }));
 vi.mock('../core/eventHub.js', () => ({ broadcastEvent: vi.fn() }));
 
 import { PublicationScopeMismatchError } from '../support/publicationScopeFence.js';
-import { PUBLICATION_SCOPE_PARK_REASON, publishApprovedWork, publishStuckWork, shouldPublishParkedWork } from './publishOnPark.js';
+import { PUBLICATION_SCOPE_PARK_REASON, WORKER_NO_CHANGES_PARK_REASON, publishApprovedWork, publishStuckWork, shouldPublishParkedWork } from './publishOnPark.js';
 
 beforeEach(() => {
   commitAndCreatePRWithHead.mockReset();
@@ -136,6 +136,28 @@ describe('publication failure classification', () => {
 
     expect(result).toMatchObject({ success: false, finalStatus: 'failed', failureDetail: expect.stringContaining('No commits to create PR from') });
     expect(result.operatorPark).toBeUndefined();
+  });
+
+  // cgf-portal AX-874, 2026-09-02: four consecutive attempts ended "No commits"
+  // and were counted as failures; the worker's own noChangesReason never
+  // reached the ledger, the Linear comment, or the operator.
+  it('parks a worker that finished with an explicit noChangesReason and nothing to publish', async () => {
+    commitAndCreatePRWithHead.mockRejectedValue(new Error('No commits to create PR from - branch has no changes compared to main'));
+    const result: { success: boolean; finalStatus: string; failureDetail?: string; operatorPark?: { code: string; reason: string }; workerResult?: { noChangesReason?: string } } = {
+      success: true,
+      finalStatus: 'approved',
+      workerResult: { noChangesReason: 'settlement tags are already split in ledger.py' },
+    };
+
+    await publishApprovedWork(info, publishable, result, undefined);
+
+    expect(result.success).toBe(false);
+    expect(result.finalStatus).toBe('failed');
+    expect(result.operatorPark).toEqual({
+      code: WORKER_NO_CHANGES_PARK_REASON,
+      reason: 'Worker finished without edits: settlement tags are already split in ledger.py',
+    });
+    expect(result.failureDetail).toBe('publication: No commits to create PR from - branch has no changes compared to main — worker: settlement tags are already split in ledger.py');
   });
 
   it('keeps every other publication failure a retryable infra error, with the cause recorded', async () => {

--- a/src/automation/publishOnPark.ts
+++ b/src/automation/publishOnPark.ts
@@ -32,12 +32,18 @@ const NO_COMMITS_TO_PUBLISH = /No commits to create PR from/;
 /** NEEDS_HUMAN code for a branch the publication-scope fence refused. */
 export const PUBLICATION_SCOPE_PARK_REASON = 'publication_scope_mismatch';
 
+/**
+ * NEEDS_HUMAN code for a worker that finished with an explicit
+ * `noChangesReason` on a branch that then had nothing to publish.
+ */
+export const WORKER_NO_CHANGES_PARK_REASON = 'worker_no_changes';
+
 /** The fields these paths read; narrower than the full pipeline result. */
 interface PublishableResult {
   success?: boolean;
   finalStatus?: string;
   prUrl?: string;
-  workerResult?: { executionOutcomeUnknown?: boolean };
+  workerResult?: { executionOutcomeUnknown?: boolean; noChangesReason?: string };
 }
 
 /** The fields these paths read off the task. */
@@ -296,14 +302,25 @@ export async function publishApprovedWork(
           result.finalStatus = 'failed';
           result.operatorPark = { code: PUBLICATION_SCOPE_PARK_REASON, reason: message };
         } else if (NO_COMMITS_TO_PUBLISH.test(message)) {
-          // The worker claimed success but left the branch identical to its
-          // base (its only edits were runtime artifacts the stager drops).
-          // That is the attempt failing at its job, not the infrastructure
-          // failing the attempt: count it against the task's retry budget so
-          // a fresh attempt gets its chance and STUCK ends it — instead of the
-          // 15-minute infra backoff that cgf-portal AX-874 rode twice in an
-          // hour on 2026-09-02 with nothing to show.
           result.finalStatus = 'failed';
+          const noChangesReason = result.workerResult?.noChangesReason?.trim();
+          if (noChangesReason) {
+            // The worker looked and said, in so many words, that the issue
+            // needs no edit. Re-running the same question is not a retry, it
+            // is the same answer at the same price (cgf-portal AX-874 gave it
+            // four times in a row on 2026-09-02, 921k tokens each, and the
+            // operator never saw a word of it: the ledger only said "No
+            // commits"). Park with the worker's statement so the operator can
+            // close the issue or send it back with what the worker missed.
+            result.failureDetail = `publication: ${message} — worker: ${noChangesReason}`;
+            result.operatorPark = { code: WORKER_NO_CHANGES_PARK_REASON, reason: `Worker finished without edits: ${noChangesReason}` };
+          }
+          // Otherwise the worker claimed edits that were only runtime
+          // artifacts the stager drops. That is the attempt failing at its
+          // job, not the infrastructure failing the attempt: count it against
+          // the task's retry budget so a fresh attempt gets its chance and
+          // STUCK ends it — instead of the 15-minute infra backoff that
+          // cgf-portal AX-874 rode twice in an hour on 2026-09-02.
         } else {
           result.finalStatus = 'infra_error';
         }


### PR DESCRIPTION
## Summary
- cgf-portal AX-874 (2026-09-02, attempts 50–53): the worker finished with `success: true`, zero files and a `noChangesReason`; publication then hit "No commits to create PR from", which #530 rightly counts as the attempt failing — but the run was re-asked the same question four times (921k tokens each), and neither the ledger, the Linear comment, nor the log carried a word of what the worker had said.
- When the branch has nothing to publish **and** the worker gave an explicit `noChangesReason`, park the run for the operator (`operatorPark.code = 'worker_no_changes'`, reason = the worker's statement). The coordinator already turns `operatorPark` into NEEDS_HUMAN and the runner's failed handler posts the reason to Linear (#526/#527), so the operator can close the issue or send it back with what was missed.
- `failureDetail` now carries the worker's reason as well (`publication: No commits… — worker: …`), and `runWorker` logs `[Worker] Finished without edits: …` at the stage where the run stops.
- A zero-diff result *without* a reason is unchanged: still `failed`, still on the retry budget.

## Test plan
- [x] `publishOnPark.test.ts`: new case — no-commits + `workerResult.noChangesReason` ⇒ `failed` + `operatorPark { worker_no_changes }` + reason in `failureDetail`; existing no-reason case still has no park
- [x] `worker.gitAuthority.test.ts`: zero-diff success with a reason stays successful and emits the log line
- [x] `npm run typecheck`, `npm run lint`, `LC_ALL=C npx vitest run src/automation src/agents/worker` (877 passed)