### PR TITLE
feat(coordination): ledger_overview tool — orchestrator read access to its own run ledger (AGT-4184)

### DIFF
--- a/src/coordination/ledgerOverviewTool.ts
+++ b/src/coordination/ledgerOverviewTool.ts
@@ -1,0 +1,121 @@
+// ============================================
+// OpenSwarm - ledger_overview coordination tool (AGT-4184)
+// ============================================
+//
+// Gives the orchestrator role read access to what the operator saw on
+// 2026-09-02 while triaging the daemon by hand: parked runs and why, the
+// day's failure buckets, and runs stuck cycling with unusually high attempt
+// counts. Read-only, bounded, and never throws into the agent loop.
+
+import Database from 'better-sqlite3';
+import { defaultAutomationDbPath } from '../automation/automationDbPath.js';
+import { aggregateFailureBuckets, type FailureBucket } from '../automation/ledgerRetrospective.js';
+import type { ToolDefinition } from '../adapters/tools.js';
+
+/** Runs that have reached a terminal or human-owned state; excluded from attempt-outlier ranking. */
+const NON_CYCLING_STATES = new Set(['DONE', 'CANCELLED', 'DECOMPOSED', 'NEEDS_HUMAN']);
+
+const FAILURE_BUCKET_WINDOW_MS = 24 * 60 * 60 * 1000;
+const PARKED_RUNS_LIMIT = 20;
+const ATTEMPT_OUTLIERS_LIMIT = 5;
+const FAILURE_BUCKETS_LIMIT = 5;
+
+export interface ParkedRunSummary {
+  identifier: string | null;
+  parkedUnder: string | null;
+  reason: string;
+  ageMinutes: number;
+  prUrl: string | null;
+}
+
+export interface AttemptOutlierSummary {
+  identifier: string | null;
+  attemptNo: number;
+  state: string;
+}
+
+export interface LedgerOverview {
+  parkedRuns: ParkedRunSummary[];
+  failureBuckets: Array<Pick<FailureBucket, 'fingerprint' | 'attempts' | 'distinctIssues' | 'identifiers'>>;
+  attemptOutliers: AttemptOutlierSummary[];
+}
+
+interface ParkedRunRow {
+  identifier: string | null;
+  last_error_code: string | null;
+  last_error_message: string | null;
+  updated_at: number;
+  pr_url: string | null;
+}
+
+interface AttemptOutlierRow {
+  identifier: string | null;
+  attempt_no: number;
+  state: string;
+}
+
+export function buildLedgerOverview(dbPath?: string, now: number = Date.now()): LedgerOverview {
+  const db = new Database(dbPath ?? defaultAutomationDbPath(), { readonly: true });
+  try {
+    const parkedRows = db.prepare(`
+      SELECT identifier, last_error_code, last_error_message, updated_at, pr_url
+      FROM automation_runs
+      WHERE state = 'NEEDS_HUMAN'
+      ORDER BY updated_at DESC
+      LIMIT ?
+    `).all(PARKED_RUNS_LIMIT) as ParkedRunRow[];
+
+    const parkedRuns: ParkedRunSummary[] = parkedRows.map((row) => ({
+      identifier: row.identifier,
+      parkedUnder: row.last_error_code,
+      reason: (row.last_error_message ?? '').slice(0, 200),
+      ageMinutes: Math.max(0, Math.round((now - row.updated_at) / 60_000)),
+      prUrl: row.pr_url,
+    }));
+
+    const failureBuckets = aggregateFailureBuckets(db, now - FAILURE_BUCKET_WINDOW_MS)
+      .slice(0, FAILURE_BUCKETS_LIMIT)
+      .map(({ fingerprint, attempts, distinctIssues, identifiers }) => ({ fingerprint, attempts, distinctIssues, identifiers }));
+
+    const placeholders = [...NON_CYCLING_STATES].map(() => '?').join(', ');
+    const outlierRows = db.prepare(`
+      SELECT identifier, attempt_no, state
+      FROM automation_runs
+      WHERE state NOT IN (${placeholders})
+      ORDER BY attempt_no DESC
+      LIMIT ?
+    `).all(...NON_CYCLING_STATES, ATTEMPT_OUTLIERS_LIMIT) as AttemptOutlierRow[];
+
+    const attemptOutliers: AttemptOutlierSummary[] = outlierRows.map((row) => ({
+      identifier: row.identifier,
+      attemptNo: row.attempt_no,
+      state: row.state,
+    }));
+
+    return { parkedRuns, failureBuckets, attemptOutliers };
+  } finally {
+    db.close();
+  }
+}
+
+export const LEDGER_OVERVIEW_TOOL_DEFINITION: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'ledger_overview',
+    description:
+      'Read-only snapshot of this deployment\'s own run ledger: parked (NEEDS_HUMAN) runs and why, the last 24h\'s failure buckets, and runs with unusually high attempt counts still cycling. Use this before asking the operator what is stuck — it is what they would look up by hand.',
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+};
+
+/** `{error}` on any failure — a broken or absent ledger must not throw into the agent loop. */
+export function executeLedgerOverview(): { content: string; isError: boolean } {
+  try {
+    return { content: JSON.stringify(buildLedgerOverview()), isError: false };
+  } catch (error) {
+    return {
+      content: JSON.stringify({ error: error instanceof Error ? error.message : String(error) }),
+      isError: true,
+    };
+  }
+}

