### PR TITLE
fix(publish): let a parked run's draft PR out past the write-scope fence

### DIFF
--- a/src/automation/publishOnPark.test.ts
+++ b/src/automation/publishOnPark.test.ts
@@ -6,7 +6,7 @@ vi.mock('../support/worktreeManager.js', () => ({ commitAndCreatePRWithHead }));
 vi.mock('../core/eventHub.js', () => ({ broadcastEvent: vi.fn() }));
 
 import { PublicationScopeMismatchError } from '../support/publicationScopeFence.js';
-import { PUBLICATION_SCOPE_PARK_REASON, WORKER_NO_CHANGES_PARK_REASON, publishApprovedWork, publishStuckWork, shouldPublishParkedWork } from './publishOnPark.js';
+import { PUBLICATION_SCOPE_PARK_REASON, WORKER_NO_CHANGES_PARK_REASON, publishApprovedWork, publishParkedIfNeeded, publishParkedWork, publishStuckWork, shouldPublishParkedWork } from './publishOnPark.js';
 
 beforeEach(() => {
   commitAndCreatePRWithHead.mockReset();
@@ -106,6 +106,44 @@ describe('afterPublication hook (per-repository fresh review)', () => {
     await publishApprovedWork(info, publishable, result, undefined, async () => { throw new Error('reviewer adapter down'); });
 
     expect(result).toMatchObject({ success: true, finalStatus: 'approved', prUrl: 'https://github.com/o/r/pull/10' });
+  });
+});
+
+describe('parked-work draft publication', () => {
+  const info = { worktreePath: '/tmp/w', originalPath: '/tmp/r', branchName: 'swarm/AGT-3844-ci-1', issueId: 'AGT-3844' };
+  const publishable = { id: 'task-1', issueIdentifier: 'AGT-3844', title: 'CI suite reserve', fileScope: ['tests/'], fileScopeSource: 'drafted' as const };
+
+  // The draft exists so the operator can see the branch. Enforcing the write
+  // scope here only hides it: AGT-3844 parked on that fence (2026-09-02)
+  // holding 42 commits whose net diff is four files, and published nothing.
+  it('publishes the branch without the write-scope fence', async () => {
+    commitAndCreatePRWithHead.mockResolvedValue({ prUrl: 'https://github.com/o/r/pull/21', headSha: 'abc' });
+
+    await publishParkedWork(info, publishable, undefined);
+
+    expect(commitAndCreatePRWithHead).toHaveBeenCalledWith(
+      info, publishable.title, 'AGT-3844', expect.any(String),
+      { draft: true, committedOnly: true },
+    );
+  });
+
+  it('publishes a park once, whichever side of the approved publish it happened on', async () => {
+    commitAndCreatePRWithHead.mockResolvedValue({ prUrl: 'https://github.com/o/r/pull/22', headSha: 'abc' });
+    const parked = { finalStatus: 'failed', operatorPark: { code: 'publication_scope_mismatch', reason: 'r' } };
+
+    expect(await publishParkedIfNeeded(info, publishable, parked, undefined)).toBe(true);
+    expect(await publishParkedIfNeeded(info, publishable, { finalStatus: 'failed' }, undefined)).toBe(false);
+    expect(await publishParkedIfNeeded(null, publishable, parked, undefined)).toBe(false);
+    expect(commitAndCreatePRWithHead).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats an operator park as a run that stopped for a person', () => {
+    expect(shouldPublishParkedWork(true, { finalStatus: 'failed', operatorPark: { code: 'worker_no_changes', reason: 'r' } })).toBe(true);
+    expect(shouldPublishParkedWork(true, { finalStatus: 'waiting_on_operator' })).toBe(true);
+    expect(shouldPublishParkedWork(true, { finalStatus: 'failed' })).toBe(false);
+    // A published run and a quarantined sandbox outcome still never publish.
+    expect(shouldPublishParkedWork(true, { finalStatus: 'waiting_on_operator', prUrl: 'https://x/1' })).toBe(false);
+    expect(shouldPublishParkedWork(true, { finalStatus: 'waiting_on_operator', workerResult: { executionOutcomeUnknown: true } })).toBe(false);
   });
 });
 
@@ -213,19 +251,17 @@ describe('publishStuckWork — terminal parks publish instead of holding', () =>
     await expect(publishStuckWork(ctx, task, 'stuck')).resolves.toBeUndefined();
   });
 
