### PR TITLE
fix(dashboard): responsive navigation and panel layouts (AGT-4238)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "node --experimental-vm-modules node_modules/vitest/vitest.mjs run",
     "test:coverage": "node --experimental-vm-modules node_modules/vitest/vitest.mjs run --coverage",
     "test:watch": "node --experimental-vm-modules node_modules/vitest/vitest.mjs",
+    "test:responsive": "tsx scripts/check-dashboard-responsive.ts",
     "chat": "node --env-file=.env --import=tsx src/support/chat.ts",
     "cli:dev": "node --env-file=.env --import=tsx src/cli.ts",
     "perf:measure": "tsx scripts/playwright-rendering-performance.ts",

--- a/scripts/README-DASHBOARD-RESPONSIVE.md
+++ b/scripts/README-DASHBOARD-RESPONSIVE.md
@@ -1,0 +1,28 @@
+# Dashboard responsive browser check
+
+Requires the project's npm dependencies and an installed Google Chrome. Run
+against a reachable OpenSwarm dashboard with real data:
+
+```sh
+npm run test:responsive -- http://localhost:3847 /tmp/openswarm-responsive
+```
+
+The default mode serves this checkout's `/static/` assets to the test browser
+while retaining the running server's HTML and API/SSE responses. It does not
+modify the server. To inspect deployed assets instead, append `--live`.
+Non-GET/HEAD requests are aborted, so the check cannot dispatch work, send a
+message, change a provider, or stop/restart the daemon.
+
+The check visits Supervisor, Cockpit, Chat, Orchestration, Threads and Warehouse
+at 320, 390, 768, 1024 and 1440 CSS pixels in light and dark themes. It verifies
+viewport overflow, reachable navigation, mobile form/detail separation,
+conversation access, sidebar positioning, input font sizes, desktop panel
+containment and the chat composer in a shortened viewport. A running API must
+answer successfully before each check. It writes `results.json` and full-page
+screenshots for 390 and 1440 pixels to the output directory.
+
+Inspect those screenshots as well as the assertions: populated content can
+expose layout defects that a page-width check alone cannot catch. Chrome mobile
+emulation does not prove physical iOS keyboard or Safari safe-area behavior.
+The preview does not replace server-rendered HTML; verify HTML changes against
+a build serving this checkout or with `--live` after deployment.

