### PR TITLE
feat(ledger): record what re-admitted a parked run

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -1138,7 +1138,7 @@ export class AutonomousRunner {
         const isSandboxOutcomeQuarantine = durableRun.lastErrorCode === SANDBOX_OUTCOME_UNKNOWN_PARK_REASON;
         if (isSandboxOutcomeQuarantine) {
           if (task.explicitDispatch === true) {
-            const resumed = this.durableRuns.resumeNeedsHuman(id);
+            const resumed = this.durableRuns.resumeNeedsHuman(id, Date.now(), 'sandbox_quarantine_dispatch');
             if (resumed) durableRun = this.durableRuns.getRun(id);
           }
           if (durableRun?.state === 'NEEDS_HUMAN') return false;
@@ -1178,8 +1178,13 @@ export class AutonomousRunner {
         if (operatorReopened || legacyQuestionAnswered || isExactOperatorQuestionPark) {
           const resumed = isExactOperatorQuestionPark
             ? this.durableRuns.resumeNeedsHumanForQuestions(id)
-            : this.durableRuns.resumeNeedsHuman(id);
+            : this.durableRuns.resumeNeedsHuman(id, Date.now(), task.explicitDispatch === true ? 'explicit_dispatch' : 'tracker_todo');
           if (resumed) {
+            // Say it out loud: a park is meant to hold until a person acts, so
+            // every re-admission is either that person or a leak.
+            if (!isExactOperatorQuestionPark) {
+              console.log(`[Scheduler] ${task.issueIdentifier ?? id} resumed from NEEDS_HUMAN (${task.explicitDispatch === true ? 'explicit dispatch' : `tracker state ${task.linearState}`}), parked under ${durableRun.lastErrorCode ?? 'unknown'}`);
+            }
             durableRun = this.durableRuns.getRun(id);
             if (resumed === 'SYNC_PENDING') this.scheduleNextHeartbeat();
           }

--- a/src/automation/durableRunCoordinator.operatorPark.test.ts
+++ b/src/automation/durableRunCoordinator.operatorPark.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -38,7 +39,8 @@ function task(id: string): TaskItem {
 // operator's; the coordinator must park it rather than schedule it again.
 describe('DurableRunCoordinator operatorPark', () => {
   it('parks immediately under the pipeline\'s own operator code, before any circuit', async () => {
-    const ledger = new RunLedger(dbPath());
+    const ledgerPath = dbPath();
+    const ledger = new RunLedger(ledgerPath);
     const coordinator = new DurableRunCoordinator({ mode: 'primary', ledger, infraFailureCircuit: 6 });
     const reason = 'publication-scope: branch contains files outside reserved write scope: uv.lock';
     const parked: PipelineResult = {
@@ -60,7 +62,13 @@ describe('DurableRunCoordinator operatorPark', () => {
       lastErrorMessage: reason,
     });
     // An explicit redispatch after the operator widens the scope resumes it.
-    expect(ledger.resumeNeedsHuman('scope')).toBe('READY');
+    expect(ledger.resumeNeedsHuman('scope', Date.now(), 'tracker_todo')).toBe('READY');
+    // The trace has to name what re-admitted a park, or an unattended resume
+    // looks exactly like an operator (cgf-portal AX-874, 2026-09-02 18:25).
+    const resumed = new Database(ledgerPath)
+      .prepare("SELECT data_json FROM automation_events WHERE issue_id = 'scope' AND kind = 'operator_resumed' ORDER BY sequence DESC LIMIT 1")
+      .get() as { data_json: string } | undefined;
+    expect(JSON.parse(resumed?.data_json ?? '{}')).toMatchObject({ trigger: 'tracker_todo', parkedUnder: 'publication_scope_mismatch' });
     coordinator.close();
     ledger.close();
   });

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -14,6 +14,7 @@ import {
   type RunClaim,
   type RunLedgerMode,
   type RunRecord,
+  type ParkResumeTrigger,
   type RunState,
   type TrackerStateObservation,
 } from './runLedger.js';
@@ -422,8 +423,8 @@ export class DurableRunCoordinator {
     return this.ledger?.markNeedsHumanForQuestions(issueId, correlationIds, reason, now) ?? false;
   }
 
-  resumeNeedsHuman(issueId: string, now = Date.now()): RunState | null {
-    return this.ledger?.resumeNeedsHuman(issueId, now) ?? null;
+  resumeNeedsHuman(issueId: string, now = Date.now(), trigger: ParkResumeTrigger = 'unspecified'): RunState | null {
+    return this.ledger?.resumeNeedsHuman(issueId, now, trigger) ?? null;
   }
 
   resumeNeedsHumanForQuestions(issueId: string, now = Date.now()): RunState | null {

--- a/src/automation/runLedger.ts
+++ b/src/automation/runLedger.ts
@@ -43,6 +43,7 @@ import type {
   IntegrationReservationClaim,
   IntegrationReservationOptions,
   LedgerMetrics,
+  ParkResumeTrigger,
   RegisterRunInput,
   RunClaim,
   RunLedgerOptions,
@@ -65,6 +66,7 @@ export type {
   IntegrationReservationClaim,
   IntegrationReservationOptions,
   LedgerMetrics,
+  ParkResumeTrigger,
   RegisterRunInput,
   RunClaim,
   RunLedgerMode,
@@ -377,7 +379,8 @@ export class RunLedger {
 
   /** Explicit operator recovery from NEEDS_HUMAN. A dead external effect resumes
    * synchronization; only implementation failures return to READY. */
-  resumeNeedsHuman(issueId: string, now = Date.now()): RunState | null {
+  /** @param trigger What re-admitted the run; see ParkResumeTrigger. */
+  resumeNeedsHuman(issueId: string, now = Date.now(), trigger: ParkResumeTrigger = 'unspecified'): RunState | null {
     const resume = this.db.transaction((): RunState | null => {
       const row = this.db.prepare('SELECT * FROM automation_runs WHERE issue_id = ?').get(issueId) as RunRow | undefined;
       if (!row || row.state !== 'NEEDS_HUMAN') return null;
@@ -409,6 +412,8 @@ export class RunLedger {
       if (updated.changes !== 1) return null;
       this.insertEvent(issueId, row.attempt_no, 'operator_resumed', 'NEEDS_HUMAN', to, {
         deadEffectsReset: deadEffects,
+        trigger,
+        parkedUnder: row.last_error_code ?? undefined,
       }, now);
       return to;
     });

--- a/src/automation/runLedgerTypes.ts
+++ b/src/automation/runLedgerTypes.ts
@@ -253,3 +253,14 @@ export const NON_FAILURE_RESULT_STATUSES: readonly string[] = [
   'operator_remediated',
   'waiting_on_operator',
 ];
+
+/**
+ * What re-admitted a NEEDS_HUMAN run. `tracker_todo` is an operator moving the
+ * card back; `explicit_dispatch` is the board or the `work` CLI; `unspecified`
+ * means a caller that has not been taught to say. Stored on the
+ * `operator_resumed` event: a park is supposed to hold until a person acts, so
+ * every re-admission is either that person or a leak — and when cgf-portal
+ * AX-874 left NEEDS_HUMAN unattended at 18:25 on 2026-09-02, the trace could
+ * only say that it had happened.
+ */
+export type ParkResumeTrigger = 'explicit_dispatch' | 'tracker_todo' | 'sandbox_quarantine_dispatch' | 'unspecified';


### PR DESCRIPTION
## Summary
- cgf-portal AX-874 was parked NEEDS_HUMAN at 16:50 (2026-09-02) after four failed attempts, and at 18:25 it was back in READY and running attempt 54 — with no operator involved. The `operator_resumed` event carried only `{deadEffectsReset: 0}`, so the trace could not say whether a person had dispatched it, the tracker card had moved to Todo, or something else re-admitted it.
- `resumeNeedsHuman` now takes a `ParkResumeTrigger` and stores it on the event together with the code the run was parked under; the heartbeat passes `explicit_dispatch` / `tracker_todo` (and `sandbox_quarantine_dispatch` for the quarantine branch) and logs the re-admission with the card state it read.
- No behaviour change to when a park resumes — this is the missing evidence for judging whether parks hold, which is what #526/#537/#538 all depend on.

## Test plan
- [x] `durableRunCoordinator.operatorPark.test.ts`: after a scope park, a `tracker_todo` resume writes `{trigger, parkedUnder}` on the event
- [x] `npm run typecheck`, `npm run lint`, `LC_ALL=C npx vitest run src/automation` (769 passed)