### PR TITLE
fix(web): keep the repository card's git line on one row (AGT-4206)

### DIFF
--- a/src/support/dashboardHtml.ts
+++ b/src/support/dashboardHtml.ts
@@ -1061,7 +1061,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
       taskIds.sort((a, b) => (taskStartMap.get(b) || 0) - (taskStartMap.get(a) || 0));
 
       let html = '<button class="log-tab' + (selectedLogTaskId === null ? ' active' : '')
-        + '" data-task="all" onclick="selectLogTab(null)">ALL</button>';
+        + '" data-task="all" onclick="selectLogTab(null)">All</button>';
 
       for (const tid of taskIds) {
         const info = taskTitleMap.get(tid);

--- a/web/static/css/supervisor.css
+++ b/web/static/css/supervisor.css
@@ -264,8 +264,11 @@ body.page-supervisor {
 }
 .issue-row:last-child, .pr-row:last-child { border-bottom: none; }
 .issue-row.issue-backlog { opacity: 0.5; }
-.git-info { display: flex; gap: var(--space-2); align-items: center; font-size: var(--text-xs); color: var(--fg-muted); }
-.git-branch-name { color: var(--info); font-family: var(--font-mono); }
+/* One line, always: a long branch name is cut with an ellipsis rather than
+   wrapped into the counts beside it. */
+.git-info { display: flex; gap: var(--space-2); align-items: center; min-width: 0; font-size: var(--text-xs); color: var(--fg-muted); white-space: nowrap; }
+.git-info > * { flex-shrink: 0; }
+.git-branch-name { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; color: var(--info); font-family: var(--font-mono); }
 .git-dirty { color: var(--warning); }
 .git-sync { color: var(--fg-muted); }
 .pr-num { min-width: 36px; color: var(--info); font-family: var(--font-mono); }


### PR DESCRIPTION
Follow-up to #560 from the first live render on vela: the branch name in a repository card wrapped into the dirty count. The git line is now a single nowrap row with the branch ellipsised; the log filter's default tab is sentence-cased. CSS + one label; `dashboardHtml.test` and `tokens.test` green.