--- a/scripts/check-dashboard-responsive.ts
+++ b/scripts/check-dashboard-responsive.ts
@@ -1,0 +1,125 @@
+/** Read-only browser regression check against a running dashboard.
+ * npx tsx scripts/check-dashboard-responsive.ts <base-url> <output-dir> [--live]
+ * By default, preview this checkout's assets over the real backend. --live
+ * checks the deployed assets. No non-GET request is allowed to reach it.
+ */
+import assert from 'node:assert/strict';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const [baseUrl, outputDir, mode] = process.argv.slice(2);
+assert(baseUrl && outputDir, 'Usage: <base-url> <output-dir> [--live]');
+const origin = new URL(baseUrl).origin;
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const staticRoot = resolve(root, 'web/static');
+const paths = ['/', '/app', '/chat', '/orchestration', '/threads', '/warehouse'];
+const results: object[] = [];
+await mkdir(outputDir, { recursive: true });
+const browser = await chromium.launch({ channel: 'chrome', headless: true });
+try {
+  for (const width of [320, 390, 768, 1024, 1440]) {
+    for (const theme of ['light', 'dark'] as const) {
+      for (const path of paths) {
+        const context = await browser.newContext({
+          viewport: { width, height: 844 }, isMobile: width <= 768,
+          hasTouch: width <= 1024, colorScheme: theme,
+        });
+        const errors: string[] = [];
+        const blocked: string[] = [];
+        await context.route('**/*', async (route) => {
+          const request = route.request();
+          if (!['GET', 'HEAD'].includes(request.method())) {
+            blocked.push(`${request.method()} ${new URL(request.url()).pathname}`);
+            await route.abort();
+            return;
+          }
+          const url = new URL(request.url());
+          if (url.origin !== origin || mode === '--live') return route.continue();
+          if (url.pathname.startsWith('/static/')) {
+            const file = resolve(staticRoot, url.pathname.slice('/static/'.length));
+            assert(file.startsWith(`${staticRoot}/`));
+            return route.fulfill({ path: file });
+          }
+          // Keep the document's real network address space. Fulfilling a
+          // synthetic document makes Chrome block private-network API/SSE.
+          return route.continue();
+        });
+        const page = await context.newPage();
+        page.on('pageerror', (error) => errors.push(error.message));
+        const ready = page.waitForResponse((response) =>
+          response.url().startsWith(`${origin}/api/`) && response.ok());
+        await page.goto(`${origin}${path}`, { waitUntil: 'load' });
+        await ready;
+        // Let API-rendered content settle; SSE prevents networkidle by design.
+        await page.waitForTimeout(700);
+        const label = `${path === '/' ? 'supervisor' : path.slice(1)}-${width}-${theme}`;
+        const size = await page.evaluate(() => ({
+          inner: innerWidth, scroll: document.documentElement.scrollWidth,
+          height: document.documentElement.scrollHeight,
+        }));
+        assert.equal(size.inner, width, `${label}: mobile viewport expanded`);
+        assert(size.scroll <= width + 1, `${label}: page overflow ${size.scroll}`);
+        if (width >= 1024 && path !== '/warehouse') {
+          assert(size.height <= 845, `${label}: desktop panels escape the viewport (${size.height}px)`);
+        }
+        assert.deepEqual(errors, [], `${label}: JavaScript errors`);
+        const nav = page.locator('.topbar-nav');
+        assert(await nav.isVisible(), `${label}: navigation hidden`);
+        const initialNavScroll = await nav.evaluate((element) => element.scrollLeft);
+        for (const link of await nav.locator('a').all()) {
+          await link.scrollIntoViewIfNeeded();
+          const hit = await link.evaluate((element) => {
+            const r = element.getBoundingClientRect();
+            return element.contains(document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2));
+          });
+          assert(hit, `${label}: navigation link obscured`);
+        }
+        await nav.evaluate((element, left) => { element.scrollLeft = left; }, initialNavScroll);
+        if (path === '/threads' && width <= 800) {
+          const form = await page.locator('.new-thread').boundingBox();
+          const detail = await page.locator('.threads-detail').boundingBox();
+          assert(form && detail && detail.y >= form.y + form.height - 1, `${label}: form/detail overlap`);
+        }
+        if (path === '/orchestration' && width <= 900) {
+          await page.locator('#thread').scrollIntoViewIfNeeded();
+          const thread = await page.locator('#thread').boundingBox();
+          assert(thread && thread.y >= 0 && thread.y < 844, `${label}: conversation unreachable`);
+        }
+        if (path === '/app' && width <= 900) {
+          await page.locator('#sidebar-toggle').click();
+          const header = await page.locator('.topbar').boundingBox();
+          const sidebar = await page.locator('#sidebar').boundingBox();
+          assert(header && sidebar && sidebar.y >= header.y + header.height - 1, `${label}: drawer overlaps navigation`);
+          const pickerFont = await page.locator('.repo-picker select').evaluate((el) => parseFloat(getComputedStyle(el).fontSize));
+          assert(pickerFont >= 16, `${label}: sidebar input text too small`);
+          await page.locator('#sidebar-toggle').click();
+        }
+        if (path === '/chat' && width <= 768) {
+          await page.setViewportSize({ width, height: 480 });
+          await page.locator('.composer .textarea').focus();
+          const composer = await page.locator('.composer').boundingBox();
+          assert(composer && composer.y >= 0 && composer.y + composer.height <= 481, `${label}: composer clipped in a short viewport`);
+          await page.setViewportSize({ width, height: 844 });
+        }
+        if (width <= 900) {
+          const smallInputs = await page.locator('.input:visible, .select:visible, .textarea:visible').evaluateAll(
+            (elements) => elements.filter((el) => parseFloat(getComputedStyle(el).fontSize) < 16).map((el) => el.id || el.className));
+          assert.deepEqual(smallInputs, [], `${label}: input text too small`);
+        }
+        await page.evaluate(() => window.scrollTo(0, 0));
+        if (width === 390 || width === 1440) {
+          await page.screenshot({ path: resolve(outputDir, `${label}.png`), fullPage: true });
+        }
+        results.push({ page: path, width, theme, ...size, errors, blocked });
+        console.log(`PASS ${label}`);
+        await context.close();
+      }
+    }
+  }
+} finally {
+  await browser.close();
+  await writeFile(resolve(outputDir, 'results.json'), JSON.stringify(results, null, 2));
+}
+console.log(`PASS ${results.length} responsive page checks`);

--- a/src/support/dashboardHtml.ts
+++ b/src/support/dashboardHtml.ts
@@ -3,7 +3,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>OpenSwarm :: Supervisor</title>
   <script src="/static/js/themeBoot.js"></script>
   <link rel="stylesheet" href="/static/css/tokens.css">

