### PR TITLE
feat(runner): ledger retrospective lane — the daemon files its own top-failure-bucket issue

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -52,6 +52,7 @@ import {
 import type { DefaultRolesConfig } from '../core/types.js';
 import * as execution from './runnerExecution.js';
 import { reportToDiscord, fetchLinearTasks, getTaskSource } from './runnerExecution.js';
+import { runLedgerRetrospective } from './ledgerRetrospective.js';
 import { t } from '../locale/index.js';
 import { SANDBOX_OUTCOME_UNKNOWN_PARK_REASON } from '../sandboxExecutor/protocol.js';
 import { decideExplicitReadmission } from './explicitDispatchReadmission.js';
@@ -2390,6 +2391,22 @@ export class AutonomousRunner {
         await this.requestApproval(decision);
       }
       this.state.consecutiveErrors = 0;
+
+      // The retrospective lane: the runner reads its own ledger and files one
+      // evidence-rich issue on the largest failure bucket, so the systemic
+      // fixes an operator would derive from the same queries happen without
+      // one. Isolated — a lane failure must not fail the heartbeat.
+      if (this.config.retrospectiveProjectId && this.durableRuns.isPrimary && !this.stopping) {
+        try {
+          const source = getTaskSource();
+          if (source) {
+            const outcome = await runLedgerRetrospective({ taskSource: source, projectId: this.config.retrospectiveProjectId });
+            if (outcome.filed) this.syslog(`🔁 Retrospective filed ${outcome.identifier}: ${outcome.reason}`);
+          }
+        } catch (error) {
+          console.warn('[AutonomousRunner] Ledger retrospective failed:', error instanceof Error ? error.message : error);
+        }
+      }
 
     } catch (error) {
       this.state.consecutiveErrors++;

--- a/src/automation/ledgerRetrospective.test.ts
+++ b/src/automation/ledgerRetrospective.test.ts
@@ -1,0 +1,122 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RunLedger } from './runLedger.js';
+import { aggregateFailureBuckets, composeRetrospectiveIssue, runLedgerRetrospective } from './ledgerRetrospective.js';
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+
+const NOW = 1_800_000_000_000;
+
+function seededDb(rows: Array<{ issue: string; attempt: number; message: string; finishedAt?: number }>): string {
+  const root = mkdtempSync(join(tmpdir(), 'openswarm-retro-'));
+  roots.push(root);
+  const path = join(root, 'automation.db');
+  new RunLedger(path).close(); // creates the real schema
+  const db = new Database(path);
+  const insertRun = db.prepare(`
+    INSERT OR IGNORE INTO automation_runs(issue_id, source, identifier, project_path, state, discovered_at, updated_at)
+    VALUES (?, 'linear', ?, '/repo', 'RETRY_AT', ?, ?)
+  `);
+  const insertAttempt = db.prepare(`
+    INSERT INTO automation_attempts(issue_id, attempt_no, lease_epoch, status, stage, started_at, finished_at, error_message, success)
+    VALUES (?, ?, 1, 'suspended', 'RETRY_AT', ?, ?, ?, 0)
+  `);
+  for (const row of rows) {
+    const finishedAt = row.finishedAt ?? NOW - 60_000;
+    insertRun.run(`uuid-${row.issue}`, row.issue, finishedAt - 1000, finishedAt);
+    insertAttempt.run(`uuid-${row.issue}`, row.attempt, finishedAt - 1000, finishedAt, row.message);
+  }
+  db.close();
+  return path;
+}
+
+function fakeSource() {
+  return {
+    createTask: vi.fn(async (title: string) => ({ id: 'issue-uuid', identifier: 'AGT-9001', title })),
+    updateState: vi.fn(async () => true),
+  };
+}
+
+// The lane encodes the operator's 2026-09-02 steering: aggregate the ledger,
+// pick the largest cross-issue bucket, file one evidence-rich issue, hand it
+// to the normal pipeline. Measurement is deterministic — no LLM.
+describe('ledger retrospective lane', () => {
+  const scopeMsg = 'publication-scope: branch contains files outside reserved write scope: uv.lock';
+  const bigBucket = Array.from({ length: 7 }, (_, i) => ({ issue: `AX-${860 + (i % 3)}`, attempt: i + 1, message: scopeMsg }));
+
+  it('aggregates normalized buckets largest-first with distinct issue counts', () => {
+    const path = seededDb([
+      ...bigBucket,
+      { issue: 'AGT-1', attempt: 1, message: 'gh: HTTP 502' },
+    ]);
+    const db = new Database(path);
+    const buckets = aggregateFailureBuckets(db, NOW - 3_600_000);
+    db.close();
+
+    expect(buckets[0]).toMatchObject({ attempts: 7, distinctIssues: 3 });
+    expect(buckets[0].identifiers).toContain('AX-860');
+    expect(buckets).toHaveLength(2);
+  });
+
+  it('files exactly one Todo issue for the top bucket, with measured numbers in the body', async () => {
+    const source = fakeSource();
+    const outcome = await runLedgerRetrospective({ taskSource: source, projectId: 'proj-1', dbPath: seededDb(bigBucket), now: NOW });
+
+    expect(outcome).toMatchObject({ filed: true, identifier: 'AGT-9001' });
+    const [title, description, projectId] = source.createTask.mock.calls[0];
+    expect(title).toMatch(/^\[Retrospective\] /);
+    expect(description).toContain('| Failed attempts | 7 |');
+    expect(description).toContain('AX-860');
+    expect(projectId).toBe('proj-1');
+    expect(source.updateState).toHaveBeenCalledWith('issue-uuid', 'Todo');
+  });
+
+  it('skips buckets below the noise floor — one loud issue is not a systemic defect', async () => {
+    const oneIssue = Array.from({ length: 10 }, (_, i) => ({ issue: 'AX-874', attempt: i + 1, message: scopeMsg }));
+    const source = fakeSource();
+
+    const outcome = await runLedgerRetrospective({ taskSource: source, projectId: 'p', dbPath: seededDb(oneIssue), now: NOW });
+
+    expect(outcome).toMatchObject({ filed: false, reason: 'no bucket above the noise floor' });
+    expect(source.createTask).not.toHaveBeenCalled();
+  });
+
+  it('runs at most once per interval, and never refiles a fingerprint inside the dedupe window', async () => {
+    const path = seededDb(bigBucket);
+    const source = fakeSource();
+
+    expect((await runLedgerRetrospective({ taskSource: source, projectId: 'p', dbPath: path, now: NOW })).filed).toBe(true);
+    // Same day: interval gate.
+    expect((await runLedgerRetrospective({ taskSource: source, projectId: 'p', dbPath: path, now: NOW + 60_000 })).reason).toBe('interval');
+    // Next day, same bucket still failing: fingerprint dedupe.
+    const db = new Database(path);
+    const later = NOW + 25 * 3_600_000;
+    db.prepare('UPDATE automation_attempts SET finished_at = ?').run(later - 60_000);
+    db.close();
+    const third = await runLedgerRetrospective({ taskSource: source, projectId: 'p', dbPath: path, now: later });
+    expect(third).toMatchObject({ filed: false, reason: 'no bucket above the noise floor' });
+    expect(source.createTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('stamps the interval even on a quiet pass, so an empty day does not shorten the next one', async () => {
+    const path = seededDb([]);
+    const source = fakeSource();
+
+    expect((await runLedgerRetrospective({ taskSource: source, projectId: 'p', dbPath: path, now: NOW })).reason).toBe('no failures in window');
+    expect((await runLedgerRetrospective({ taskSource: source, projectId: 'p', dbPath: path, now: NOW + 60_000 })).reason).toBe('interval');
+  });
+
+  it('composes a body that survives an ugly example verbatim but bounded', () => {
+    const { title, description } = composeRetrospectiveIssue({
+      fingerprint: 'x'.repeat(200), attempts: 9, distinctIssues: 4, maxAttemptNo: 53,
+      identifiers: ['A-1'], example: 'y'.repeat(2000),
+    }, 24);
+    expect(title.length).toBeLessThanOrEqual('[Retrospective] '.length + 90);
+    expect(description).toContain('y'.repeat(600));
+    expect(description).not.toContain('y'.repeat(601));
+  });
+});

--- a/src/automation/ledgerRetrospective.ts
+++ b/src/automation/ledgerRetrospective.ts
@@ -1,0 +1,175 @@
+// ============================================
+// OpenSwarm - Ledger retrospective lane
+// ============================================
+//
+// The daemon files its own top-failure-bucket issue. On 2026-09-02 the
+// deployed runner spent hundreds of attempts publishing zero PRs while every
+// underlying defect was visible in three fixed ledger queries; the operator's
+// per-tick steering — aggregate failures, pick the largest bucket, file one
+// evidence-rich issue, let the normal pipeline work it — is algorithmic, so
+// it runs here as a deterministic job. No LLM is involved in measurement: the
+// intelligence is spent by the worker that picks the filed issue up.
+
+import Database from 'better-sqlite3';
+import { normalizeErrorForLoop } from '../support/stuckDetector.js';
+import { defaultAutomationDbPath } from './automationDbPath.js';
+import type { TaskState } from './taskSource.js';
+
+/** How far back a run's attempts count toward a bucket. */
+const WINDOW_MS = 24 * 60 * 60 * 1000;
+/** At most one filed issue per this interval, whatever the ledger holds. */
+const INTERVAL_MS = 24 * 60 * 60 * 1000;
+/** A fingerprint that was already filed stays quiet for this long. */
+const DEDUPE_MS = 7 * 24 * 60 * 60 * 1000;
+/**
+ * Noise floor: a bucket is only worth an issue when it repeats across issues.
+ * Eagerly filed findings measured 79% noise on AGT-4088 (2026-09-02); a
+ * systemic defect shows up as the same failure on unrelated tasks.
+ */
+const MIN_ATTEMPTS = 6;
+const MIN_DISTINCT_ISSUES = 2;
+
+const LAST_RUN_KEY = 'retrospective_last_run_at';
+const FINGERPRINT_KEY_PREFIX = 'retrospective_filed:';
+
+export interface FailureBucket {
+  fingerprint: string;
+  attempts: number;
+  distinctIssues: number;
+  maxAttemptNo: number;
+  /** Up to five example issue identifiers, most-attempted first. */
+  identifiers: string[];
+  /** One raw error message, verbatim, as evidence. */
+  example: string;
+}
+
+interface AttemptRow {
+  identifier: string | null;
+  attempt_no: number;
+  error_message: string;
+}
+
+/** Aggregate the window's failed attempts into normalized failure buckets, largest first. */
+export function aggregateFailureBuckets(db: Database.Database, since: number): FailureBucket[] {
+  const rows = db.prepare(`
+    SELECT r.identifier, a.attempt_no, a.error_message
+    FROM automation_attempts a JOIN automation_runs r USING (issue_id)
+    WHERE a.finished_at >= ? AND a.error_message IS NOT NULL AND a.error_message != ''
+      AND (a.success IS NULL OR a.success = 0)
+  `).all(since) as AttemptRow[];
+
+  const buckets = new Map<string, FailureBucket & { issueAttempts: Map<string, number> }>();
+  for (const row of rows) {
+    const fingerprint = normalizeErrorForLoop(row.error_message).slice(0, 160);
+    if (!fingerprint) continue;
+    let bucket = buckets.get(fingerprint);
+    if (!bucket) {
+      bucket = { fingerprint, attempts: 0, distinctIssues: 0, maxAttemptNo: 0, identifiers: [], example: row.error_message, issueAttempts: new Map() };
+      buckets.set(fingerprint, bucket);
+    }
+    bucket.attempts += 1;
+    bucket.maxAttemptNo = Math.max(bucket.maxAttemptNo, row.attempt_no);
+    const id = row.identifier ?? 'unknown';
+    bucket.issueAttempts.set(id, (bucket.issueAttempts.get(id) ?? 0) + 1);
+  }
+
+  return [...buckets.values()]
+    .map(({ issueAttempts, ...bucket }) => ({
+      ...bucket,
+      distinctIssues: issueAttempts.size,
+      identifiers: [...issueAttempts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5).map(([id]) => id),
+    }))
+    .sort((a, b) => b.attempts - a.attempts || b.distinctIssues - a.distinctIssues);
+}
+
+/** The filed issue's title and body, templated from measured numbers only. */
+export function composeRetrospectiveIssue(bucket: FailureBucket, windowHours: number): { title: string; description: string } {
+  const title = `[Retrospective] ${bucket.fingerprint.slice(0, 90)}`;
+  const description = [
+    '## Measured (auto-filed by the ledger retrospective lane)',
+    '',
+    `The largest failure bucket of the last ${windowHours}h on this deployment's own run ledger:`,
+    '',
+    '| Metric | Value |',
+    '| --- | --- |',
+    `| Failed attempts | ${bucket.attempts} |`,
+    `| Distinct issues | ${bucket.distinctIssues} (${bucket.identifiers.join(', ')}) |`,
+    `| Highest attempt number | ${bucket.maxAttemptNo} |`,
+    '',
+    '**Verbatim example:**',
+    '',
+    '```',
+    bucket.example.slice(0, 600),
+    '```',
+    '',
+    '## Task',
+    '',
+    'Find the systemic cause of this bucket in the runner/pipeline code — not in the individual tasks that hit it — and fix it at the root. The attempts above are symptoms; a fix that merely retries them differently is not done.',
+    '',
+    '## DoD',
+    '',
+    '- [ ] Root cause named, with the code path that produced the bucket',
+    '- [ ] Fix with a regression test that reproduces the bucket shape',
+    '- [ ] typecheck / lint / tests green',
+  ].join('\n');
+  return { title, description };
+}
+
+export interface RetrospectiveTaskSource {
+  createTask(title: string, description: string, projectId?: string): Promise<{ id: string; identifier?: string; title?: string } | { error: string }>;
+  updateState(issueId: string, state: TaskState): Promise<boolean>;
+}
+
+export interface RetrospectiveResult {
+  filed: boolean;
+  reason: string;
+  identifier?: string;
+}
+
+/**
+ * Run one retrospective pass: gate on interval, aggregate, gate on noise floor
+ * and fingerprint dedupe, then file exactly one issue and put it in Todo so
+ * the heartbeat works it like any other task. Every gate is recorded in the
+ * returned reason so a silent pass is still explainable from the log line.
+ */
+export async function runLedgerRetrospective(options: {
+  taskSource: RetrospectiveTaskSource;
+  projectId: string;
+  dbPath?: string;
+  now?: number;
+}): Promise<RetrospectiveResult> {
+  const now = options.now ?? Date.now();
+  const db = new Database(options.dbPath ?? defaultAutomationDbPath());
+  try {
+    // The ledger owns this table; a retrospective running against a fresh
+    // database before the first RunLedger open must not crash on it.
+    db.exec('CREATE TABLE IF NOT EXISTS automation_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)');
+    const readMeta = db.prepare('SELECT value FROM automation_meta WHERE key = ?');
+    const writeMeta = db.prepare('INSERT INTO automation_meta(key, value) VALUES(?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value');
+
+    const lastRun = Number((readMeta.get(LAST_RUN_KEY) as { value: string } | undefined)?.value ?? 0);
+    if (now - lastRun < INTERVAL_MS) return { filed: false, reason: 'interval' };
+
+    const buckets = aggregateFailureBuckets(db, now - WINDOW_MS);
+    const eligible = buckets.find((bucket) => {
+      if (bucket.attempts < MIN_ATTEMPTS || bucket.distinctIssues < MIN_DISTINCT_ISSUES) return false;
+      const filedAt = Number((readMeta.get(FINGERPRINT_KEY_PREFIX + bucket.fingerprint) as { value: string } | undefined)?.value ?? 0);
+      return now - filedAt >= DEDUPE_MS;
+    });
+    // The interval stamp is written on every completed pass, found bucket or
+    // not — a quiet day must not make the next pass run early.
+    writeMeta.run(LAST_RUN_KEY, String(now));
+    if (!eligible) return { filed: false, reason: buckets.length === 0 ? 'no failures in window' : 'no bucket above the noise floor' };
+
+    const issue = composeRetrospectiveIssue(eligible, WINDOW_MS / 3_600_000);
+    const created = await options.taskSource.createTask(issue.title, issue.description, options.projectId);
+    if ('error' in created) return { filed: false, reason: `createTask: ${created.error}` };
+    // Todo is what admits it to the heartbeat; a filing that stays in the
+    // default triage state would be a report, not a lane.
+    await options.taskSource.updateState(created.id, 'Todo');
+    writeMeta.run(FINGERPRINT_KEY_PREFIX + eligible.fingerprint, String(now));
+    return { filed: true, reason: `filed for bucket "${eligible.fingerprint.slice(0, 60)}" (${eligible.attempts} attempts / ${eligible.distinctIssues} issues)`, identifier: created.identifier ?? created.id };
+  } finally {
+    db.close();
+  }
+}

--- a/src/automation/runnerTypes.ts
+++ b/src/automation/runnerTypes.ts
@@ -66,6 +66,8 @@ export interface AutonomousConfig {
   automationLedgerMode?: 'off' | 'shadow' | 'primary';
   /** Override ~/.openswarm/automation.db (primarily tests/operations). */
   automationDbPath?: string;
+  /** Linear project for the daemon's self-filed retrospective issues; unset disables the lane. */
+  retrospectiveProjectId?: string;
   /** Fenced execution lease duration; renewed at one third of this interval. */
   automationLeaseMs?: number;
   /** Grace period for real executor exit during service shutdown. */

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -320,6 +320,8 @@ const AutonomousConfigSchema = z.object({
   /** SQLite execution-truth rollout. primary is fail-closed; shadow only observes. */
   automationLedgerMode: z.enum(['off', 'shadow', 'primary']).default('primary'),
   automationDbPath: z.string().min(1).optional(),
+  /** Linear project the daemon files its own retrospective issues into; unset = lane off. */
+  retrospectiveProjectId: z.string().min(1).optional(),
   automationLeaseMs: z.number().int().min(60_000).max(24 * 60 * 60_000).default(10 * 60_000),
   shutdownGraceMs: z.number().int().min(0).max(5 * 60_000).default(30_000),
   /** Default role configuration */
@@ -719,6 +721,7 @@ function transformConfig(raw: RawConfig): SwarmConfig {
       maxConcurrentPerProject: raw.autonomous.maxConcurrentPerProject,
       automationLedgerMode: raw.autonomous.automationLedgerMode,
       automationDbPath: raw.autonomous.automationDbPath ? expandPath(raw.autonomous.automationDbPath) : undefined,
+      retrospectiveProjectId: raw.autonomous.retrospectiveProjectId,
       automationLeaseMs: raw.autonomous.automationLeaseMs,
       shutdownGraceMs: raw.autonomous.shutdownGraceMs,
       defaultRoles: raw.autonomous.defaultRoles,

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -294,6 +294,7 @@ async function startServiceLocked(config: SwarmConfig): Promise<void> {
       maxConcurrentPerProject: config.autonomous.maxConcurrentPerProject,
       automationLedgerMode: config.autonomous.automationLedgerMode,
       automationDbPath: config.autonomous.automationDbPath,
+      retrospectiveProjectId: config.autonomous.retrospectiveProjectId,
       automationLeaseMs: config.autonomous.automationLeaseMs,
       shutdownGraceMs: config.autonomous.shutdownGraceMs,
       allowSameProjectConcurrent: config.autonomous.allowSameProjectConcurrent,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -586,6 +586,8 @@ export type AutonomousStartupConfig = {
   /** Durable execution ledger rollout mode. */
   automationLedgerMode?: 'off' | 'shadow' | 'primary';
   automationDbPath?: string;
+  /** Linear project for the daemon's self-filed retrospective issues; unset disables the lane. */
+  retrospectiveProjectId?: string;
   automationLeaseMs?: number;
   shutdownGraceMs?: number;
   /** Default role configuration */


### PR DESCRIPTION
## Summary (AGT-4181)
- Today's finding: the daemon treadmilled all day because nobody *inside* the system looks at the system — its action space per failure is {retry, escalate, park}, while every fix I shipped today (#524–#541) came from the same three ledger queries plus "top bucket → root fix". That steering is algorithmic; this encodes it.
- `ledgerRetrospective.ts` (deterministic, no LLM): aggregate the last 24h of failed attempts by `normalizeErrorForLoop` fingerprint → apply a noise floor (≥6 attempts across ≥2 distinct issues — one loud issue is not a systemic defect, and eager filing measured 79% noise on AGT-4088) → file **one** AGT-4180-format issue (measured table, verbatim example, root-cause DoD) into the configured project → move it to Todo so the normal pipeline works it autonomously. Interval (24h) and per-fingerprint dedupe (7d) live in `automation_meta`; the interval stamps even on quiet passes.
- Heartbeat hook is primary-only, opt-in via `autonomous.retrospectiveProjectId`, and failure-isolated (a lane error cannot fail the heartbeat). Unset = zero behavior change.
- Human stays the merge gate; OpenSwarm-repo PRs already run the publication fresh review (#528).

## Test plan
- [x] `ledgerRetrospective.test.ts` (real RunLedger schema): largest-first aggregation with distinct-issue counts; files exactly one Todo issue with measured numbers; noise floor skips a single-issue bucket; interval + fingerprint dedupe across simulated days; quiet pass still stamps the interval; body caps title/example lengths
- [x] `npm run typecheck`, `npm run lint`, `LC_ALL=C npx vitest run src/automation src/core/config.test.ts` (828 passed)