### PR TITLE
fix(ledger): preserve pipeline and worktree failure causes (AGT-4237)

### DIFF
--- a/src/agents/pairPipeline.test.ts
+++ b/src/agents/pairPipeline.test.ts
@@ -467,6 +467,7 @@ describe('PairPipeline model selection', () => {
 
     expect(result.finalStatus).toBe('infra_error');
     expect(result.success).toBe(false);
+    expect(result.failureDetail).toBe('worker: codex CLI failed with code 1: Reading prompt from stdin...');
     // Same result-contract guarantee as the rate-limit case above (INT-2424).
     expect(result.stages).toHaveLength(1);
     expect(result.stages[0]).toMatchObject({ stage: 'worker', success: false });
@@ -489,7 +490,21 @@ describe('PairPipeline model selection', () => {
 
     expect(result.finalStatus).toBe('infra_error');
     expect(result.stages).toHaveLength(1);
+    expect(result.failureDetail).toBe('worker: getaddrinfo ENOTFOUND api.openai.com');
     expect(result.stages[0]).toMatchObject({ stage: 'worker', success: false });
+  });
+
+  it.each([
+    [new Error('model resolver configuration invalid'), 'failed', 'model resolver configuration invalid'],
+    ['getaddrinfo ENOTFOUND api.openai.com', 'infra_error', 'getaddrinfo ENOTFOUND api.openai.com'],
+  ])('preserves an exception before a stage result exists: %s', async (error, status, message) => {
+    const { PairPipeline } = await import('./pairPipeline.js');
+    const pipeline = new PairPipeline({ stages: ['worker'], maxIterations: 1 });
+    pipeline.on('stage:start', () => { throw error; });
+    const result = await pipeline.run(task(), process.cwd());
+    expect(result.finalStatus).toBe(status);
+    expect(result.stages).toEqual([]);
+    expect(result.failureDetail).toBe(`pipeline: ${message}`);
   });
 
   // INT-2393: when role model is omitted, the pipeline:stage events must carry

--- a/src/agents/pairPipeline.ts
+++ b/src/agents/pairPipeline.ts
@@ -241,6 +241,7 @@ export class PairPipeline extends EventEmitter {
         sessionId: session.id,
         stages,
         finalStatus: cancelled ? 'cancelled' : rateLimited ? 'rate_limited' : infra ? 'infra_error' : 'failed',
+        failureDetail: `${classifiedStage?.stage ?? 'pipeline'}: ${error instanceof Error ? error.message : String(error)}`,
         failureSignal: isTimeoutError(error) ? 'timeout' : undefined,
         rateLimitResetsAt: rateLimited && (error as RateLimitError).resetsAt
           ? (error as RateLimitError).resetsAt! * 1000

--- a/src/agents/pairPipelineTypes.ts
+++ b/src/agents/pairPipelineTypes.ts
@@ -118,11 +118,9 @@ export interface PipelineResult {
   prUrl?: string;
   totalCost?: CostInfo;
   /**
-   * Cause of a failure that happened outside the staged pipeline — today the
-   * publication step, which runs after every stage succeeded. `stages[]`
-   * cannot carry it (there is no 'pr' stage), and without it the ledger
-   * recorded these attempts with no message at all (vela AGT-3844: 48
-   * attempts, half of them blank).
+   * Operation/stage and original cause of the terminal failure, including
+   * thrown pipeline errors, worktree setup, durable fences and publication.
+   * Takes precedence over prior stage feedback in the failure ledger.
    */
   failureDetail?: string;
   /**

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -836,7 +836,7 @@ export class AutonomousRunner {
       // resumes on its own. This is what kept completable tasks (worker had already
       // edited files) STUCK in production. (INT-2010)
       if (result.finalStatus === 'infra_error') {
-        const detail = result.workerResult?.error || result.reviewResult?.feedback || 'infra/CLI execution error';
+        const detail = pickPipelineFailureDetail(result) || 'infra/CLI execution error';
         if (task.issueId) {
           // Fixed mid-range backoff — we intentionally don't bump failure counts,
           // so there's no attempt number to scale by.
@@ -1104,6 +1104,7 @@ export class AutonomousRunner {
       this.recordPipelineHistory(task, {
         success: false, sessionId: `scheduler-error-${task.id}-${Date.now()}`, stages: [],
         finalStatus: timeout ? 'infra_error' : 'failed', failureSignal: timeout ? 'timeout' : undefined,
+        failureDetail: `scheduler execution: ${error instanceof Error ? error.message : String(error)}`,
         totalDuration: Math.max(0, Date.now() - startedAt), iterations: 0,
         taskContext: { issueIdentifier: task.issueIdentifier || task.issueId, projectName: task.linearProject?.name, projectPath, taskTitle: task.title },
       });
@@ -1455,6 +1456,7 @@ export class AutonomousRunner {
       return {
         success: false,
         sessionId: `repo-admission-error-${Date.now()}`,
+        failureDetail: `repository admission policy: ${error instanceof Error ? error.message : String(error)}`,
         stages: [],
         finalStatus: 'infra_error',
         totalDuration: 0,

--- a/src/automation/durableRunCoordinator.failureDetail.test.ts
+++ b/src/automation/durableRunCoordinator.failureDetail.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import { DurableRunCoordinator } from './durableRunCoordinator.js';
+import { RunLedger } from './runLedger.js';
+import type { PipelineResult } from '../agents/pairPipeline.js';
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+
+describe('failure detail persistence (AGT-4237)', () => {
+  it.each(['infra_error', 'failed'] as const)('persists %s causes in attempts and runs without staged errors', async (status) => {
+    const root = mkdtempSync(join(tmpdir(), 'osw-failure-detail-'));
+    roots.push(root);
+    const path = join(root, 'automation.db');
+    const ledger = new RunLedger(path);
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', ledger, infraFailureCircuit: 2 });
+    const reader = new Database(path, { readonly: true });
+    const task = { id: 'issue', issueId: 'issue', issueIdentifier: 'AGT-TEST', source: 'linear' as const, title: 'task', priority: 2, createdAt: Date.now() };
+    const detail = status === 'infra_error'
+      ? 'worktree creation: Preserved worktree requires reconciliation (valid=true, branch=swarm/AX-868): /work/cgf-portal/worktree/6627815b'
+      : 'pytest missing; prerequisite AGT-3961 remains open';
+    const outcome: PipelineResult = {
+      success: false, sessionId: 's', stages: [], finalStatus: status, totalDuration: 0, iterations: 1,
+      ...(status === 'infra_error' ? { failureDetail: detail } : {
+        workerResult: { success: false, summary: detail, filesChanged: [], commands: [], output: '' },
+      }),
+    };
+    try {
+      await coordinator.execute(task, '/repo', async () => outcome);
+      expect(coordinator.getRun('issue')?.lastErrorMessage).toBe(detail);
+      expect(reader.prepare('SELECT error_message FROM automation_attempts WHERE issue_id = ?').get('issue'))
+        .toEqual({ error_message: detail });
+      if (status === 'infra_error') {
+        expect(ledger.markReady('issue')).toBe(true);
+        await coordinator.execute(task, '/repo', async () => outcome);
+        expect(coordinator.getRun('issue')).toMatchObject({ state: 'NEEDS_HUMAN', lastErrorCode: 'infra_circuit_open' });
+        expect(coordinator.getRun('issue')?.lastErrorMessage).toContain(detail);
+      }
+    } finally {
+      reader.close(); coordinator.close(); ledger.close();
+    }
+  });
+});

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -114,6 +114,7 @@ function fencedResult(result: PipelineResult): PipelineResult {
     ...result,
     success: false,
     finalStatus: 'infra_error',
+    failureDetail: 'durable completion: lease fence rejected result from an expired or replaced owner',
     failureSignal: result.failureSignal ?? 'timeout',
   };
 }

--- a/src/automation/runnerExecution.coverage.test.ts
+++ b/src/automation/runnerExecution.coverage.test.ts
@@ -787,7 +787,7 @@ describe('runnerExecution.ts coverage extension', () => {
     it('returns a repository-scoped infra_error without ever constructing the pipeline when worktree creation fails (AGT-4038)', async () => {
       createWorktree.mockRejectedValue(new Error('git worktree add: disk full'));
       const result = await executePipeline(makeCtx({ worktreeMode: true }), task(), '/repo');
-      expect(result).toMatchObject({ finalStatus: 'infra_error', success: false });
+      expect(result).toMatchObject({ finalStatus: 'infra_error', success: false, failureDetail: 'worktree creation: git worktree add: disk full' });
       expect(result.repositoryInfra).toBe(true); // disk full is the repo's own fault
       expect(createPipelineFromConfig).not.toHaveBeenCalled();
     });
@@ -798,7 +798,7 @@ describe('runnerExecution.ts coverage extension', () => {
     ])('does not blame the repository when %s (AGT-4038)', async (_label, message) => {
       createWorktree.mockRejectedValue(new WorktreeCoordinationError(message));
       const result = await executePipeline(makeCtx({ worktreeMode: true }), task(), '/repo');
-      expect(result).toMatchObject({ finalStatus: 'infra_error', success: false });
+      expect(result).toMatchObject({ finalStatus: 'infra_error', success: false, failureDetail: `worktree creation: ${message}` });
       expect(result.repositoryInfra).toBeFalsy(); // coordination, not disk/git health
     });
 
@@ -811,7 +811,7 @@ describe('runnerExecution.ts coverage extension', () => {
         onPublication: vi.fn(async () => true),
       };
       const result = await executePipeline(makeCtx({ worktreeMode: true, durability }), task(), '/repo');
-      expect(result).toMatchObject({ success: false, finalStatus: 'infra_error' });
+      expect(result).toMatchObject({ success: false, finalStatus: 'infra_error', failureDetail: 'worktree attachment: sqlite busy' });
       expect(result.repositoryInfra).toBeFalsy(); // ledger contention, not the repo's git state
       expect(createPipelineFromConfig).not.toHaveBeenCalled();
       expect(preserveWorktree).toHaveBeenCalledWith(expect.objectContaining({ issueId: 'issue-1' }), 'worktree setup or durable attachment failed');
@@ -982,13 +982,13 @@ describe('runnerExecution.ts coverage extension', () => {
       rejectFence(false);
       const result = await execution;
 
-      expect(result).toMatchObject({ success: false, finalStatus: 'infra_error' });
+      expect(result).toMatchObject({ success: false, finalStatus: 'infra_error', failureDetail: 'Durable stage transition (worker): durable lease fence rejected the event' });
       expect(commitAndCreatePR).not.toHaveBeenCalled();
       expect(preserveWorktree).toHaveBeenCalledTimes(1);
       expect(removeWorktree).not.toHaveBeenCalled();
       const runOptions = fp.run.mock.calls[0][2] as { signal: AbortSignal };
       expect(runOptions.signal.aborted).toBe(true);
-      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Durable stage transition failed'), expect.any(Error));
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Durable stage transition (worker) failed'), expect.any(Error));
     });
 
     it('posts a worker-start audit comment only for the worker stage on a task with an issueId', async () => {

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -890,6 +890,7 @@ export async function executePipeline(
           iterations: 0,
           totalDuration: 0,
           finalStatus: 'infra_error',
+          failureDetail: 'worktree attachment: durable lease fence rejected worktree attachment',
           stages: [],
         };
       }
@@ -931,6 +932,7 @@ export async function executePipeline(
         totalDuration: 0,
         finalStatus: 'infra_error',
         repositoryInfra: !worktreeInfo && !isCoordinationFailure,
+        failureDetail: `worktree ${worktreeInfo ? 'attachment' : 'creation'}: ${err instanceof Error ? err.message : String(err)}`,
         stages: [],
       };
     }
@@ -1029,7 +1031,7 @@ export async function executePipeline(
       console.log(`[${taskPrefix}] Stage started: ${stage}`);
       if (ctx.durability) {
         trackPipelineEffect(
-          'Durable stage transition',
+          `Durable stage transition (${stage})`,
           () => ctx.durability!.onStage(stage),
           true,
         );
@@ -1195,6 +1197,7 @@ export async function executePipeline(
     if (lifecycleFailure) {
       result.success = false;
       result.finalStatus = 'infra_error';
+      result.failureDetail = lifecycleFailure.message;
     }
 
     const parkedPublished = await publishParkedIfNeeded(worktreeInfo, task, result, ctx.durability);

--- a/src/automation/runnerState.coverage.test.ts
+++ b/src/automation/runnerState.coverage.test.ts
@@ -303,6 +303,28 @@ describe('pickFailureDetail (INT-2504)', () => {
 describe('pickPipelineFailureDetail stage fallback', () => {
   const base = { success: false, sessionId: 's', iterations: 1, totalDuration: 10 } as const;
 
+  it.each(['haltReason', 'noChangesReason', 'summary'])('preserves a failed worker %s when error is absent', (field) => {
+    expect(mod.pickPipelineFailureDetail({
+      ...base, finalStatus: 'failed', stages: [],
+      workerResult: { success: false, error: 'Unknown error', [field]: 'pytest missing; prerequisite AGT-3961 remains open' },
+    } as never)).toBe('pytest missing; prerequisite AGT-3961 remains open');
+  });
+
+  it('does not treat a successful worker summary as a failure cause', () => {
+    expect(mod.pickPipelineFailureDetail({
+      ...base, finalStatus: 'failed', stages: [],
+      workerResult: { success: true, summary: 'Implementation complete' },
+    } as never)).toBeUndefined();
+  });
+
+  it('keeps the terminal exception ahead of earlier stage feedback', () => {
+    expect(mod.pickPipelineFailureDetail({
+      ...base, finalStatus: 'infra_error', stages: [],
+      failureDetail: 'worktree attachment: sqlite busy',
+      reviewResult: { decision: 'approve', feedback: 'approved' },
+    } as never)).toBe('worktree attachment: sqlite busy');
+  });
+
   it('names the failed stage when no typed sub-result carries the error', () => {
     // vela 2026-09-01: guards, security audit and publication all fail through
     // stages[], and 57% of that day's ledger rows had no error message.

--- a/src/automation/runnerState.ts
+++ b/src/automation/runnerState.ts
@@ -219,6 +219,14 @@ export function pickFailureDetail(candidates: Array<string | undefined>): string
 
 /** Prefer the stage that actually failed over earlier successful feedback. */
 export function pickPipelineFailureDetail(result: PipelineResult): string | undefined {
+  const workerFailure = result.workerResult?.success === false
+    ? pickFailureDetail([
+      result.workerResult.error,
+      result.workerResult.haltReason,
+      result.workerResult.noChangesReason,
+      result.workerResult.summary,
+    ])
+    : undefined;
   const testerFailure = result.testerResult?.success === false
     ? pickFailureDetail([
       result.testerResult.error,
@@ -243,7 +251,7 @@ export function pickPipelineFailureDetail(result: PipelineResult): string | unde
     testerFailure,
     result.lastReviewFeedback,
     result.reviewResult?.feedback,
-    result.workerResult?.error,
+    workerFailure,
     stageError,
     result.stuckReason,
   ]);


### PR DESCRIPTION
VELA recorded 15 of 19 recent infrastructure failures without a cause. All 15 were AX-868 worktree setup failures: the catch logged the exception but returned only `infra_error`. Failed workers also explained missing pytest/prerequisites in `haltReason`, `noChangesReason`, or `summary`, while the ledger extractor read only `error`.

Preserve operation/stage and the original exception in `failureDetail` for pipeline catches, worktree setup/attachment, durable fences, repository policy and scheduler errors. Read failed-worker explanations and use the same extractor in scheduler logging. This also lets the existing identical-infrastructure-failure circuit recognize repeated worktree failures; no retry limits or scope fences are relaxed.

Validation:

- Full suite: 5,533 passed, 10 skipped (398 files passed, 1 skipped).
- Targeted producer/coordinator/state tests: 257 passed; final scheduler check: 55 passed.
- Actual SQLite regression verifies both attempt/run messages and the existing infra circuit.
- Typecheck and build passed; lint has zero errors and one existing warning in webTools.test.ts.
- `openswarm review --path . --adapter codex-responses`: APPROVE on final working tree.

Related: AGT-4237, AGT-4234. Keep AGT-4237 In Progress until the post-deployment 24-hour blank-message rate is measured below 5% and the cause distribution is reported.
