### PR TITLE
fix(decomposition): deterministic duplicate-sibling guard before sub-issue creation (AGT-2908)

### DIFF
--- a/src/automation/duplicateSubIssueGuard.test.ts
+++ b/src/automation/duplicateSubIssueGuard.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { findDuplicateSibling, titleSimilarity, fileScopeOverlap, type ExistingSibling } from './duplicateSubIssueGuard.js';
+
+const sibling = (over: Partial<ExistingSibling>): ExistingSibling => ({
+  id: 'sib-id',
+  identifier: 'AGT-1',
+  title: 'sibling title',
+  fileScope: [],
+  ...over,
+});
+
+// Real AGT-2908 evidence: five sub-issues, all scoped to the same 4 files, with
+// titles that differ only in a bracketed prefix.
+const AGT_2908_FILE_SCOPE = [
+  'api/models/db.py',
+  'api/models/schemas.py',
+  'api/routes/analyze.py',
+  'tests/test_analyze_history.py',
+];
+
+describe('findDuplicateSibling', () => {
+  it('flags the AGT-2908 shape: identical multi-file scope, differently prefixed titles', () => {
+    const candidate = { title: '[API Schema] Define the Detect analysis history response contract', fileScope: AGT_2908_FILE_SCOPE };
+    const existing = [
+      sibling({ identifier: 'AGT-2735', title: '[Backend] Add the durable single-analysis model and response schemas', fileScope: AGT_2908_FILE_SCOPE }),
+    ];
+    const match = findDuplicateSibling(candidate, existing);
+    expect(match?.sibling.identifier).toBe('AGT-2735');
+    expect(match?.fileScopeScore).toBe(1);
+  });
+
+  it('does not flag a candidate with no file scope, even with an identical title', () => {
+    const candidate = { title: 'Add durable single-analysis model and response schemas', fileScope: [] };
+    const existing = [sibling({ title: 'Add durable single-analysis model and response schemas', fileScope: AGT_2908_FILE_SCOPE })];
+    expect(findDuplicateSibling(candidate, existing)).toBeNull();
+  });
+
+  it('does not flag two unrelated single-file tasks sharing one trivial file', () => {
+    const candidate = { title: 'Bump the eslint dependency version', fileScope: ['package.json'] };
+    const existing = [sibling({ title: 'Rotate the deploy signing key', fileScope: ['package.json'] })];
+    expect(findDuplicateSibling(candidate, existing)).toBeNull();
+  });
+
+  it('flags two single-file tasks about the same file with overlapping intent', () => {
+    const candidate = { title: 'fix(envFile): warn on a divergent ambient value', fileScope: ['src/core/envFile.ts'] };
+    const existing = [sibling({ identifier: 'AGT-4154', title: 'fix(envFile): shell export silently shadows a divergent .env value', fileScope: ['src/core/envFile.ts'] })];
+    expect(findDuplicateSibling(candidate, existing)?.sibling.identifier).toBe('AGT-4154');
+  });
+
+  it('does not flag two files in scope that share nothing else', () => {
+    const candidate = { title: 'Add a new CLI flag', fileScope: ['src/cli.ts', 'src/cli.test.ts'] };
+    const existing = [sibling({ title: 'Fix a race in the daemon scheduler', fileScope: ['src/automation/scheduler.ts', 'src/automation/scheduler.test.ts'] })];
+    expect(findDuplicateSibling(candidate, existing)).toBeNull();
+  });
+
+  it('prefers the strongest match when several siblings share file scope', () => {
+    const candidate = { title: 'Persist completed analyses and expose isolated history APIs', fileScope: AGT_2908_FILE_SCOPE };
+    const existing = [
+      sibling({ identifier: 'AGT-2735', title: 'Add the durable single-analysis model and response schemas', fileScope: AGT_2908_FILE_SCOPE }),
+      sibling({ identifier: 'AGT-2742', title: 'Persist completed analyses and expose isolated history APIs', fileScope: AGT_2908_FILE_SCOPE }),
+    ];
+    expect(findDuplicateSibling(candidate, existing)?.sibling.identifier).toBe('AGT-2742');
+  });
+});
+
+describe('titleSimilarity', () => {
+  it('ignores bracket and conventional-commit prefixes', () => {
+    expect(titleSimilarity('[Backend] Add durable history', 'feat(backend): add durable history')).toBeGreaterThan(0.5);
+  });
+
+  it('returns 0 for titles with nothing in common', () => {
+    expect(titleSimilarity('Rotate the deploy signing key', 'Bump the eslint dependency version')).toBe(0);
+  });
+});
+
+describe('fileScopeOverlap', () => {
+  it('is 1 for identical scopes regardless of order', () => {
+    expect(fileScopeOverlap(['a.ts', 'b.ts'], ['b.ts', 'a.ts'])).toBe(1);
+  });
+
+  it('is 0 for disjoint scopes', () => {
+    expect(fileScopeOverlap(['a.ts'], ['b.ts'])).toBe(0);
+  });
+});

