### PR TITLE
fix(filesystem): resolve workspace and static files symlink-safely (AGT-3424)

### DIFF
--- a/src/adapters/diagnosticsTool.test.ts
+++ b/src/adapters/diagnosticsTool.test.ts
@@ -103,6 +103,49 @@ describe('runDiagnosticsTool (INT-3105)', () => {
     const text = await runDiagnosticsTool(['src/main.rs'], '/tmp');
     expect(text).toContain('bash tool');
   });
+
+  it('refuses a Python path outside the project root (AGT-3424) instead of handing it to ruff', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'osw-diag-escape-'));
+    const outside = await mkdtemp(path.join(tmpdir(), 'osw-diag-outside-'));
+    const outsideFile = path.join(outside, 'secret.py');
+    await writeFile(outsideFile, 'password = "hunter2"\n', 'utf8');
+    try {
+      const text = await runDiagnosticsTool([outsideFile], dir);
+      expect(text).toContain('refused 1 path(s) outside the project root');
+      expect(text).toContain(outsideFile);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses a `../`-escaping Python path relative to cwd', async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), 'osw-diag-parent-'));
+    const dir = path.join(parent, 'project');
+    await mkdir(dir);
+    await writeFile(path.join(parent, 'sibling.py'), 'x = 1\n', 'utf8');
+    try {
+      const text = await runDiagnosticsTool(['../sibling.py'], dir);
+      expect(text).toContain('refused 1 path(s) outside the project root');
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('still runs tsc on in-root files while refusing an escaping .py sibling', async () => {
+    const dir = await tsProject({ 'src/a.ts': 'export const a: number = 1;\n' });
+    const outside = await mkdtemp(path.join(tmpdir(), 'osw-diag-outside-'));
+    const outsideFile = path.join(outside, 'secret.py');
+    await writeFile(outsideFile, 'x = 1\n', 'utf8');
+    try {
+      const text = await runDiagnosticsTool(['src/a.ts', outsideFile], dir);
+      expect(text).toContain('[tsc] clean');
+      expect(text).toContain('[ruff] refused 1 path(s) outside the project root');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  }, 60_000);
 });
 
 describe('agenticLoop diagnostics exposure (INT-3105)', () => {

--- a/src/adapters/diagnosticsTool.ts
+++ b/src/adapters/diagnosticsTool.ts
@@ -81,6 +81,27 @@ function isMissingBinary(err: unknown): boolean {
 }
 
 /**
+ * Split requested paths into those that canonically resolve inside `cwd` and
+ * those that escape it. Python paths get no project-relative bound the way
+ * `runTsc`'s tsconfig walk gives TypeScript (`nearestTsconfigDir` only
+ * matches directories under `root`) — without this, an absolute or
+ * `../`-escaping path would hand `ruff` (and its output, echoed back to the
+ * calling model) a file entirely outside the workspace.
+ */
+function containWorkspacePaths(cwd: string, files: string[]): { kept: string[]; escaped: string[] } {
+  const root = realpathSync(path.resolve(cwd));
+  const kept: string[] = [];
+  const escaped: string[] = [];
+  for (const file of files) {
+    const abs = path.isAbsolute(file) ? file : path.resolve(root, file);
+    const real = existsSync(abs) ? realpathSync(abs) : abs;
+    if (real === root || real.startsWith(root + path.sep)) kept.push(file);
+    else escaped.push(file);
+  }
+  return { kept, escaped };
+}
+
+/**
  * Resolve the TypeScript compiler deterministically: the nearest
  * `node_modules/.bin/tsc` walking up from the project (a real repo's own
  * dependency), else `tsc` from PATH (npm-script contexts). NOT `npx tsc` —
@@ -217,16 +238,20 @@ export async function runDiagnosticsTool(paths: unknown, cwd: string): Promise<s
   }
 
   const tsFiles = requested.filter((f) => /\.(ts|tsx|mts|cts)$/.test(f));
-  const pyFiles = requested.filter((f) => /\.pyi?$/.test(f));
+  const { kept: pyFiles, escaped: pyEscaped } = containWorkspacePaths(cwd, requested.filter((f) => /\.pyi?$/.test(f)));
   const checks: Promise<CheckOutcome>[] = [];
   if (tsFiles.length > 0) checks.push(runTsc(cwd, new Set(tsFiles)));
   if (pyFiles.length > 0) checks.push(runRuff(cwd, pyFiles));
   if (checks.length === 0) {
+    if (pyEscaped.length > 0) {
+      return `diagnostics: refused ${pyEscaped.length} path(s) outside the project root: ${pyEscaped.join(', ')}`;
+    }
     return `diagnostics: no TypeScript/Python files among ${requested.join(', ')} — use the bash tool to run this project's own checks.`;
   }
 
   const outcomes = await Promise.all(checks);
   const lines: string[] = [];
+  if (pyEscaped.length > 0) lines.push(`[ruff] refused ${pyEscaped.length} path(s) outside the project root: ${pyEscaped.join(', ')}`);
   for (const { label, output, infraError } of outcomes) {
     if (infraError) lines.push(`[${label}] SKIPPED: ${infraError}`);
     else if (output) lines.push(`[${label}] errors:\n${output}`);

--- a/src/cli/designPipeline.test.ts
+++ b/src/cli/designPipeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { analyzePackageJson, detectStack, generateWorkflow, runDesignPipeline } from './designPipeline.js';
@@ -64,6 +64,30 @@ describe('runDesignPipeline (INT-1956)', () => {
       expect(runDesignPipeline({ path: dir, force: true }).wrote).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not write through a symlinked ci.yml with --force (AGT-3424)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dp-'));
+    const outsideDir = mkdtempSync(join(tmpdir(), 'dp-outside-'));
+    const outsideFile = join(outsideDir, 'sensitive.yml');
+    writeFileSync(outsideFile, 'do-not-touch\n');
+    try {
+      writeFileSync(join(dir, 'go.mod'), 'module x\n');
+      mkdirSync(join(dir, '.github', 'workflows'), { recursive: true });
+      const outPath = join(dir, '.github', 'workflows', 'ci.yml');
+      symlinkSync(outsideFile, outPath);
+
+      const r = runDesignPipeline({ path: dir, force: true });
+
+      expect(r.wrote).toBe(true);
+      // The outside file's content must be untouched — the symlink itself
+      // was replaced by a fresh regular file, not written through.
+      expect(readFileSync(outsideFile, 'utf8')).toBe('do-not-touch\n');
+      expect(readFileSync(outPath, 'utf8')).toContain('go test ./...');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(outsideDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/cli/designPipeline.ts
+++ b/src/cli/designPipeline.ts
@@ -9,6 +9,7 @@
 
 import { closeSync, existsSync, openSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { atomicWriteFileSync } from '../support/atomicFile.js';
 
 export type Ecosystem = 'node' | 'python' | 'rust' | 'go' | 'generic';
 
@@ -120,7 +121,11 @@ export function runDesignPipeline(opts: DesignPipelineOptions = {}): { wrote: bo
   if (opts.dryRun) return { wrote: false, path: outPath, yaml };
   mkdirSync(dirname(outPath), { recursive: true });
   if (opts.force) {
-    writeFileSync(outPath, yaml);
+    // A plain writeFileSync follows a symlink at outPath and writes through
+    // it to whatever it points at; atomicWriteFileSync's rename-based swap
+    // replaces the destination itself instead, closing that race regardless
+    // of what got planted there between the mkdir above and this write.
+    atomicWriteFileSync(outPath, yaml);
   } else {
     let fd: number | undefined;
     try {

--- a/src/cli/initWizard.test.ts
+++ b/src/cli/initWizard.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { buildWizardConfig } from './initWizard.js';
 import { loadConfig } from '../core/config.js';
-import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { writeFileSync, readFileSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -77,5 +77,58 @@ describe('buildWizardConfig adapter validity (INT-1844)', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('runInitWizard symlink guards (AGT-3424)', () => {
+  let dir: string | null = null;
+  let outsideDir: string | null = null;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    if (outsideDir) rmSync(outsideDir, { recursive: true, force: true });
+    dir = null;
+    outsideDir = null;
+  });
+
+  function mockExitAndErrors(): { errorSpy: ReturnType<typeof vi.spyOn> } {
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    return { errorSpy };
+  }
+
+  it('refuses a config.yaml symlinked to an arbitrary (non-daemon) target', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'initwiz-symlink-'));
+    outsideDir = mkdtempSync(join(tmpdir(), 'initwiz-outside-'));
+    const outsideFile = join(outsideDir, 'other-config.yaml');
+    writeFileSync(outsideFile, 'adapter: codex\n');
+    symlinkSync(outsideFile, join(dir, 'config.yaml'));
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+    const { errorSpy } = mockExitAndErrors();
+
+    const { runInitWizard } = await import('./initWizard.js');
+    await expect(runInitWizard()).rejects.toThrow('process.exit(1)');
+
+    expect(errorSpy.mock.calls.flat().join(' ')).toContain('symlink to');
+    expect(readFileSync(outsideFile, 'utf8')).toBe('adapter: codex\n');
+  });
+
+  it('refuses a symlinked .env even when config.yaml is a plain file', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'initwiz-symlink-'));
+    outsideDir = mkdtempSync(join(tmpdir(), 'initwiz-outside-'));
+    const outsideFile = join(outsideDir, 'other.env');
+    writeFileSync(outsideFile, 'SECRET=leak\n');
+    symlinkSync(outsideFile, join(dir, '.env'));
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+    const { errorSpy } = mockExitAndErrors();
+
+    const { runInitWizard } = await import('./initWizard.js');
+    await expect(runInitWizard()).rejects.toThrow('process.exit(1)');
+
+    expect(errorSpy.mock.calls.flat().join(' ')).toContain('.env is a symlink');
+    expect(readFileSync(outsideFile, 'utf8')).toBe('SECRET=leak\n');
   });
 });

--- a/src/cli/initWizard.ts
+++ b/src/cli/initWizard.ts
@@ -203,29 +203,48 @@ async function setupLinear(envVars: Record<string, string>, cwd: string): Promis
   if (result.teamId) envVars.LINEAR_TEAM_ID = result.teamId;
 }
 
+/** Absolute realpath of `path` if it's a symlink; null if it's not a symlink (or doesn't exist). */
+function symlinkTargetOf(path: string): string | null {
+  try {
+    if (lstatSync(path).isSymbolicLink()) return realpathSync(path);
+  } catch {
+    // cxt-ignore: error_swallow — stat failure → treat as not a symlink
+  }
+  return null;
+}
+
 export async function runInitWizard(opts: InitWizardOptions = {}): Promise<void> {
   const cwd = process.cwd();
   const configPath = join(cwd, 'config.yaml');
   const envPath = join(cwd, '.env');
 
   if (existsSync(configPath)) {
-    // Guard: if cwd/config.yaml is a symlink into the daemon's global config
-    // (~/.config/openswarm), `init` here would clobber the running daemon's
-    // settings (agents, allowedProjects, …). Refuse even with --force.
-    let symlinkTarget: string | null = null;
-    try {
-      if (lstatSync(configPath).isSymbolicLink()) symlinkTarget = realpathSync(configPath);
-    } catch {
-      symlinkTarget = null; // cxt-ignore: error_swallow — stat failure → treat as a plain file
-    }
-    if (symlinkTarget && symlinkTarget.startsWith(join(homedir(), '.config', 'openswarm'))) {
+    const symlinkTarget = symlinkTargetOf(configPath);
+    if (symlinkTarget?.startsWith(join(homedir(), '.config', 'openswarm'))) {
+      // Specifically the daemon's global config: `init` here would clobber
+      // the running daemon's settings (agents, allowedProjects, …).
       console.error(`config.yaml is a symlink to the daemon's global config:\n    ${symlinkTarget}`);
       console.error('Running `init` here would overwrite your running daemon configuration.');
       console.error('Run init in a different repo, or edit the daemon config directly.');
       process.exit(1);
     }
+    if (symlinkTarget) {
+      // Any other symlink target: writing through it (even with --force)
+      // silently replaces whatever the user linked config.yaml to.
+      console.error(`config.yaml is a symlink to:\n    ${symlinkTarget}`);
+      console.error('Refusing to overwrite a symlinked config target — remove the symlink first if you really want to replace it, or edit it directly.');
+      process.exit(1);
+    }
     if (!opts.force) {
       console.error('config.yaml already exists. Use --force to overwrite, or edit it directly.');
+      process.exit(1);
+    }
+  }
+  if (existsSync(envPath)) {
+    const symlinkTarget = symlinkTargetOf(envPath);
+    if (symlinkTarget) {
+      console.error(`.env is a symlink to:\n    ${symlinkTarget}`);
+      console.error('Refusing to write secrets through a symlinked .env — remove the symlink first if you really want to replace it, or edit it directly.');
       process.exit(1);
     }
   }

--- a/src/core/envFile.test.ts
+++ b/src/core/envFile.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, statSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, statSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir, platform, homedir as realHomedir } from 'node:os';
 import { join } from 'node:path';
 import { formatShadowWarning, writeEnvVars } from './envFile.js';
@@ -64,6 +64,22 @@ describe('writeEnvVars', () => {
     const p = freshEnvPath();
     writeEnvVars(p, { SECRET: 'x' });
     expect(statSync(p).mode & 0o777).toBe(0o600);
+  });
+
+  it('refuses to write through a symlinked .env instead of reading it and severing the link (AGT-3424)', () => {
+    if (platform() === 'win32') return; // symlinkSync requires elevated perms on Windows CI
+    const p = freshEnvPath();
+    const outsideDir = mkdtempSync(join(tmpdir(), 'env-outside-'));
+    const outside = join(outsideDir, 'not-an-env-file.txt');
+    writeFileSync(outside, 'sensitive-content\n');
+    try {
+      symlinkSync(outside, p);
+      expect(() => writeEnvVars(p, { SECRET: 'x' })).toThrow(/symlink/);
+      // Neither the symlink itself nor the file it points to changed.
+      expect(readFileSync(outside, 'utf8')).toBe('sensitive-content\n');
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/core/envFile.ts
+++ b/src/core/envFile.ts
@@ -11,7 +11,7 @@
 // more general one.
 
 import { createHash } from 'node:crypto';
-import { existsSync, readFileSync } from 'node:fs';
+import { closeSync, constants, existsSync, openSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { atomicWriteFileSync } from '../support/atomicFile.js';
@@ -121,12 +121,39 @@ function formatEnvLine(key: string, value: string): string {
 }
 
 /**
+ * Read the current .env content for merging, refusing a symlinked path
+ * instead of silently reading through it. A plain `existsSync` + `readFileSync`
+ * check-then-use is racy: a symlink swapped in between the two calls would
+ * both leak an arbitrary file's content into the merge below and get
+ * silently severed by the atomic write that follows. Opening with
+ * `O_NOFOLLOW` and reading via the same held fd closes that window.
+ */
+function readExistingEnvFile(path: string): string {
+  let fd: number;
+  try {
+    fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return ''; // genuinely no existing file — start fresh
+    if (code === 'ELOOP') {
+      throw new Error(`${path} is a symlink — refusing to read/overwrite it. Remove the symlink first if you really want to replace it.`);
+    }
+    throw err;
+  }
+  try {
+    return readFileSync(fd, 'utf8');
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
  * Upsert KEY=value pairs into a .env file (used by `openswarm init`). Existing
  * lines for a key are replaced in place (order + comments preserved); new keys
  * are appended. The file is written 0600 since it holds secrets.
  */
 export function writeEnvVars(path: string, kv: Record<string, string>): void {
-  const existing = existsSync(path) ? readFileSync(path, 'utf8') : '';
+  const existing = readExistingEnvFile(path);
   const lines = existing.length ? existing.split(/\r?\n/) : [];
   const remaining = new Map(Object.entries(kv));
 

--- a/src/support/staticAssets.test.ts
+++ b/src/support/staticAssets.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from 'node
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
-  contentTypeFor, readStaticAsset, readThreadBoardShell, resolveStaticRoot, StaticAssetError,
+  contentTypeFor, readAppShell, readStaticAsset, readThreadBoardShell, resolveStaticRoot, StaticAssetError,
 } from './staticAssets.js';
 
 describe('contentTypeFor', () => {
@@ -73,5 +73,29 @@ describe('readStaticAsset', () => {
     void dir;
     const asset = await readStaticAsset('/static/js/main.mjs');
     expect(asset.contentType).toContain('text/javascript');
+  });
+});
+
+describe('readAppShell symlink replacement (AGT-3424)', () => {
+  it('refuses app.html when it has been replaced with a symlink to an external file', async () => {
+    const root = resolveStaticRoot();
+    expect(root).toBeTruthy();
+    const appHtmlPath = join(root!, 'app.html');
+    const backupPath = join(root!, 'app.html.bak-agt3424-test');
+    const escapeDir = mkdtempSync(join(tmpdir(), 'osw-static-escape-'));
+    const outside = join(escapeDir, 'not-app-html.html');
+    writeFileSync(outside, '<html>should never be served as app.html</html>');
+
+    const { renameSync, existsSync: exists, unlinkSync } = await import('node:fs');
+    renameSync(appHtmlPath, backupPath);
+    try {
+      symlinkSync(outside, appHtmlPath);
+      const body = await readAppShell();
+      expect(body).toBeNull();
+    } finally {
+      if (exists(appHtmlPath)) unlinkSync(appHtmlPath);
+      renameSync(backupPath, appHtmlPath);
+      rmSync(escapeDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/support/staticAssets.ts
+++ b/src/support/staticAssets.ts
@@ -8,8 +8,8 @@
 // so the source directory is the fallback. Resolution happens once per lookup
 // rather than at module load so a build finishing mid-session is picked up.
 
-import { existsSync, realpathSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
+import { constants, existsSync, realpathSync } from 'node:fs';
+import { open } from 'node:fs/promises';
 import { join, dirname, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -53,12 +53,59 @@ export class StaticAssetError extends Error {
   }
 }
 
+type ContainedReadResult =
+  | { ok: true; body: Buffer }
+  | { ok: false; reason: 'escaped' | 'not-found' };
+
+/**
+ * Resolve `relative` under `root` and read it — one race-safe strategy
+ * shared by every caller below instead of a bespoke check per call site.
+ * `realpathSync` resolves symlinked path segments (including a symlinked
+ * directory further up the chain, or the leaf itself) up front so an escape
+ * can be told apart from a plain miss; the actual read then opens that
+ * resolved path with `O_NOFOLLOW`, so a same-instant swap into a symlink in
+ * the window between the check and the read fails the open instead of
+ * following it out of root.
+ */
+async function readContainedFile(root: string, relative: string): Promise<ContainedReadResult> {
+  let rootReal: string;
+  try {
+    rootReal = realpathSync(root);
+  } catch {
+    return { ok: false, reason: 'not-found' };
+  }
+  const candidate = resolve(rootReal, relative);
+  if (candidate !== rootReal && !candidate.startsWith(rootReal + sep)) {
+    return { ok: false, reason: 'escaped' };
+  }
+  let real: string;
+  try {
+    real = realpathSync(candidate);
+  } catch {
+    return { ok: false, reason: 'not-found' };
+  }
+  if (real !== rootReal && !real.startsWith(rootReal + sep)) {
+    return { ok: false, reason: 'escaped' };
+  }
+  let handle;
+  try {
+    handle = await open(real, constants.O_RDONLY | constants.O_NOFOLLOW);
+  } catch {
+    // Genuinely missing, or a same-instant swap into a symlink — both are a
+    // read-step failure; the escape class was already handled above.
+    return { ok: false, reason: 'not-found' };
+  }
+  try {
+    return { ok: true, body: await handle.readFile() };
+  } finally {
+    await handle.close();
+  }
+}
+
 /**
  * Read a static asset by its URL path under /static/. Throws StaticAssetError
  * 404 when the file (or the whole static root) is missing, and 403 when the
- * requested path escapes the static root — `resolve()` collapses `..`
- * segments, and the realpath check keeps a symlink planted inside the root
- * from serving files outside it.
+ * requested path escapes the static root.
  */
 export async function readStaticAsset(urlPath: string): Promise<{ body: Buffer; contentType: string }> {
   const root = resolveStaticRoot();
@@ -67,81 +114,42 @@ export async function readStaticAsset(urlPath: string): Promise<{ body: Buffer; 
   const relative = decodeURIComponent(urlPath.replace(/^\/static\/?/, ''));
   if (!relative || relative.includes('\0')) throw new StaticAssetError(404, 'Not found');
 
-  const rootReal = realpathSync(root);
-  const candidate = resolve(rootReal, relative);
-  if (candidate !== rootReal && !candidate.startsWith(rootReal + sep)) {
-    throw new StaticAssetError(403, 'Forbidden');
+  const result = await readContainedFile(root, relative);
+  if (!result.ok) {
+    throw result.reason === 'escaped' ? new StaticAssetError(403, 'Forbidden') : new StaticAssetError(404, 'Not found');
   }
-
-  let fileReal: string;
-  try {
-    fileReal = realpathSync(candidate);
-  } catch {
-    throw new StaticAssetError(404, 'Not found');
-  }
-  if (fileReal !== rootReal && !fileReal.startsWith(rootReal + sep)) {
-    throw new StaticAssetError(403, 'Forbidden');
-  }
-
-  try {
-    const body = await readFile(fileReal);
-    return { body, contentType: contentTypeFor(candidate) };
-  } catch {
-    throw new StaticAssetError(404, 'Not found');
-  }
+  return { body: result.body, contentType: contentTypeFor(relative) };
 }
 
-/** The /app entry document, or null when assets are not present. */
-/** The /orchestration page shell, from the same static root as /app. */
-export async function readOrchestrationShell(): Promise<Buffer | null> {
+/** A fixed page-shell file at the static root — null when assets aren't built, missing, or unsafe to read. */
+async function readShellFile(filename: string): Promise<Buffer | null> {
   const root = resolveStaticRoot();
   if (!root) return null;
-  try {
-    return await readFile(join(root, 'orchestration.html'));
-  } catch {
-    return null;
-  }
+  const result = await readContainedFile(root, filename);
+  return result.ok ? result.body : null;
+}
+
+/** The /orchestration page shell, from the same static root as /app. */
+export async function readOrchestrationShell(): Promise<Buffer | null> {
+  return readShellFile('orchestration.html');
 }
 
 /** The /chat room shell (AGT-4019), from the same static root as /app. */
 export async function readChatShell(): Promise<Buffer | null> {
-  const root = resolveStaticRoot();
-  if (!root) return null;
-  try {
-    return await readFile(join(root, 'chat.html'));
-  } catch {
-    return null;
-  }
+  return readShellFile('chat.html');
 }
 
 /** The operator warehouse shell (AGT-4128). */
 export async function readWarehouseShell(): Promise<Buffer | null> {
-  const root = resolveStaticRoot();
-  if (!root) return null;
-  try {
-    return await readFile(join(root, 'warehouse.html'));
-  } catch {
-    return null;
-  }
+  return readShellFile('warehouse.html');
 }
 
 /** Durable repository thread board (AGT-4130). */
 export async function readThreadBoardShell(): Promise<Buffer | null> {
-  const root = resolveStaticRoot();
-  if (!root) return null;
-  try {
-    return await readFile(join(root, 'threads.html'));
-  } catch {
-    return null;
-  }
+  return readShellFile('threads.html');
 }
 
+/** The /app entry document, or null when assets are not present. */
 export async function readAppShell(): Promise<Buffer | null> {
-  const root = resolveStaticRoot();
-  if (!root) return null;
-  try {
-    return await readFile(join(root, 'app.html'));
-  } catch {
-    return null;
-  }
+  return readShellFile('app.html');
 }


### PR DESCRIPTION
## Summary
- **diagnostics tool**: Python paths passed to `ruff` get the same canonical workspace containment TypeScript already has via `runTsc`'s tsconfig walk — an absolute or `../`-escaping path is refused (and reported, not silently dropped) instead of being handed to `ruff` and its output echoed back to the calling model
- **init wizard**: reject ANY symlinked `config.yaml`/`.env` target, not just the narrow daemon-global-config case; `writeEnvVars`'s existing-file read is now `O_NOFOLLOW` + read-via-held-fd instead of a check-then-use `existsSync`/`readFileSync` race
- **design-pipeline**: `--force` CI workflow write uses `atomicWriteFileSync` (rename-based — replaces the destination instead of writing through it) instead of a plain `writeFileSync` that follows a symlink at the destination
- **static assets**: consolidated `readStaticAsset`'s two-step realpath-check-then-plain-`readFile` (still had a TOCTOU window between the check and the read) and all five shell readers (`app`/`orchestration`/`chat`/`warehouse`/`threads` — previously with **no** containment check at all) into one shared realpath-containment + `O_NOFOLLOW`-open primitive

## Test plan
- [x] New/updated tests: `diagnosticsTool.test.ts` (+3), `designPipeline.test.ts` (+1 symlink-race), `initWizard.test.ts` (+2 symlink-guard), `envFile.test.ts` (+1 symlink-refusal), `staticAssets.test.ts` (+1 app.html-symlink regression)
- [x] `npm run typecheck` / `npm run lint` clean
- [x] `LC_ALL=C npx vitest run` — 390 files / 5463 tests passed, 1 file / 10 tests skipped (pre-existing)
- [x] Pre-commit hook green