### PR TITLE
fix(env): warn when a shell export silently shadows a divergent .env value (AGT-4154)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ import { runCli } from './runners/cliRunner.js';
 import { setDefaultAdapter } from './adapters/index.js';
 import { readProviderOverride } from './core/providerOverride.js';
 import { loadConfig, validateConfig, generateSampleConfig } from './core/config.js';
-import { loadEnvFile } from './core/envFile.js';
+import { formatShadowWarning, loadEnvFile } from './core/envFile.js';
 import { initTelemetry, track } from './telemetry/telemetry.js';
 import { maybeAutoUpdate } from './support/updateNotifier.js';
 import { safeConsole } from './support/safeLog.js';
@@ -21,7 +21,8 @@ import { parsePositiveIntegerOption, parseTcpPortOption } from './cli/optionPars
 // Load .env so CLI commands (e.g. `auth login --provider linear` reading
 // LINEAR_OAUTH_CLIENT_ID) see the same env the daemon does. Idempotent; never
 // overrides an already-set shell var.
-loadEnvFile();
+const cliEnvLoad = loadEnvFile();
+for (const shadowed of cliEnvLoad.shadowedKeys) console.warn(formatShadowWarning(shadowed));
 
 // Read version from package.json so it stays in sync with the published package.
 // cli.js lives at <pkg>/dist/cli.js, so package.json is one directory up.

--- a/src/core/envFile.test.ts
+++ b/src/core/envFile.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, statSync, rmSync } from 'node:fs';
 import { tmpdir, platform, homedir as realHomedir } from 'node:os';
 import { join } from 'node:path';
-import { writeEnvVars } from './envFile.js';
+import { formatShadowWarning, writeEnvVars } from './envFile.js';
 
 vi.mock('node:os', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:os')>();
@@ -127,5 +127,63 @@ describe('loadEnvFile', () => {
     loadEnvFile();
 
     expect(process.env.SHELL_WINS).toBe('from-shell');
+  });
+
+  it('reports a shadowed key when the ambient value differs from the file (AGT-4154)', () => {
+    projectDir = mkdtempSync(join(tmpdir(), 'env-project-'));
+    mockedHome = mkdtempSync(join(tmpdir(), 'env-home-'));
+    const envPath = join(projectDir, '.env');
+    writeFileSync(envPath, 'DIVERGES=file-value\n');
+
+    stashEnv('DIVERGES', 'OPENSWARM_ENV', 'OPENSWARM_CONFIG');
+    delete process.env.OPENSWARM_ENV;
+    delete process.env.OPENSWARM_CONFIG;
+    process.env.DIVERGES = 'ambient-value';
+    vi.spyOn(process, 'cwd').mockReturnValue(projectDir);
+
+    const result = loadEnvFile();
+
+    expect(result.shadowedKeys).toHaveLength(1);
+    expect(result.shadowedKeys[0]).toMatchObject({ key: 'DIVERGES', sourcePath: envPath });
+    expect(result.shadowedKeys[0].fileFingerprint).not.toBe(result.shadowedKeys[0].ambientFingerprint);
+
+    const warning = formatShadowWarning(result.shadowedKeys[0]);
+    expect(warning).not.toContain('file-value');
+    expect(warning).not.toContain('ambient-value');
+    expect(warning).toContain('DIVERGES');
+    expect(warning).toContain(envPath);
+  });
+
+  it('stays silent when the ambient value is identical to the file', () => {
+    projectDir = mkdtempSync(join(tmpdir(), 'env-project-'));
+    mockedHome = mkdtempSync(join(tmpdir(), 'env-home-'));
+    writeFileSync(join(projectDir, '.env'), 'SAME=matching\n');
+
+    stashEnv('SAME', 'OPENSWARM_ENV', 'OPENSWARM_CONFIG');
+    delete process.env.OPENSWARM_ENV;
+    delete process.env.OPENSWARM_CONFIG;
+    process.env.SAME = 'matching';
+    vi.spyOn(process, 'cwd').mockReturnValue(projectDir);
+
+    const result = loadEnvFile();
+
+    expect(result.shadowedKeys).toEqual([]);
+  });
+
+  it('reports no shadow when the ambient value is unset (the key is simply loaded)', () => {
+    projectDir = mkdtempSync(join(tmpdir(), 'env-project-'));
+    mockedHome = mkdtempSync(join(tmpdir(), 'env-home-'));
+    writeFileSync(join(projectDir, '.env'), 'FRESH=from-file\n');
+
+    stashEnv('FRESH', 'OPENSWARM_ENV', 'OPENSWARM_CONFIG');
+    delete process.env.OPENSWARM_ENV;
+    delete process.env.OPENSWARM_CONFIG;
+    delete process.env.FRESH;
+    vi.spyOn(process, 'cwd').mockReturnValue(projectDir);
+
+    const result = loadEnvFile();
+
+    expect(result.shadowedKeys).toEqual([]);
+    expect(process.env.FRESH).toBe('from-file');
   });
 });

