### PR TITLE
fix(pipeline): park a stuck loop of empty worker results for the operator

### DIFF
--- a/src/agents/agentPair.ts
+++ b/src/agents/agentPair.ts
@@ -44,6 +44,9 @@ export interface WorkerResult {
   executionOutcomeUnknown?: boolean; // sandbox command may have partially mutated; quarantine, do not retry
   operatorQuestionCorrelationIds?: string[]; // exact durable questions that stopped this attempt
   noChangesReason?: string;     // Explicit justification for a successful no-edit outcome
+  /** Claimed success, changed nothing, and gave no noChangesReason — a contract
+   *  violation the caller cannot tell apart from "nothing to do" (AX-868). */
+  zeroDiffWithoutReason?: boolean;
   uncertaintySignals?: string[]; // Detected uncertainty phrases
   costInfo?: CostInfo;
 }

--- a/src/agents/pairPipeline.coverage.test.ts
+++ b/src/agents/pairPipeline.coverage.test.ts
@@ -389,6 +389,49 @@ describe('PairPipeline coverage extension', () => {
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Same error repeated'));
   });
 
+  // cgf-portal AX-868 reached attempt 27 and AGT-3844 attempt 53 on 2026-09-02
+  // this way: the worker claimed success, changed nothing, gave no reason, and
+  // the run was re-asked the same question at ~900k tokens a time.
+  it('parks a stuck loop of empty worker results for the operator instead of leaving it retryable', async () => {
+    runWorker.mockResolvedValue({
+      success: false,
+      summary: 'nothing',
+      filesChanged: [],
+      commands: [],
+      output: '',
+      zeroDiffWithoutReason: true,
+      error: 'Worker reported success with no changed files and no explicit noChangesReason.',
+    });
+
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker'],
+      maxIterations: 4,
+      roles: { worker: { enabled: true, timeoutMs: 0 } },
+    });
+
+    const result = await pipeline.run(task(), process.cwd());
+
+    expect(result.failureSignal).toBe('stuck');
+    expect(result.operatorPark).toEqual({
+      code: 'worker_no_changes',
+      reason: expect.stringContaining('without changing a file'),
+    });
+  });
+
+  it('leaves an ordinary stuck loop retryable — only the empty-worker contract parks', async () => {
+    runWorker.mockRejectedValue(new Error('the config loader keeps failing the same schema validation check'));
+
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({
+      stages: ['worker'],
+      maxIterations: 4,
+      roles: { worker: { enabled: true, timeoutMs: 0 } },
+    });
+
+    expect((await pipeline.run(task(), process.cwd())).operatorPark).toBeUndefined();
+  });
+
   // ============================================
   // Pipeline guards (blocking vs non-blocking)
   // ============================================

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -40,6 +40,7 @@ import type {
   PipelineRunMetadata,
   StageResult,
 } from './pairPipelineTypes.js';
+import { WORKER_NO_CHANGES_PARK_REASON } from './pairPipelineTypes.js';
 import * as reviewerAgent from './reviewer.js';
 import * as testerAgent from './tester.js';
 import * as documenterAgent from './documenter.js';
