### PR TITLE
fix(runner): honor unknownScopeAdmission in the pre-admission worktree gate (AGT-4233)

### DIFF
--- a/src/automation/autonomousRunner.coverage.test.ts
+++ b/src/automation/autonomousRunner.coverage.test.ts
@@ -26,19 +26,21 @@ import type { DecisionResult, TaskItem } from '../orchestration/decisionEngine.j
 import type { AutonomousConfig } from './runnerTypes.js';
 import type { ITaskSource } from './taskSource.js';
 
-const { detectFileConflictsMock, resolveTaskFileScopeMock, fileScopesConflictMock } = vi.hoisted(() => ({
+const { detectFileConflictsMock, resolveTaskFileScopeMock, describeScopeConflictMock } = vi.hoisted(() => ({
   detectFileConflictsMock: vi.fn(),
   resolveTaskFileScopeMock: vi.fn(async (task: TaskItem) => {
     task.fileScope ??= [`scope/${task.id}`];
     return task.fileScope;
   }),
-  fileScopesConflictMock: vi.fn(() => false),
+  // null = no conflict. The runner now reads a reason object so it can log WHY
+  // a candidate was deferred, not just that it was (AGT-4233).
+  describeScopeConflictMock: vi.fn((): unknown => null),
 }));
 
 vi.mock('../orchestration/conflictDetector.js', () => ({
   detectFileConflicts: detectFileConflictsMock,
   resolveTaskFileScope: resolveTaskFileScopeMock,
-  fileScopesConflict: fileScopesConflictMock,
+  describeScopeConflict: describeScopeConflictMock,
 }));
 
 const { runLedgerRetrospectiveMock } = vi.hoisted(() => ({
@@ -174,8 +176,8 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
       candidate.fileScope ??= [`scope/${candidate.id}`];
       return candidate.fileScope;
     });
-    fileScopesConflictMock.mockReset();
-    fileScopesConflictMock.mockReturnValue(false);
+    describeScopeConflictMock.mockReset();
+    describeScopeConflictMock.mockReturnValue(null);
   }, 30000);
 
   afterEach(() => {
@@ -286,7 +288,7 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
       const internal = r as unknown as Internal;
       const candidate = task({ id: 'candidate', fileScope: ['src/shared.ts'] });
       const activeTask = task({ id: 'active', fileScope: ['src/shared.ts'] });
-      fileScopesConflictMock.mockReturnValueOnce(true);
+      describeScopeConflictMock.mockReturnValueOnce({ kind: 'overlap', shared: ['src/shared.ts'] });
       internal.scheduler.getRunningTasks = () => [{
         runId: 'active-run',
         task: activeTask,
@@ -300,7 +302,10 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
       const safe = await internal.detectSafeCandidateIds([{ task: candidate, projectPath: '/repo' }]);
 
       expect(safe).toEqual(new Set());
-      expect(fileScopesConflictMock).toHaveBeenCalledWith(candidate.fileScope, activeTask.fileScope);
+      // Third argument is the admission policy the durable gate also reads;
+      // passing it is the fix for AGT-4233.
+      expect(describeScopeConflictMock)
+        .toHaveBeenCalledWith(candidate.fileScope, activeTask.fileScope, 'serialize');
       expect(detectFileConflictsMock).not.toHaveBeenCalled();
     });
 
@@ -385,7 +390,7 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
       const internal = r as unknown as Internal;
       const candidate = task({ id: 'candidate', fileScope: ['src/shared.ts'] });
       const activeTask = task({ id: 'active', fileScope: ['src/shared.ts'] });
-      fileScopesConflictMock.mockReturnValueOnce(true);
+      describeScopeConflictMock.mockReturnValueOnce({ kind: 'overlap', shared: ['src/shared.ts'] });
       internal.scheduler.getRunningTasks = () => [{
         runId: 'active-run',
         task: activeTask,
@@ -399,7 +404,10 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
       const safe = await internal.detectSafeCandidateIds([{ task: candidate, projectPath: '/repo' }]);
 
       expect(safe).toEqual(new Set());
-      expect(fileScopesConflictMock).toHaveBeenCalledWith(candidate.fileScope, activeTask.fileScope);
+      // Third argument is the admission policy the durable gate also reads;
+      // passing it is the fix for AGT-4233.
+      expect(describeScopeConflictMock)
+        .toHaveBeenCalledWith(candidate.fileScope, activeTask.fileScope, 'serialize');
       expect(detectFileConflictsMock).not.toHaveBeenCalled();
     });
 

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -76,9 +76,10 @@ import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { checkAllMonitors, getActiveMonitors } from './longRunningMonitor.js';
 import {
+  describeScopeConflict,
   detectFileConflicts,
-  fileScopesConflict,
   resolveTaskFileScope,
+  type ScopeConflictReason,
 } from '../orchestration/conflictDetector.js';
 import { resolveAdapterDefaultModel } from '../agents/stageModelResolver.js';
 import type { AutonomousConfig, RunnerState } from './runnerTypes.js';
@@ -143,6 +144,26 @@ export function worktreeFanoutEnabled(config: Pick<AutonomousConfig,
   'allowSameProjectConcurrent' | 'worktreeMode'
 >): boolean {
   return (config.allowSameProjectConcurrent ?? true) && (config.worktreeMode ?? false);
+}
+
+/** Short, stable label for a task in operator-facing logs. */
+function taskLabel(task: TaskItem): string {
+  return task.issueIdentifier || task.id.slice(0, 8);
+}
+
+/**
+ * One-line cause for a deferral log. Without this the operator only sees that a
+ * candidate was deferred, not whether a scope was unknown or which files
+ * actually collided — the gap that made AGT-4233 need a ledger dig to diagnose.
+ * The file list is capped so one blocked heartbeat cannot flood the log.
+ */
+function describeConflictCause(reason: ScopeConflictReason, activeLabel: string): string {
+  if (reason.kind === 'unknown-candidate') return 'candidate write scope unknown';
+  if (reason.kind === 'unknown-active') return `${activeLabel} write scope unknown`;
+  if (reason.shared.length === 0) return `overlaps ${activeLabel}`;
+  const shown = reason.shared.slice(0, 3);
+  const rest = reason.shared.length - shown.length;
+  return `overlaps ${activeLabel} on ${shown.join(', ')}${rest > 0 ? ` +${rest} more` : ''}`;
 }
 
 export type RunnableCandidate = { task: TaskItem; projectPath: string };
@@ -2676,15 +2697,32 @@ export class AutonomousRunner {
         // alone leaves a race window across heartbeat cycles.
         const active = this.scheduler.getRunningTasks()
           .filter(running => normalizeProjectPath(running.projectPath) === projPath);
+        // Read the SAME policy the durable admission gate reads
+        // (admitsConflictScope, runLedgerScope.ts). While this gate ignored it,
+        // `unknownScopeAdmission: admit` was live on vela yet one running task
+        // still deferred every other candidate — 11 of 12 slots idle with 126
+        // executable tasks waiting (AGT-4233).
+        const admission = this.config.unknownScopeAdmission ?? 'serialize';
         const runnable = group.filter(candidate => {
-          const conflict = active.some(running => fileScopesConflict(
-            candidate.task.fileScope,
-            running.task.fileScope,
-          ));
-          if (conflict) {
-            this.syslog(`Conflict with active worktree — deferring: ${candidate.task.issueIdentifier || candidate.task.id.slice(0, 8)} ${candidate.task.title}`);
+          let blockedBy: { label: string; reason: ScopeConflictReason } | undefined;
+          for (const running of active) {
+            const reason = describeScopeConflict(
+              candidate.task.fileScope,
+              running.task.fileScope,
+              admission,
+            );
+            if (reason) {
+              blockedBy = { label: taskLabel(running.task), reason };
+              break;
+            }
           }
-          return !conflict;
+          if (blockedBy) {
+            this.syslog(
+              `Conflict with active worktree (${describeConflictCause(blockedBy.reason, blockedBy.label)})`
+              + ` — deferring: ${taskLabel(candidate.task)} ${candidate.task.title}`,
+            );
+          }
+          return !blockedBy;
         });
         if (runnable.length === 0) continue;
 

--- a/src/orchestration/conflictDetector.test.ts
+++ b/src/orchestration/conflictDetector.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { detectFileConflicts } from './conflictDetector.js';
+import { describeScopeConflict, detectFileConflicts, fileScopesConflict } from './conflictDetector.js';
 import type { TaskItem } from './decisionEngine.js';
 
 // These tests exercise the planner-declared `fileScope` path. When every task
@@ -154,5 +154,69 @@ describe('detectFileConflicts (planner-declared file scope)', () => {
     );
 
     expect(result.safe.map((t) => t.id)).toEqual(['unknown']);
+  });
+});
+
+
+// The pre-admission worktree gate compares one candidate against one live
+// worker. It used to ignore `unknownScopeAdmission` entirely, so `admit` was
+// honoured by the durable gate and silently dropped here — one running task
+// deferred every other candidate and left 11 of 12 slots idle (AGT-4233).
+describe('describeScopeConflict', () => {
+  it('defers an unknown candidate scope under serialize', () => {
+    expect(describeScopeConflict(undefined, ['src/a.ts'], 'serialize'))
+      .toEqual({ kind: 'unknown-candidate' });
+  });
+
+  it('defers an unknown active scope under serialize', () => {
+    expect(describeScopeConflict(['src/a.ts'], [], 'serialize'))
+      .toEqual({ kind: 'unknown-active' });
+  });
+
+  it('admits an unknown scope on either side under admit', () => {
+    expect(describeScopeConflict(undefined, ['src/a.ts'], 'admit')).toBeNull();
+    expect(describeScopeConflict(['src/a.ts'], undefined, 'admit')).toBeNull();
+    expect(describeScopeConflict(undefined, undefined, 'admit')).toBeNull();
+  });
+
+  it('still refuses two known scopes that overlap, even under admit', () => {
+    expect(describeScopeConflict(['src/a.ts'], ['src/a.ts'], 'admit'))
+      .toEqual({ kind: 'overlap', shared: ['src/a.ts'] });
+  });
+
+  it('names every candidate entry that collides, so a deferral can be read', () => {
+    const reason = describeScopeConflict(
+      ['src/a.ts', 'src/b.ts', 'docs/readme.md'],
+      ['src/a.ts', 'src/b.ts'],
+      'admit',
+    );
+
+    expect(reason).toEqual({ kind: 'overlap', shared: ['src/a.ts', 'src/b.ts'] });
+  });
+
+  it('treats a directory scope as covering its files', () => {
+    expect(describeScopeConflict(['src/api/handler.ts'], ['src/api'], 'admit'))
+      .toEqual({ kind: 'overlap', shared: ['src/api/handler.ts'] });
+  });
+
+  it('lets disjoint known scopes run together under either policy', () => {
+    expect(describeScopeConflict(['src/a.ts'], ['src/b.ts'], 'serialize')).toBeNull();
+    expect(describeScopeConflict(['src/a.ts'], ['src/b.ts'], 'admit')).toBeNull();
+  });
+
+  it('defaults to serialize when no policy is passed', () => {
+    expect(describeScopeConflict(undefined, ['src/a.ts'])).toEqual({ kind: 'unknown-candidate' });
+  });
+});
+
+describe('fileScopesConflict (compatibility wrapper)', () => {
+  it('keeps the historical fail-closed answer for unknown scopes', () => {
+    expect(fileScopesConflict(undefined, ['src/a.ts'])).toBe(true);
+    expect(fileScopesConflict(['src/a.ts'], [])).toBe(true);
+  });
+
+  it('reports overlap and disjointness as before', () => {
+    expect(fileScopesConflict(['src/a.ts'], ['src/a.ts'])).toBe(true);
+    expect(fileScopesConflict(['src/a.ts'], ['src/b.ts'])).toBe(false);
   });
 });

--- a/src/orchestration/conflictDetector.ts
+++ b/src/orchestration/conflictDetector.ts
@@ -169,12 +169,62 @@ export async function resolveTaskFileScope(
   return [];
 }
 
+/**
+ * Why a candidate cannot start beside an active worker. `overlap` carries the
+ * candidate-side entries that matched, so a deferral can name files instead of
+ * only asserting a conflict.
+ */
+export type ScopeConflictReason =
+  | { kind: 'overlap'; shared: string[] }
+  | { kind: 'unknown-candidate' }
+  | { kind: 'unknown-active' };
+
+/** Candidate-side entries that overlap something the active worker will write. */
+function sharedScopeEntries(candidate: Set<string>, active: Set<string>): string[] {
+  const shared: string[] = [];
+  for (const entry of candidate) {
+    for (const other of active) {
+      if (conflictScopeEntriesOverlap(entry, other)) {
+        shared.push(entry);
+        break;
+      }
+    }
+  }
+  return shared;
+}
+
+/**
+ * Compare one candidate's write scope against one active worker's.
+ *
+ * `serialize` is the historical fail-closed rule: an unknown scope on either
+ * side blocks. `admit` is the same rule the durable admission gate already
+ * applies (`admitsConflictScope`, src/automation/runLedgerScope.ts) — an
+ * unknown scope is not evidence of a conflict, while two KNOWN scopes that
+ * overlap are still refused.
+ *
+ * Both gates must read one policy. vela ran with `unknownScopeAdmission: admit`
+ * while this gate still serialized every repository, so one running task
+ * deferred every other candidate and left 11 of 12 slots idle (AGT-4233) — the
+ * same symptom #518 measured and fixed on the durable gate alone.
+ */
+export function describeScopeConflict(
+  candidate: string[] | undefined,
+  active: string[] | undefined,
+  unknownScopeAdmission: 'serialize' | 'admit' = 'serialize',
+): ScopeConflictReason | null {
+  const a = normalizeScope(candidate);
+  const b = normalizeScope(active);
+  const admitUnknown = unknownScopeAdmission === 'admit';
+  if (a.size === 0) return admitUnknown ? null : { kind: 'unknown-candidate' };
+  if (b.size === 0) return admitUnknown ? null : { kind: 'unknown-active' };
+  // Cheap set test first; only enumerate the matches when there is one.
+  if (!conflictScopesOverlap(a, b)) return null;
+  return { kind: 'overlap', shared: sharedScopeEntries(a, b) };
+}
+
 /** Unknown scope conflicts fail closed while another same-repo worker is live. */
 export function fileScopesConflict(left: string[] | undefined, right: string[] | undefined): boolean {
-  const a = normalizeScope(left);
-  const b = normalizeScope(right);
-  if (a.size === 0 || b.size === 0) return true;
-  return conflictScopesOverlap(a, b);
+  return describeScopeConflict(left, right, 'serialize') !== null;
 }
 
 /**


### PR DESCRIPTION
## Problem

The daemon has **two** conflict gates. Only one reads the admission policy.

| Gate | Location | Reads `unknownScopeAdmission` |
|---|---|---|
| durable admission | `runLedgerScope.ts:40` `admitsConflictScope` | yes |
| pre-admission worktree | `autonomousRunner.ts` | **no** |

The second called `fileScopesConflict`, which treats an unknown scope on either side as a conflict unconditionally.

So `unknownScopeAdmission: admit` was live on vela while this gate still serialized every repository. Measured today on cgf-portal:

```
[HB]   Parallel mode | slots: 11 free / 12 max | running: 1
[HB]   Tasks: 20 enabled-or-uncached / 126 executable / 470 total
[HB] Conflict with active worktree — deferring: AX-911 …
     … 9 in a row …
[HB] — No new tasks queued (skipped: 11)
```

One running task deferred every other candidate. That is the same symptom #518 measured (9 of 12 idle) and fixed — on the durable gate alone.

## Change

- **`describeScopeConflict()`** applies the durable gate's rule and reports *why*: `unknown-candidate` / `unknown-active` / `overlap` with the colliding entries. `fileScopesConflict` now wraps it at `'serialize'`, so its answers are byte-for-byte unchanged.
- The runner passes `this.config.unknownScopeAdmission` and **logs the cause**, so a deferral names the blocking task and the files. Diagnosing this needed a ledger dig precisely because that log line said nothing.

## Why this is safe

Admitting an unknown scope here does not weaken the final guarantee: a candidate must still clear the **durable** gate before it can claim a run, and that gate is untouched. This change only stops the earlier gate from refusing work the later gate would have allowed.

Two known scopes that overlap are still refused under either policy.

## Verification

- `npm test` — 397 files / 5524 tests passed, 1 skipped file
- `npm run typecheck`, `npm run lint` — clean (`--listFiles` confirmed both edited files are inside the checked project)
- 10 new unit tests cover serialize/admit × unknown/overlap/disjoint, directory-prefix scopes, and the default policy
- `autonomousRunner.coverage.test.ts` updated: it mocked `fileScopesConflict` and would otherwise have passed against a function the runner no longer calls

## Follow-up

Deploy to vela and confirm `slots free` drops with cgf-portal running in parallel. If deferrals remain, the new log line now says which files collided.

Closes AGT-4233.