-  it('drops an inferred file scope, which is advisory and would block publication', async () => {
-    commitAndCreatePRWithHead.mockResolvedValue({ prUrl: 'https://github.com/o/r/pull/9', headSha: 'sha' });
+  // This used to enforce a declared scope and drop an inferred one. Both now
+  // publish: the worktree is deleted moments after this call, so a fenced
+  // refusal does not protect the operator's instruction — it destroys the work
+  // that would have shown them it was broken. A draft PR merges nothing.
+  it('publishes the branch as a draft without a write-scope fence, whatever the scope source', async () => {
+    for (const fileScopeSource of ['declared', 'drafted', 'inferred'] as const) {
+      commitAndCreatePRWithHead.mockResolvedValue({ prUrl: 'https://github.com/o/r/pull/9', headSha: 'sha' });
 
-    await publishStuckWork(ctx, { ...task, fileScope: ['src/a.ts'], fileScopeSource: 'inferred' }, 'stuck');
+      await publishStuckWork(ctx, { ...task, fileScope: ['src/a.ts'], fileScopeSource }, 'stuck');
 
-    expect(commitAndCreatePRWithHead.mock.calls[0][4]).toMatchObject({ fileScope: undefined });
-  });
-
-  it('enforces a declared file scope', async () => {
-    commitAndCreatePRWithHead.mockResolvedValue({ prUrl: 'https://github.com/o/r/pull/9', headSha: 'sha' });
-
-    await publishStuckWork(ctx, { ...task, fileScope: ['src/a.ts'], fileScopeSource: 'declared' }, 'stuck');
-
-    expect(commitAndCreatePRWithHead.mock.calls[0][4]).toMatchObject({ fileScope: ['src/a.ts'] });
+      expect(commitAndCreatePRWithHead.mock.calls.at(-1)?.[4]).toEqual({ draft: true });
+    }
   });
 });

--- a/src/automation/publishOnPark.ts
+++ b/src/automation/publishOnPark.ts
@@ -42,6 +42,7 @@ interface PublishableResult {
   finalStatus?: string;
   prUrl?: string;
   workerResult?: { executionOutcomeUnknown?: boolean; noChangesReason?: string };
+  operatorPark?: { code: string; reason: string };
 }
 
 /** The fields these paths read off the task. */
