### PR TITLE
fix(runner): retrospective lane was unreachable in parallel mode

### DIFF
--- a/src/automation/autonomousRunner.coverage.test.ts
+++ b/src/automation/autonomousRunner.coverage.test.ts
@@ -41,6 +41,14 @@ vi.mock('../orchestration/conflictDetector.js', () => ({
   fileScopesConflict: fileScopesConflictMock,
 }));
 
+const { runLedgerRetrospectiveMock } = vi.hoisted(() => ({
+  runLedgerRetrospectiveMock: vi.fn(async () => ({ filed: false, reason: 'no failures in window' })),
+}));
+
+vi.mock('./ledgerRetrospective.js', () => ({
+  runLedgerRetrospective: runLedgerRetrospectiveMock,
+}));
+
 // writeProviderOverride writes unconditionally to ~/.config/openswarm/ (no dryRun
 // guard, no env override) — mock it so switchProvider() tests never touch the real
 // filesystem outside the sandbox.
@@ -137,7 +145,9 @@ type Internal = {
     listRuns(states?: readonly string[]): Array<{ issueId: string; lastErrorCode?: string }>;
     getRun(issueId: string): { state: string; leaseExpiresAt?: number; prUrl?: string } | null;
     markReady(issueId: string): boolean;
+    isPrimary: boolean;
   };
+  maybeRunLedgerRetrospective(): Promise<void>;
   rateLimitUntil: number;
   scheduleNextHeartbeat(): void;
   executeTaskPairMode: ReturnType<typeof vi.fn>;
@@ -877,6 +887,64 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
       const [, , note] = source.logStuck.mock.calls[0];
       expect(String(note)).toContain('Needs human');
       expect(source.updateState).not.toHaveBeenCalled(); // early-stuck bypasses the normal rejection tally
