### PR TITLE
fix(shell-safety): close expansion-based destructive command guard bypasses (AGT-3436)

### DIFF
--- a/src/adapters/tools.test.ts
+++ b/src/adapters/tools.test.ts
@@ -398,6 +398,41 @@ describe('Safety guards (isCommandBlocked via bash)', () => {
     expect(result.content).not.toContain('BLOCKED');
   });
 
+  // AGT-3436: a lexical check cannot evaluate shell expansion, so these three
+  // execute a blocked command while never containing its literal substring —
+  // quote-splitting, backslash-escaping, and mid-word command/variable
+  // substitution all reconstruct `rm -rf` (or `chmod 777`) at shell-eval time.
+  const expansionBypassCommands = [
+    "r'm' -rf /foo",
+    'r\\m -rf /foo',
+    'r$(true)m -rf /foo',
+    'r`true`m -rf /foo',
+    'chmod 7"7"7 somefile',
+    'r${empty}m -rf /foo',
+    'r"$(true)"m -rf /foo', // mid-word splice hidden from the raw text by quotes, exposed once they are stripped
+  ];
+
+  it.each(expansionBypassCommands)('blocks expansion-based bypass: %s', async (cmd) => {
+    const result = await executeTool(makeCall('bash', { command: cmd }), TMP_DIR);
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain('BLOCKED');
+  });
+
+  // Whitespace-delimited substitution (the overwhelmingly common real-world
+  // shape) must keep working — only mid-word gluing is rejected.
+  const legitimateExpansionCommands = [
+    'echo "hello world"',
+    'VERSION=$(cat package.json)',
+    'for f in $(ls); do echo "$f"; done',
+    'git commit -m "fix: rename variable"',
+    'echo `date`',
+  ];
+
+  it.each(legitimateExpansionCommands)('allows legitimate expansion: %s', async (cmd) => {
+    const result = await executeTool(makeCall('bash', { command: cmd }), TMP_DIR);
+    expect(result.content).not.toContain('BLOCKED');
+  });
+
   it.each([
     'curl --config ./request.conf',
     'bash ./send-message.sh',

--- a/src/adapters/tools.ts
+++ b/src/adapters/tools.ts
@@ -274,8 +274,63 @@ async function searchWithGitGrep(
   }
 }
 
+/**
+ * A lexical guard cannot evaluate shell expansion, so `BLOCKED_COMMANDS` is
+ * matched against both the raw command and this normalized form, and one
+ * further shape is rejected outright. Two bypass classes, both real ways a
+ * command can execute `rm -rf /` while never containing that literal
+ * substring: (AGT-3436)
+ *
+ *  1. Quote/backslash splitting — bash strips quote delimiters and escaping
+ *     backslashes before running a command, so `r'm' -rf /` and `r\m -rf /`
+ *     both execute as `rm -rf /`. Stripping them here before matching makes
+ *     the check see what the shell will actually see.
+ *  2. Mid-word substitution — `$(...)`, `` `...` ``, or `${...}` glued
+ *     directly onto adjacent letters/digits with no separating whitespace
+ *     (e.g. `r$(true)m -rf /`) can splice a blocked verb together from
+ *     pieces whose output cannot be known without running them. This shape
+ *     is vanishingly rare in legitimate scripts — substitution is almost
+ *     always its own whitespace-delimited word (`X=$(cmd)`, `for f in
+ *     $(ls)`) — so `isCommandBlocked` rejects it unconditionally rather than
+ *     guessing at what it might evaluate to.
+ */
+function normalizeForGuard(command: string): string {
+  return command
+    .replace(/\\(.)/g, '$1')
+    .replace(/['"]/g, '');
+}
+
+/** Command/parameter-substitution spans; open and close pair unambiguously (unlike bare backticks alone). */
+const SUBSTITUTION_SPAN_PATTERNS = [/\$\([^()]*\)/g, /\$\{[^{}]*\}/g, /`[^`]*`/g];
+
+/**
+ * True if any substitution span is glued directly onto an adjacent word
+ * character with no separating whitespace — the shape a blocked verb gets
+ * spliced together through (`r$(true)m`, `` r`true`m ``, `r${empty}m`).
+ * Only the true boundary characters matter: `` `date` `` on its own is
+ * ordinary, whitespace-delimited usage and must not trip this — it is the
+ * word character immediately touching the span's open or close delimiter
+ * that makes the output impossible to verify lexically.
+ */
+function hasMidWordSubstitution(command: string): boolean {
+  for (const spanPattern of SUBSTITUTION_SPAN_PATTERNS) {
+    for (const match of command.matchAll(spanPattern)) {
+      const start = match.index ?? 0;
+      const end = start + match[0].length;
+      const before = command[start - 1];
+      const after = command[end];
+      if ((before && /[A-Za-z0-9_]/.test(before)) || (after && /[A-Za-z0-9_]/.test(after))) return true;
+    }
+  }
+  return false;
+}
+
 function isCommandBlocked(command: string): boolean {
-  return BLOCKED_COMMANDS.some(pattern => pattern.test(command));
+  const normalized = normalizeForGuard(command);
+  // Checked against both forms: quoting can hide a mid-word splice from the
+  // raw text (`r"$(true)"m`) until the quotes are stripped away.
+  if (hasMidWordSubstitution(command) || hasMidWordSubstitution(normalized)) return true;
+  return BLOCKED_COMMANDS.some(pattern => pattern.test(command) || pattern.test(normalized));
 }
 
 // ============ 도구 실행기 ============


### PR DESCRIPTION
## Summary
- `isCommandBlocked` matched `BLOCKED_COMMANDS` regexes against the raw command string only — a lexical check that cannot evaluate shell expansion, so any construct the shell resolves before running the command could bypass it without the literal blocked substring ever appearing in the text:
  - **Quote-splitting**: `r'm' -rf /`, `chmod 7"7"7` (bash drops quote delimiters, concatenating the adjacent fragments back into `rm`/`777`).
  - **Backslash-escaping**: `r\m -rf /` (bash drops the backslash and keeps the escaped character).
  - **Mid-word command/parameter substitution**: `r$(true)m`, `` r`true`m ``, `r${empty}m` splice a blocked verb together from pieces whose actual output cannot be known without running them.
- Adds `normalizeForGuard()` (strips quote delimiters and backslash-escapes before matching, closing the first two classes) and `hasMidWordSubstitution()` (rejects any `$(...)`, `${...}`, or `` `...` `` span glued directly onto an adjacent word character with no separating whitespace — checked against both the raw and normalized text, since quoting can hide a splice from the raw text until the quotes are stripped, e.g. `r"$(true)"m`).
- Whitespace-delimited substitution — the overwhelmingly common real shape (`X=$(cmd)`, `for f in $(ls)`, `` `date` `` used on its own) — is unaffected and keeps working.

## Test plan
- [x] `npx vitest run src/adapters/tools.test.ts` — 88/88, including 7 new bypass cases (quote-split, backslash-escape, `$(...)`/backtick/`${...}` mid-word splice, and the quote-hidden mid-word variant) and 5 new "must stay allowed" cases for legitimate whitespace-delimited substitution
- [x] `npx vitest run` (full suite) — 390 files / 5455 tests passed, 0 regressions
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] pre-commit hook (oxlint + typecheck + file-size gate) — passed