--- a/src/coordination/orchestratorAgent.test.ts
+++ b/src/coordination/orchestratorAgent.test.ts
@@ -278,6 +278,7 @@ describe('runOrchestrator', () => {
     expect(result.toolsGranted).toEqual([
       'host_read_file', 'host_search_files',
       'tracker_cached_issue', 'tracker_save_comment', 'coordination_answer_question',
+      'ledger_overview',
     ]);
     expect(spawnCli).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       mcpTools: expect.arrayContaining([

--- a/src/coordination/orchestratorTrackerTools.test.ts
+++ b/src/coordination/orchestratorTrackerTools.test.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import { RunLedger } from '../automation/runLedger.js';
 
 const originalCoordinationFile = process.env.OPENSWARM_COORDINATION_FILE;
 const originalAutomationDb = process.env.OPENSWARM_AUTOMATION_DB;
@@ -216,5 +218,65 @@ describe('orchestrator tracker tools', () => {
     expect(found.content).toContain('src/app.ts');
     const none = await tools.executeOrchestratorTrackerTool('host_search_files', { pattern: 'this-string-is-absent-zzzz' }, orchestrator);
     expect(none).toMatchObject({ isError: false, content: '(no matches)' });
+  });
+});
+
+describe('ledger_overview (AGT-4184)', () => {
+  it('is unavailable to worker/reviewer roles', async () => {
+    const { tools } = await setup();
+    for (const actorRole of ['worker', 'reviewer']) {
+      const result = await tools.executeOrchestratorTrackerTool('ledger_overview', {}, {
+        repository: '/repo', taskId: actorRole, actor: `${actorRole}-a`, actorRole,
+      });
+      expect(result).toMatchObject({ isError: true, content: expect.stringContaining('orchestrator') });
+    }
+  });
+
+  it('returns parked runs, failure buckets, and attempt outliers from a seeded ledger', async () => {
+    const { tools } = await setup();
+    new RunLedger(process.env.OPENSWARM_AUTOMATION_DB!).close(); // creates the real schema
+    const db = new Database(process.env.OPENSWARM_AUTOMATION_DB!);
+    const now = Date.now();
+    const insertRun = db.prepare(`
+      INSERT INTO automation_runs(issue_id, source, identifier, project_path, state, attempt_no, last_error_code, last_error_message, pr_url, discovered_at, updated_at)
+      VALUES (?, 'linear', ?, '/repo', ?, ?, ?, ?, ?, ?, ?)
+    `);
+    insertRun.run('run-parked', 'AX-1', 'NEEDS_HUMAN', 3, 'publication_scope_mismatch', 'x'.repeat(300), null, now - 120_000, now - 60_000);
+    insertRun.run('run-cycling', 'AX-2', 'RETRY_AT', 47, null, null, null, now - 600_000, now - 10_000);
+    insertRun.run('run-done', 'AX-3', 'DONE', 99, null, null, 'https://github.com/x/y/pull/1', now - 600_000, now - 5_000);
+    const insertAttempt = db.prepare(`
+      INSERT INTO automation_attempts(issue_id, attempt_no, lease_epoch, status, stage, started_at, finished_at, error_message, success)
+      VALUES (?, ?, 1, 'suspended', 'RETRY_AT', ?, ?, ?, 0)
+    `);
+    for (let i = 0; i < 6; i++) {
+      insertRun.run(`run-fail-${i}`, `AX-fail-${i}`, 'RETRY_AT', 1, null, null, null, now - 600_000, now - 60_000);
+      insertAttempt.run(`run-fail-${i}`, 1, now - 60_000, now - 59_000, 'Worker reported success with no changed files and no explicit noChangesReason.');
+    }
+    db.close();
+
+    const orchestrator = { repository: '/repo', taskId: 'orchestrator:sweep', actor: 'orchestrator-a', actorRole: 'orchestrator' };
+    const result = await tools.executeOrchestratorTrackerTool('ledger_overview', {}, orchestrator);
+    expect(result.isError).toBe(false);
+    const overview = JSON.parse(result.content);
+
+    expect(overview.parkedRuns).toHaveLength(1);
+    expect(overview.parkedRuns[0]).toMatchObject({ identifier: 'AX-1', parkedUnder: 'publication_scope_mismatch' });
+    expect(overview.parkedRuns[0].reason.length).toBe(200); // truncated from 300 'x's
+
+    expect(overview.attemptOutliers[0]).toMatchObject({ identifier: 'AX-2', attemptNo: 47, state: 'RETRY_AT' });
+    expect(overview.attemptOutliers.some((row: { identifier: string }) => row.identifier === 'AX-1')).toBe(false);
+    expect(overview.attemptOutliers.some((row: { identifier: string }) => row.identifier === 'AX-3')).toBe(false);
+
+    expect(overview.failureBuckets[0].attempts).toBe(6);
+    expect(overview.failureBuckets[0].distinctIssues).toBe(6);
+  });
+
+  it('returns a bounded {error} instead of throwing when the ledger is unreadable', async () => {
+    const { tools } = await setup();
+    process.env.OPENSWARM_AUTOMATION_DB = join(dir, 'does-not-exist', 'automation.db');
+    const orchestrator = { repository: '/repo', taskId: 'orchestrator:sweep', actor: 'orchestrator-a', actorRole: 'orchestrator' };
+    const result = await tools.executeOrchestratorTrackerTool('ledger_overview', {}, orchestrator);
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content)).toHaveProperty('error');
   });
 });