@@ -67,9 +68,13 @@ export function shouldPublishParkedWork(
   hasWorktree: boolean,
   result: PublishableResult,
 ): boolean {
-  return hasWorktree && result.finalStatus === 'waiting_on_operator'
-    && result.workerResult?.executionOutcomeUnknown !== true
-    && !result.prUrl;
+  if (!hasWorktree || result.workerResult?.executionOutcomeUnknown === true || result.prUrl) return false;
+  // `waiting_on_operator` is one way a run stops for a person; an
+  // `operatorPark` — the publication-scope fence, a worker that delivered
+  // nothing — is another, and it was added without this. vega-agent AGT-3844
+  // parked that way on 2026-09-02 holding 42 commits whose net diff is four
+  // files, and published nothing at all.
+  return result.finalStatus === 'waiting_on_operator' || Boolean(result.operatorPark);
 }
 
 /**
@@ -111,8 +116,13 @@ export async function publishParkedWork(
         + ' reviewed — this PR is a draft on purpose.',
       // Draft, and committed work only: nothing reviewed this, and the tree
       // must stay exactly as the worker left it so the resume continues.
-      { draft: true, committedOnly: true,
-        fileScope: enforcedFileScope(task) },
+      //
+      // No write-scope fence. The fence stops an unreviewed run from
+      // *delivering* files it never reserved; this PR delivers nothing — it is
+      // how the person the run is waiting on sees what it built. Enforcing it
+      // here only hides the branch, which is the exact failure this function
+      // exists to fix (AGT-3844 parked on that fence holding 42 commits).
+      { draft: true, committedOnly: true },
     );
     // The ledger records the PR; the pipeline result deliberately does NOT.
     //
@@ -138,6 +148,25 @@ export async function publishParkedWork(
       console.warn(`[Runner] Could not publish parked work for ${task.issueIdentifier}: ${detail}`);
     }
   }
+}
+
+/**
+ * Publish a parked run's branch as a draft, once, if this outcome is a park.
+ *
+ * Called on both sides of the approved publish because a run parks either
+ * before it (the pipeline sets `operatorPark`) or during it (the scope fence
+ * refuses the push). vega-agent AGT-3844 parked the second way on 2026-09-02
+ * holding 42 commits — a four-file CI fix — and published nothing at all.
+ */
+export async function publishParkedIfNeeded(
+  worktreeInfo: WorktreeInfo | null | undefined,
+  task: PublishableTask,
+  result: PublishableResult,
+  durability: ExecutionDurabilityHooks | undefined,
+): Promise<boolean> {
+  if (!worktreeInfo || !shouldPublishParkedWork(true, result)) return false;
+  await publishParkedWork(worktreeInfo, task, durability);
+  return true;
 }
 
 /**
@@ -202,8 +231,10 @@ export async function publishStuckWork(
       // pre-cleanup WIP commit normally captures it first and makes this a
       // no-op (a clean tree skips the whole commit phase) — but that commit
       // swallows its own failures, and this is the second chance.
-      { draft: true,
-        fileScope: enforcedFileScope(task) },
+      // No write-scope fence, for the reason publishParkedWork documents: a
+      // draft PR nobody merged is how the operator sees the work, and this
+      // tree is about to be deleted.
+      { draft: true },
     );
     broadcastEvent({
       type: 'log',

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -32,7 +32,7 @@ import type { ITaskSource } from './taskSource.js';
 import {createWorktree, hasRecoverableWorktree, preserveWorktree, removeWorktree, WorktreeCoordinationError,  } from '../support/worktreeManager.js';
 import type { WorktreeInfo } from '../support/worktreeManager.js';
 import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
-import { publishApprovedWork, publishParkedWork, shouldPublishParkedWork } from './publishOnPark.js';
+import { publishApprovedWork, publishParkedIfNeeded } from './publishOnPark.js';
 import { loadPublicationFreshReview, loadRepoMetadata } from '../support/repoMetadata.js';
 import { prepareAttemptBranch } from '../support/branchLineage.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
@@ -1215,9 +1215,7 @@ export async function executePipeline(
       result.finalStatus = 'infra_error';
     }
 
-    if (shouldPublishParkedWork(Boolean(worktreeInfo), result) && worktreeInfo) {
-      await publishParkedWork(worktreeInfo, task, ctx.durability);
-    }
+    const parkedPublished = await publishParkedIfNeeded(worktreeInfo, task, result, ctx.durability);
 
     // The repository, not the daemon, decides whether its published PRs get
     // the agentic fresh review (openswarm.json `publication.freshReview`).
@@ -1240,6 +1238,7 @@ export async function executePipeline(
         });
       } : undefined,
     );
+    if (!parkedPublished) await publishParkedIfNeeded(worktreeInfo, task, result, ctx.durability);
 
     keepWorktree = !(result.success && result.finalStatus === 'approved');
     return result;


### PR DESCRIPTION
## Summary
- vega-agent AGT-3844 parked under `publication_scope_mismatch` at 19:50 today holding **42 commits whose net diff is four files** (`.github/workflows/ci.yml`, a bounded-install test, and two data files) — and published nothing. The operator has no way to see it.
- Both park publications (`publishParkedWork`, `publishStuckWork`) passed `enforcedFileScope(task)` into `commitAndCreatePRWithHead`, so the branch fence refused them. That fence exists to stop an unreviewed run from *delivering* files it never reserved; a draft PR delivers nothing, and in `publishStuckWork` the refusal actively destroys the work, because the worktree is removed moments later.
- `shouldPublishParkedWork` now also fires for an `operatorPark` result (the three park codes added today all carry `finalStatus: 'failed'`), and `publishParkedIfNeeded` is called on both sides of the approved publish — a run parks before publication (pipeline) or during it (the fence), and only the first case was covered.
- The approved, autonomous publication path keeps the fence unchanged.

## Test plan
- [x] `publishOnPark.test.ts`: park draft publishes with `{draft, committedOnly}` and no `fileScope`; stuck draft publishes for declared/drafted/inferred alike (replacing the two tests that asserted the old enforcement, with the reason recorded); `shouldPublishParkedWork` fires on `operatorPark` but never on a plain failure, an existing `prUrl`, or a quarantined sandbox outcome; `publishParkedIfNeeded` publishes exactly once
- [x] `npm run typecheck`, `npm run lint`, `LC_ALL=C npx vitest run src/automation` (771 passed)