+    });
+  });
+
+
+  // vela deploys with maxConcurrentTasks 12 + pairMode true and never took any
+  // other branch — the lane sat behind a `return` that only serial-mode
+  // heartbeats reached, so it never ran a single time in production (AGT-4181
+  // follow-up, 2026-09-03). These exercise the extracted gate directly.
+  describe('maybeRunLedgerRetrospective (AGT-4181 follow-up)', () => {
+    beforeEach(() => {
+      runLedgerRetrospectiveMock.mockClear();
+      runLedgerRetrospectiveMock.mockResolvedValue({ filed: false, reason: 'no failures in window' });
+    });
+
+    function primaryRunner(over: Partial<AutonomousConfig> = {}) {
+      const r = new AutonomousRunner(cfg({ retrospectiveProjectId: 'proj-1', ...over }));
+      const internal = r as unknown as Internal;
+      Object.defineProperty(internal.durableRuns, 'isPrimary', { value: true, configurable: true });
+      return internal;
+    }
+
+    it('calls the lane when configured, primary, and a task source is registered', async () => {
+      runnerExecution.setTaskSource(mockTaskSource());
+      const internal = primaryRunner();
+
+      await internal.maybeRunLedgerRetrospective();
+
+      expect(runLedgerRetrospectiveMock).toHaveBeenCalledWith(expect.objectContaining({ projectId: 'proj-1' }));
+    });
+
+    it('does nothing without retrospectiveProjectId configured', async () => {
+      runnerExecution.setTaskSource(mockTaskSource());
+      const r = new AutonomousRunner(cfg());
+      const internal = r as unknown as Internal;
+      Object.defineProperty(internal.durableRuns, 'isPrimary', { value: true, configurable: true });
+
+      await internal.maybeRunLedgerRetrospective();
+
+      expect(runLedgerRetrospectiveMock).not.toHaveBeenCalled();
+    });
+
+    it('does nothing on a non-primary (shadow/replica) coordinator', async () => {
+      runnerExecution.setTaskSource(mockTaskSource());
+      const r = new AutonomousRunner(cfg({ retrospectiveProjectId: 'proj-1' }));
+      const internal = r as unknown as Internal;
+      Object.defineProperty(internal.durableRuns, 'isPrimary', { value: false, configurable: true });
+
+      await internal.maybeRunLedgerRetrospective();
+
+      expect(runLedgerRetrospectiveMock).not.toHaveBeenCalled();
+    });
+
+    it('swallows a lane failure without throwing', async () => {
+      runnerExecution.setTaskSource(mockTaskSource());
+      const internal = primaryRunner();
+      runLedgerRetrospectiveMock.mockRejectedValueOnce(new Error('ledger unreachable'));
+
+      await expect(internal.maybeRunLedgerRetrospective()).resolves.toBeUndefined();
     });
   });
 });

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -2063,6 +2063,25 @@ export class AutonomousRunner {
    * Log unmapped/disabled project skips as one aggregate line per category,
    * and stay silent while the summary is identical to the previous heartbeat.
    */
+  /**
+   * The retrospective lane (AGT-4181): the runner reads its own ledger and
+   * files one evidence-rich issue on the largest failure bucket, so the
+   * systemic fixes an operator would derive from the same queries happen
+   * without one. Isolated — a lane failure must not fail the heartbeat.
+   */
+  private async maybeRunLedgerRetrospective(): Promise<void> {
+    if (!this.config.retrospectiveProjectId || !this.durableRuns.isPrimary || this.stopping) return;
+    try {
+      const source = getTaskSource();
+      if (source) {
+        const outcome = await runLedgerRetrospective({ taskSource: source, projectId: this.config.retrospectiveProjectId });
+        if (outcome.filed) this.syslog(`🔁 Retrospective filed ${outcome.identifier}: ${outcome.reason}`);
+      }
+    } catch (error) {
+      console.warn('[AutonomousRunner] Ledger retrospective failed:', error instanceof Error ? error.message : error);
+    }
+  }
+
   private syslogSkipSummary(unmapped: Map<string, number>, disabled: Map<string, number>): void {
     const fmt = (m: Map<string, number>) => [...m.entries()]
       .sort((a, b) => b[1] - a[1])
@@ -2370,43 +2389,34 @@ export class AutonomousRunner {
         this.syslog(`  Filtered: ${tasks.length} → ${filteredTasks.length} (skipped ${tasks.length - filteredTasks.length} completed/failed)`);
       }
 
-      // Parallel processing mode
+      // Parallel processing mode. vela runs this branch on every heartbeat
+      // (maxConcurrentTasks 12, pairMode true) — an early `return` here used to
+      // skip everything below, including the retrospective lane (AGT-4181):
+      // it was configured and deployed for 9+ hours (2026-09-02 20:26–
+      // 2026-09-03 07:55) and never ran once, because vela never takes the
+      // serial branch the lane's call sat in. `else` instead of `return` so
+      // both branches reach the shared tail.
       if (this.config.maxConcurrentTasks && this.config.maxConcurrentTasks > 1 && this.config.pairMode) {
         await this.heartbeatParallel(filteredTasks);
-        return;
-      }
+      } else {
+        // 3. Run Decision Engine (single task)
+        this.syslog('⟳ Running Decision Engine...');
+        const decision = await this.engine.heartbeat(filteredTasks);
+        if (this.stopping) return;
+        this.syslog(`→ Decision: ${decision.action} — ${decision.reason}`);
+        this.state.lastDecision = decision;
 
-      // 3. Run Decision Engine (single task)
-      this.syslog('⟳ Running Decision Engine...');
-      const decision = await this.engine.heartbeat(filteredTasks);
-      if (this.stopping) return;
-      this.syslog(`→ Decision: ${decision.action} — ${decision.reason}`);
-      this.state.lastDecision = decision;
-
-      // 4. Handle decision
-      if (decision.action === 'execute' && decision.task) {
-        await this.executeTaskPairMode(decision.task);
-      } else if (decision.action === 'defer' && decision.task) {
-        this.state.pendingApproval = decision.task;
-        await this.requestApproval(decision);
+        // 4. Handle decision
+        if (decision.action === 'execute' && decision.task) {
+          await this.executeTaskPairMode(decision.task);
+        } else if (decision.action === 'defer' && decision.task) {
+          this.state.pendingApproval = decision.task;
+          await this.requestApproval(decision);
+        }
       }
       this.state.consecutiveErrors = 0;
 
-      // The retrospective lane: the runner reads its own ledger and files one
-      // evidence-rich issue on the largest failure bucket, so the systemic
-      // fixes an operator would derive from the same queries happen without
-      // one. Isolated — a lane failure must not fail the heartbeat.
-      if (this.config.retrospectiveProjectId && this.durableRuns.isPrimary && !this.stopping) {
-        try {
-          const source = getTaskSource();
-          if (source) {
-            const outcome = await runLedgerRetrospective({ taskSource: source, projectId: this.config.retrospectiveProjectId });
-            if (outcome.filed) this.syslog(`🔁 Retrospective filed ${outcome.identifier}: ${outcome.reason}`);
-          }
-        } catch (error) {
-          console.warn('[AutonomousRunner] Ledger retrospective failed:', error instanceof Error ? error.message : error);
-        }
-      }
+      await this.maybeRunLedgerRetrospective();
 
     } catch (error) {
       this.state.consecutiveErrors++;


### PR DESCRIPTION
## Summary
- Confirmed on vela's live ledger: `automation_meta` has zero rows for `retrospective_last_run_at` after 9+ hours running with `retrospectiveProjectId` configured (set 2026-09-02 20:26, deployed 22:27, checked 2026-09-03 07:55) — the lane writes that key on every completed pass, filed or not, so its total absence means the function body never executed even once.
- Cause: `heartbeatParallel`'s branch ended with `return`, which skipped everything below it in `heartbeat()` — `consecutiveErrors = 0` and the retrospective-lane call both sat after that return, in code only the serial (non-parallel) path could reach. vela runs `maxConcurrentTasks: 12` + `pairMode: true`, so **every heartbeat takes the parallel branch**; the lane has been dead code in production since #542 merged.
- Fix: `if`/`else` instead of an early return, so both branches converge on the shared tail. Extracted the lane into `maybeRunLedgerRetrospective()` (mirrors how `heartbeatParallel` is already exposed for direct testing, since `heartbeat()`'s main body is deliberately not unit-tested for real-I/O reasons per this test file's own header comment).

## Test plan
- [x] `autonomousRunner.coverage.test.ts`: new `maybeRunLedgerRetrospective` suite — calls the lane when configured+primary+task-source registered; no-ops without `retrospectiveProjectId`; no-ops when not primary; swallows a lane failure without throwing
- [x] `npm run typecheck`, `npm run lint`, `LC_ALL=C npx vitest run src/automation` (782 passed)