### PR TITLE
fix: ignore pytest-local artifacts at publication fence

### DIFF
--- a/src/support/worktreeEphemeral.test.ts
+++ b/src/support/worktreeEphemeral.test.ts
@@ -35,6 +35,7 @@ describe('isEphemeralWorktreeArtifact', () => {
   it('still recognises the worktree-level scratch it always did', () => {
     expect(isEphemeralWorktreeArtifact('.venv')).toBe(true);
     expect(isEphemeralWorktreeArtifact('pytest-of-openswarm/pytest-3/x')).toBe(true);
+    expect(isEphemeralWorktreeArtifact('pytest-local/test_case_current')).toBe(true);
     expect(isEphemeralWorktreeArtifact('.trash/AX-1/pytest-a3/out')).toBe(true);
   });
 

--- a/src/support/worktreeEphemeral.ts
+++ b/src/support/worktreeEphemeral.ts
@@ -16,7 +16,11 @@ const VENV_ENTRY = /^\.?venv(?:[\w-]*|\.bak)$/;
 export function isEphemeralWorktreeArtifact(file: string): boolean {
   return VENV_DIR.test(file)
     || VENV_ENTRY.test(file)
-    || file === 'pytest-local'
+    // Some verification harnesses write their basetemp under the repository
+    // root as `pytest-local/<case>`. Keep the whole tree out of preserved WIP
+    // and publication-scope checks; only the directory itself was ignored
+    // before, so its committed children could trigger a false scope park.
+    || /^pytest-local(?:\/|$)/.test(file)
     // pytest's basetemp (`pytest-of-<user>/…`) anywhere in the tree, and the
     // whole worktree-local `.trash/` quarantine (cgf-portal ships secrets under
     // `.trash/<issue>/pytest-a3/…` which is not named pytest-of-*).
@@ -69,4 +73,3 @@ export function ephemeralPathspecRoots(files: string[]): string[] {
   }
   return roots;
 }
-


### PR DESCRIPTION
## Problem
Verification runs that commit `pytest-local/<case>` scratch output were rejected by the publication-scope fence as out-of-scope source files. This parked the run with `publication_scope_mismatch` even though the files were ephemeral test artifacts.

## Change
Treat the entire `pytest-local/` tree as ephemeral in the shared artifact classifier used by WIP staging, resume filtering, purge, and the publication fence.

## Validation
- `npm test -- --run src/support/worktreeEphemeral.test.ts` (6 passed)
- `npm run typecheck`
- `openswarm review --path .` — APPROVE
