### PR TITLE
feat(openrouter): sort ZDR-eligible providers by throughput

### DIFF
--- a/src/adapters/openrouter.test.ts
+++ b/src/adapters/openrouter.test.ts
@@ -123,7 +123,7 @@ describe('OpenRouterCliAdapter', () => {
     const callApi = createApiCaller('sk-or-test', 'z-ai/glm-4.7-flash');
     await callApi([{ role: 'user', content: 'hi' }], []);
     const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
-    expect(body.provider).toEqual({ data_collection: 'deny' });
+    expect(body.provider).toEqual({ data_collection: 'deny', sort: 'throughput' });
     expect(body.reasoning).toBeUndefined(); // not disabled unless requested
   });
 

--- a/src/adapters/openrouter.ts
+++ b/src/adapters/openrouter.ts
@@ -271,7 +271,15 @@ export function createApiCaller(apiKey: string, model: string, opts: ApiCallerOp
       // 단, OpenAI provider는 data_collection:deny 플래그를 거부("Provider returned
       // error")하므로 제외한다. OpenAI는 API 데이터를 학습에 쓰지 않아(정책상) ZDR
       // 강제가 불필요하다. non-OpenAI 모델에만 적용한다.
-      body.provider = { data_collection: 'deny' };
+      //
+      // sort: 'throughput' picks the fastest ZDR-eligible endpoint instead of
+      // OpenRouter's default (load-balanced / cheapest-first) order. The
+      // 2026-06-09 worker benchmark found the same model 5x slower on one
+      // provider than another (qwen3-coder: 2759 tok/s on DeepInfra vs 160 on
+      // Novita) — provider, not model choice, was the dominant speed factor.
+      // A slow provider burns a stage's turn/timeout budget for no quality
+      // gain, so throughput is worth more here than shaving cents off price.
+      body.provider = { data_collection: 'deny', sort: 'throughput' };
     }
     // 추론 불필요 역할은 reasoning 토큰을 끈다. glm-4.7-flash처럼 non-thinking
     // 모델엔 무영향, 추론형 모델(glm-5 등)을 worker로 바꿔도 토큰 낭비를 막는다.


### PR DESCRIPTION
## Summary
- 2026-06-09's own worker benchmark (`project_model_benchmark` memory) found the dominant speed factor for non-frontier models was **provider**, not model: the same `qwen3-coder` ran 2759 tok/s on DeepInfra vs 160 tok/s on Novita, a >17x gap OpenRouter's default routing had no opinion on.
- Add `sort: 'throughput'` to the provider preferences object every ZDR-required call already sends. Picks the fastest ZDR-eligible endpoint instead of default (load-balanced/cheapest-first) ordering — a slow provider burns a stage's turn/timeout budget for the same output.
- Scope: the single point every non-pinned, non-OpenAI OpenRouter call passes through (`openrouter.ts`'s ZDR branch). Explicit `OPENROUTER_PROVIDER_ONLY` pins (deterministic test/sponsorship routing) and OpenAI-hosted models (ZDR-exempt, effectively single-provider) are untouched.

## Test plan
- [x] `openrouter.test.ts`: ZDR provider object now asserts `{ data_collection: 'deny', sort: 'throughput' }`
- [x] `npm run typecheck`, `npm run lint`, `LC_ALL=C npx vitest run src/adapters` (579 passed)