--- a/src/coordination/orchestratorTrackerTools.ts
+++ b/src/coordination/orchestratorTrackerTools.ts
@@ -8,6 +8,7 @@ import type { ToolDefinition } from '../adapters/tools.js';
 import { answerHumanQuestion } from './humanQuestions.js';
 import { getCoordinationStore } from './coordinationStore.js';
 import { repositoryKey } from './repositoryCell.js';
+import { executeLedgerOverview, LEDGER_OVERVIEW_TOOL_DEFINITION } from './ledgerOverviewTool.js';
 
 const execFileAsync = promisify(execFile);
 const HOST_READ_MAX_BYTES = 200_000;
@@ -119,6 +120,7 @@ export const ORCHESTRATOR_TRACKER_TOOL_DEFINITIONS: ToolDefinition[] = [
       },
     },
   },
+  LEDGER_OVERVIEW_TOOL_DEFINITION,
 ];
 
 export const ORCHESTRATOR_TRACKER_TOOL_NAMES: ReadonlySet<string> = new Set(
@@ -240,6 +242,10 @@ export async function executeOrchestratorTrackerTool(
 
   if (name === 'host_read_file' || name === 'host_search_files') {
     return executeHostReadTool(name, args, context);
+  }
+
+  if (name === 'ledger_overview') {
+    return executeLedgerOverview();
   }
 
   if (name === 'coordination_answer_question') {


### PR DESCRIPTION
## Summary
- Coordinator Slice 1: gives the orchestrator role a read-only `ledger_overview` tool exposing the same data the operator manually checked while triaging the daemon by hand — parked (NEEDS_HUMAN) runs and why, the last 24h's failure buckets (reuses `aggregateFailureBuckets` from `ledgerRetrospective.ts`), and runs still cycling with unusually high attempt counts.
- Wired through the existing `executeOrchestratorTrackerTool` dispatch, so it inherits the same orchestrator-only role gate as `tracker_cached_issue`/`tracker_save_comment` — asserted directly in tests (worker/reviewer roles rejected).
- Opens the database read-only (`better-sqlite3` `{readonly: true}`) and never throws into the agent loop — any failure (missing/corrupt db) surfaces as `{error}` in the tool result, tested directly.
- Worker/reviewer pipelines never wire `ORCHESTRATOR_TRACKER_TOOL_DEFINITIONS` at all, so this is unreachable from those roles structurally, not just by the runtime gate.

## Test plan
- [x] `npx vitest run src/coordination/orchestratorTrackerTools.test.ts` — 9/9, including 3 new `ledger_overview` cases (role gate, seeded-ledger shape, unreadable-db error path)
- [x] `npx vitest run` (full suite) — 390 files / 5437 tests passed, 0 regressions (updated one golden `toolsGranted` list to include the new tool)
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] pre-commit hook (oxlint + typecheck + file-size gate) — passed