--- a/src/core/envFile.ts
+++ b/src/core/envFile.ts
@@ -10,14 +10,36 @@
 // earlier (more specific) file wins over the same key in a later,
 // more general one.
 
+import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { atomicWriteFileSync } from '../support/atomicFile.js';
 
+/** A key a .env file held that an ambient (shell-exported) value shadowed with a *different* value. */
+export interface ShadowedEnvKey {
+  key: string;
+  /** The .env file the divergent value was found in. */
+  sourcePath: string;
+  fileFingerprint: string;
+  ambientFingerprint: string;
+}
+
 export interface EnvLoadResult {
   paths: string[];
   loadedKeys: string[];
+  /** Keys skipped because a shell export already set them to a *different* value (AGT-4154). */
+  shadowedKeys: ShadowedEnvKey[];
+}
+
+/** Short, one-way fingerprint for comparing two secret values without ever printing either. */
+function fingerprint(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
+/** Render one shadowed-key entry as a safe, human-readable warning line. */
+export function formatShadowWarning(entry: ShadowedEnvKey): string {
+  return `⚠️  ${entry.key}: ambient shell value (${entry.ambientFingerprint}) differs from ${entry.sourcePath} (${entry.fileFingerprint}) — the ambient value wins`;
 }
 
 function getSearchPaths(): string[] {
@@ -142,6 +164,8 @@ export function writeEnvVars(path: string, kv: Record<string, string>): void {
 export function loadEnvFile(): EnvLoadResult {
   const paths: string[] = [];
   const loadedKeys: string[] = [];
+  const shadowedKeys: ShadowedEnvKey[] = [];
+  const alreadyReported = new Set<string>();
 
   for (const path of getSearchPaths()) {
     if (!existsSync(path)) continue;
@@ -152,11 +176,21 @@ export function loadEnvFile(): EnvLoadResult {
       const parsed = parseLine(rawLine);
       if (parsed === null) continue;
       const [key, value] = parsed;
-      if (process.env[key] !== undefined) continue;
+      const ambient = process.env[key];
+      if (ambient !== undefined) {
+        // Identical values are not a divergence — stay silent, and only report
+        // the first file that diverges per key (a later, more general file
+        // repeating the same shadow would just be noise).
+        if (ambient !== value && !alreadyReported.has(key)) {
+          alreadyReported.add(key);
+          shadowedKeys.push({ key, sourcePath: path, fileFingerprint: fingerprint(value), ambientFingerprint: fingerprint(ambient) });
+        }
+        continue;
+      }
       process.env[key] = value;
       loadedKeys.push(key);
     }
   }
 
-  return { paths, loadedKeys };
+  return { paths, loadedKeys, shadowedKeys };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,12 @@ dns.setDefaultResultOrder('ipv4first');
 // Load .env before anything else — config.yaml uses ${LINEAR_API_KEY} etc.
 // and would otherwise silently disable integrations when the daemon is
 // launched from a non-interactive shell without those vars exported.
-import { loadEnvFile } from './core/envFile.js';
+import { formatShadowWarning, loadEnvFile } from './core/envFile.js';
 const envLoad = loadEnvFile();
 if (envLoad.paths.length > 0) {
   console.log(`Loaded env from: ${envLoad.paths.join(', ')} (${envLoad.loadedKeys.length} keys)`);
 }
+for (const shadowed of envLoad.shadowedKeys) console.warn(formatShadowWarning(shadowed));
 
 // Strip Claude Code session markers so child processes (worker, planner) can launch Claude CLI
 // Without this, running the service from inside a Claude Code session blocks all CLI spawns.


### PR DESCRIPTION
## Summary
- `loadEnvFile()` skipped any key already present in `process.env` without ever comparing the value against what the file held. Precedence is correct and deliberate (a shell export must win, matching `node --env-file` / `dotenv`) — this is not a request to change that. The defect is that a *divergence* between the two was completely unobservable.
- Real cost: a stale `~/.zshrc` export holding a revoked `LINEAR_API_KEY` silently beat the repo's valid `.env`, costing ~1h of misdirected debugging that ended in decompiling `@linear/sdk`'s minified header builder — all irrelevant, because the SDK was being handed a revoked string the whole time.
- Adds `EnvLoadResult.shadowedKeys`: populated only when the ambient value differs from the file's (identical values stay silent — not a divergence). Never carries the raw secret in either direction — both sides are reduced to a 12-char sha256 fingerprint via `formatShadowWarning()`.
- Logged once at startup from both places that call `loadEnvFile()` (`src/index.ts`, `src/cli.ts`).

## Test plan
- [x] `npx vitest run src/core/envFile.test.ts` — 10/10, including 3 new cases: divergent value produces exactly one shadow entry with non-matching fingerprints and the warning never contains either raw value; identical ambient value produces no entry; ambient unset loads normally with no entry
- [x] `npx vitest run` (full suite) — 390 files / 5440 tests passed, 0 regressions
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] pre-commit hook (oxlint + typecheck + file-size gate) — passed