### PR TITLE
chore(release): 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.22.0 — 2026-09-04
+
+### Changed
+
+- **One design system across the web surface (AGT-4201).** Cockpit, chat, orchestration, threads, warehouse, and the supervisor / issue-board pages now draw every colour, spacing, radius, type size, and motion value from `tokens.css`; the semantic vocabulary (`--bg-*`, `--fg-*`, accent / danger / warning / success, role / kind / status colours) replaces four divergent palettes and 150+ hardcoded hex values. Shared primitives in `shell.css` (sticky topbar with one navigation, buttons, inputs, chips, badges, cards, status and empty states, focus ring, reduced-motion) back every page.
+- **Light theme.** `[data-theme="light"]` is a value swap applied before first paint by `themeBoot.js`; every page has a toggle that persists the choice and follows the OS until one is made.
+- **Chat composer and stream following.** Autogrowing textarea (Enter sends, Shift+Enter breaks the line, IME-safe), Send disabled on empty, in-place sending state, draft persistence, labelled attachment chips, drop overlay. The room stays pinned to the newest line until the operator scrolls up, then offers "↓ Latest" and announces arrivals once per batch to assistive tech.
+- **Destructive actions confirm in the page**, naming the target: resolving a repository thread, overwriting a warehouse file.
+- **Inter (latin variable subset, OFL) is vendored** as the brand font with a Korean system fallback stack.
+
+### Added
+
+- `tests/web/tokens.test.ts` — the token contract: every `var()` resolves, no colour literal outside `tokens.css`, no inline `<style>` in a page shell, every shell links tokens + shell + theme boot in order and shares one navigation, every icon-only button has a name.
+
+### Fixed
+
+- **CI: `npm ci` no longer waits on the registry audit / fund endpoints** (`--prefer-offline --no-audit --no-fund`), which had stalled the Lint job for its whole timeout; lint / typecheck timeouts widened to 10 minutes.
+
 ## 0.21.6 — 2026-09-03
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.21.6",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.21.6",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.21.6",
+  "version": "0.22.0",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Version bump + CHANGELOG for 0.22.0 — the UI surface refactor (AGT-4201, #558) and the CI `npm ci` hardening. Merging this triggers release.yml (npm publish → tag → GitHub release → docker-publish dispatch → GHCR `0.22.0` / `0.22` / `latest`).