### PR TITLE
fix(responses): reject incomplete terminal streams

### DIFF
--- a/src/adapters/codexResponses.test.ts
+++ b/src/adapters/codexResponses.test.ts
@@ -138,6 +138,33 @@ describe('unsupported-model fallback', () => {
   });
 });
 
+describe('Responses stream terminal events', () => {
+  it('propagates an incomplete 200 stream instead of returning an empty successful response', async () => {
+    const fetchMock = vi.fn(async () => new Response(
+      [
+        'data: {"type":"response.incomplete","response":{"incomplete_details":{"reason":"max_output_tokens"}}}',
+        'data: [DONE]',
+        '',
+      ].join('\n'),
+      { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    type CreateApiCaller = (
+      initialToken: string,
+      accountId: string,
+      store: unknown,
+      model: string,
+    ) => (messages: ChatMessage[], tools: ToolDefinition[]) => Promise<unknown>;
+    const adapter = new CodexResponsesAdapter() as unknown as { createApiCaller: CreateApiCaller };
+
+    await expect(adapter.createApiCaller('token', 'account', {}, 'gpt-5.6-terra')(
+      [{ role: 'user', content: 'Return a short answer.' }],
+      [],
+    )).rejects.toThrow('incomplete');
+  });
+});
+
 describe('chatToResponsesInput', () => {
   it('lifts system messages into instructions and keeps user/assistant as input', () => {
     const messages: ChatMessage[] = [

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -133,6 +133,8 @@ interface SseEvent {
   arguments?: string;
   response?: {
     model?: string;
+    incomplete_details?: { reason?: string };
+    error?: { message?: string };
     usage?: { input_tokens?: number; output_tokens?: number; input_tokens_details?: { cached_tokens?: number } };
   };
 }
@@ -241,6 +243,7 @@ async function consumeResponsesStream(
 
   const decoder = new TextDecoder();
   let buffer = '';
+  let terminalError: string | undefined;
   // Reasoning summary streams token-by-token; buffer and emit whole lines so the
   // live log shows readable thoughts instead of one-word-per-line spam.
   let reasoningBuf = '';
@@ -257,6 +260,11 @@ async function consumeResponsesStream(
   const handle = (ev: SseEvent | null) => {
     if (!ev) return;
     events.push(ev);
+    if (ev.type === 'response.incomplete') {
+      terminalError = `Responses stream incomplete${ev.response?.incomplete_details?.reason ? `: ${ev.response.incomplete_details.reason}` : ''}`;
+    } else if (ev.type === 'response.failed') {
+      terminalError = `Responses stream failed${ev.response?.error?.message ? `: ${ev.response.error.message}` : ''}`;
+    }
     if (onToken && ev.type === 'response.output_text.delta' && ev.delta) onToken(ev.delta);
     if (onReasoning && ev.type === 'response.reasoning_summary_text.delta' && ev.delta) {
       reasoningBuf += ev.delta;
@@ -277,6 +285,8 @@ async function consumeResponsesStream(
   }
   handle(parseSseLine(buffer));
   flushReasoning(true);
+
+  if (terminalError) throw new Error(terminalError);
 
   return reduceResponsesEvents(events);
 }


### PR DESCRIPTION
## What

Reject terminal `response.incomplete` and `response.failed` SSE events from the Responses API instead of reducing them to an empty successful `stop` response.

## Why

A Responses request can return HTTP 200 while ending unsuccessfully, for example when it exhausts `max_output_tokens`. Previously that stream was treated as a normal empty assistant answer, which could let the agentic loop continue from a false success state.

## How

- Capture terminal incomplete and failed events while consuming the SSE stream.
- Preserve the provider diagnostic reason/message when present.
- Throw after the stream is consumed so callers receive a failed run rather than an empty completion.
- Add a regression test for an HTTP 200 stream ending in `response.incomplete`.

## Testing

- `npm test -- --run src/adapters/codexResponses.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

The full suite could not complete locally because the existing `better-sqlite3` native binary was built for a different Node ABI; the focused suite and static checks above pass.

Related discussion: #556