### PR TITLE
fix(worktree): credit a resumed branch's committed work to the worker

### DIFF
--- a/src/support/worktreeManager.test.ts
+++ b/src/support/worktreeManager.test.ts
@@ -376,6 +376,32 @@ describe('preserveWorktree → createWorktree resume roundtrip (INT-2503)', () =
     expect(() => git(repo, 'show', 'swarm/INT-9-test:pytest-of-openswarm/pytest-1/current')).toThrow();
   });
 
+  // vega-agent AGT-3844 sat on five task commits at attempt 53, cgf-portal
+  // AX-868 on six at attempt 27, and neither ever opened a PR: the resumed
+  // worker made no new edit (the work was done), saw an empty file list, and
+  // failed the zero-diff contract before publication looked at the branch.
+  it('credits committed task work from earlier attempts when nothing is preserved as WIP', async () => {
+    const originBare = join(root, 'origin-resume.git');
+    execFileSync('git', ['init', '--bare', '-b', 'main', originBare], { stdio: 'pipe' });
+    git(repo, 'remote', 'remove', 'origin');
+    git(repo, 'remote', 'add', 'origin', originBare);
+    git(repo, 'push', '-u', 'origin', 'main');
+
+    const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-committed');
+    writeFileSync(join(info.worktreePath, 'app.py'), 'base\ndelivered\n');
+    writeFileSync(join(info.worktreePath, 'helper.py'), 'delivered\n');
+    git(info.worktreePath, 'add', '-A');
+    git(info.worktreePath, 'commit', '--no-verify', '-m', 'feat(INT-9): deliver the fix');
+    // Only runtime leftovers are dirty — exactly what a resumed vela worktree
+    // looks like once its delivery has been committed.
+    writeFileSync(join(info.worktreePath, '.venv'), 'runtime-link-placeholder\n');
+    await preserveWorktree(info, 'session did not succeed');
+
+    const resumed = await createWorktree(repo, 'INT-9', 'swarm/INT-9-committed');
+
+    expect(resumed.resumedTaskFiles?.sort()).toEqual(['app.py', 'helper.py']);
+  });
+
   it('purges runtime artifacts that a legacy WIP commit already tracked on resume', async () => {
     const info = await createWorktree(repo, 'INT-9', 'swarm/INT-9-test');
     writeFileSync(join(info.worktreePath, 'app.py'), 'base\nlegacy-partial\n');

--- a/src/support/worktreeManager.ts
+++ b/src/support/worktreeManager.ts
@@ -7,7 +7,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
-import { isEphemeralWorktreeArtifact } from './worktreeEphemeral.js';
+import { getResumedTaskFiles } from './worktreeResumeFiles.js';
 import { stagePreservableWorktreeChanges, purgeTrackedEphemeralArtifacts } from './worktreeEphemeralOps.js';
 import { getInstanceId } from './healthEndpoint.js';
 import { readyReusedPullRequest } from './pullRequestReady.js';
@@ -81,31 +81,6 @@ export interface WorktreeInfo {
   resumedTaskFiles?: string[];
 }
 
-async function getPreservedTaskFiles(worktreePath: string): Promise<string[]> {
-  const log = await git(worktreePath, 'log', '--format=%H%x09%s', '-n', '100').catch(() => '');
-  const commits = log.split('\n').filter(Boolean).map((line) => {
-    const tab = line.indexOf('\t');
-    return { hash: line.slice(0, tab), subject: line.slice(tab + 1) };
-  });
-  // Artifact-purge commits are an internal continuation of the same WIP
-  // checkpoint. Treating them as a new base would make the actual source diff
-  // disappear on the next resume.
-  const isPreservedWip = (subject: string): boolean =>
-    subject.startsWith('wip: preserved partial work')
-    || subject === 'wip: remove ephemeral runtime artifacts (auto)';
-  let preservedCount = 0;
-  while (commits[preservedCount] && isPreservedWip(commits[preservedCount].subject)) preservedCount += 1;
-  if (preservedCount === 0) return [];
-
-  const base = commits[preservedCount]?.hash;
-  const diffArgs = base
-    ? ['diff', '--name-only', base, 'HEAD']
-    : ['diff-tree', '--root', '--no-commit-id', '--name-only', '-r', 'HEAD'];
-  const files = await git(worktreePath, ...diffArgs);
-  return [...new Set(files.split('\n').filter((file) =>
-    file && file !== PRESERVE_MARKER && !isEphemeralWorktreeArtifact(file)
-  ))];
-}
 
 /** Runtime ownership metadata must never be published in a task branch/PR. */
 async function stripRuntimeMarkerFromGit(worktreePath: string): Promise<void> {
@@ -812,7 +787,7 @@ export async function createWorktree(
       await purgeTrackedEphemeralArtifacts(worktreePath);
       const resumed: WorktreeInfo = {
         worktreePath, branchName, originalPath: repoPath, issueId,
-        resumedTaskFiles: await getPreservedTaskFiles(worktreePath),
+        resumedTaskFiles: await getResumedTaskFiles(worktreePath),
       };
       resumed.activeMarkerToken = await writeActiveWorktreeMarker(resumed);
       try {
@@ -847,7 +822,7 @@ export async function createWorktree(
     await purgeTrackedEphemeralArtifacts(worktreePath);
     const resumed: WorktreeInfo = {
       worktreePath, branchName, originalPath: repoPath, issueId,
-      resumedTaskFiles: await getPreservedTaskFiles(worktreePath),
+      resumedTaskFiles: await getResumedTaskFiles(worktreePath),
     };
     resumed.activeMarkerToken = await writeActiveWorktreeMarker(resumed);
     await linkSharedPaths(repoPath, worktreePath);
@@ -881,7 +856,7 @@ export async function createWorktree(
 
   const info: WorktreeInfo = {
     worktreePath, branchName, originalPath: repoPath, issueId,
-    resumedTaskFiles: branchExists ? await getPreservedTaskFiles(worktreePath) : undefined,
+    resumedTaskFiles: branchExists ? await getResumedTaskFiles(worktreePath) : undefined,
   };
   if (branchExists) await purgeTrackedEphemeralArtifacts(worktreePath);
   // Written before dependency setup or worker invocation. A crash anywhere after

--- a/src/support/worktreeResumeFiles.ts
+++ b/src/support/worktreeResumeFiles.ts
@@ -1,0 +1,70 @@
+// ============================================
+// OpenSwarm - Resumed worktree file attribution
+// ============================================
+//
+// Which files a resumed worktree should hand back to the worker as "work this
+// task has already done". Split out of worktreeManager.ts, which sits at the
+// repository's 1500-line file cap.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { isEphemeralWorktreeArtifact } from './worktreeEphemeral.js';
+import { resolveBaseRef } from './worktreeManager.js';
+
+const execFileAsync = promisify(execFile);
+const GIT_TIMEOUT_MS = 60_000;
+const PRESERVE_MARKER = '.openswarm-preserved';
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', ['-C', cwd, ...args], { timeout: GIT_TIMEOUT_MS });
+  return stdout;
+}
+
+async function getPreservedTaskFiles(worktreePath: string): Promise<string[]> {
+  const log = await git(worktreePath, 'log', '--format=%H%x09%s', '-n', '100').catch(() => '');
+  const commits = log.split('\n').filter(Boolean).map((line) => {
+    const tab = line.indexOf('\t');
+    return { hash: line.slice(0, tab), subject: line.slice(tab + 1) };
+  });
+  // Artifact-purge commits are an internal continuation of the same WIP
+  // checkpoint. Treating them as a new base would make the actual source diff
+  // disappear on the next resume.
+  const isPreservedWip = (subject: string): boolean =>
+    subject.startsWith('wip: preserved partial work')
+    || subject === 'wip: remove ephemeral runtime artifacts (auto)';
+  let preservedCount = 0;
+  while (commits[preservedCount] && isPreservedWip(commits[preservedCount].subject)) preservedCount += 1;
+  if (preservedCount === 0) return [];
+
+  const base = commits[preservedCount]?.hash;
+  const diffArgs = base
+    ? ['diff', '--name-only', base, 'HEAD']
+    : ['diff-tree', '--root', '--no-commit-id', '--name-only', '-r', 'HEAD'];
+  return dedupeTaskFiles(await git(worktreePath, ...diffArgs));
+}
+
+function dedupeTaskFiles(files: string): string[] {
+  return [...new Set(files.split('\n').filter((file) =>
+    file && file !== PRESERVE_MARKER && !isEphemeralWorktreeArtifact(file)
+  ))];
+}
+
+/**
+ * Files this task has already written in this worktree, whether they sit in
+ * WIP-preserve commits or in the task commits earlier attempts made.
+ *
+ * Only the WIP case used to count. A resumed branch whose work was already
+ * committed therefore looked empty to the worker: it made no new edit (the
+ * work is done), Git reported no diff, and the run failed on the zero-diff
+ * contract before publication ever saw the branch. vega-agent AGT-3844 sat on
+ * five such commits at attempt 53 and cgf-portal AX-868 on six at attempt 27,
+ * with no pull request for either — finished work, stranded.
+ */
+export async function getResumedTaskFiles(worktreePath: string): Promise<string[]> {
+  const preserved = await getPreservedTaskFiles(worktreePath);
+  if (preserved.length > 0) return preserved;
+  const base = await resolveBaseRef(worktreePath).catch(() => null);
+  if (!base) return [];
+  const committed = await git(worktreePath, 'diff', '--name-only', `${base.ref}...HEAD`).catch(() => '');
+  return dedupeTaskFiles(committed);
+}


### PR DESCRIPTION
## Summary
- On vela right now: `swarm/AGT-3844-*` holds 5 commits ahead of origin/main and `swarm/AX-868-*` holds 6 — real deliveries, no pull request for either, re-run on every heartbeat (attempt 53 and 27 respectively).
- Cause: `getPreservedTaskFiles` only reads files out of the leading `wip: preserved partial work` commits. Once an attempt committed the work as a task commit, a resumed run got `resumedTaskFiles: []`; the worker made no new edit (correct — the work is done), `worker.ts` saw zero changed files, and the attempt failed the zero-diff contract before `publishApprovedWork` was ever reached.
- Resume now falls back to `<base>...HEAD` when nothing is preserved as WIP, so the worker result carries the delivered file list and the pipeline can take the branch through review, tester and publication. All three `resumedTaskFiles` call sites use it.
- WIP-preserve behaviour, ephemeral-artifact filtering and the scope fence (which applies to *fresh* edits only) are unchanged. The helpers moved to `worktreeResumeFiles.ts` because `worktreeManager.ts` is at the 1500-line pre-commit cap.

## Test plan
- [x] `worktreeManager.test.ts`: a branch whose delivery is a task commit (only runtime leftovers dirty) resumes with `resumedTaskFiles = ['app.py','helper.py']`; the existing WIP-preserve cases still return exactly the preserved file
- [x] `npm run typecheck`, `npm run lint`, `LC_ALL=C npx vitest run src/support src/automation` (1414 passed)