--- a/src/automation/duplicateSubIssueGuard.ts
+++ b/src/automation/duplicateSubIssueGuard.ts
@@ -1,0 +1,110 @@
+// Deterministic duplicate-sibling detection for decomposition drafts (AGT-2908).
+//
+// The LLM-based draft gate (draftGrooming.ts) compares top-level tasks against
+// each other before a decomposition run starts; it never sees the sub-issues a
+// decomposition is about to create. AGT-2908's real incident was two different
+// top-level parents each independently decomposing the same work into a
+// `schema` / `persist` / `test` triad, five times over — every duplicate card
+// shared an *identical* File scope block and differed only in a title prefix
+// (`[Backend]` vs `[API Schema]` vs `[API Contract]`). File scope is therefore
+// the load-bearing signal here, not title wording alone: two sub-tasks that
+// touch the same files are duplicates far more reliably than two that merely
+// share vocabulary (`fix(auth): ...` siblings routinely share words).
+
+export interface DuplicateCandidate {
+  title: string;
+  fileScope: string[];
+}
+
+export interface ExistingSibling extends DuplicateCandidate {
+  id: string;
+  identifier: string;
+}
+
+export interface DuplicateMatch {
+  sibling: ExistingSibling;
+  titleScore: number;
+  fileScopeScore: number;
+}
+
+const STOPWORDS = new Set([
+  'a', 'an', 'the', 'and', 'or', 'for', 'of', 'to', 'in', 'on', 'with', 'is', 'are', 'be', 'this', 'that', 'via',
+]);
+
+/** Strips a leading `[Bracket]`, `fix(scope):`, or `word:` prefix before tokenizing. */
+const PREFIX_PATTERN = /^\s*(\[[^\]]+\]|[a-z][\w-]*\([\w./-]+\):|[a-z]+:)\s*/i;
+
+export function normalizeTitleTokens(title: string): Set<string> {
+  const stripped = title.replace(PREFIX_PATTERN, '');
+  const tokens = stripped
+    .toLowerCase()
+    .split(/[^a-z0-9가-힣]+/)
+    .filter((token) => token.length > 2 && !STOPWORDS.has(token));
+  return new Set(tokens);
+}
+
+function jaccard(a: ReadonlySet<string>, b: ReadonlySet<string>): number {
+  if (a.size === 0 && b.size === 0) return 0;
+  let intersection = 0;
+  for (const item of a) if (b.has(item)) intersection += 1;
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+export function titleSimilarity(a: string, b: string): number {
+  return jaccard(normalizeTitleTokens(a), normalizeTitleTokens(b));
+}
+
+function normalizeFileScope(paths: readonly string[]): Set<string> {
+  return new Set(paths.map((p) => p.trim().toLowerCase()).filter(Boolean));
+}
+
+function fileScopeIntersectionCount(a: readonly string[], b: readonly string[]): number {
+  const setB = normalizeFileScope(b);
+  let count = 0;
+  for (const item of normalizeFileScope(a)) if (setB.has(item)) count += 1;
+  return count;
+}
+
+export function fileScopeOverlap(a: readonly string[], b: readonly string[]): number {
+  return jaccard(normalizeFileScope(a), normalizeFileScope(b));
+}
+
+/**
+ * Best-matching existing sibling this candidate duplicates, or null.
+ *
+ * A candidate with no file scope at all is never flagged — there is nothing
+ * to anchor the comparison, and title similarity alone is too easy to
+ * false-positive on. Two gates, either of which is enough on its own:
+ *
+ *  1. At least 2 shared files — a strong, hard-to-hit-by-accident signal on
+ *     its own, regardless of how differently the two titles are phrased
+ *     (this is exactly the AGT-2908 shape: identical multi-file scope).
+ *  2. Exactly 1 shared file that is the *entirety* of both candidates' scope,
+ *     plus a real title-token overlap — catches single-file sub-tasks about
+ *     the same file with similar intent, without flagging two unrelated
+ *     single-file tasks that happen to share one trivial file (e.g. both
+ *     touching `package.json`).
+ */
+export function findDuplicateSibling(
+  candidate: DuplicateCandidate,
+  existing: readonly ExistingSibling[],
+  minTitleSimilarity = 0.2,
+): DuplicateMatch | null {
+  if (candidate.fileScope.length === 0) return null;
+  let best: DuplicateMatch | null = null;
+  for (const sibling of existing) {
+    if (sibling.fileScope.length === 0) continue;
+    const shared = fileScopeIntersectionCount(candidate.fileScope, sibling.fileScope);
+    if (shared === 0) continue;
+    const fileScopeScore = fileScopeOverlap(candidate.fileScope, sibling.fileScope);
+    const titleScore = titleSimilarity(candidate.title, sibling.title);
+    const isDuplicate = shared >= 2
+      || (shared === 1 && fileScopeScore === 1 && titleScore >= minTitleSimilarity);
+    if (!isDuplicate) continue;
+    if (!best || fileScopeScore + titleScore > best.fileScopeScore + best.titleScore) {
+      best = { sibling, titleScore, fileScopeScore };
+    }
+  }
+  return best;
+}

--- a/src/automation/reviewerFollowups.ts
+++ b/src/automation/reviewerFollowups.ts
@@ -1,0 +1,53 @@
+// Extracted from runnerExecution.ts to stay under its 1500-line pre-commit cap
+// (AGT-2908 follow-up). Takes its task source as an explicit parameter, so it
+// had no dependency on that file's module-private `taskSource` variable.
+
+import { reviewerFollowupId } from './decompositionIds.js';
+import type { ITaskSource } from './taskSource.js';
+import type { ReviewResult } from '../agents/agentPair.js';
+
+/**
+ * File the reviewer's recommendedActions as follow-ups when it approves
+ * (INT-1611 restore / INT-1704). With a `parentIssueId` they become sub-issues;
+ * without one (INT-1968) they are created as top-level issues so review can still
+ * "just file them" off a non-issue branch. Gated by `autoFile` (default OFF);
+ * caps at 10; each create is best-effort (failures logged, never throw).
+ * Returns the count filed.
+ */
+export async function fileReviewerFollowups(
+  source: ITaskSource | null,
+  parentIssueId: string | null | undefined,
+  review: ReviewResult,
+  opts: { autoFile?: boolean; projectId?: string; requireApprove?: boolean } = {},
+): Promise<number> {
+  // Autonomous pipeline files only on approve; the manual `review` command files
+  // regardless of decision (requireApprove: false). (INT-1704 / INT-1969)
+  const requireApprove = opts.requireApprove ?? true;
+  if (!opts.autoFile || !source) return 0;
+  if (requireApprove && review.decision !== 'approve') return 0;
+  const actions = (review.recommendedActions ?? []).slice(0, 10);
+  let filed = 0;
+  for (const [index, a] of actions.entries()) {
+    const title = `[${a.type}] ${a.title}`;
+    const body = a.location
+      ? `Follow-up from reviewer.\n\nLocation: ${a.location}`
+      : 'Follow-up recommended by the reviewer.';
+    try {
+      let created: Awaited<ReturnType<ITaskSource['createSubIssue']>>;
+      if (parentIssueId) {
+        created = await source.createSubIssue(parentIssueId, title, body, {
+          priority: 3,
+          projectId: opts.projectId,
+          idempotencyId: reviewerFollowupId(parentIssueId, index, a),
+        });
+      } else {
+        created = await source.createTask(title, body, opts.projectId);
+      }
+      if ('error' in created) throw new Error(created.error);
+      filed += 1;
+    } catch (err) {
+      console.error(`[Runner] follow-up issue create failed (${a.title}):`, err);
+    }
+  }
+  return filed;
+}

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -5,7 +5,7 @@
 
 import { buildBranchName } from '../support/branchNaming.js';
 import { EmbedBuilder } from 'discord.js';
-import { decompositionChildId, reviewerFollowupId } from './decompositionIds.js';
+import { decompositionChildId } from './decompositionIds.js';
 import { pathIsUnderAny, taskEventKey, type TaskItem, type DecisionResult } from '../orchestration/decisionEngine.js';
 import { normalizeProjectPath } from '../orchestration/taskScheduler.js';
 import type { ExecutorResult } from '../orchestration/workflow.js';
@@ -25,7 +25,8 @@ import { analyzeIssue } from '../knowledge/index.js';
 import { runDraftAnalysis, type DraftAnalysis } from '../agents/draftAnalyzer.js';
 import { loadAuthoritativeOperatorFeedback } from '../coordination/operatorGuidance.js';
 import { t } from '../locale/index.js';
-import { formatTaskDescription } from '../linear/format.js';
+import { formatTaskDescription, parseFileScopeFromDescription } from '../linear/format.js';
+import { findDuplicateSibling, type ExistingSibling } from './duplicateSubIssueGuard.js';
 import { broadcastEvent } from '../core/eventHub.js';
 import type { Notifier } from '../notify/notifier.js';
 import type { ITaskSource } from './taskSource.js';
@@ -44,6 +45,8 @@ import { pipelineMetadata } from './pipelineMetadata.js';
 import { refreshExecutionTaskContext } from './executionTaskContext.js';
 export { formatExecutionCommentContext } from './executionTaskContext.js';
 export { rateLimitedPipelineResult } from './pipelinePreflight.js';
+import { fileReviewerFollowups } from './reviewerFollowups.js';
+export { fileReviewerFollowups } from './reviewerFollowups.js';
 
 export const PIPELINE_EFFECT_TIMEOUT_MS = 30_000;
 
@@ -333,51 +336,6 @@ export { decompositionChildId };
  * dispatch endpoint so both behave identically (no logic fork). The caller must
  * have already created the parent issue (`parentIssueId`).
  */
-/**
- * File the reviewer's recommendedActions as follow-ups when it approves
- * (INT-1611 restore / INT-1704). With a `parentIssueId` they become sub-issues;
- * without one (INT-1968) they are created as top-level issues so review can still
- * "just file them" off a non-issue branch. Gated by `autoFile` (default OFF);
- * caps at 10; each create is best-effort (failures logged, never throw).
- * Returns the count filed.
- */
-export async function fileReviewerFollowups(
-  source: ITaskSource | null,
-  parentIssueId: string | null | undefined,
-  review: ReviewResult,
-  opts: { autoFile?: boolean; projectId?: string; requireApprove?: boolean } = {},
-): Promise<number> {
-  // Autonomous pipeline files only on approve; the manual `review` command files
-  // regardless of decision (requireApprove: false). (INT-1704 / INT-1969)
-  const requireApprove = opts.requireApprove ?? true;
-  if (!opts.autoFile || !source) return 0;
-  if (requireApprove && review.decision !== 'approve') return 0;
-  const actions = (review.recommendedActions ?? []).slice(0, 10);
-  let filed = 0;
-  for (const [index, a] of actions.entries()) {
-    const title = `[${a.type}] ${a.title}`;
-    const body = a.location
-      ? `Follow-up from reviewer.\n\nLocation: ${a.location}`
-      : 'Follow-up recommended by the reviewer.';
-    try {
-      let created: Awaited<ReturnType<ITaskSource['createSubIssue']>>;
-      if (parentIssueId) {
-        created = await source.createSubIssue(parentIssueId, title, body, {
-          priority: 3,
-          projectId: opts.projectId,
-          idempotencyId: reviewerFollowupId(parentIssueId, index, a),
-        });
-      } else {
-        created = await source.createTask(title, body, opts.projectId);
-      }
-      if ('error' in created) throw new Error(created.error);
-      filed += 1;
-    } catch (err) {
-      console.error(`[Runner] follow-up issue create failed (${a.title}):`, err);
-    }
-  }
-  return filed;
-}
 
 export async function createSubIssuesWithDependencies(
   parentIssueId: string,
@@ -403,8 +361,32 @@ export async function createSubIssuesWithDependencies(
   }> = [];
   const creationErrors: string[] = [];
 
+  // Existing siblings a re-decomposition (or an over-splitting planner) might
+  // duplicate — deterministic file-scope+title check, not the LLM draft gate,
+  // which only ever compares top-level tasks against each other. (AGT-2908)
+  const existingSiblings: ExistingSibling[] = taskSource?.getChildren
+    ? (await taskSource.getChildren(parentIssueId).catch(() => []))
+      .map((child) => ({ id: child.id, identifier: child.identifier, title: child.title, fileScope: parseFileScopeFromDescription(child.description) }))
+    : [];
+
   for (const [index, subTask] of subTasks.entries()) {
     const fileScope = (subTask.fileScope ?? []).filter((f) => typeof f === 'string' && f.trim().length > 0);
+
+    const duplicate = findDuplicateSibling({ title: subTask.title, fileScope }, [...existingSiblings, ...createdSubIssues]);
+    if (duplicate) {
+      console.log(`[AutonomousRunner] Reusing existing sub-issue ${duplicate.sibling.identifier} for "${subTask.title}"`
+        + ` — duplicate of an existing sibling (file-scope ${duplicate.fileScopeScore.toFixed(2)}, title ${duplicate.titleScore.toFixed(2)})`);
+      createdSubIssues.push({
+        id: duplicate.sibling.id,
+        identifier: duplicate.sibling.identifier,
+        title: duplicate.sibling.title,
+        dependencies: subTask.dependencies || [],
+        topoRank: index,
+        estimatedMinutes: subTask.estimatedMinutes,
+        fileScope,
+      });
+      continue;
+    }
 
     const subDescription = formatTaskDescription({
       summary: subTask.description,

--- a/src/automation/taskSource.ts
+++ b/src/automation/taskSource.ts
@@ -80,6 +80,8 @@ export interface ITaskSource {
     description: string,
     options?: { priority?: number; projectId?: string; estimatedMinutes?: number; idempotencyId?: string },
   ): Promise<SubIssueResult>;
+  /** Existing sub-issues of a parent, for deterministic decomposition dedup (AGT-2908). */
+  getChildren?(parentId: string): Promise<Array<{ id: string; identifier: string; title: string; description: string }>>;
   logPairStart(issueId: string, sessionId: string, projectPath: string): Promise<void>;
   logPairComplete(issueId: string, sessionId: string, stats: PairCompleteStats): Promise<void>;
   logBlocked(issueId: string, sessionName: string, reason: string): Promise<void>;
@@ -148,6 +150,9 @@ export class LinearTaskSource implements ITaskSource {
   }
   createSubIssue(parentId: string, title: string, description: string, options?: { priority?: number; projectId?: string; estimatedMinutes?: number; idempotencyId?: string }): Promise<SubIssueResult> {
     return linear.createSubIssue(parentId, title, description, options);
+  }
+  getChildren(parentId: string): Promise<Array<{ id: string; identifier: string; title: string; description: string }>> {
+    return linear.getIssueChildren(parentId);
   }
   logPairStart(issueId: string, sessionId: string, projectPath: string): Promise<void> { return linear.logPairStart(issueId, sessionId, projectPath); }
   logPairComplete(issueId: string, sessionId: string, stats: PairCompleteStats): Promise<void> { return linear.logPairComplete(issueId, sessionId, stats); }

--- a/src/linear/format.ts
+++ b/src/linear/format.ts
@@ -223,3 +223,10 @@ export function formatTaskDescription(input: TaskDescriptionInput): string {
   }
   return body;
 }
+
+/** Inverse of formatTaskDescription's "File scope:" fact line, for dedup comparisons (AGT-2908). */
+export function parseFileScopeFromDescription(description: string): string[] {
+  const match = description.match(/file scope:\s*(.+)/i);
+  if (!match) return [];
+  return match[1].split(',').map((f) => f.trim()).filter(Boolean);
+}

--- a/src/linear/linear.ts
+++ b/src/linear/linear.ts
@@ -968,6 +968,27 @@ export async function markIssueDuplicate(issueId: string, canonicalIssueId: stri
   }
 }
 
+/** Existing sub-issues of a parent, for deterministic decomposition dedup (AGT-2908). */
+export async function getIssueChildren(
+  issueId: string,
+): Promise<Array<{ id: string; identifier: string; title: string; description: string }>> {
+  if (!isLinearInitialized()) return [];
+  try {
+    const linear = getClient();
+    const parent = await linear.issue(issueId);
+    const children = await parent.children();
+    return children.nodes.map((child) => ({
+      id: child.id,
+      identifier: child.identifier,
+      title: child.title,
+      description: child.description ?? '',
+    }));
+  } catch (error) {
+    console.error(`[Linear] Failed to fetch children of ${issueId}:`, error);
+    return [];
+  }
+}
+
 /**
  * Add a comment to an issue
  */


### PR DESCRIPTION
## Summary
- The existing draft-stage duplicate check (`draftGrooming.ts`'s `applyDraftGates`) only compares top-level tasks against each other via an LLM call — it never sees the sub-issues a decomposition is about to create.
- The real AGT-2908 incident was two different top-level parents independently decomposing the same work into a schema/persist/test triad, five times over — every duplicate shared an identical File scope and differed only in a title prefix (`[Backend]` vs `[API Schema]` vs `[API Contract]`). The local per-parent `decompositionState` cache can't see across separately-decomposed parents, so nothing in the existing pipeline could have caught this.
- Adds `src/automation/duplicateSubIssueGuard.ts`: a deterministic (non-LLM), pure, unit-tested file-scope + title-similarity check. `createSubIssuesWithDependencies` now fetches the parent's existing children fresh from Linear (`ITaskSource.getChildren` → `linear.getIssueChildren` → SDK `issue.children()`) and checks each planned sub-issue against those siblings *and* against sub-issues already created in this same run, before creating anything. A match reuses the existing sibling's id/identifier instead of creating a duplicate.
- Extracted `fileReviewerFollowups` into `reviewerFollowups.ts` (unchanged behavior, re-exported for the existing dynamic-import call site and test) to keep `runnerExecution.ts` under its 1500-line pre-commit cap.

## Test plan
- [x] `npx vitest run src/automation/duplicateSubIssueGuard.test.ts` — 10/10 new tests, including the real AGT-2908 title/file-scope fixture
- [x] `npx vitest run` (full suite) — 390 files / 5434 tests passed, 0 regressions
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] pre-commit hook (oxlint + typecheck + file-size gate) — passed