### PR TITLE
fix(publish): record the lease-fence rejection, not the reviewer's last word

### DIFF
--- a/src/automation/publishOnPark.test.ts
+++ b/src/automation/publishOnPark.test.ts
@@ -109,6 +109,33 @@ describe('afterPublication hook (per-repository fresh review)', () => {
   });
 });
 
+describe('approved publish, lease fence rejection (cgf-portal AX-1020, 2026-08-31)', () => {
+  // Losing beforePublish did not set failureDetail. pickPipelineFailureDetail
+  // then fell back to lastReviewFeedback — a reviewer's APPROVAL text recorded
+  // as if it were the failure, twice, on a run that was actually blocked by
+  // the lease fence for reasons the ledger never captured.
+  it('records the fence, not the reviewer\'s last word, as the failure cause', async () => {
+    const durability = { beforePublish: vi.fn(async () => false), onPublication: vi.fn() } as unknown as ExecutionDurabilityHooks;
+    const result: { success: boolean; finalStatus: string; failureDetail?: string; lastReviewFeedback?: string } = {
+      success: true,
+      finalStatus: 'approved',
+      lastReviewFeedback: '검증 근거를 확인했습니다... 리뷰 결론은 승인입니다.',
+    };
+
+    await publishApprovedWork(
+      { worktreePath: '/tmp/w', originalPath: '/tmp/r', branchName: 'swarm/AX-1020', issueId: 'AX-1020' },
+      { id: 'task-1', issueIdentifier: 'AX-1020', title: 'Verify' },
+      result,
+      durability,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.finalStatus).toBe('infra_error');
+    expect(result.failureDetail).toMatch(/^publication: lease fence rejected/);
+    expect(commitAndCreatePRWithHead).not.toHaveBeenCalled();
+  });
+});
+
 describe('parked-work draft publication', () => {
   const info = { worktreePath: '/tmp/w', originalPath: '/tmp/r', branchName: 'swarm/AGT-3844-ci-1', issueId: 'AGT-3844' };
   const publishable = { id: 'task-1', issueIdentifier: 'AGT-3844', title: 'CI suite reserve', fileScope: ['tests/'], fileScopeSource: 'drafted' as const };

--- a/src/automation/publishOnPark.ts
+++ b/src/automation/publishOnPark.ts
@@ -275,6 +275,13 @@ export async function publishApprovedWork(
     if (!publishAllowed) {
       result.success = false;
       result.finalStatus = 'infra_error';
+      // Without this the ledger fell back to `lastReviewFeedback` — an
+      // approved run's fence rejection then recorded the REVIEWER'S APPROVAL
+      // TEXT as if it were the failure. cgf-portal AX-1020 hit this twice
+      // (2026-08-31): both attempts read as SentryAudits sign-off, and the
+      // actual cause — the fence, and why it fired — was unrecoverable once
+      // the container's log was gone.
+      result.failureDetail = 'publication: lease fence rejected the approved publish (a newer generation now owns this run, or the lease expired)';
       console.warn(`[Worktree] Publication fenced for ${task.issueIdentifier}; preserving worktree`);
     } else {
       try {


### PR DESCRIPTION
## Summary
- cgf-portal AX-1020's last two attempts (2026-08-31) both read `infra_error` in the ledger with the message... being SentryAudits' approval text ("리뷰 결론은 승인입니다" / independent re-run confirmed the audit). The run was approved, then something the ledger never named blocked its publish.
- Cause: `publishApprovedWork`'s `beforePublish` fence rejection sets `finalStatus = 'infra_error'` but never sets `failureDetail`. `pickPipelineFailureDetail` (runnerState.ts) falls back through a priority list and lands on `lastReviewFeedback` — for an approved run, that's the reviewer's sign-off, recorded as if it were the failure.
- Now sets `failureDetail` explicitly to name the fence. Same class as today's other signal-loss fixes (#537–#539): the real cause existed in memory for one call and was never written down.

## Test plan
- [x] `publishOnPark.test.ts`: a fenced approved publish records `failureDetail` starting with "publication: lease fence rejected", not the reviewer's approval text
- [x] `npm run typecheck`, `npm run lint`, `LC_ALL=C npx vitest run src/automation` (778 passed)