### PR TITLE
fix(adapters): stop reporting an upstream 402 as "no parseable verdict" (AGT-4215)

### DIFF
--- a/src/adapters/agenticLoop.ts
+++ b/src/adapters/agenticLoop.ts
@@ -497,6 +497,32 @@ export async function runAgenticLoop(options: AgenticLoopOptions): Promise<Agent
         throw err;
       }
       onLog?.(`✖ API error: ${msg}`);
+      // Swallowing an API error hands the caller a "result" whose entire body is an
+      // error string. Downstream, parseReviewerResult finds no verdict in it and
+      // reports "no parseable verdict", so the CLI blames the adapter and tells the
+      // operator to check `codex exec`. The case that surfaced this was a 402
+      // billing failure from an upstream BYOK provider: a payment problem presented
+      // as a parser bug, across 14/14 audit areas.
+      //
+      // Swallow ONLY when this run has already caused a side effect worth keeping.
+      // That is the property INT-2520 protects — a worker may have edited files or
+      // run commands that throwing would discard — and `editToolCount` /
+      // `executedCommands` state it directly. A turn counter does not: a read-only
+      // run (reviewer, auditor, `openswarm review`) has no edit or bash tool at all,
+      // so it can never acquire progress, yet a turn-based test would start
+      // swallowing from its second call and reproduce the very misdiagnosis above
+      // one turn later.
+      //
+      // The 'agentic-loop:' prefix is what makes propagation work. Returning a
+      // plain error here would be re-swallowed by each in-process adapter's own
+      // catch into `{exitCode: 1, stdout: ''}`, and spawnCli does not inspect
+      // exitCode for adapters that implement run() — the empty stdout would reach
+      // the parser and produce the same wrong message. The prefix matches
+      // INFRA_ERROR_PATTERNS, so isInfraError re-throws it at every layer and the
+      // real cause reaches the operator. (AGT-4215)
+      if (editToolCount === 0 && executedCommands.length === 0) {
+        throw new Error(`agentic-loop: API call failed with no work to preserve: ${msg}`, { cause: err });
+      }
       finalText = `API error: ${msg}`;
       break;
     }