--- a/web/static/app.html
+++ b/web/static/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>OpenSwarm · Cockpit</title>
   <script src="/static/js/themeBoot.js"></script>
   <link rel="stylesheet" href="/static/css/tokens.css" />

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -186,6 +186,11 @@
 }
 .console-toggle:hover { color: var(--fg-primary); border-color: var(--border-strong); }
 
+@media (max-width: 900px), (pointer: coarse) {
+  .console-toggle, .issue-row { min-height: 44px; }
+  .repo-picker select { min-height: 44px; font-size: 16px; }
+}
+
 .work-card .console {
   margin-top: var(--space-2);
   /* Deep ground against the card so the stream reads as a terminal. */

--- a/web/static/css/chat.css
+++ b/web/static/css/chat.css
@@ -4,6 +4,7 @@
 
 body.page-chat {
   height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/web/static/css/cockpit.css
+++ b/web/static/css/cockpit.css
@@ -4,6 +4,7 @@
 
 body.page-cockpit {
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
   display: grid;
   grid-template:
@@ -272,5 +273,4 @@ body[data-view="sessions"] .view-sessions { display: flex; }
   body[data-view="issues"] .view-issues { grid-template-columns: minmax(0, 1fr); }
   /* Off-canvas needs a way back on-canvas — the toggle lives in the topbar. */
   .sidebar-toggle { display: inline-flex; }
-  .topbar-nav { display: none; }
 }

--- a/web/static/css/orchestration.css
+++ b/web/static/css/orchestration.css
@@ -3,6 +3,7 @@
 
 body.page-orchestration {
   height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -35,6 +36,7 @@ body.page-orchestration {
 #controls input[type="search"] { min-width: 160px; }
 #controls label { display: flex; align-items: center; gap: var(--space-1); font-size: var(--text-sm); color: var(--fg-muted); }
 #controls input[type="checkbox"] { accent-color: var(--accent); }
+#controls .input, #controls .select { width: auto; }
 #idle-count { color: var(--fg-muted); }
 
 #stats { display: flex; gap: var(--space-2); margin-left: auto; flex-wrap: wrap; }
@@ -176,8 +178,21 @@ body.page-orchestration {
 .composer-status.is-error { color: var(--danger); }
 
 @media (max-width: 900px) {
-  .orch-main { flex-direction: column; }
-  #graph-wrap { min-height: 40vh; }
-  .orch-aside { width: auto; max-height: 55vh; border-left: 0; border-top: 1px solid var(--border); }
-  #stats { margin-left: 0; }
+  body.page-orchestration { height: auto; overflow: auto; }
+  .orch-main { flex: none; flex-direction: column; }
+  #controls { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); width: 100%; }
+  #controls .input, #controls .select { width: 100%; min-height: 44px; font-size: 16px; }
+  #controls input[type="search"] { grid-column: 1 / -1; min-width: 0; }
+  #controls label { min-height: 44px; grid-column: 1 / -1; }
+  #stats { margin-left: 0; flex-wrap: nowrap; overflow-x: auto; width: 100%; }
+  #stats .stat { flex-shrink: 0; }
+  #graph-wrap { flex: none; overflow-x: auto; }
+  #graph { width: max(100%, 720px); height: 440px; }
+  #legend { position: static; width: 100%; display: flex; flex-wrap: wrap; gap: var(--space-1) var(--space-3); border-radius: 0; }
+  #legend .legend-section { margin: 0; padding: 0; border: 0; display: contents; }
+  .orch-aside { width: auto; border-left: 0; border-top: 1px solid var(--border); }
+  #feed { flex: none; max-height: 40dvh; }
+  #thread { flex: none; min-height: 180px; padding-bottom: env(safe-area-inset-bottom); }
+  .transcript { flex: none; max-height: 50dvh; }
+  .composer .textarea { min-height: 44px; font-size: 16px; }
 }

--- a/web/static/css/shell.css
+++ b/web/static/css/shell.css
@@ -99,6 +99,7 @@ button:disabled { cursor: default; }
   top: 0;
   z-index: var(--z-dropdown);
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   gap: var(--space-4);
   min-height: var(--topbar-h);
@@ -148,6 +149,19 @@ button:disabled { cursor: default; }
 .topbar-nav a[aria-current="page"] { color: var(--accent); background: var(--accent-subtle); }
 .topbar-spacer { flex: 1; }
 .topbar-actions { display: flex; align-items: center; gap: var(--space-2); }
+
+/* Keep page navigation on its own, scrollable row before the header crowds
+   out the links. The cockpit's mobile drawer uses this same header height. */
+@media (max-width: 1100px) {
+  :root { --topbar-h: 89px; }
+  .topbar { flex-wrap: wrap; gap: 0 var(--space-2); padding: 0 var(--space-3); }
+  .topbar > .brand, .topbar > .page-title, .topbar-actions { min-height: 44px; }
+  .topbar-nav { order: 2; flex: 0 0 100%; height: 44px; }
+  .topbar-nav a { flex-shrink: 0; min-height: 44px; }
+}
+@media (max-width: 480px) {
+  .topbar .page-title { display: none; }
+}
 
 /* ── Buttons ─────────────────────────────────────────────────────────── */
 
@@ -215,6 +229,15 @@ button:disabled { cursor: default; }
 .input::placeholder, .textarea::placeholder { color: var(--fg-muted); }
 .textarea { resize: vertical; }
 .select { appearance: auto; }
+
+/* Prevent flex/grid inputs from imposing their intrinsic width on a page. */
+.input, .select, .textarea { min-width: 0; }
+
+@media (max-width: 900px), (pointer: coarse) {
+  .btn, .btn-sm { min-height: 44px; }
+  .btn-icon, .btn-icon.btn-sm { width: 44px; min-width: 44px; }
+  body .input, body .select, body .textarea { min-height: 44px; font-size: 16px; }
+}
 .field { display: grid; gap: var(--space-1); }
 .field > label { color: var(--fg-secondary); font-size: var(--text-xs); }
 

--- a/web/static/css/supervisor.css
+++ b/web/static/css/supervisor.css
@@ -23,6 +23,7 @@
 
 body.page-supervisor {
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -509,10 +510,11 @@ body.page-supervisor {
 
 @media (max-width: 768px) {
   body.page-supervisor { height: auto; overflow: auto; }
-  .topbar-nav, .topbar .page-title { display: none; }
   .control-group { min-width: 0; }
-  .provider-toggle { flex-wrap: wrap; min-width: 0; max-width: 100%; }
-  .stats-bar { white-space: normal; flex-wrap: wrap; gap: var(--space-3); }
+  .provider-toggle { overflow-x: auto; min-width: 0; max-width: 100%; }
+  .provider-btn { flex-shrink: 0; min-height: 44px; }
+  .stats-bar { gap: var(--space-4); }
+  .stats-bar .stat { flex-shrink: 0; }
 
   .tab-bar { display: flex; border-bottom: 1px solid var(--border); background: var(--bg-surface); }
   .tab {

--- a/web/static/css/threads.css
+++ b/web/static/css/threads.css
@@ -4,12 +4,14 @@
 
 body.page-threads {
   min-height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   font-size: var(--text-sm);
 }
 
-.topbar #repo { min-width: 240px; max-width: 40vw; }
+.topbar #repo { width: 240px; max-width: 40vw; }
 
 .threads-status {
   min-height: 28px;
@@ -28,10 +30,10 @@ body.page-threads {
 
 /* ── List ────────────────────────────────────────────────────────────── */
 
-.threads-list { min-width: 0; display: flex; flex-direction: column; border-right: 1px solid var(--border); background: var(--bg-surface); }
+.threads-list { min-width: 0; min-height: 0; overflow-y: auto; display: flex; flex-direction: column; border-right: 1px solid var(--border); background: var(--bg-surface); }
 .toolbar { display: flex; gap: var(--space-2); padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--border); }
 .toolbar .select { flex: 1; }
-#threads { flex: 1; overflow: auto; }
+#threads { flex: 1; min-height: 120px; overflow: auto; }
 
 .thread-card {
   width: 100%;
@@ -61,7 +63,7 @@ body.page-threads {
 
 /* ── Detail ──────────────────────────────────────────────────────────── */
 
-.threads-detail { min-width: 0; display: flex; flex-direction: column; }
+.threads-detail { min-width: 0; min-height: 0; display: flex; flex-direction: column; }
 #empty { padding: var(--space-6); }
 #detail { display: none; min-height: 0; flex: 1; flex-direction: column; }
 #detail.visible { display: flex; }
@@ -88,9 +90,19 @@ body.page-threads {
 .reply-form .textarea { min-height: 54px; resize: vertical; }
 
 @media (max-width: 800px) {
+  body.page-threads { height: auto; overflow: auto; }
   .threads-main { grid-template-columns: 1fr; height: auto; }
-  .threads-list { border-right: 0; max-height: 50vh; }
-  .threads-detail { min-height: 50vh; }
-  .topbar #repo { max-width: 100%; }
+  .threads-list { overflow: visible; border-right: 0; border-bottom: 1px solid var(--border); }
+  #threads { flex: none; max-height: 40dvh; }
+  .threads-detail { min-height: 240px; }
+  #messages { flex: none; max-height: 60dvh; }
+  .reply-form { padding-bottom: max(var(--space-3), env(safe-area-inset-bottom)); }
   .two { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 1100px) {
+  .page-threads .topbar .page-title { display: none; }
+  .page-threads .topbar-actions { flex: 1; min-width: 0; }
+  .page-threads .topbar-spacer { display: none; }
+  .topbar #repo { flex: 1; width: 0; max-width: none; }
 }

--- a/web/static/css/warehouse.css
+++ b/web/static/css/warehouse.css
@@ -29,7 +29,8 @@ body.page-warehouse { min-height: 100vh; }
   padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--border);
 }
-.breadcrumbs { display: flex; align-items: center; gap: var(--space-1); flex: 1; overflow-x: auto; }
+.breadcrumbs { display: flex; align-items: center; gap: var(--space-1); flex: 1; min-width: 0; overflow-x: auto; }
+.breadcrumbs > * { flex-shrink: 0; }
 .breadcrumbs span { color: var(--fg-muted); }
 
 .table-wrap { overflow: auto; min-height: 520px; }
@@ -102,7 +103,10 @@ td.empty { padding: var(--space-12); text-align: center; white-space: normal; }
 .rules strong { color: var(--fg-primary); }
 
 @media (max-width: 860px) {
-  .warehouse-main { grid-template-columns: 1fr; }
-  .upload { order: -1; }
+  .warehouse-main { grid-template-columns: minmax(0, 1fr); gap: var(--space-3); padding: var(--space-3); padding-bottom: max(var(--space-3), env(safe-area-inset-bottom)); }
+  .table-wrap { min-height: 240px; }
+  th, td { padding: var(--space-2); }
+  .file-name, .download, .text-button, .breadcrumbs button { min-height: 44px; }
+  .overwrite { min-height: 44px; }
   th:nth-child(2), td:nth-child(2), th:nth-child(4), td:nth-child(4) { display: none; }
 }

--- a/web/static/orchestration.html
+++ b/web/static/orchestration.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>OpenSwarm · Orchestration</title>
   <script src="/static/js/themeBoot.js"></script>
   <link rel="stylesheet" href="/static/css/tokens.css" />

--- a/web/static/threads.html
+++ b/web/static/threads.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>OpenSwarm · Repository threads</title>
   <script src="/static/js/themeBoot.js"></script>
   <link rel="stylesheet" href="/static/css/tokens.css" />

--- a/web/static/warehouse.html
+++ b/web/static/warehouse.html
@@ -2,7 +2,7 @@
 <html lang="ko">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>OpenSwarm · Warehouse</title>
   <script src="/static/js/themeBoot.js"></script>
   <link rel="stylesheet" href="/static/css/tokens.css" />


### PR DESCRIPTION
Mobile Threads expanded a 390px viewport to 599px and its new-thread form overlapped the detail panel. Desktop Threads also stretched to more than 10,000px with a populated list. The shared header hid or clipped page navigation, and Orchestration's stacked panels escaped a non-scrolling body.

This change gives narrow headers a dedicated navigation row, contains desktop thread panels while allowing mobile forms to flow, makes the mobile graph horizontally scrollable and its conversation reachable, and improves input/touch sizing, dynamic viewport sizing and safe-area spacing. Warehouse shows files before upload controls on mobile.

Validation:
- Read-only Chrome checks against VELA's real API/SSE with this checkout's static assets: 60/60 combinations passed (6 pages × 5 widths, 320–1440px × light/dark), including short-viewport composer access. Mobile and desktop screenshots inspected.
- Negative control against deployed assets fails at `supervisor-320-light: navigation hidden`.
- Web UI tests: 265 passed across 19 files; typecheck and build passed. Lint: 0 errors, one pre-existing warning in `webTools.test.ts`.
- OpenSwarm working-tree review: APPROVE (final staged 16-file diff). The initial request to track/document the browser check was addressed with `npm run test:responsive` and its README.
- OpenSwarm PR fresh review: APPROVE against `90a3cd1`.
- CI: all eight checks passed on `90a3cd1`, including Docker build, sandbox and Windows checks. The first Tests attempt passed all 5,534 assertions but failed during Vitest log RPC teardown in the unchanged `autonomousRunner.coverage.test.ts`; its 55-test local isolation and the same-commit CI rerun passed. Original failure evidence is preserved.

Chrome emulation does not prove physical Safari/keyboard behavior. Preview replaces static assets, not server-rendered HTML; production assets have not been changed. The running daemon and AGT-4237 observation cron remain intact.

Closes AGT-4238