@@ -1287,6 +1288,18 @@ export class PairPipeline extends EventEmitter {
       failureSignal: context.stuckReason ? 'stuck'
         : context.guardsResult?.results.some(r => r.blocking && !r.passed) || context.testerResult?.success === false ? 'gate-fail' : undefined,
       stuckReason: context.stuckReason,
+      // The session stopped because the worker claimed success, changed
+      // nothing and gave no reason — three times, across a model escalation
+      // and a fresh context. A new attempt runs the same prompt into the same
+      // silence: cgf-portal AX-868 reached attempt 27 and AGT-3844 attempt 53
+      // that way on 2026-09-02, each attempt ~900k tokens, and the operator
+      // was never told the agent had produced nothing at all.
+      operatorPark: context.stuckReason && context.workerResult?.zeroDiffWithoutReason
+        ? {
+          code: WORKER_NO_CHANGES_PARK_REASON,
+          reason: `Worker claimed success without changing a file and without a noChangesReason (${context.stuckReason.toLowerCase()}). The issue needs a human: either it asks for something the agent cannot express as a diff, or its description does not say what to change.`,
+        }
+        : undefined,
       totalDuration: Date.now() - startTime,
       iterations: context.currentIteration,
       workerResult: context.workerResult,

--- a/src/agents/pairPipelineTypes.ts
+++ b/src/agents/pairPipelineTypes.ts
@@ -135,6 +135,15 @@ export interface PipelineResult {
   operatorPark?: { code: string; reason: string };
 }
 
+/**
+ * NEEDS_HUMAN code for a worker that delivered no edits — either with an
+ * explicit `noChangesReason` (publication then has nothing to open a PR from)
+ * or by repeating the empty-result contract violation until the session gave
+ * up. Both mean the same thing to an operator: the agent will not produce a
+ * diff for this issue as written.
+ */
+export const WORKER_NO_CHANGES_PARK_REASON = 'worker_no_changes';
+
 export interface PipelineContext {
   task: TaskItem;
   projectPath: string;

--- a/src/agents/worker.gitAuthority.test.ts
+++ b/src/agents/worker.gitAuthority.test.ts
@@ -37,6 +37,9 @@ describe('runWorker Git authority (INT-2609)', () => {
     expect(result.success).toBe(false);
     expect(result.filesChanged).toEqual([]);
     expect(result.error).toContain('no changed files');
+    // The pipeline parks a session that repeats this outcome; it needs to tell
+    // it apart from every other worker failure.
+    expect(result.zeroDiffWithoutReason).toBe(true);
   });
 
   it('keeps a zero-diff success that carries a noChangesReason, and says so in the log', async () => {

--- a/src/agents/worker.ts
+++ b/src/agents/worker.ts
@@ -486,6 +486,7 @@ export async function runWorker(options: WorkerOptions): Promise<WorkerResult> {
           emitWorkerStatus(options, `[Worker] Finished without edits: ${noChangesReason.slice(0, 500)}`);
         } else {
           parsedResult.success = false;
+          parsedResult.zeroDiffWithoutReason = true;
           parsedResult.error = 'Worker reported success with no changed files and no explicit noChangesReason.';
         }
       }

--- a/src/automation/publishOnPark.ts
+++ b/src/automation/publishOnPark.ts
@@ -17,6 +17,8 @@ import { enforcedFileScope, type FileScopeSource } from '../orchestration/writeS
 import { PublicationScopeMismatchError } from '../support/publicationScopeFence.js';
 import { commitAndCreatePRWithHead, type WorktreeInfo } from '../support/worktreeManager.js';
 import type { PipelineResult } from '../agents/pairPipelineTypes.js';
+import { WORKER_NO_CHANGES_PARK_REASON } from '../agents/pairPipelineTypes.js';
+
 import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
 
 /** Runs once after a reviewed publication succeeded and was durably recorded. */
@@ -32,11 +34,7 @@ const NO_COMMITS_TO_PUBLISH = /No commits to create PR from/;
 /** NEEDS_HUMAN code for a branch the publication-scope fence refused. */
 export const PUBLICATION_SCOPE_PARK_REASON = 'publication_scope_mismatch';
 
-/**
- * NEEDS_HUMAN code for a worker that finished with an explicit
- * `noChangesReason` on a branch that then had nothing to publish.
- */
-export const WORKER_NO_CHANGES_PARK_REASON = 'worker_no_changes';
+export { WORKER_NO_CHANGES_PARK_REASON } from '../agents/pairPipelineTypes.js';
 
 /** The fields these paths read; narrower than the full pipeline result. */
 interface PublishableResult {


### PR DESCRIPTION
## Summary
- Top failure bucket on vela in the last 24h (20 attempts): `Worker reported success with no changed files and no explicit noChangesReason.` The session retries it 3× (model escalation → fresh context → StuckDetector), the attempt then fails into the retry budget, and the next attempt asks the same question again — cgf-portal AX-868 is at attempt 27, AGT-3844 at attempt 53, ~900k tokens each, with nothing in the ledger or Linear telling the operator the agent produced no diff at all.
- `WorkerResult.zeroDiffWithoutReason` marks that exact contract violation (set where worker.ts already rejects the result), and `PairPipeline` parks the session under `operatorPark { code: 'worker_no_changes' }` when it is what made the run stuck. The coordinator turns that into NEEDS_HUMAN and the runner posts the reason to the tracker (#526/#527), so the run stops instead of re-buying the same silence.
- Reuses the code #537 introduced for the publication-side variant (worker gave a reason, branch had nothing to publish); the constant now lives in `pairPipelineTypes.ts` and `publishOnPark` re-exports it.
- Every other stuck loop (a real repeated error) is untouched and still retryable.

## Test plan
- [x] `pairPipeline.coverage.test.ts`: empty-worker stuck loop ⇒ `failureSignal: 'stuck'` + `operatorPark { worker_no_changes }`; ordinary stuck loop ⇒ no park
- [x] `worker.gitAuthority.test.ts`: the rejected zero-diff result carries the flag
- [x] `npm run typecheck`, `npm run lint`, `LC_ALL=C npx vitest run src/agents src/automation` (1527 passed)