### PR TITLE
fix(update): verify the resolved version after install before claiming success (AGT-3183)

### DIFF
--- a/src/support/updateNotifier.coverage.test.ts
+++ b/src/support/updateNotifier.coverage.test.ts
@@ -204,16 +204,21 @@ describe('maybeAutoUpdate - real install/reexec + stale-fetch branch', () => {
       write,
       install,
       reexec,
+      resolvedVersion: () => '0.13.0',
     });
 
-    expect(writeCache).toHaveBeenCalledWith({ latest: '0.12.0', checkedAt: 1_000 });
+    expect(writeCache).toHaveBeenCalledWith({ latest: '0.12.0', checkedAt: 1_000, failedInstallVersion: undefined });
     expect(install).toHaveBeenCalledWith('@intrect/openswarm');
     expect(reexec).toHaveBeenCalledOnce();
   });
 
   it('installs via the real defaultInstall (execFileSync succeeds) and re-execs via defaultReexec', async () => {
     mockedExecFileSync.mockReturnValue(Buffer.from(''));
-    mockedSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>);
+    // First spawnSync call is the real resolvedVersion() check (AGT-3183) —
+    // report the new version so verification passes; second is defaultReexec.
+    mockedSpawnSync
+      .mockReturnValueOnce({ stdout: '0.13.0', status: 0 } as unknown as ReturnType<typeof spawnSync>)
+      .mockReturnValueOnce({ status: 0 } as ReturnType<typeof spawnSync>);
     const write = vi.fn();
 
     await maybeAutoUpdate('0.12.0', {
@@ -229,7 +234,7 @@ describe('maybeAutoUpdate - real install/reexec + stale-fetch branch', () => {
       ['install', '-g', '@intrect/openswarm@latest'],
       expect.objectContaining({ stdio: 'inherit' })
     );
-    expect(mockedSpawnSync).toHaveBeenCalledOnce();
+    expect(mockedSpawnSync).toHaveBeenCalledTimes(2);
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
@@ -254,7 +259,9 @@ describe('maybeAutoUpdate - real install/reexec + stale-fetch branch', () => {
 
   it('defaultReexec falls back to exit code 0 when spawnSync reports no status', async () => {
     mockedExecFileSync.mockReturnValue(Buffer.from(''));
-    mockedSpawnSync.mockReturnValue({ status: null } as unknown as ReturnType<typeof spawnSync>);
+    mockedSpawnSync
+      .mockReturnValueOnce({ stdout: '0.13.0', status: 0 } as unknown as ReturnType<typeof spawnSync>) // resolvedVersion()
+      .mockReturnValueOnce({ status: null } as unknown as ReturnType<typeof spawnSync>); // defaultReexec()
 
     await maybeAutoUpdate('0.12.0', {
       ...base,

--- a/src/support/updateNotifier.test.ts
+++ b/src/support/updateNotifier.test.ts
@@ -100,7 +100,7 @@ describe('maybeNotifyUpdate (INT-2270)', () => {
 describe('maybeAutoUpdate (INT-2394)', () => {
   const base = { argv: ['n', 'c', 'start'], env: {} as NodeJS.ProcessEnv, isTTY: true };
 
-  it('installs and re-execs when a newer version exists', async () => {
+  it('installs and re-execs when a newer version exists and resolves after install', async () => {
     const install = vi.fn(() => true);
     const reexec = vi.fn();
     const write = vi.fn();
@@ -109,6 +109,7 @@ describe('maybeAutoUpdate (INT-2394)', () => {
       readCache: () => ({ latest: '0.13.0', checkedAt: 1000 }),
       now: () => 1001,
       write, install, reexec,
+      resolvedVersion: () => '0.13.0',
     });
     expect(install).toHaveBeenCalledWith('@intrect/openswarm');
     expect(reexec).toHaveBeenCalledOnce();
@@ -139,6 +140,57 @@ describe('maybeAutoUpdate (INT-2394)', () => {
     });
     expect(install).toHaveBeenCalledOnce();
     expect(reexec).not.toHaveBeenCalled();
+  });
+
+  it('does not claim success or re-exec when install exits 0 but the resolved version is unchanged (AGT-3183)', async () => {
+    const install = vi.fn(() => true);
+    const reexec = vi.fn();
+    const writeCache = vi.fn();
+    const out = vi.fn();
+    await maybeAutoUpdate('0.12.0', {
+      ...base,
+      readCache: () => ({ latest: '0.13.0', checkedAt: 1000 }),
+      now: () => 1001,
+      writeCache, install, reexec,
+      write: out, // deps.write is the output writer, not the cache writer
+      resolvedVersion: () => '0.12.0', // install "succeeded" but the running binary still reports the old version
+      installPrefix: () => '/some/other/prefix',
+    });
+    expect(reexec).not.toHaveBeenCalled();
+    expect(writeCache).toHaveBeenCalledWith({ latest: '0.12.0', checkedAt: 1001, failedInstallVersion: '0.13.0' });
+    const warned = out.mock.calls.map((call) => call[0] as string).join('\n');
+    expect(warned).not.toContain('Updated');
+    expect(warned).toContain('0.13.0');
+    expect(warned).toContain('/some/other/prefix');
+  });
+
+  it('suppresses reinstalling a version already confirmed not to take effect', async () => {
+    const install = vi.fn(() => true);
+    const reexec = vi.fn();
+    await maybeAutoUpdate('0.12.0', {
+      ...base,
+      readCache: () => ({ latest: '0.13.0', checkedAt: 1000, failedInstallVersion: '0.13.0' }),
+      now: () => 1001,
+      install, reexec,
+    });
+    expect(install).not.toHaveBeenCalled();
+    expect(reexec).not.toHaveBeenCalled();
+  });
+
+  it('retries once a genuinely newer version is published, even after a prior failure', async () => {
+    const install = vi.fn(() => true);
+    const reexec = vi.fn();
+    await maybeAutoUpdate('0.12.0', {
+      ...base,
+      // Previously failed on 0.13.0, but the cached `latest` here is 0.14.0 —
+      // a new version was published since, so the suppression must not apply.
+      readCache: () => ({ latest: '0.14.0', checkedAt: 1000, failedInstallVersion: '0.13.0' }),
+      now: () => 1001,
+      install, reexec,
+      resolvedVersion: () => '0.14.0',
+    });
+    expect(install).toHaveBeenCalledOnce();
+    expect(reexec).toHaveBeenCalledOnce();
   });
 
   it('falls back to a passive notice when opted out', async () => {

--- a/src/support/updateNotifier.ts
+++ b/src/support/updateNotifier.ts
@@ -21,6 +21,8 @@ const CACHE_PATH = join(homedir(), '.openswarm', 'update-check.json');
 interface UpdateCache {
   latest: string;
   checkedAt: number;
+  /** A `latest` version we already installed-and-verified as NOT taking effect (AGT-3183) — skip reinstalling it. */
+  failedInstallVersion?: string;
 }
 
 /** Numeric semver compare (pre-release tags ignored). `latest` strictly newer? Pure. */
@@ -150,6 +152,60 @@ function defaultInstall(pkg: string): boolean {
 }
 
 /**
+ * What re-running the exact command `defaultReexec` is about to run would
+ * report as its own version — not what npm just installed. `npm install`
+ * exiting 0 only proves the package landed somewhere; when that somewhere is
+ * not on the resolution path this process's own entry point re-execs into
+ * (prefix/PATH mismatch — nvm/homebrew/asdf, a stray `npm link`, ...), the
+ * binary that actually runs next is unchanged. This asks the same question
+ * `reexec()` is about to answer, before claiming success. (AGT-3183)
+ */
+function resolvedVersion(): string | null {
+  try {
+    const entry = process.argv[1];
+    if (!entry) return null;
+    const result = spawnSync(process.execPath, [entry, '--version'], {
+      encoding: 'utf8',
+      timeout: 10_000,
+      env: { ...process.env, OPENSWARM_UPDATED: '1' },
+    });
+    const out = (result.stdout ?? '').trim();
+    return out.length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Best-effort `npm prefix -g`, for the diagnostic warning only — never throws. */
+function installPrefix(): string | null {
+  try {
+    const result = spawnSync('npm', ['prefix', '-g'], { encoding: 'utf8', timeout: 5_000 });
+    const out = (result.stdout ?? '').trim();
+    return out.length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Explains a verified-unchanged install instead of silently claiming "Updated" and looping. */
+function formatInstallMismatchWarning(
+  latest: string,
+  resolved: string | null,
+  current: string,
+  getInstallPrefix: () => string | null,
+): string {
+  const lines = [
+    `\n  ${c.dim('npm installed')} ${c.green(latest)} ${c.dim('but the binary this process re-execs into still resolves to')} ${c.dim(resolved ?? current)}.`,
+    `  ${c.dim("npm's global install prefix likely does not match what actually runs `openswarm` — mixed nvm/homebrew/asdf, or a stray `npm link`.")}`,
+  ];
+  const prefix = getInstallPrefix();
+  if (prefix) lines.push(`  ${c.dim(`npm installed to: ${prefix}`)}`);
+  lines.push(`  ${c.dim(`Currently running from: ${process.argv[1] ?? 'unknown'}`)}`);
+  lines.push(`  ${c.dim(`Run npm i -g ${PKG} manually and check which one PATH resolves.`)}\n`);
+  return lines.join('\n');
+}
+
+/**
  * Re-run the current command with the freshly-installed binary. Marks the child
  * with OPENSWARM_UPDATED=1 so it won't try to update again (loop guard), waits
  * for it, and exits with its code. Does not return on success. (INT-2394)
@@ -165,6 +221,10 @@ function defaultReexec(): void {
 export interface AutoUpdateDeps extends NotifierDeps {
   install?: (pkg: string) => boolean;
   reexec?: () => void;
+  /** What re-execing would actually report as its version, post-install. Injectable for tests. (AGT-3183) */
+  resolvedVersion?: () => string | null;
+  /** Best-effort `npm prefix -g`, for the mismatch diagnostic only. Injectable for tests. (AGT-3183) */
+  installPrefix?: () => string | null;
 }
 
 /**
@@ -173,6 +233,14 @@ export interface AutoUpdateDeps extends NotifierDeps {
  * when opted out (OPENSWARM_NO_AUTO_UPDATE). Skips CI/non-TTY/meta invocations
  * (never installs unattended) and no-ops once re-executed (OPENSWARM_UPDATED).
  * Uses the same 24h cache as the notice. Never throws. (INT-2394)
+ *
+ * `npm install` exiting 0 only proves the package landed somewhere — not that
+ * the binary this process re-execs into changed (INT-2394 assumed it did and
+ * looped forever when npm's install prefix and PATH disagreed, AGT-3183). So a
+ * successful install is verified against `resolvedVersion()` before it is
+ * reported or re-exec'd into; a verified-unchanged version is remembered
+ * (`failedInstallVersion`) so the next run skips straight to a passive notice
+ * instead of paying for another `npm install` it already knows won't take.
  */
 export async function maybeAutoUpdate(current: string, deps: AutoUpdateDeps = {}): Promise<void> {
   try {
@@ -191,25 +259,46 @@ export async function maybeAutoUpdate(current: string, deps: AutoUpdateDeps = {}
     const out = deps.write ?? ((s: string) => process.stderr.write(s));
     const install = deps.install ?? defaultInstall;
     const reexec = deps.reexec ?? defaultReexec;
+    const getResolvedVersion = deps.resolvedVersion ?? resolvedVersion;
+    const getInstallPrefix = deps.installPrefix ?? installPrefix;
 
     const cache = read();
     let latest = cache?.latest ?? null;
+    const failedInstallVersion = cache?.failedInstallVersion;
     const fresh = cache != null && now() - cache.checkedAt < DAY_MS;
     if (!fresh) {
       const fetched = await fetchFn();
       // Keep the downloaded version in memory for this re-exec decision, but
-      // do not persist remote registry data to the local cache.
-      write({ latest: current, checkedAt: now() });
+      // do not persist remote registry data to the local cache. Carry the
+      // failure marker forward — a routine daily refresh must not forget it.
+      write({ latest: current, checkedAt: now(), failedInstallVersion });
       if (fetched) latest = fetched;
     }
 
     if (!latest || !isNewer(latest, current)) return;
 
+    if (failedInstallVersion === latest) {
+      // Already installed-and-verified this exact version as a no-op once —
+      // reinstalling every run is the actual cost the bug report measured
+      // ("모든 명령이 수 초씩 느려지고"). Fall back to the passive notice.
+      out(formatUpdateNotice(current, latest));
+      return;
+    }
+
     out(`\n  ${c.dim('Updating')} ${c.dim(current)} ${c.dim('→')} ${c.green(latest)}…\n`);
     if (!install(PKG)) {
       out(`  ${c.dim(`Auto-update failed; continuing on ${current}. Run npm i -g ${PKG} manually.`)}\n`);
+      write({ latest: current, checkedAt: now(), failedInstallVersion: latest });
       return;
     }
+
+    const resolved = getResolvedVersion();
+    if (resolved == null || isNewer(latest, resolved)) {
+      out(formatInstallMismatchWarning(latest, resolved, current, getInstallPrefix));
+      write({ latest: current, checkedAt: now(), failedInstallVersion: latest });
+      return;
+    }
+
     out(`  ${c.green('Updated')} ${c.dim('→')} ${c.green(latest)}. ${c.dim('Restarting…')}\n`);
     reexec(); // replaces/exits the process on success
   } catch {


### PR DESCRIPTION
## Summary
- `maybeAutoUpdate` declared success from `npm install`'s exit code alone and re-executed the current entry script. When npm's global install prefix disagrees with what actually runs `openswarm` (mixed nvm/homebrew/asdf, a stray `npm link`), the new version lands somewhere the process never resolves into — every subsequent invocation repeated the same "Updated" + restart, never actually moving off the old binary, while paying for a fresh `npm install` on every single command.
- Adds `resolvedVersion()`: after a successful install, spawns the exact command `defaultReexec` is about to run with `--version` and checks it reports a version at least as new as `latest` before claiming success or re-executing.
- A verified mismatch prints a diagnostic (npm's install prefix + the path currently running from) instead of "Updated", and records `failedInstallVersion` in the existing 24h cache so the next run skips straight to a passive notice instead of reinstalling a version it already confirmed won't take — this directly addresses the measured cost ("모든 명령이 수 초씩 느려지고") of reinstalling every single command.
- A genuinely newer version published later (cache's `latest` advances past the recorded `failedInstallVersion`) is retried normally.

## Test plan
- [x] `npx vitest run src/support/updateNotifier.test.ts src/support/updateNotifier.coverage.test.ts` — 37/37, including 4 new cases (verified-unchanged → diagnostic not "Updated", suppressed reinstall for a known-failed version, retry once a genuinely newer version is published) plus 3 existing real-subprocess tests updated to inject/mock the new verification step
- [x] `npx vitest run` (full suite) — 390 files / 5440 tests passed, 0 regressions
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] pre-commit hook (oxlint + typecheck + file-size gate) — passed