### PR TITLE
fix(ci): release.yml explicitly dispatches docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,15 +1,29 @@
 # Build and publish the OpenSwarm daemon image to GHCR.
 #
-# Triggered by the GitHub release that release.yml creates after an npm
-# publish, so the image version always matches a published npm version.
-# workflow_dispatch exists for rebuilding an image (base-image CVE, Dockerfile
-# fix) without cutting a new release.
+# `release: published` never actually fires here on its own: release.yml's
+# `gh release create` runs under the default GITHUB_TOKEN, and GitHub
+# deliberately does not let a GITHUB_TOKEN-authored event trigger another
+# workflow (loop prevention) — confirmed 2026-09-03 by zero runs of this
+# workflow ever, across every prior release. release.yml instead calls
+# `gh workflow run docker-publish.yml -f version=<x.y.z>` right after
+# creating the release; a `workflow_dispatch` triggered via the API this way
+# is exempt from that restriction. The `version` input lets that dispatch
+# produce the same semver + latest tags a native release event would
+# (docker/metadata-action's `value=` override below), instead of just a
+# `:main` branch tag. workflow_dispatch WITHOUT a version (e.g. a manual
+# rebuild for a base-image CVE, no new release) still works — it falls back
+# to the plain branch tag.
 name: Docker Publish
 
 on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to tag (e.g. 0.21.6) — set by release.yml. Leave empty for a plain branch-tag rebuild.'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -36,17 +50,20 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/openswarm
-          # On a release event this yields the semver tags (0.21.1 / 0.21 / latest);
-          # a manual dispatch from a branch yields a branch tag instead of
-          # clobbering latest.
+          # On a release event, or a workflow_dispatch carrying `version`
+          # (release.yml's own trigger — see the file header), this yields
+          # the semver tags (0.21.1 / 0.21 / latest) via the explicit
+          # `value=` override on the dispatch path. A bare manual dispatch
+          # (no version input) yields a branch tag instead of clobbering
+          # latest.
           # latest=auto attaches `latest` to semver tags only — pinned here so
           # a future metadata-action default change cannot silently stop
           # updating `latest` on releases.
           flavor: |
             latest=auto
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},value=v${{ github.event.inputs.version }},enable=${{ github.event.inputs.version != '' }}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ github.event.inputs.version }},enable=${{ github.event.inputs.version != '' }}
             type=ref,event=branch
 
       - uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,18 @@
 name: Release
 
 # Auto-release on a version bump: when a merge to main changes package.json and
-# the version has no tag yet, gate → publish to npm → tag → GitHub release.
-# So the release flow is just "merge a version-bump PR". (INT-2270)
+# the version has no tag yet, gate → publish to npm → tag → GitHub release →
+# dispatch docker-publish.yml. So the release flow is just "merge a
+# version-bump PR". (INT-2270)
 #
 # Requires a repo secret NPM_TOKEN (npm automation token). GITHUB_TOKEN is
-# provided automatically for the tag + release.
+# provided automatically for the tag + release + docker-publish dispatch.
+#
+# The docker-publish.yml dispatch (not its own `release: published` trigger)
+# is required, not cosmetic: GitHub does not let a GITHUB_TOKEN-authored
+# event trigger another workflow, so without this explicit dispatch the GHCR
+# image silently never gets built (confirmed 2026-09-03 — zero runs across
+# every prior release). See docker-publish.yml's own header for the other half.
 
 on:
   push:
@@ -15,6 +22,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 env:
   NODE_VERSION: '22'
@@ -121,3 +129,14 @@ jobs:
             if [ -z "$NOTES" ]; then NOTES="Release v$VERSION"; fi
             gh release create "v$VERSION" --title "v$VERSION" --notes "$NOTES"
           fi
+
+      # See the "Requires a repo secret..." note above: release's own
+      # `release: published` event cannot trigger this workflow itself, so
+      # dispatch it explicitly with the version so it tags semver + latest
+      # instead of falling back to a plain branch tag.
+      - name: Trigger Docker image publish
+        if: steps.ver.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: gh workflow run docker-publish.yml --ref main -f version="$VERSION"


### PR DESCRIPTION
## Summary
GHCR images have never been auto-published for this repo — confirmed via the Actions API: `docker-publish.yml` shows zero runs, ever, across every prior release (v0.21.1–v0.21.5). Root cause: `release.yml`'s `gh release create` runs under the default `GITHUB_TOKEN`, and GitHub's loop-prevention rule means a `GITHUB_TOKEN`-authored event never triggers another workflow's `on:` trigger — so `docker-publish.yml`'s `on: release: published` silently never fired.

Fix: `release.yml` now explicitly dispatches `docker-publish.yml` via `gh workflow run` (exempt from the no-cascade rule) with the version as an input; `docker-publish.yml` uses `docker/metadata-action`'s `value=` override so that dispatch produces the same semver + `latest` tags a native release event would, instead of falling back to a bare branch tag. No new secret required.

Verified live (not just reasoned about): dispatched this branch's `docker-publish.yml` with `version=0.21.6` — the resulting image was tagged `0.21.6`, `0.21`, and `latest` correctly.

## Test plan
- [x] Test-dispatched from this branch with `-f version=0.21.6`, confirmed `DOCKER_METADATA_OUTPUT_TAGS` includes `0.21.6` / `0.21` / `latest`
- [x] Bare `workflow_dispatch` (no version) still falls back to the branch tag — unchanged from before
- N/A: no application code touched (workflow YAML only)