### PR TITLE
fix(runtime): make CLI and daemon shutdown deterministic (AGT-3408)

### DIFF
--- a/src/auth/openBrowser.ts
+++ b/src/auth/openBrowser.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 
-function getOpenCommand(url: string): { command: string; args: string[] } {
+export function getOpenCommand(url: string): { command: string; args: string[] } {
   if (process.platform === 'darwin') {
     return { command: 'open', args: [url] };
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -788,33 +788,21 @@ program
   .option('-p, --port <port>', 'Port number', parseTcpPortOption, 3847)
   .option('--no-open', 'Start server without opening browser')
   .action(async (opts: { port: number; open: boolean }) => {
-    const port = opts.port;
     const { startWebServer, stopWebServer } = await import('./support/web.js');
-    await startWebServer(port);
-    console.log(`Dashboard running at http://localhost:${port}`);
-
-    if (opts.open) {
-      const { exec } = await import('node:child_process');
-      const url = `http://localhost:${port}`;
-      const cmd = process.platform === 'darwin' ? `open "${url}"`
-        : process.platform === 'win32' ? `start "${url}"`
-        : `xdg-open "${url}"`;
-      exec(cmd, (err) => {
-        if (err) console.log(`Open ${url} in your browser`);
-      });
-    }
-
-    // Keep process alive
-    let stopping = false;
-    process.once('SIGINT', () => {
-      if (stopping) return;
-      stopping = true;
-      void stopWebServer()
-        .catch((error) => console.error('[Dashboard] graceful shutdown failed:', error))
-        .finally(() => {
-          console.log('\nDashboard stopped.');
-          process.exitCode = 0;
-        });
+    const { spawn } = await import('node:child_process');
+    const { getOpenCommand } = await import('./auth/openBrowser.js');
+    const { runDashCommand } = await import('./cli/dashHandler.js');
+    await runDashCommand(opts.port, opts.open, {
+      startWebServer,
+      stopWebServer,
+      spawnBrowser: (url) => {
+        const { command, args } = getOpenCommand(url);
+        return spawn(command, args, { stdio: 'ignore', windowsHide: true });
+      },
+      onSignal: (signal, handler) => { process.once(signal, handler); },
+      log: (message) => console.log(message),
+      logError: (message, error) => console.error(message, error),
+      setExitCode: (code) => { process.exitCode = code; },
     });
   });
 
@@ -1007,7 +995,7 @@ async function launchChatTui(sessionId?: string): Promise<void> {
   let branch: string | undefined;
   try {
     const { execFileSync } = await import('node:child_process');
-    branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd, stdio: ['ignore', 'pipe', 'ignore'] })
+    branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd, stdio: ['ignore', 'pipe', 'ignore'], timeout: 3_000 })
       .toString()
       .trim() || undefined;
   } catch {

--- a/src/cli/daemon.coverage.test.ts
+++ b/src/cli/daemon.coverage.test.ts
@@ -44,6 +44,7 @@ function stubFetch(impl: (url: string, init?: { signal?: AbortSignal }) => Promi
 const STATE_DIR = join(TEST_HOME, '.config', 'openswarm');
 const PID_FILE = join(STATE_DIR, 'openswarm.pid');
 const LOG_FILE = join(STATE_DIR, 'logs', 'openswarm.log');
+const START_LOCK_FILE = join(STATE_DIR, 'openswarm.start.lock');
 
 beforeAll(() => {
   mkdirSync(STATE_DIR, { recursive: true });
@@ -52,9 +53,11 @@ beforeAll(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+  spawnMock.mockClear();
   indexPathState.exists = true;
   rmSync(PID_FILE, { force: true });
   rmSync(LOG_FILE, { force: true });
+  rmSync(START_LOCK_FILE, { force: true });
 });
 
 describe('startDaemon', () => {
@@ -112,6 +115,24 @@ describe('startDaemon', () => {
 
     await expect(startDaemon()).rejects.toThrow(/no pid assigned/);
     expect(existsSync(PID_FILE)).toBe(false);
+  });
+
+  it('serializes two concurrent starts (AGT-3408) — only one spawns, the other sees it and refuses', async () => {
+    const { startDaemon } = await import('./daemon.js');
+    stubFetch(async () => new Response('', { status: 500 })); // port never serving
+    // Use this test process's own (genuinely alive) pid so the loser's
+    // isOwnedDaemonProcess() check finds a real, owned daemon rather than a
+    // dead pid it would otherwise clean up and race past.
+    spawnMock.mockImplementation(() => ({ pid: process.pid, unref: vi.fn() }));
+
+    const results = await Promise.allSettled([startDaemon(), startDaemon()]);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0].reason as Error).message).toMatch(/already running \(pid/);
   });
 });
 

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -13,11 +13,13 @@ import { closeSync, existsSync, fstatSync, mkdirSync, openSync, readFileSync, re
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { withFileLock } from '../support/fileLock.js';
 
 const STATE_DIR = join(homedir(), '.config', 'openswarm');
 const LOG_DIR = join(STATE_DIR, 'logs');
 const PID_FILE = join(STATE_DIR, 'openswarm.pid');
 const LOG_FILE = join(LOG_DIR, 'openswarm.log');
+const START_LOCK_FILE = join(STATE_DIR, 'openswarm.start.lock');
 const DAEMON_PORT = 3847;
 /** launchd service label the install script (scripts/install-service.sh) bootstraps. */
 const LAUNCHD_LABEL = 'com.intrect.openswarm';
@@ -107,10 +109,20 @@ function closeFdQuietly(fd: number): void {
  * Start the service as a detached background process.
  * Returns the child PID on success.
  * Throws if a daemon is already running (PID file OR port 3847 responding).
+ *
+ * The existing-pid check, port probe, spawn, and pidfile write are a single
+ * critical section: two `openswarm start` invocations racing through it
+ * unlocked can both pass the "nothing running yet" checks and each spawn a
+ * daemon on the same task queue. A short-lived file lock serializes them —
+ * the second invocation sees the first one's fresh PID file/port and fails
+ * with the normal "already running" error instead of racing it.
  */
 export async function startDaemon(): Promise<{ pid: number; logFile: string }> {
   ensureStateDirs();
+  return withFileLock(START_LOCK_FILE, startDaemonLocked, { timeoutMs: 5_000 });
+}
 
+async function startDaemonLocked(): Promise<{ pid: number; logFile: string }> {
   const existing = readPidFile();
   if (existing !== null && isOwnedDaemonProcess(existing)) {
     throw new Error(

--- a/src/cli/dashHandler.test.ts
+++ b/src/cli/dashHandler.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runDashCommand, type DashDeps, type DashChildProcessLike } from './dashHandler.js';
+
+function fakeChild(): DashChildProcessLike & { emit(event: 'error' | 'close', arg?: unknown): void } {
+  const listeners: Record<string, ((arg?: unknown) => void)[]> = {};
+  return {
+    on(event: string, listener: (arg?: unknown) => void) {
+      (listeners[event] ??= []).push(listener);
+      return this;
+    },
+    emit(event, arg) {
+      for (const l of listeners[event] ?? []) l(arg);
+    },
+  } as DashChildProcessLike & { emit(event: 'error' | 'close', arg?: unknown): void };
+}
+
+function baseDeps(overrides: Partial<DashDeps> = {}): { deps: DashDeps; signals: Record<string, () => void> } {
+  const signals: Record<string, () => void> = {};
+  const deps: DashDeps = {
+    startWebServer: vi.fn(async () => {}),
+    stopWebServer: vi.fn(async () => {}),
+    spawnBrowser: vi.fn(() => fakeChild()),
+    onSignal: (signal, handler) => { signals[signal] = handler; },
+    log: vi.fn(),
+    logError: vi.fn(),
+    setExitCode: vi.fn(),
+    ...overrides,
+  };
+  return { deps, signals };
+}
+
+describe('runDashCommand (AGT-3408)', () => {
+  it('registers the same shutdown for SIGINT and SIGTERM, and it runs stopWebServer exactly once even if both fire', async () => {
+    const { deps, signals } = baseDeps();
+    await runDashCommand(3847, false, deps);
+
+    expect(signals.SIGINT).toBeTypeOf('function');
+    expect(signals.SIGTERM).toBeTypeOf('function');
+
+    signals.SIGINT();
+    signals.SIGTERM(); // a second signal while stopping must be a no-op
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(deps.stopWebServer).toHaveBeenCalledTimes(1);
+    expect(deps.setExitCode).toHaveBeenCalledWith(0);
+  });
+
+  it('SIGTERM alone runs the same cleanup as SIGINT', async () => {
+    const { deps, signals } = baseDeps();
+    await runDashCommand(3847, false, deps);
+
+    signals.SIGTERM();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(deps.stopWebServer).toHaveBeenCalledTimes(1);
+    expect(deps.log).toHaveBeenCalledWith('\nDashboard stopped.');
+  });
+
+  it('logs the shutdown failure but still reports the server stopped', async () => {
+    const { deps, signals } = baseDeps({ stopWebServer: vi.fn(async () => { throw new Error('boom'); }) });
+    await runDashCommand(3847, false, deps);
+
+    signals.SIGINT();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(deps.logError).toHaveBeenCalledWith('[Dashboard] graceful shutdown failed:', expect.any(Error));
+    expect(deps.setExitCode).toHaveBeenCalledWith(0);
+  });
+
+  it('spawns the browser once with the dashboard URL when open is true', async () => {
+    const { deps } = baseDeps();
+    await runDashCommand(4000, true, deps);
+    expect(deps.spawnBrowser).toHaveBeenCalledWith('http://localhost:4000');
+  });
+
+  it('does not spawn a browser when open is false', async () => {
+    const { deps } = baseDeps();
+    await runDashCommand(4000, false, deps);
+    expect(deps.spawnBrowser).not.toHaveBeenCalled();
+  });
+
+  it('reports a fallback once when the browser launcher errors, and does not double-report on close', async () => {
+    const child = fakeChild();
+    const { deps } = baseDeps({ spawnBrowser: vi.fn(() => child) });
+    await runDashCommand(4000, true, deps);
+
+    child.emit('error', new Error('spawn ENOENT'));
+    child.emit('close', 1);
+
+    expect(deps.log).toHaveBeenCalledWith('Open http://localhost:4000 in your browser');
+    expect(vi.mocked(deps.log).mock.calls.filter((c) => c[0].startsWith('Open ')).length).toBe(1);
+  });
+
+  it('reports a fallback when the launcher exits non-zero without an error event', async () => {
+    const child = fakeChild();
+    const { deps } = baseDeps({ spawnBrowser: vi.fn(() => child) });
+    await runDashCommand(4000, true, deps);
+
+    child.emit('close', 127);
+
+    expect(deps.log).toHaveBeenCalledWith('Open http://localhost:4000 in your browser');
+  });
+
+  it('does not report a fallback when the launcher exits 0', async () => {
+    const child = fakeChild();
+    const { deps } = baseDeps({ spawnBrowser: vi.fn(() => child) });
+    await runDashCommand(4000, true, deps);
+
+    child.emit('close', 0);
+
+    expect(vi.mocked(deps.log).mock.calls.some((c) => c[0].startsWith('Open '))).toBe(false);
+  });
+});

--- a/src/cli/dashHandler.ts
+++ b/src/cli/dashHandler.ts
@@ -1,0 +1,56 @@
+// ============================================
+// OpenSwarm - `openswarm dash` (AGT-3408)
+// ============================================
+// Extracted from cli.ts's inline action so the SIGINT/SIGTERM dedupe and
+// browser-launch wiring are directly testable, matching the rest of the
+// codebase's delegate-to-handler convention.
+
+export interface DashChildProcessLike {
+  on(event: 'error', listener: (err: Error) => void): unknown;
+  on(event: 'close', listener: (code: number | null) => void): unknown;
+}
+
+export interface DashDeps {
+  startWebServer: (port: number) => Promise<void>;
+  stopWebServer: () => Promise<void>;
+  spawnBrowser: (url: string) => DashChildProcessLike;
+  onSignal: (signal: NodeJS.Signals, handler: () => void) => void;
+  log: (message: string) => void;
+  logError: (message: string, error: unknown) => void;
+  setExitCode: (code: number) => void;
+}
+
+export async function runDashCommand(port: number, open: boolean, deps: DashDeps): Promise<void> {
+  await deps.startWebServer(port);
+  deps.log(`Dashboard running at http://localhost:${port}`);
+
+  if (open) {
+    const url = `http://localhost:${port}`;
+    const child = deps.spawnBrowser(url);
+    let reportedOpenFailure = false;
+    const reportOpenFailure = (): void => {
+      if (reportedOpenFailure) return;
+      reportedOpenFailure = true;
+      deps.log(`Open ${url} in your browser`);
+    };
+    child.on('error', reportOpenFailure);
+    child.on('close', (code) => { if (code !== 0) reportOpenFailure(); });
+  }
+
+  // Keep process alive; SIGINT and SIGTERM converge on the same idempotent
+  // cleanup so `dash` shuts down its server cleanly regardless of which one
+  // arrives (e.g. a process manager sending SIGTERM vs. a user's Ctrl+C).
+  let stopping = false;
+  const shutdown = (): void => {
+    if (stopping) return;
+    stopping = true;
+    void deps.stopWebServer()
+      .catch((error) => deps.logError('[Dashboard] graceful shutdown failed:', error))
+      .finally(() => {
+        deps.log('\nDashboard stopped.');
+        deps.setExitCode(0);
+      });
+  };
+  deps.onSignal('SIGINT', shutdown);
+  deps.onSignal('SIGTERM', shutdown);
+}

--- a/src/cli/doctorHandler.test.ts
+++ b/src/cli/doctorHandler.test.ts
@@ -1,0 +1,47 @@
+// AGT-3408: `failedChecks` used to live at module scope and only ever grow —
+// a second `handleDoctor()` call in the same process (e.g. the daemon or a
+// long-lived shell re-running the CLI module) reported failures from a run
+// whose underlying issue was since fixed.
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('../adapters/index.js', () => ({
+  listAvailableAdapters: vi.fn(),
+}));
+vi.mock('../core/config.js', () => ({
+  findConfigFile: () => '/tmp/config.yaml',
+}));
+vi.mock('../telemetry/telemetry.js', () => ({
+  track: vi.fn(async () => {}),
+}));
+vi.mock('../auth/index.js', () => ({
+  AuthProfileStore: class {
+    getProfile(): null {
+      return null;
+    }
+  },
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('handleDoctor failedChecks reset (AGT-3408)', () => {
+  it('does not carry a failing check over into the next invocation once it is fixed', async () => {
+    const { listAvailableAdapters } = await import('../adapters/index.js');
+    const { track } = await import('../telemetry/telemetry.js');
+    const { handleDoctor } = await import('./doctorHandler.js');
+
+    // process.exit would otherwise kill the test runner on the fatal run.
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    vi.mocked(listAvailableAdapters).mockResolvedValueOnce([]); // run 1: no usable provider — fails
+    await handleDoctor();
+    vi.mocked(listAvailableAdapters).mockResolvedValueOnce(['codex']); // run 2: fixed
+    await handleDoctor();
+
+    const details = vi.mocked(track).mock.calls.map((call) => call[0].detail);
+    expect(details[0]).toContain('providers');
+    expect(details[1]).not.toContain('providers');
+  });
+});

--- a/src/cli/doctorHandler.ts
+++ b/src/cli/doctorHandler.ts
@@ -25,7 +25,7 @@ type Status = 'ok' | 'warn' | 'fail';
  * from the label rather than passed separately so a new `line()` call cannot
  * forget it — an unrecognised label simply contributes nothing.
  */
-const failedChecks = new Set<string>();
+let failedChecks = new Set<string>();
 
 /** Label → stable check name. Labels carry variable parts; these do not. */
 function checkName(label: string): string | undefined {
@@ -70,6 +70,7 @@ async function portFree(port: number): Promise<boolean> {
 }
 
 export async function handleDoctor(): Promise<void> {
+  failedChecks = new Set<string>();
   console.log(banner('doctor — environment check'));
   let fatal = false;
 

--- a/src/cli/prResolve.test.ts
+++ b/src/cli/prResolve.test.ts
@@ -4,13 +4,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // destructures {stdout}, so the mock must control that exact shape rather
 // than rely on generic callback-to-promise conversion.
 const { execImpl } = vi.hoisted(() => ({
-  execImpl: vi.fn(async (_cmd: string, _args: string[]) => ({ stdout: '', stderr: '' })),
+  execImpl: vi.fn(async (_cmd: string, _args: string[], _opts?: Record<string, unknown>) => ({ stdout: '', stderr: '' })),
 }));
 
 vi.mock('node:child_process', () => {
   const CUSTOM = Symbol.for('nodejs.util.promisify.custom');
   function execFile() { throw new Error('execFile called without promisify in test'); }
-  (execFile as unknown as Record<symbol, unknown>)[CUSTOM] = (cmd: string, args: string[]) => execImpl(cmd, args);
+  (execFile as unknown as Record<symbol, unknown>)[CUSTOM] = (cmd: string, args: string[], opts?: Record<string, unknown>) => execImpl(cmd, args, opts);
   return { execFile };
 });
 
@@ -44,7 +44,7 @@ describe('resolveRepoName (INT-3282)', () => {
     execImpl.mockResolvedValueOnce({ stdout: 'o/r\n', stderr: '' });
     const result = await resolveRepoName('/tmp/proj');
     expect(result).toBe('o/r');
-    expect(execImpl).toHaveBeenCalledWith('gh', expect.arrayContaining(['repo', 'view']));
+    expect(execImpl).toHaveBeenCalledWith('gh', expect.arrayContaining(['repo', 'view']), expect.objectContaining({ timeout: expect.any(Number) }));
   });
 
   it('throws when gh returns something without a slash', async () => {
@@ -60,8 +60,8 @@ describe('resolveOriginRepo (INT-3282)', () => {
       .mockResolvedValueOnce({ stdout: 'o/r\n', stderr: '' }); // gh repo view <url>
     const result = await resolveOriginRepo('/tmp/proj');
     expect(result).toBe('o/r');
-    expect(execImpl).toHaveBeenCalledWith('git', ['remote', 'get-url', 'origin']);
-    expect(execImpl).toHaveBeenCalledWith('gh', expect.arrayContaining(['repo', 'view', 'https://github.com/o/r.git']));
+    expect(execImpl).toHaveBeenCalledWith('git', ['remote', 'get-url', 'origin'], expect.objectContaining({ timeout: expect.any(Number) }));
+    expect(execImpl).toHaveBeenCalledWith('gh', expect.arrayContaining(['repo', 'view', 'https://github.com/o/r.git']), expect.objectContaining({ timeout: expect.any(Number) }));
   });
 
   it('throws when gh returns something without a slash for the origin URL', async () => {
@@ -94,7 +94,19 @@ describe('resolvePR (INT-3282)', () => {
       .mockResolvedValueOnce({ stdout: JSON.stringify(ghView), stderr: '' });
     const result = await resolvePR({ path: '/tmp/proj' });
     expect(result.number).toBe(9);
-    expect(execImpl).toHaveBeenCalledWith('gh', expect.arrayContaining(['pr', 'view']));
+    expect(execImpl).toHaveBeenCalledWith('gh', expect.arrayContaining(['pr', 'view']), expect.objectContaining({ timeout: expect.any(Number) }));
+  });
+
+  it('bounds gh/git subprocess lifetime so a hung CLI cannot hang the command (AGT-3408)', async () => {
+    execImpl
+      .mockResolvedValueOnce({ stdout: 'o/r\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: JSON.stringify(ghView), stderr: '' });
+    await resolvePR({ path: '/tmp/proj' });
+    for (const call of execImpl.mock.calls) {
+      const opts = call[2] as Record<string, unknown> | undefined;
+      expect(opts?.timeout).toBeTypeOf('number');
+      expect(opts?.timeout).toBeGreaterThan(0);
+    }
   });
 
   it('reports the branch name and a create hint when there is no open PR', async () => {

--- a/src/cli/prResolve.ts
+++ b/src/cli/prResolve.ts
@@ -8,13 +8,21 @@ import type { PRInfo } from '../github/github.js';
 
 const execFileAsync = promisify(execFile);
 
+// Metadata lookups only (repo view / pr view / rev-parse) — never a clone or
+// fetch — so a bound well under the multi-minute timeouts used elsewhere for
+// network-heavy git operations still leaves headroom while catching a hung
+// `gh`/`git` (stalled network, blocked on an auth prompt) instead of hanging
+// the whole PR command indefinitely.
+const GH_TIMEOUT_MS = 30_000;
+const GIT_TIMEOUT_MS = 30_000;
+
 async function gh(cwd: string, ...args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync('gh', args, { cwd, maxBuffer: 4 * 1024 * 1024 });
+  const { stdout } = await execFileAsync('gh', args, { cwd, maxBuffer: 4 * 1024 * 1024, timeout: GH_TIMEOUT_MS });
   return stdout;
 }
 
 async function git(cwd: string, ...args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync('git', args, { cwd });
+  const { stdout } = await execFileAsync('git', args, { cwd, timeout: GIT_TIMEOUT_MS });
   return stdout;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,19 @@ async function main(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
   process.on('SIGTERM', () => shutdown('SIGTERM'));
 
+  // An uncaught error leaves the process in a state Node no longer guarantees
+  // — but exiting bare still skips `stopService()`/PID-file cleanup, leaking
+  // the dashboard server and letting the next `openswarm start` see a stale
+  // PID file. Route both through the same shutdown path SIGTERM uses.
+  process.on('uncaughtException', (err) => {
+    console.error('Uncaught exception:', err);
+    void shutdown('uncaughtException');
+  });
+  process.on('unhandledRejection', (reason) => {
+    console.error('Unhandled rejection:', reason);
+    void shutdown('unhandledRejection');
+  });
+
   // Start service
   try {
     await startService(config);

--- a/src/support/web.serviceControl.test.ts
+++ b/src/support/web.serviceControl.test.ts
@@ -1,0 +1,100 @@
+// AGT-3408: the /api/service/* routes shell out to `systemctl` with no bound
+// on how long it may run. A wedged user service manager left the HTTP request
+// open indefinitely; these routes now pass a `timeout` and turn a timeout
+// into the same controlled error response as any other systemctl failure.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createServer } from 'node:net';
+
+type ExecFileCb = (err: (Error & { killed?: boolean }) | null, stdout: string, stderr: string) => void;
+
+const execFileMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return { ...actual, execFile: execFileMock };
+});
+
+import { startWebServer, stopWebServer } from './web.js';
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const s = createServer();
+    s.once('error', reject);
+    s.listen(0, '127.0.0.1', () => {
+      const addr = s.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      s.close((err) => (err ? reject(err) : resolve(port)));
+    });
+  });
+}
+
+/** Simulate a timed-out child_process.execFile callback (what Node passes on timeout). */
+function stubTimeout(): void {
+  execFileMock.mockImplementation(((...args: unknown[]) => {
+    const cb = args[args.length - 1] as ExecFileCb;
+    const err = Object.assign(new Error('Command failed'), { killed: true, signal: 'SIGTERM' });
+    cb(err, '', '');
+    return {};
+  }) as unknown as typeof import('node:child_process').execFile);
+}
+
+function stubSuccess(stdout: string): void {
+  execFileMock.mockImplementation(((...args: unknown[]) => {
+    const cb = args[args.length - 1] as ExecFileCb;
+    cb(null, stdout, '');
+    return {};
+  }) as unknown as typeof import('node:child_process').execFile);
+}
+
+describe('/api/service/* systemctl bounds (AGT-3408)', () => {
+  afterEach(async () => {
+    await stopWebServer();
+    execFileMock.mockReset();
+  });
+
+  it('passes a timeout option to every systemctl invocation', async () => {
+    stubSuccess('active');
+    const port = await freePort();
+    await startWebServer(port);
+
+    await fetch(`http://127.0.0.1:${port}/api/service/status`);
+    await fetch(`http://127.0.0.1:${port}/api/service/stop`, { method: 'POST' });
+    await fetch(`http://127.0.0.1:${port}/api/service/restart`, { method: 'POST' });
+
+    expect(execFileMock).toHaveBeenCalledTimes(3);
+    for (const call of execFileMock.mock.calls) {
+      const opts = call[2] as Record<string, unknown>;
+      expect(opts.timeout).toBeTypeOf('number');
+      expect(opts.timeout).toBeGreaterThan(0);
+    }
+  });
+
+  it('status reports "unknown" instead of hanging when systemctl times out', async () => {
+    stubTimeout();
+    const port = await freePort();
+    await startWebServer(port);
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/service/status`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'unknown' });
+  });
+
+  it('stop returns a controlled 500 instead of hanging when systemctl times out', async () => {
+    stubTimeout();
+    const port = await freePort();
+    await startWebServer(port);
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/service/stop`, { method: 'POST' });
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: expect.any(String) });
+  });
+
+  it('restart returns a controlled 500 instead of hanging when systemctl times out', async () => {
+    stubTimeout();
+    const port = await freePort();
+    await startWebServer(port);
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/service/restart`, { method: 'POST' });
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: expect.any(String) });
+  });
+});

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -69,6 +69,11 @@ function isAllowedOrigin(origin: string): boolean {
   return false;
 }
 
+// `systemctl` talking to a wedged user service manager can hang past any
+// caller's patience; bound it so a stuck call surfaces as a controlled error
+// instead of leaving the HTTP request open indefinitely.
+const SYSTEMCTL_TIMEOUT_MS = 10_000;
+
 // Never leak raw Error objects (which include stack traces in many runtimes)
 // or arbitrary thrown values to HTTP responses.
 function safeErrorMessage(err: unknown): string {
@@ -969,8 +974,8 @@ export async function startWebServer(port: number = 3847): Promise<void> {
       } else if (url === '/api/service/status' && req.method === 'GET') {
         try {
           const result = await new Promise<string>((resolve) => {
-            execFile('systemctl', ['--user', 'is-active', 'openswarm'], (_err, stdout) => {
-              resolve(stdout.trim());
+            execFile('systemctl', ['--user', 'is-active', 'openswarm'], { timeout: SYSTEMCTL_TIMEOUT_MS }, (err, stdout) => {
+              resolve(err ? 'unknown' : stdout.trim());
             });
           });
           res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -984,7 +989,7 @@ export async function startWebServer(port: number = 3847): Promise<void> {
       } else if (url === '/api/service/stop' && req.method === 'POST') {
         try {
           await new Promise<void>((resolve, reject) => {
-            execFile('systemctl', ['--user', 'stop', 'openswarm'], (err) => {
+            execFile('systemctl', ['--user', 'stop', 'openswarm'], { timeout: SYSTEMCTL_TIMEOUT_MS }, (err) => {
               if (err) reject(err); else resolve();
             });
           });
@@ -999,7 +1004,7 @@ export async function startWebServer(port: number = 3847): Promise<void> {
       } else if (url === '/api/service/restart' && req.method === 'POST') {
         try {
           await new Promise<void>((resolve, reject) => {
-            execFile('systemctl', ['--user', 'restart', 'openswarm'], (err) => {
+            execFile('systemctl', ['--user', 'restart', 'openswarm'], { timeout: SYSTEMCTL_TIMEOUT_MS }, (err) => {
               if (err) reject(err); else resolve();
             });
           });


### PR DESCRIPTION
## Summary
- SIGTERM now runs the same dashboard cleanup as SIGINT (`dash` command)
- Uncaught exceptions/rejections route through the same controlled daemon shutdown as SIGINT/SIGTERM instead of skipping PID-file cleanup and `stopService()`
- Browser launch (`dash --open`) uses argv-based `spawn`, no shell string interpolation
- Git branch lookup before the chat TUI is bounded (3s timeout)
- Detached daemon startup is now mutually exclusive via a short-lived file lock (`src/support/fileLock.ts`, already used elsewhere), closing a TOCTOU race between concurrent `openswarm start` invocations
- `openswarm doctor`'s failed-check state resets per invocation instead of accumulating at module scope for the life of the process
- `gh`/`git` subprocess calls in PR command helpers are timeout-bounded (30s — metadata lookups only, not clones)
- Dashboard's `systemctl` status/stop/restart calls are timeout-bounded, with `status` reporting `'unknown'` and `stop`/`restart` returning a controlled 500 instead of hanging the request

Also extracted the `dash` command's inline logic into `cli/dashHandler.ts` so the SIGINT/SIGTERM dedupe and browser-launch fallback are directly testable — matching the delegate-to-handler pattern the rest of `cli.ts` already follows (it was the one holdout with untested inline logic).

## Test plan
- [x] New tests: `dashHandler.test.ts` (8), `doctorHandler.test.ts` (1), `daemon.coverage.test.ts` concurrency case, `prResolve.test.ts` timeout assertions, `web.serviceControl.test.ts` (4)
- [x] `npm run typecheck` / `npm run lint` clean
- [x] `LC_ALL=C npx vitest run` — 393 files / 5470 tests passed, 1 file / 10 tests skipped (pre-existing)
- [x] Pre-commit hook green