### PR TITLE
chore(release): v0.21.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.21.6 — 2026-09-03
+
+### Fixed
+
+- **Duplicate sub-issue decomposition.** A deterministic file-scope + title-similarity guard reuses an existing sibling sub-issue instead of creating a near-duplicate when a task gets decomposed twice (AGT-2908).
+- **Shell-expansion bypasses of the destructive-command guard.** Quote-splitting, backslash-escaping, and mid-word command/parameter substitution (including quote-hidden variants) are now rejected; common whitespace-delimited substitution stays allowed (AGT-3436).
+- **CLI/daemon shutdown determinism.** SIGTERM now runs the same dashboard cleanup as SIGINT; uncaught exceptions/rejections route through the same controlled daemon shutdown; browser launch no longer shells out through string interpolation; `openswarm start` is mutually exclusive via a file lock (closing a TOCTOU race between concurrent starts); `openswarm doctor`'s failed-check state resets per invocation instead of accumulating for the process lifetime; PR-command and dashboard subprocess calls are timeout-bounded (AGT-3408).
+- **Symlink-safe workspace/static file resolution.** Python diagnostics paths get canonical workspace containment; `openswarm init` refuses any symlinked config.yaml/.env target (not just the daemon's global config) and writes secrets race-safely; `design-pipeline --force` no longer writes through a symlinked destination; static asset resolution (including the five page shells) uses one race-safe realpath + `O_NOFOLLOW` strategy (AGT-3424).
+- **A shell export silently shadowing a `.env` value now warns**, naming the key and file without ever printing the values (AGT-4154).
+- **Auto-update no longer claims success when the reinstalled binary didn't actually change** — it re-verifies the resolved version after install and surfaces a controlled warning instead (AGT-3183).
+
+### Added
+
+- **Orchestrator `ledger_overview` tool** — read access to parked runs, attempt outliers, and failure buckets from its own run ledger (AGT-4184).
+
 ## 0.21.5 — 2026-09-01
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.21.5",
+      "version": "0.21.6",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.21.5",
-  "description": "Autonomous AI agent orchestrator \u2014 Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
+  "version": "0.21.6",
+  "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Bumps the published npm package / GHCR image to include today's 8 shipped fixes, which are already live on vela via the autodeploy lane (AGT-4182) but not yet reflected in the published npm package or semver-tagged docker image (release.yml only fires on a `package.json` version change).

- AGT-2908 — duplicate sub-issue decomposition guard
- AGT-3436 — shell-expansion guard bypasses closed
- AGT-3408 — CLI/daemon shutdown determinism
- AGT-3424 — symlink-safe workspace/static file resolution
- AGT-4154 — shadowed .env warning
- AGT-3183 — auto-update install verification
- AGT-4184 — orchestrator `ledger_overview` tool
- AGT-4187 — (retrospective, no code — verified already fixed)

No functional changes in this PR — version bump + CHANGELOG entry only. Merging triggers `release.yml` (npm publish + tag + GitHub release) → `docker-publish.yml` (GHCR semver-tagged image).

## Test plan
- [x] `npm run typecheck` / `npm run lint` clean
- [x] Pre-commit hook green