### PR TITLE
fix(verify): restore isolated Python verification on VELA (AGT-4223)

### DIFF
--- a/src/sandboxExecutor/bubblewrap.ts
+++ b/src/sandboxExecutor/bubblewrap.ts
@@ -14,6 +14,7 @@ import {
   untrackCliProcessTree,
 } from '../adapters/processTree.js';
 import { linkedMainCheckoutOf } from '../security/gitWorktreeIdentity.js';
+import { isPrivateWorkspaceFile } from '../support/environmentFiles.js';
 import type { SandboxExecutionResult } from './protocol.js';
 
 export interface WorkspaceIdentity {
@@ -246,16 +247,6 @@ interface FixedSecretMask {
 const SECRET_DIRECTORIES = new Set(['.aws', '.ssh', '.gnupg', '.kube', '.docker']);
 const SKIP_SCAN_DIRECTORIES = new Set(['.git', 'node_modules', '.venv', '.venv-verify', 'venv', 'target', 'dist', 'build']);
 
-function looksSensitiveFile(name: string): boolean {
-  const lower = name.toLowerCase();
-  if (lower === '.env' || (lower.startsWith('.env.')
-      && !['.env.example', '.env.sample', '.env.template'].includes(lower))) return true;
-  if (['.dev.vars', '.envrc', '.npmrc', '.pypirc', '.netrc', 'credentials', 'credentials.json', 'service-account.json',
-    'id_rsa', 'id_ed25519'].includes(lower)) return true;
-  return /\.(?:pem|key|p12|pfx)$/.test(lower)
-    || /(?:credential|service-account|private-key).+\.json$/.test(lower);
-}
-
 export async function discoverWorkspaceSecretMasks(workspace: string, roots: string[]): Promise<SecretMask[]> {
   const masks: SecretMask[] = [];
   const pending = [workspace];
@@ -274,7 +265,7 @@ export async function discoverWorkspaceSecretMasks(workspace: string, roots: str
         continue;
       }
       const sensitiveDirectoryLink = entry.isSymbolicLink() && SECRET_DIRECTORIES.has(entry.name);
-      if (!sensitiveDirectoryLink && !looksSensitiveFile(entry.name)) continue;
+      if (!sensitiveDirectoryLink && !isPrivateWorkspaceFile(entry.name)) continue;
       if (entry.isSymbolicLink()) {
         let target: string;
         try {

--- a/src/support/environmentFiles.ts
+++ b/src/support/environmentFiles.ts
@@ -1,0 +1,21 @@
+/** Environment values are private; only these explicit example names are inputs. */
+export function isPrivateEnvironmentFile(name: string): boolean {
+  const lower = name.toLowerCase();
+  return lower === '.env' || (lower.startsWith('.env.')
+    && !['.env.example', '.env.sample', '.env.template'].includes(lower));
+}
+
+export function isPrivateConfigurationFile(name: string): boolean {
+  const lower = name.toLowerCase();
+  if (isPrivateEnvironmentFile(name)) return true;
+  if (['.dev.vars', '.envrc', '.npmrc', '.pypirc', '.netrc', 'credentials', 'credentials.json', 'service-account.json',
+    'id_rsa', 'id_ed25519'].includes(lower)) return true;
+  return false;
+}
+
+/** The same private file names are omitted from source snapshots and masked by bwrap. */
+export function isPrivateWorkspaceFile(name: string): boolean {
+  const lower = name.toLowerCase();
+  return isPrivateConfigurationFile(name) || /\.(?:pem|key|p12|pfx)$/.test(lower)
+    || /(?:credential|service-account|private-key).+\.json$/.test(lower);
+}

--- a/src/support/isolatedPath.ts
+++ b/src/support/isolatedPath.ts
@@ -3,6 +3,7 @@
 // ============================================
 
 import { execFile } from 'node:child_process';
+import { constants } from 'node:fs';
 import { cp, lstat, mkdir, readdir, readlink, realpath, rm, symlink } from 'node:fs/promises';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { promisify } from 'node:util';
@@ -10,7 +11,18 @@ import { promisify } from 'node:util';
 const exec = promisify(execFile);
 const COPY_TIMEOUT_MS = 5 * 60_000;
 
-async function copyWithCloneFallback(source: string, target: string): Promise<void> {
+async function copyWithCloneFallback(
+  source: string, target: string, exclude?: (path: string) => boolean, label = '',
+): Promise<void> {
+  if (exclude) {
+    // Filter before reading files or following dependency links. Reflinks still
+    // give independent writes where the filesystem supports them.
+    await cp(source, target, {
+      recursive: true, verbatimSymlinks: true, mode: constants.COPYFILE_FICLONE,
+      filter: (path) => !exclude(join(label, relative(source, path))),
+    });
+    return;
+  }
   try {
     if (process.platform === 'darwin') {
       // APFS clonefile: independent writes with near-constant-time/space copies.
@@ -47,14 +59,16 @@ export async function copyIsolatedPath(
   target: string,
   sandboxRoot: string,
   label: string,
+  exclude?: (path: string) => boolean,
 ): Promise<void> {
+  if (exclude?.(label)) return;
   const physicalSource = await realpath(source);
   await mkdir(dirname(target), { recursive: true });
-  await copyWithCloneFallback(physicalSource, target);
+  await copyWithCloneFallback(physicalSource, target, exclude, label);
   // Always validate the destination tree. Even a previously sanitized snapshot
   // is mutable filesystem state; trusting it here would turn an intermediate
   // symlink change into a sandbox escape or unexpected dereference.
-  await isolateCopiedTreeSymlinks(sandboxRoot, target, physicalSource, label);
+  await isolateCopiedTreeSymlinks(sandboxRoot, target, physicalSource, label, exclude);
 }
 
 async function isolateCopiedTreeSymlinks(
@@ -62,6 +76,7 @@ async function isolateCopiedTreeSymlinks(
   current: string,
   sourceCurrent: string,
   label: string,
+  exclude?: (path: string) => boolean,
 ): Promise<void> {
   const info = await lstat(current);
   if (info.isSymbolicLink()) {
@@ -99,8 +114,8 @@ async function isolateCopiedTreeSymlinks(
       return;
     }
     await rm(current, { force: true });
-    await copyWithCloneFallback(physicalTarget, current);
-    await isolateCopiedTreeSymlinks(sandboxRoot, current, physicalTarget, label);
+    await copyWithCloneFallback(physicalTarget, current, exclude, label);
+    await isolateCopiedTreeSymlinks(sandboxRoot, current, physicalTarget, label, exclude);
     return;
   }
   if (!info.isDirectory()) return;
@@ -113,6 +128,7 @@ async function isolateCopiedTreeSymlinks(
       join(current, entry.name),
       join(sourceCurrent, entry.name),
       `${label}/${entry.name}`,
+      exclude,
     );
   }
 }

--- a/src/verify/environment.test.ts
+++ b/src/verify/environment.test.ts
@@ -1,0 +1,166 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, expect, it } from 'vitest';
+import { runVerify } from './runner.js';
+
+let root: string;
+let repo: string;
+function git(...args: string[]): void {
+  execFileSync('git', ['-C', repo, ...args], { stdio: 'pipe' });
+}
+beforeEach(async () => {
+  root = await realpath(await mkdtemp(join(tmpdir(), 'openswarm-verify-environment-')));
+  repo = join(root, 'repo');
+  await mkdir(join(repo, 'apps/pipelines'), { recursive: true });
+  git('init', '-b', 'main');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'Test');
+  await writeFile(join(repo, 'apps/pipelines/source.txt'), 'source');
+  git('add', '.');
+  git('commit', '-m', 'base');
+});
+afterEach(async () => { await rm(root, { recursive: true, force: true }); });
+
+it.each(['.env', 'apps/pipelines/.env.local', 'apps/pipelines/.dev.vars'])('omits external %s without dereferencing it', async (path) => {
+  // A dangling target proves that snapshot preparation never needs to open it.
+  await symlink(join(root, 'unreadable-secret'), join(repo, path));
+  await writeFile(join(repo, '.env.example'), 'PUBLIC_EXAMPLE=1');
+  const [result] = await runVerify({
+    projectPath: repo, baseRef: 'HEAD',
+    commands: [{ name: 'environment', kind: 'test', run: `test ! -e ${path} && test ! -L ${path} && test -f .env.example` }],
+  });
+  expect(result).toMatchObject({ headStatus: 'pass', newFailure: false });
+});
+
+it('omits tracked environment files from both head and base while retaining comparison evidence', async () => {
+  await writeFile(join(repo, '.env'), 'PRIVATE_VALUE=must-not-copy');
+  git('add', '.env');
+  git('commit', '-m', 'tracked environment');
+  const inspected: string[] = [];
+  const [result] = await runVerify({
+    projectPath: repo, baseRef: 'HEAD',
+    commands: [{ name: 'comparison', kind: 'test', run: 'exit 1' }],
+    sandboxExecutorSessionFactory: async (workspace) => {
+      expect(existsSync(join(workspace, '.env'))).toBe(false);
+      inspected.push(workspace);
+      return { execute: async () => ({ output: 'same assertion', exitCode: 1, signal: null, timedOut: false }) };
+    },
+  });
+  expect(inspected).toHaveLength(2);
+  expect(result).toMatchObject({ headStatus: 'fail', baseStatus: 'fail', newFailure: false });
+});
+
+it('omits environment files inside configured shared data without resolving their links', async () => {
+  await mkdir(join(repo, 'data'));
+  await symlink(join(root, 'unreadable-secret'), join(repo, 'data/.env'));
+  await writeFile(join(repo, 'data/input.txt'), 'input');
+  await writeFile(join(repo, 'openswarm.json'), JSON.stringify({ sandbox: { sharedPaths: ['data'] } }));
+  const [result] = await runVerify({
+    projectPath: repo, baseRef: 'HEAD',
+    commands: [{ name: 'shared', kind: 'test', run: 'test ! -L data/.env && test -f data/input.txt' }],
+  });
+  expect(result).toMatchObject({ headStatus: 'pass', newFailure: false });
+});
+
+it.each(['.venv', '.venv-verify', 'venv'])('copies the command-local %s independently for head and base', async (name) => {
+  const dependency = join(repo, 'apps/pipelines', name);
+  await mkdir(join(dependency, 'bin'), { recursive: true });
+  await writeFile(join(root, 'interpreter'), 'external dependency');
+  await symlink(join(root, 'interpreter'), join(dependency, 'bin/python'));
+  await writeFile(join(dependency, 'state'), 'original');
+  const sitePackages = join(dependency, 'lib/python3.12/site-packages');
+  await mkdir(sitePackages, { recursive: true });
+  const editablePath = join(sitePackages, '_editable.pth');
+  const originalEditable = `${repo}/apps/pipelines/src\nimport unrelated_hook\n/outside/src\n`;
+  await writeFile(editablePath, originalEditable);
+  await mkdir(join(sitePackages, 'certifi'));
+  await writeFile(join(sitePackages, 'certifi/cacert.pem'), 'public CA bundle');
+  await symlink(join(root, 'unreadable-secret'), join(sitePackages, '.env'));
+  const inspected: string[] = [];
+  const [result] = await runVerify({
+    projectPath: repo, baseRef: 'HEAD',
+    commands: [{ name: 'pytest:apps/pipelines', kind: 'test', cwd: 'apps/pipelines', run: `./${name}/bin/python -m pytest` }],
+    sandboxExecutorSessionFactory: async (workspace) => {
+      const copy = join(workspace, 'apps/pipelines', name);
+      expect(await readFile(join(copy, 'bin/python'), 'utf8')).toBe('external dependency');
+      expect(await readFile(join(copy, 'state'), 'utf8')).toBe('original');
+      expect(await readFile(join(copy, 'lib/python3.12/site-packages/_editable.pth'), 'utf8'))
+        .toBe(`${workspace}/apps/pipelines/src\nimport unrelated_hook\n/outside/src\n`);
+      expect(await readFile(join(copy, 'lib/python3.12/site-packages/certifi/cacert.pem'), 'utf8')).toBe('public CA bundle');
+      expect(existsSync(join(copy, 'lib/python3.12/site-packages/.env'))).toBe(false);
+      await writeFile(join(copy, 'bin/python'), 'mutated in sandbox');
+      await writeFile(join(copy, 'state'), 'mutated in sandbox');
+      inspected.push(workspace);
+      return { execute: async () => ({ output: 'same assertion', exitCode: 1, signal: null, timedOut: false }) };
+    },
+  });
+  expect(inspected).toHaveLength(2);
+  expect(result).toMatchObject({ headStatus: 'fail', baseStatus: 'fail', newFailure: false });
+  expect(await readFile(join(root, 'interpreter'), 'utf8')).toBe('external dependency');
+  expect(await readFile(join(dependency, 'state'), 'utf8')).toBe('original');
+  expect(await readFile(editablePath, 'utf8')).toBe(originalEditable);
+});
+
+it('ignores an unused nested virtualenv but still rejects an unrelated escaping source link', async () => {
+  await mkdir(join(repo, 'unused/.venv/bin'), { recursive: true });
+  await symlink(join(root, 'external'), join(repo, 'unused/.venv/bin/python'));
+  const options = {
+    projectPath: repo, baseRef: 'HEAD',
+    commands: [{ name: 'source', kind: 'test' as const, run: 'test ! -e unused/.venv && test -f apps/pipelines/source.txt' }],
+  };
+  expect((await runVerify(options))[0].headStatus).toBe('pass');
+  await symlink(join(root, 'external'), join(repo, 'escape'));
+  expect((await runVerify(options))[0]).toMatchObject({ headStatus: 'fail', securityFailure: true });
+});
+
+it('omits ignored local asset links and disables checkout hooks for base comparison', async () => {
+  await writeFile(join(repo, '.gitignore'), 'local-data\n');
+  git('add', '.gitignore');
+  git('commit', '-m', 'local data policy');
+  await symlink(join(root, 'private-customer-data'), join(repo, 'local-data'));
+  const hook = join(repo, '.git/hooks/post-checkout');
+  await writeFile(hook, '#!/bin/sh\ntouch hook-ran\n');
+  await chmod(hook, 0o755);
+  const [result] = await runVerify({
+    projectPath: repo, baseRef: 'HEAD',
+    commands: [{ name: 'comparison', kind: 'test', run: 'if test -e hook-ran || test -L local-data; then echo polluted; else echo isolated; fi; exit 1' }],
+  });
+  expect(result).toMatchObject({ headStatus: 'fail', baseStatus: 'fail', newFailure: false });
+  expect(result.rawOutputTail).not.toContain('polluted');
+});
+
+it('rejects tracked external links even when an ignore rule matches their name', async () => {
+  await symlink(join(root, 'external'), join(repo, 'tracked-link'));
+  git('add', 'tracked-link');
+  git('commit', '-m', 'tracked link');
+  await writeFile(join(repo, '.gitignore'), 'tracked-link\n');
+  const [result] = await runVerify({
+    projectPath: repo, baseRef: 'HEAD', commands: [{ name: 'source', kind: 'test', run: 'true' }],
+  });
+  expect(result).toMatchObject({ headStatus: 'fail', securityFailure: true });
+});
+
+it('rebases a linked worktree editable install from its verified main checkout', async () => {
+  const shared = join(repo, 'apps/pipelines/.venv/lib/python3.12/site-packages');
+  await mkdir(shared, { recursive: true });
+  await writeFile(join(shared, '_editable.pth'), `${repo}/apps/pipelines/src\n`);
+  const linked = join(root, 'linked');
+  git('worktree', 'add', '--detach', linked, 'HEAD');
+  await symlink(join(repo, 'apps/pipelines/.venv'), join(linked, 'apps/pipelines/.venv'));
+  let inspected = false;
+  const [result] = await runVerify({
+    projectPath: linked, baseRef: 'HEAD',
+    commands: [{ name: 'source', kind: 'test', cwd: 'apps/pipelines', run: 'true' }],
+    sandboxExecutorSessionFactory: async (workspace) => {
+      const content = await readFile(join(workspace, 'apps/pipelines/.venv/lib/python3.12/site-packages/_editable.pth'), 'utf8');
+      expect(content).toBe(`${workspace}/apps/pipelines/src\n`);
+      inspected = true;
+      return { execute: async () => ({ output: 'inspected', exitCode: 0, signal: null, timedOut: false, truncated: false, outputLimitExceeded: false }) };
+    },
+  });
+  expect(inspected).toBe(true);
+  expect(result.headStatus).toBe('pass');
+});

--- a/src/verify/pythonEnvironment.ts
+++ b/src/verify/pythonEnvironment.ts
@@ -1,0 +1,49 @@
+import { readFile, readdir, realpath, writeFile } from 'node:fs/promises';
+import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { linkedMainCheckoutOf } from '../security/gitWorktreeIdentity.js';
+
+/** Relocate plain-path editable installs (including uv's .pth) to this snapshot. */
+export async function rebasePythonEnvironment(
+  sourceProject: string, sandboxProject: string, sharedPath: string,
+): Promise<void> {
+  if (!['.venv', '.venv-verify', 'venv'].includes(basename(sharedPath))) return;
+  const sourceRoots = [resolve(sourceProject), await realpath(sourceProject), linkedMainCheckoutOf(sourceProject)]
+    .filter((root): root is string => root !== null)
+    .sort((a, b) => b.length - a.length);
+  const environment = join(sandboxProject, sharedPath);
+  const siteDirectories = [join(environment, 'Lib', 'site-packages')];
+  try {
+    for (const entry of await readdir(join(environment, 'lib'), { withFileTypes: true })) {
+      if (entry.isDirectory() && /^python\d+\.\d+$/.test(entry.name)) {
+        siteDirectories.push(join(environment, 'lib', entry.name, 'site-packages'));
+      }
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  for (const directory of siteDirectories) {
+    let entries;
+    try { entries = await readdir(directory, { withFileTypes: true }); }
+    catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw error;
+    }
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.pth')) continue;
+      const path = join(directory, entry.name);
+      const content = await readFile(path, 'utf8');
+      const rebased = content.split(/(?<=\n)/).map((line) => {
+        const value = line.trim();
+        if (!isAbsolute(value)) return line; // Never execute or rewrite import statements.
+        for (const root of sourceRoots) {
+          const suffix = relative(root, value);
+          if (suffix !== '..' && !suffix.startsWith(`..${sep}`) && !isAbsolute(suffix)) {
+            return line.replace(value, join(sandboxProject, suffix));
+          }
+        }
+        return line;
+      }).join('');
+      if (rebased !== content) await writeFile(path, rebased);
+    }
+  }
+}

--- a/src/verify/runner.ts
+++ b/src/verify/runner.ts
@@ -4,17 +4,19 @@ import { constants } from 'node:fs';
 import { access, cp, mkdir, mkdtemp, open, readFile, readdir, readlink, realpath, rm } from 'node:fs/promises';
 import { existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { delimiter, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { basename, delimiter, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { promisify } from 'node:util';
 import { isInfraError } from '../adapters/errorClassification.js';
 import { describeLinuxSandbox, formatSandboxUnavailable, makeSandboxCache, makeSystemProbe } from './sandboxDiagnostics.js';
 import { copyIsolatedPath } from '../support/isolatedPath.js';
+import { isPrivateConfigurationFile, isPrivateWorkspaceFile } from '../support/environmentFiles.js';
 import { loadRepoMetadata } from '../support/repoMetadata.js';
 import { resolveSharedPaths } from '../support/worktreeManager.js';
 import { atomicWriteFileSync } from '../support/atomicFile.js';
 import { terminateProcessesWithEnvMarker } from '../adapters/processTree.js';
 import type { SandboxExecutorSession } from '../sandboxExecutor/protocol.js';
 import type { VerifyCommand } from './manifest.js';
+import { rebasePythonEnvironment } from './pythonEnvironment.js';
 
 const OUTPUT_TAIL_BYTES = 8 * 1024;
 const FINGERPRINT_BYTES = 4 * 1024 * 1024;
@@ -63,15 +65,52 @@ async function verificationSharedPaths(projectPath: string, commands: VerifyComm
   const paths = new Set(resolveSharedPaths(projectPath, metadata));
   for (const command of commands) {
     const directory = command.cwd ?? '';
-    const nodeModules = join(directory, 'node_modules');
-    try {
-      await access(join(projectPath, nodeModules));
-      paths.add(nodeModules);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    const localDirectory = relative(resolve(projectPath), resolve(projectPath, directory));
+    if (localDirectory === '..' || localDirectory.startsWith(`..${sep}`) || isAbsolute(localDirectory)) {
+      throw new Error(`[security] verify cwd escapes project root: ${directory}`);
+    }
+    for (const name of ['node_modules', '.venv-verify', '.venv', 'venv']) {
+      const dependency = join(localDirectory, name);
+      try {
+        await access(join(projectPath, dependency));
+        paths.add(dependency);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
     }
   }
-  return [...paths];
+  return [...paths].filter((path) => !isPrivateEnvironmentPath(path))
+    .filter((path, _, all) => !all.some((parent) => parent !== path && pathCoveredBy(path, [parent])));
+}
+
+function isPrivateEnvironmentPath(path: string): boolean {
+  return path.split(sep).some(isPrivateWorkspaceFile);
+}
+
+function sharedPathSecretFilter(sharedPath: string): (path: string) => boolean {
+  // Like the companion's secret scan, dependency payloads retain packaged
+  // certificates (e.g. certifi/cacert.pem). Local configuration stays excluded.
+  return ['node_modules', '.venv', '.venv-verify', 'venv'].includes(basename(sharedPath))
+    ? (path) => path.split(sep).some(isPrivateConfigurationFile)
+    : isPrivateEnvironmentPath;
+}
+
+/** Use one policy before validation and copying: omitted paths cannot escape. */
+function omitVerificationSource(path: string, sharedPaths: string[]): boolean {
+  return path.split(sep).some((segment) =>
+    ['.git', 'node_modules', '.venv', '.venv-verify', '.venv.bak', 'venv'].includes(segment))
+    || isPrivateEnvironmentPath(path)
+    || isEphemeralVerificationArtifact(path)
+    || pathCoveredBy(path, sharedPaths);
+}
+
+async function removePrivateEnvironmentFiles(directory: string): Promise<void> {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    if (entry.name === '.git') continue;
+    const path = join(directory, entry.name);
+    if (isPrivateWorkspaceFile(entry.name)) await rm(path, { recursive: true, force: true });
+    else if (entry.isDirectory()) await removePrivateEnvironmentFiles(path);
+  }
 }
 
 function pathCoveredBy(path: string, roots: string[]): boolean {
@@ -529,27 +568,39 @@ async function runTrustedCommand(
   return await runCommand(command, root, env, sandboxExecutorSessionFactory);
 }
 
-async function validateSandboxSymlinks(projectPath: string, sharedPaths: string[]): Promise<void> {
+async function validateSandboxSymlinks(
+  projectPath: string, sharedPaths: string[], omitIgnoredLinks = false,
+): Promise<Set<string>> {
   const projectRoot = await realpath(projectPath);
+  const ignoredLinks = new Set<string>();
+  const rejectOrOmit = async (path: string): Promise<void> => {
+    if (omitIgnoredLinks) {
+      try {
+        await execFileAsync('git', ['-C', projectPath, 'check-ignore', '-q', '--', path], { timeout: GIT_TIMEOUT_MS });
+        ignoredLinks.add(path);
+        return;
+      } catch (error) {
+        if ((error as { code?: number }).code !== 1) throw error;
+      }
+    }
+    throw new Error(`[security] verify sandbox rejects escaping symlink: ${path}`);
+  };
   const visit = async (directory: string): Promise<void> => {
     for (const entry of await readdir(directory, { withFileTypes: true })) {
       const source = join(directory, entry.name);
       const path = relative(projectRoot, source);
-      if (
-        path.split(sep).some((segment) => segment === '.git' || segment === 'node_modules')
-        || isEphemeralVerificationArtifact(path)
-        || pathCoveredBy(path, sharedPaths)
-      ) continue;
+      if (omitVerificationSource(path, sharedPaths)) continue;
       if (entry.isSymbolicLink()) {
         const target = await readlink(source);
         const resolvedTarget = resolve(dirname(source), target);
         if (isAbsolute(target) || (resolvedTarget !== projectRoot && !resolvedTarget.startsWith(`${projectRoot}${sep}`))) {
-          throw new Error(`[security] verify sandbox rejects escaping symlink: ${path}`);
+          await rejectOrOmit(path);
+          continue;
         }
         try {
           const realTarget = await realpath(source);
           if (realTarget !== projectRoot && !realTarget.startsWith(`${projectRoot}${sep}`)) {
-            throw new Error(`[security] verify sandbox rejects escaping symlink: ${path}`);
+            await rejectOrOmit(path);
           }
         } catch (error) {
           if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
@@ -569,6 +620,7 @@ async function validateSandboxSymlinks(projectPath: string, sharedPaths: string[
     }
   };
   await visit(projectRoot);
+  return ignoredLinks;
 }
 
 async function createVerifySandboxRoot(prefix: string, scratchRoot?: string): Promise<string> {
@@ -587,7 +639,7 @@ async function createHeadSandbox(
     await git(projectPath, ['clone', '--quiet', '--no-hardlinks', '--no-checkout', projectPath, project]);
     await git(project, ['checkout', '--quiet', '--detach', headCommit]);
     const sharedPaths = await verificationSharedPaths(projectPath, commands);
-    await validateSandboxSymlinks(projectPath, sharedPaths);
+    const ignoredLinks = await validateSandboxSymlinks(projectPath, sharedPaths, true);
     // Mirror the source working tree exactly, including deletions and renames,
     // while retaining only the sandbox's independent Git metadata.
     for (const entry of await readdir(project)) {
@@ -601,16 +653,7 @@ async function createHeadSandbox(
       verbatimSymlinks: true,
       filter: (source) => {
         const path = relative(projectPath, source);
-        return path === '' || (
-          !path.split(sep).some((segment) =>
-            segment === '.git'
-            || segment === 'node_modules'
-            ||             segment === '.venv'
-            || segment === '.venv-verify'
-            || segment === '.venv.bak')
-          && !isEphemeralVerificationArtifact(path)
-          && !pathCoveredBy(path, sharedPaths)
-        );
+        return path === '' || (!omitVerificationSource(path, sharedPaths) && !ignoredLinks.has(path));
       },
     });
     for (const sharedPath of sharedPaths) {
@@ -619,7 +662,9 @@ async function createHeadSandbox(
         join(project, sharedPath),
         project,
         sharedPath,
+        sharedPathSecretFilter(sharedPath),
       );
+      await rebasePythonEnvironment(projectPath, project, sharedPath);
     }
     // Validate what was actually copied, closing the source validation/copy
     // race before any repository-controlled command can execute.
@@ -634,7 +679,9 @@ async function createHeadSandbox(
 async function git(projectPath: string, args: string[]): Promise<string> {
   return await new Promise((resolveResult, reject) => {
     const maxOutputBytes = 4 * 1024 * 1024;
-    const child = spawn('git', ['-C', projectPath, ...args], {
+    // Checkout hooks belong to the live developer environment. Running them in
+    // a verification worktree can restore external data/secrets after filtering.
+    const child = spawn('git', ['-C', projectPath, '-c', 'core.hooksPath=/dev/null', ...args], {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: process.platform !== 'win32',
     });
@@ -696,6 +743,7 @@ async function runAtBase(
     worktreePath = join(root, 'worktree');
     await git(projectPath, ['worktree', 'add', '--detach', worktreePath, baseCommit]);
     worktreeAdded = true;
+    await removePrivateEnvironmentFiles(worktreePath);
     // A detached worktree intentionally has no ignored dependencies/data. Copy
     // them into the base sandbox so failed-check comparison cannot mutate the
     // HEAD checkout through a shared symlink.
@@ -708,7 +756,8 @@ async function runAtBase(
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
       }
-      await copyIsolatedPath(join(projectPath, sharedPath), target, worktreePath, sharedPath);
+      await copyIsolatedPath(join(projectPath, sharedPath), target, worktreePath, sharedPath, sharedPathSecretFilter(sharedPath));
+      await rebasePythonEnvironment(projectPath, worktreePath, sharedPath);
     }
     const baseBin = join(worktreePath, 'node_modules', '.bin');
     const env = { ...process.env, PATH: `${baseBin}${delimiter}${process.env.PATH ?? ''}` };


### PR DESCRIPTION
CGF worktrees repeatedly stopped before pytest because local `.env`/`.dev.vars`, customer-data links, and nested virtualenv interpreters were rejected as escaping symlinks. Eight tasks parked after repeated attempts. Copying the virtualenv alone also left uv editable installs pointing at the original checkout.

Use the same exclusion policy before source validation and copy; omit private configuration and ignored external local-asset links without dereferencing them. Keep tracked and ordinary source-link containment. Disable checkout hooks in disposable verification worktrees. Independently copy command-local Python dependencies for HEAD/base and relocate plain-path editable `.pth` entries to the snapshot, retaining dependency CA bundles.

Validation:
- 12 environment regressions; the initial 8 tests all failed before the fix.
- Full suite: 5,545 passed / 10 skipped. Typecheck and build pass; lint has no errors (one unchanged warning in webTools.test.ts).
- OpenSwarm working-tree review: APPROVE; fresh PR review: APPROVE.
- VELA attested companion, CGF commit `a882db13ea2731ab0a5a35a2f80c282ba2d73b23`: Python/pytest import succeeds, project module path asserted inside disposable checkout, real full pytest **1,932 passed / 57 skipped**.
- Live baseline comparison: intentional HEAD-only failure yields `headStatus=fail`, `baseStatus=pass`, `newFailure=true`; baseline pytest also **1,932 passed / 57 skipped**.

Deployment and affected-task recovery will be verified after CI and the fresh PR review.

Fixes https://linear.app/intrect/issue/AGT-4223