--- a/src/adapters/errorClassification.ts
+++ b/src/adapters/errorClassification.ts
@@ -38,6 +38,7 @@ const INFRA_ERROR_PATTERNS = [
   'enomem', // out of memory — same class: host resource exhaustion, not a bad edit
   'git-tracker:', // git snapshot/diff failed mid-run — infra, not a task verdict (colon-anchored to avoid prose) (INT-2521)
   'reviewer-stage:', // reviewer ran but its output couldn't be parsed into a verdict — infra, not a quality reject (INT-2521)
+  'agentic-loop:', // the in-process tool loop could not complete a single API call — infra, not a verdict (AGT-4215)
   'verify-runner:', // deterministic verifier could not execute; not a quality failure (INT-2662)
   'throttle-retry:', // a 429/limit throttle survived its retry budget — infra for that call, NOT a spent quota (INT-2907)
   'fetch failed', // undici: the real code hides in error.cause.code (checked below)

--- a/src/adapters/rateLimitError.test.ts
+++ b/src/adapters/rateLimitError.test.ts
@@ -16,6 +16,10 @@ describe('per-provider usage-limit recognition (INT-2520 audit)', () => {
     ['OpenAI 429 rate_limit_exceeded', '{"error":{"code":"rate_limit_exceeded","message":"Rate limit reached for gpt-5 …"}}'],
     ['OpenAI 429 insufficient_quota', '{"error":{"type":"insufficient_quota","message":"You exceeded your current quota, please check your plan and billing details."}}'],
     ['OpenRouter 402 insufficient credits', '{"error":{"code":402,"message":"Insufficient credits. Add more to continue."}}'],
+    // Verbatim from the run that surfaced AGT-4215: OpenRouter relaying an upstream
+    // BYOK provider's own exhausted-balance wording, which is NOT "insufficient credits".
+    ['OpenRouter 402 relaying upstream BYOK balance',
+      '{"error":{"message":"Provider returned error","code":402,"metadata":{"raw":"{\\"code\\":402,\\"msg\\":\\"insufficient balance\\"}","provider_name":"AtlasCloud","is_byok":true}}}'],
     ['HTTP 429 too many requests (local)', 'Local API error (429): Too Many Requests'],
   ];
   for (const [name, output] of REAL_LIMIT_OUTPUTS) {
@@ -32,6 +36,12 @@ describe('per-provider usage-limit recognition (INT-2520 audit)', () => {
       'Implemented credit purchase flow and out-of-stock handling.',
       'The cache window is 5min; processed 429 rows in the batch.',
       'Refactored rateLimiter.ts to reset the counter each window.',
+      // "insufficient balance" is the stock error string of wallet/payment code, and
+      // these signatures are scanned against raw model output. A worker editing such
+      // a repo must not pause the scheduler — which is why the AGT-4215 signature is
+      // anchored on the provider's JSON key rather than added as a bare substring.
+      "throw new Error('Insufficient balance') // wallet guard",
+      'if (res.status === 402) throw new Error("Insufficient balance for this transfer");',
     ];
     for (const b of benign) {
       expect(matchesRateLimitMessage(b)).toBe(false);
@@ -154,10 +164,92 @@ describe('runAgenticLoop rate-limit propagation (INT-1906 blocker)', () => {
     ).rejects.toThrow(/fetch failed/);
   });
 
-  it('does NOT re-throw an ordinary (non-rate-limit, non-infra) API error', async () => {
-    const callApi = async () => { throw new Error('the model returned malformed JSON'); };
-    const res = await runAgenticLoop({ prompt: 'x', cwd: process.cwd(), model: 't', callApi, webTools: false, maxTurns: 2 });
+  // The preserve-progress property this has guarded since INT-2520: an error that is
+  // neither a rate limit nor infra must not kill a run that has already caused a SIDE
+  // EFFECT, because a worker may have edited files or run commands that throwing
+  // would discard. AGT-4215 moved the boundary rather than removing the property —
+  // it is now keyed on that side effect (editToolCount / executedCommands) instead of
+  // on a turn counter, so a read-only run, which can never acquire one, is never
+  // silently handed an error string as its "result".
+  it('does NOT re-throw an ordinary API error once the run has done real work', async () => {
+    let n = 0;
+    const callApi = async () => {
+      n += 1;
+      if (n === 1) {
+        return {
+          choices: [{
+            message: { role: 'assistant', content: null, tool_calls: [
+              { id: 'c1', type: 'function' as const, function: { name: 'bash', arguments: JSON.stringify({ command: 'echo agt4215' }) } },
+            ] },
+            finish_reason: 'tool_calls',
+          }],
+        };
+      }
+      throw new Error('the model returned malformed JSON');
+    };
+    const res = await runAgenticLoop({ prompt: 'x', cwd: process.cwd(), model: 't', callApi: callApi as never, webTools: false, maxTurns: 3 });
+    expect(res.executedCommands.length).toBeGreaterThan(0);
     expect(res.text).toContain('API error');
+  });
+
+  // The read-only case the turn-based first cut missed: a reviewer has no edit or
+  // bash tool, so it can never accumulate progress. A failure on its SECOND call
+  // must still propagate, or the operator gets "no parseable verdict" one turn later.
+  it('re-throws when a later call fails but the run never produced a side effect', async () => {
+    let n = 0;
+    const callApi = async () => {
+      n += 1;
+      if (n === 1) {
+        return {
+          choices: [{
+            message: { role: 'assistant', content: null, tool_calls: [
+              { id: 'c1', type: 'function' as const, function: { name: 'read_file', arguments: JSON.stringify({ path: 'nope.ts' }) } },
+            ] },
+            finish_reason: 'tool_calls',
+          }],
+        };
+      }
+      throw new Error('the model returned malformed JSON');
+    };
+    await expect(
+      runAgenticLoop({ prompt: 'x', cwd: process.cwd(), model: 't', callApi: callApi as never, webTools: false, maxTurns: 3 }),
+    ).rejects.toThrow(/agentic-loop: API call failed with no work to preserve/);
+  });
+
+  // The other side of that boundary. Returning this as a normal result gave the
+  // caller a "success" whose entire body was an error string; parseReviewerResult
+  // then reported "no parseable verdict" and the CLI blamed the adapter. Measured
+  // on 14/14 audit areas where the real cause was a 402 billing failure. (AGT-4215)
+  it('re-throws an ordinary API error that kills the FIRST call', async () => {
+    const callApi = async () => { throw new Error('the model returned malformed JSON'); };
+    await expect(
+      runAgenticLoop({ prompt: 'x', cwd: process.cwd(), model: 't', callApi, webTools: false, maxTurns: 2 }),
+    ).rejects.toThrow(/agentic-loop: API call failed with no work to preserve/);
+  });
+
+  // And it must be classified as infra, or each in-process adapter's own catch
+  // re-swallows it into {exitCode: 1, stdout: ''} — spawnCli does not inspect
+  // exitCode for adapters implementing run(), so the empty stdout would reach the
+  // parser and reproduce the very message this fix removes. (AGT-4215)
+  it('marks that first-call failure as infra so every layer re-throws it', async () => {
+    const callApi = async () => { throw new Error('the model returned malformed JSON'); };
+    const err = await runAgenticLoop({ prompt: 'x', cwd: process.cwd(), model: 't', callApi, webTools: false, maxTurns: 2 })
+      .then(() => null, (e: unknown) => e);
+    expect(isInfraError(err)).toBe(true);
+  });
+
+  // End-to-end shape of the reported incident: the upstream 402 arrives on call #1.
+  // It must surface as a RateLimitError (pause + a billing message), never as a
+  // swallowed result the reviewer parser turns into "no parseable verdict".
+  it('surfaces an upstream "insufficient balance" 402 on the first call as a rate limit', async () => {
+    const callApi = async () => {
+      // Verbatim shape: the phrase arrives nested inside a JSON string, so the real
+      // bytes carry backslashes — \"msg\":\"insufficient balance\".
+      throw new Error(String.raw`OpenRouter API error (402): {"error":{"message":"Provider returned error","code":402,"metadata":{"raw":"{\"code\":402,\"msg\":\"insufficient balance\"}","provider_name":"AtlasCloud","is_byok":true}}}`);
+    };
+    await expect(
+      runAgenticLoop({ prompt: 'x', cwd: process.cwd(), model: 't', callApi, webTools: false, maxTurns: 2 }),
+    ).rejects.toBeInstanceOf(RateLimitError);
   });
 
   it('preserves a TYPED RateLimitError whose human message detectRateLimit would miss (INT-2519)', async () => {
@@ -271,6 +363,18 @@ describe('resolveLimitResponse gating (INT-2907)', () => {
   it('still pauses on the out-of-credits 402 openrouter actually sends', async () => {
     await expect(
       resolveLimitResponse('openrouter', 402, new Headers(), '{"error":{"message":"Insufficient credits. Add more to continue."}}', state()),
+    ).rejects.toBeInstanceOf(RateLimitError);
+  });
+
+  // An upstream BYOK provider proxied through OpenRouter reports ITS balance, in its
+  // own words. Before AGT-4215 this matched no signature, so it returned 'other' and
+  // the agentic loop swallowed it into a normal result — the operator was told the
+  // reviewer produced "no parseable verdict" when the account simply needed topping up.
+  it('pauses on a 402 relaying an upstream provider\'s "insufficient balance"', async () => {
+    const body = '{"error":{"message":"Provider returned error","code":402,"metadata":'
+      + '{"raw":"{\\"code\\":402,\\"msg\\":\\"insufficient balance\\"}","provider_name":"AtlasCloud","is_byok":true}}}';
+    await expect(
+      resolveLimitResponse('openrouter', 402, new Headers(), body, state()),
     ).rejects.toBeInstanceOf(RateLimitError);
   });
 });

--- a/src/adapters/rateLimitError.ts
+++ b/src/adapters/rateLimitError.ts
@@ -74,6 +74,18 @@ const RATE_LIMIT_REGEXES: readonly RegExp[] = [
   // or as an "(429)" status echo from an adapter's error wrapper.
   /\b429\b[\s\S]{0,30}(rate.?limit|too many|quota)/,
   /error \(429\)/,
+  // An upstream BYOK provider proxied THROUGH OpenRouter reports ITS exhausted
+  // balance in its own words — OpenRouter answers 402 with
+  // metadata.raw = {"code":402,"msg":"insufficient balance"}. A bare
+  // "insufficient balance" substring cannot go in the list above: it is the stock
+  // error string of wallet/payment/banking code, and these signatures are scanned
+  // against raw model output, so a worker merely editing such a repo would trip it
+  // and pause the scheduler. Anchoring on the JSON key keeps it provider-shaped.
+  // The backslashes are not optional: the phrase arrives nested inside a JSON
+  // STRING, so the real bytes are \"msg\":\"insufficient balance\" — a pattern
+  // written without them matches the shape people expect and never the one that
+  // actually arrives. (AGT-4215)
+  /"msg\\?"\s*:\s*\\?"insufficient balance/,
 ];
 
 /** True when `text` carries any provider's usage/rate/quota-limit signature. */
@@ -140,6 +152,11 @@ const QUOTA_EXHAUSTED_SUBSTRINGS: readonly string[] = [
   'insufficient_quota',
   'exceeded your current quota',
   'insufficient credits',
+  // Spent money, not a short window: an upstream BYOK provider relaying its own
+  // empty balance through OpenRouter. Waiting cannot clear it, so it belongs here
+  // (pause) rather than in the throttle path, which would burn the retry budget
+  // on three escalating sleeps and then fail anyway. (AGT-4215)
+  'insufficient balance',
   'requires more credits',
   'purchase more credits',
   'out of credits',


### PR DESCRIPTION
## Symptom

`openswarm review --max` on the openrouter provider failed **14/14 audit areas**, every one with:

```
reviewer-stage: produced no parseable verdict: Reviewer output carried no verdict
```

and the CLI told the operator to *"check the adapter with a trivial run (e.g. `codex exec`)"* and try `--adapter claude`. Both point at the wrong subsystem. The real cause was an **HTTP 402** from an upstream BYOK provider relayed through OpenRouter:

```json
{"error":{"message":"Provider returned error","code":402,
  "metadata":{"raw":"{\"code\":402,\"msg\":\"insufficient balance\"}",
              "provider_name":"AtlasCloud","is_byok":true}}}
```

A billing failure rendered as a parser bug.

## Root cause

The 402 slipped all three nets in `runAgenticLoop`'s catch:

| Net | Why it missed |
| --- | --- |
| `err instanceof RateLimitError` | `resolveLimitResponse` returned `'other'`, so the adapter threw a plain `Error` |
| `detectRateLimit` | `RATE_LIMIT_SUBSTRINGS` had `insufficient credits`, never the upstream's own wording |
| `isInfraError` | 402 is excluded **by design** — *"429/402 are handled as RateLimitError, not here"* |

Falling through all three, the loop swallowed it into `finalText = "API error: …"` and returned **exitCode 0**. That body reached `parseReviewerResult`, which correctly found no verdict in it.

## Changes

**`rateLimitError.ts`** — recognise the upstream wording, anchored on the provider's JSON key rather than as a bare substring. `insufficient balance` is the stock error string of wallet/payment code and these lists are scanned against **raw model output**, so a bare entry would let a worker editing a payments repo pause the scheduler. The pattern also allows the backslashes the phrase really arrives with, since it is nested inside a JSON string:

```ts
/"msg\\?"\s*:\s*\\?"insufficient balance/
```

It additionally joins `QUOTA_EXHAUSTED_SUBSTRINGS`: a spent balance cannot be waited out, so it must pause rather than burn three escalating throttle sleeps and fail anyway. (That second list was only discovered because the new test asserted `rejects` and got `'retry'`.)

**`agenticLoop.ts`** — propagate an API error when the run has produced no side effect, instead of returning it as a normal result:

```ts
if (editToolCount === 0 && executedCommands.length === 0) {
  throw new Error(`agentic-loop: API call failed with no work to preserve: ${msg}`, { cause: err });
}
```

The test is the **side effect, not the turn index**. The INT-2520 property being protected is "do not discard a worker's edits", and a read-only run — reviewer, auditor, `openswarm review`, i.e. this incident's exact path — has no edit or bash tool at all, so it can never acquire progress. A turn-based boundary would only have moved the same misdiagnosis one call later.

**`errorClassification.ts`** — register the `agentic-loop:` marker alongside the existing `reviewer-stage:` / `verify-runner:` / `git-tracker:` convention. This is load-bearing: `spawnCli` returns an adapter's `CliRunResult` **without inspecting exitCode** for adapters implementing `run()`, and `reviewer.ts` has no exitCode check at all. Without the marker the throw is re-swallowed into `{exitCode: 1, stdout: ''}` and the empty stdout reproduces the original message.

## Verification

End-to-end against the exhausted provider, before and after:

```
- Review gate did NOT run: reviewer-stage: produced no parseable verdict…
+ Review gate did NOT run — usage limit: HTTP 402 out of credits.
```

A run without the provider pin completes normally (24 API calls, 0 × 402).

- Full suite **5514 passed, 0 failed**, 10 skipped
- `rateLimitError.test.ts` 49/49 — covers the verbatim wire format at all three entry points, the read-only second-call gap, and two payment-code strings in the false-positive guard
- `tsc --noEmit` clean · `oxlint` 0 warnings / 0 errors

Review gates: tier-1 `openswarm review` APPROVE, plus an independent subagent review whose two findings (the turn-vs-progress boundary, and the under-anchored signature) are both folded in above; re-review APPROVE with no new findings.

Closes AGT-4215.
