### PR TITLE
fix(adapters): stop concurrent codex-responses reviewers queueing inside undici (AGT-4220)

### DIFF
--- a/src/adapters/codexResponses.test.ts
+++ b/src/adapters/codexResponses.test.ts
@@ -14,6 +14,19 @@ import { runAgenticLoop, type ChatMessage } from './agenticLoop.js';
 import { RateLimitError } from './rateLimitError.js';
 import type { ToolDefinition } from './tools.js';
 
+// The adapter sends Codex traffic through undici's own fetch with a dedicated
+// HTTP/1.1 dispatcher (AGT-4220), so `vi.stubGlobal('fetch', ...)` alone no
+// longer intercepts it. Delegating the module's fetch to the global keeps every
+// existing stub in this file meaningful, and the init object — `dispatcher`
+// included — still reaches the stub, so it stays assertable.
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: (url: unknown, init: unknown) => (globalThis.fetch as unknown as (u: unknown, i: unknown) => unknown)(url, init),
+  };
+});
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
@@ -425,6 +438,22 @@ describe('429 throttle vs spent quota (INT-2907)', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('sends Codex traffic on a dedicated HTTP/1.1 dispatcher, not the global pool (AGT-4220)', async () => {
+    // chatgpt.com negotiates h2, and Node's global fetch then carries every
+    // concurrent request as a stream over a couple of connections. The server
+    // admits few concurrent streams per connection, so N reviewers in one
+    // process queued INSIDE undici: measured at concurrency 4, create ->
+    // sendHeaders was 17.30s median while the server answered in 1.07s. Losing
+    // this dispatcher silently reintroduces that, and nothing else in the suite
+    // would notice — the requests still succeed, just serialised.
+    const fetchMock = vi.fn(async () => okStream());
+    const callApi = callerWith(fetchMock);
+    await callApi([{ role: 'user', content: 'hi' }], []);
+
+    const init = fetchMock.mock.calls[0]?.[1] as { dispatcher?: unknown } | undefined;
+    expect(init?.dispatcher).toBeDefined();
   });
 
   it('waits out a concurrency throttle and retries instead of reporting a usage limit', async () => {

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -5,6 +5,8 @@
 // (unlike the codex `exec` CLI, which is a black box). INT-1586.
 // ============================================
 
+import { Agent, fetch as undiciFetch } from 'undici';
+
 import type {
   CliAdapter,
   CliRunOptions,
@@ -48,6 +50,28 @@ type ResponsesInputItem =
   | { role: 'user' | 'assistant'; content: string }
   | { type: 'function_call'; call_id: string; name: string; arguments: string }
   | { type: 'function_call_output'; call_id: string; output: string };
+
+/**
+ * Dedicated dispatcher for Codex Responses traffic, pinned to HTTP/1.1.
+ *
+ * Node's global fetch negotiates h2 with this origin, and undici then carries
+ * several concurrent requests as streams over a couple of connections. The
+ * server admits only a few concurrent streams per connection, so with N
+ * reviewers in one process a request sat in undici waiting for a stream slot:
+ * measured at concurrency 4, `create -> sendHeaders` was 17.30s median while
+ * the server itself answered in 1.07s. Splitting the same work across four
+ * processes was fast purely because each got its own connection.
+ *
+ * One connection per in-flight request restores that, without needing a
+ * process boundary. undici's own `fetch` is required — a dispatcher built from
+ * the npm package is rejected by the copy bundled inside Node's global fetch
+ * (same constraint as support/outboundUrl.ts). (AGT-4220)
+ */
+let codexDispatcher: Agent | undefined;
+function getCodexDispatcher(): Agent {
+  codexDispatcher ??= new Agent({ allowH2: false, connections: 64, pipelining: 1 });
+  return codexDispatcher;
+}
 
 /**
  * Resolve the reasoning effort for a Responses API request. An explicit effort
@@ -489,7 +513,11 @@ export class CodexResponsesAdapter implements CliAdapter {
       // NOTE: never set max_output_tokens — the Codex backend rejects it with HTTP 400.
       const doCall = async (accessToken: string): Promise<ChatLikeResponse> => {
         const request = this.prepareRequest(body);
-        const res = await fetch(request.url, {
+        // undici's Response is spec-compatible with the global one; the DOM lib
+        // types are structurally distinct, so cross the boundary once, here —
+        // same bridge support/outboundUrl.ts makes.
+        const res = await undiciFetch(request.url, {
+          dispatcher: getCodexDispatcher(),
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -502,7 +530,7 @@ export class CodexResponsesAdapter implements CliAdapter {
           body: request.body,
           // The caller's signal AND this call's own deadline. Either aborts.
           signal: abortSignalWithDeadline(signal, timeoutMs),
-        });
+        } as never) as unknown as Response;
 
         if (!res.ok) {
           const errText = await res.text().catch(() => '');


### PR DESCRIPTION
## Problem

`openswarm review --max --adapter codex-responses` failed **every** area with `timeout after 300000ms` at concurrency 4 — reportedly fine at 16 before.

## Root cause

`chatgpt.com` negotiates **h2**, and Node's global `fetch` then carries concurrent requests as streams over a couple of connections. The server admits few concurrent streams per connection, so the Nth reviewer's request waited for a slot **before it was ever written to a socket**.

Splitting one request into `create → sendHeaders` (client) and `sendHeaders → headers` (server) over 39 calls at concurrency 4 located it exactly:

```
queueMs   med= 17.30s   ← waiting inside undici
serverMs  med=  1.07s   ← the server was always fast
```

Fanning the same areas across four processes was fast for one reason only: each got its own connection.

## Fix

A dedicated HTTP/1.1 dispatcher for Codex traffic — `new Agent({ allowH2: false, connections: 64, pipelining: 1 })` — buys that back without a process boundary. undici's own `fetch` is required; a dispatcher built from the npm package is rejected by the copy bundled inside Node's global fetch (the constraint `support/outboundUrl.ts` already documents).

## Measured

| | before (conc 4) | after (conc 16) |
|---|---|---|
| `queueMs` | 17.30s | **0.01s** (p90 0.03s, max 0.12s) |
| `serverMs` | 1.07s | 0.99s |
| areas | 4/4 timeout | **16/16 verdicts, 0 timeouts, exit 0** |

213 calls at concurrency 16 on the default 300s budget. Per-call latency 1.00s against a concurrency-1 baseline of 7.3s — faster than serial.

## Tests

Nine tests stubbed the transport with `vi.stubGlobal('fetch', ...)` and stopped intercepting. The module's fetch now delegates to the global in tests, keeping every existing stub meaningful while still passing `init` through so the dispatcher stays assertable.

The added guard matters because reverting to global fetch **fails nothing** — requests still succeed, merely serialised. Verified red against the pre-fix tree: that guard alone fails, the other 32 pass.

Full suite 5515 passed, 0 failed; tsc and oxlint clean.

## Ruled out by measurement first

Adapter/auth health · area file count and byte size · prompt token size (normalised to s/1k) · server-side account limits · CPU starvation · event-loop blocking (p99 16.7ms) · undici throughput · a per-area `prompt_cache_key` split (no latency effect — reverted) · a regression in c49f24a (its parent reproduces identically).

## Follow-up, not in scope

`gpt` · `openrouter` · `atlascloud` · `lmstudio` · `cc-router` are in-process adapters too; whichever of their hosts negotiate h2 will show the same symptom. Each needs its own measurement.

AGT-4220

🤖 Generated with [Claude Code](https://claude.com/claude-code)