### PR TITLE
feat(automation): let a DoD contract resolve deterministic parks (AGT-4241)

### DIFF
--- a/docs/DOD_CONTRACT.md
+++ b/docs/DOD_CONTRACT.md
@@ -1,0 +1,38 @@
+# Executable DoD contract
+
+An issue may declare the coordinator-owned part of its Definition of Done in a
+fenced JSON block. The block is policy only: verification commands still come
+from the repository's trusted verify configuration, and no command from an
+issue description is executed.
+
+```openswarm:dod
+{
+  "version": 1,
+  "completion": {
+    "noChanges": "park"
+  },
+  "automation": {
+    "scopeMismatch": "retry_ephemeral",
+    "maxRepairs": 1
+  }
+}
+```
+
+## What the coordinator will resolve
+
+| Outcome | Default without a contract | With a contract |
+| -- | -- | -- |
+| Worker stated that no source edit is required (`Worker finished without edits: …`) | Park | `completion.noChanges: complete` marks the run Done |
+| Worker claimed success with zero diff and no reason | Park | Always park — that is an unfinished run, not a no-op |
+| Publication fence lists *only* ephemeral artifacts | One bounded retry (residual) | `automation.scopeMismatch` and `maxRepairs` (0–3) |
+| A source/test/docs file is outside reserved scope | Park | Always park — a contract cannot widen write scope |
+| Malformed `openswarm:dod` block | Park, with the parse error | — |
+
+`completion.noChanges` may be `complete` only when the worker actually stated
+why no edit was required. The silent stuck-loop park (same code, different
+reason) is never auto-completed.
+
+The live publication fence already drops ephemeral artifacts before it throws
+(`assertBranchWithinWriteScope`). The ephemeral retry is residual defence for
+a park reason that still lists only those paths. Repairs are capped at three.
+The default is one.

--- a/src/agents/pairPipelineTypes.ts
+++ b/src/agents/pairPipelineTypes.ts
@@ -131,6 +131,8 @@ export interface PipelineResult {
    * on three such runs on 2026-09-02 before anyone looked.
    */
   operatorPark?: { code: string; reason: string };
+  /** Deterministic coordinator action applied before durable park/complete. */
+  coordinatorResolution?: { action: 'complete' | 'retry'; reason: string };
 }
 
 /**
@@ -141,6 +143,8 @@ export interface PipelineResult {
  * diff for this issue as written.
  */
 export const WORKER_NO_CHANGES_PARK_REASON = 'worker_no_changes';
+/** Publication-path park: the worker stated why no source edit was required. */
+export const WORKER_NO_CHANGES_STATEMENT_PREFIX = 'Worker finished without edits:';
 
 export interface PipelineContext {
   task: TaskItem;

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -116,6 +116,7 @@ import {
 } from './explicitDispatchRecovery.js';
 import { buildInstructionCapsule } from '../agents/instructionCapsule.js';
 import type { IntegrationConflictEvidence } from './integrationCoordinator.js';
+import { coordinatorResolutionComment, planCoordinatorResolution } from './coordinatorResolution.js';
 
 // Re-export types and integration setters (used by service.ts)
 export { setNotifier, setTaskSource } from './runnerExecution.js';
@@ -598,6 +599,16 @@ export class AutonomousRunner {
       console.log(`[Scheduler] Task completed: ${taskCtx} ${task.title}`);
       broadcastEvent({ type: 'task:completed', data: { taskId: taskEventKey(task), success: result.success, duration: result.totalDuration } });
       this.recordPipelineHistory(task, result);
+      if (result.coordinatorResolution?.action === 'complete' && task.issueId) {
+        const marker = `coordinator-complete:${task.issueId}:${result.sessionId}`;
+        const source = getTaskSource();
+        if (source) {
+          source.addComment(task.issueId, coordinatorResolutionComment({
+            action: 'complete',
+            reason: result.coordinatorResolution.reason,
+          }), marker).catch((error) => console.warn('[Coordinator] Completion note failed:', error));
+        }
+      }
       await reportToDiscord(formatPipelineResultEmbed(result));
 
       // Track as completed ONLY on success to prevent re-selection (persist to disk)
@@ -694,6 +705,17 @@ export class AutonomousRunner {
       const retryLabel = new Date(retryAt).toISOString();
       console.log(`[Scheduler] Task deferred: ${taskCtx} ${task.title} — retry at ${retryLabel}`);
       this.recordPipelineHistory(task, result);
+      if (result.coordinatorResolution?.action === 'retry' && task.issueId) {
+        const marker = `coordinator-retry:${task.issueId}:${result.sessionId}`;
+        const source = getTaskSource();
+        if (source) {
+          source.addComment(task.issueId, coordinatorResolutionComment({
+            action: 'retry',
+            reason: result.coordinatorResolution.reason,
+            retryAt,
+          }), marker).catch((error) => console.warn('[Coordinator] Retry note failed:', error));
+        }
+      }
       broadcastEvent({
         type: 'log',
         data: {
@@ -1481,6 +1503,11 @@ export class AutonomousRunner {
         successEffect: (result, claim) => buildCompletionEffect(task, result, claim.attemptNo),
         cancelEffect: (_result, claim) => buildCancellationEffect(task, claim.attemptNo),
         retryCancellation: () => this.stopping,
+        resolveOperatorPark: (parkedTask, parkedResult, attemptNo) => planCoordinatorResolution({
+          task: parkedTask,
+          result: parkedResult,
+          attemptNo,
+        }),
       },
     );
   }

--- a/src/automation/coordinatorResolution.test.ts
+++ b/src/automation/coordinatorResolution.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { WORKER_NO_CHANGES_PARK_REASON } from '../agents/pairPipelineTypes.js';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import { PUBLICATION_SCOPE_PARK_REASON } from './publishOnPark.js';
+import { coordinatorResolutionComment, planCoordinatorResolution } from './coordinatorResolution.js';
+import { formatDoDContract } from './dodContract.js';
+
+const task = (description?: string): Pick<TaskItem, 'description'> => ({ description });
+const park = (code: string, reason = 'publication-scope: branch contains files outside reserved write scope: pytest-local/case/output.txt') => ({
+  operatorPark: { code, reason },
+});
+
+describe('coordinator resolution plan', () => {
+  it('retries an ephemeral-only publication fence once', () => {
+    const plan = planCoordinatorResolution({
+      task: task(),
+      result: park(PUBLICATION_SCOPE_PARK_REASON),
+      attemptNo: 1,
+      now: 1000,
+    });
+    expect(plan).toMatchObject({ action: 'retry', retryAt: 31_000 });
+  });
+
+  it('does not retry a source file outside scope', () => {
+    const plan = planCoordinatorResolution({
+      task: task(),
+      result: park(PUBLICATION_SCOPE_PARK_REASON, 'publication-scope: branch contains files outside reserved write scope: src/security.ts'),
+      attemptNo: 1,
+    });
+    expect(plan.action).toBe('park');
+  });
+
+  it('does not retry when an ephemeral artifact is mixed with a source file', () => {
+    const plan = planCoordinatorResolution({
+      task: task(),
+      result: park(
+        PUBLICATION_SCOPE_PARK_REASON,
+        'publication-scope: branch contains files outside reserved write scope: pytest-local/case/output.txt, src/security.ts',
+      ),
+      attemptNo: 1,
+    });
+    expect(plan.action).toBe('park');
+  });
+
+  it('stops retrying after the repair budget', () => {
+    const plan = planCoordinatorResolution({
+      task: task(),
+      result: park(PUBLICATION_SCOPE_PARK_REASON),
+      attemptNo: 2,
+    });
+    expect(plan.action).toBe('park');
+  });
+
+  it('honours an explicit park policy for ephemeral fences', () => {
+    const description = formatDoDContract({
+      version: 1,
+      completion: { noChanges: 'park' },
+      automation: { scopeMismatch: 'park', maxRepairs: 1 },
+    });
+    const plan = planCoordinatorResolution({
+      task: task(description),
+      result: park(PUBLICATION_SCOPE_PARK_REASON),
+      attemptNo: 1,
+    });
+    expect(plan.action).toBe('park');
+  });
+
+  it('completes only when the issue explicitly allows no changes', () => {
+    const description = formatDoDContract({
+      version: 1,
+      completion: { noChanges: 'complete' },
+      automation: { scopeMismatch: 'park', maxRepairs: 0 },
+    });
+    expect(planCoordinatorResolution({
+      task: task(description),
+      result: park(WORKER_NO_CHANGES_PARK_REASON, 'Worker finished without edits: already satisfied'),
+      attemptNo: 1,
+    })).toMatchObject({ action: 'complete' });
+  });
+
+  it('does not complete a silent zero-diff stuck loop even with noChanges: complete', () => {
+    const description = formatDoDContract({
+      version: 1,
+      completion: { noChanges: 'complete' },
+      automation: { scopeMismatch: 'park', maxRepairs: 0 },
+    });
+    const plan = planCoordinatorResolution({
+      task: task(description),
+      result: park(
+        WORKER_NO_CHANGES_PARK_REASON,
+        'Worker claimed success without changing a file and without a noChangesReason (same output produced 3 times). The issue needs a human: either it asks for something the agent cannot express as a diff, or its description does not say what to change.',
+      ),
+      attemptNo: 1,
+    });
+    expect(plan.action).toBe('park');
+  });
+
+  it('keeps no-change work parked without explicit authority', () => {
+    expect(planCoordinatorResolution({
+      task: task(),
+      result: park(WORKER_NO_CHANGES_PARK_REASON, 'Worker finished without edits: no source change required'),
+      attemptNo: 1,
+    }).action).toBe('park');
+  });
+
+  it('fails closed when a contract block is malformed', () => {
+    const malformed = '```openswarm:dod\n{"version":1}\n```';
+    const plan = planCoordinatorResolution({
+      task: task(malformed),
+      result: park(PUBLICATION_SCOPE_PARK_REASON),
+      attemptNo: 1,
+    });
+    expect(plan).toMatchObject({ action: 'park', reason: expect.stringContaining('Malformed DoD contract') });
+  });
+
+  it('includes the retry instant in the operator comment', () => {
+    const comment = coordinatorResolutionComment({
+      action: 'retry',
+      reason: 'ephemeral only',
+      retryAt: Date.parse('2026-09-09T04:00:00.000Z'),
+    });
+    expect(comment).toContain('2026-09-09T04:00:00.000Z');
+  });
+});

--- a/src/automation/coordinatorResolution.ts
+++ b/src/automation/coordinatorResolution.ts
@@ -1,0 +1,104 @@
+// ============================================
+// OpenSwarm — deterministic coordinator resolution plans
+// ============================================
+
+import {
+  WORKER_NO_CHANGES_PARK_REASON,
+  WORKER_NO_CHANGES_STATEMENT_PREFIX,
+  type PipelineResult,
+} from '../agents/pairPipelineTypes.js';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import { isEphemeralWorktreeArtifact } from '../support/worktreeEphemeral.js';
+import { parseDoDContract } from './dodContract.js';
+
+/** Same value as PUBLICATION_SCOPE_PARK_REASON; kept local so this plan stays pure. */
+const PUBLICATION_SCOPE_PARK_REASON = 'publication_scope_mismatch';
+
+export type CoordinatorResolution =
+  | { action: 'complete'; reason: string }
+  | { action: 'retry'; reason: string; retryAt: number }
+  | { action: 'park'; reason: string };
+
+export interface CoordinatorResolutionInput {
+  task: Pick<TaskItem, 'description'>;
+  result: Pick<PipelineResult, 'operatorPark'>;
+  /** Durable attempt number, including the current attempt. */
+  attemptNo: number;
+  now?: number;
+}
+
+const EPHEMERAL_RETRY_DELAY_MS = 30_000;
+const DEFAULT_MAX_REPAIRS = 1;
+
+function scopePaths(reason: string): string[] {
+  const marker = 'outside reserved write scope:';
+  const index = reason.toLowerCase().indexOf(marker);
+  if (index < 0) return [];
+  return reason.slice(index + marker.length)
+    .split(',')
+    .map((path) => path.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Decide whether the coordinator can resolve a deterministic park.
+ *
+ * The plan is pure and bounded. It never broadens a source write scope, runs a
+ * command from an issue, or treats a missing contract as business authority.
+ * An ephemeral-only publication-scope park is residual defence: the live fence
+ * already drops those artifacts before throwing. A silent zero-diff stuck loop
+ * is never treated as a proven no-op, even with an explicit complete contract.
+ */
+export function planCoordinatorResolution(input: CoordinatorResolutionInput): CoordinatorResolution {
+  const park = input.result.operatorPark;
+  if (!park) return { action: 'park', reason: 'No operator park was supplied' };
+  const parsed = parseDoDContract(input.task.description);
+  if (parsed.error) {
+    return { action: 'park', reason: `Malformed DoD contract: ${parsed.error}` };
+  }
+  const contract = parsed.contract;
+
+  // Two parks share WORKER_NO_CHANGES_PARK_REASON. Only the publication
+  // variant carries the worker's stated no-edit proof. The stuck-loop variant
+  // (claimed success, zero diff, no reason) must stay parked even when the
+  // contract allows no-change completion.
+  const provenNoChange = park.code === WORKER_NO_CHANGES_PARK_REASON
+    && park.reason.startsWith(WORKER_NO_CHANGES_STATEMENT_PREFIX);
+  if (provenNoChange && contract?.completion.noChanges === 'complete') {
+    return {
+      action: 'complete',
+      reason: 'The issue DoD explicitly declares a no-change completion as acceptable.',
+    };
+  }
+
+  // assertBranchWithinWriteScope already drops ephemeral artifacts before it
+  // throws, so a live fence should never emit an ephemeral-only reason. Keep
+  // the residual retry for a park string that still lists only those paths
+  // (older daemons, or a constructor that bypassed the fence filter).
+  if (park.code === PUBLICATION_SCOPE_PARK_REASON) {
+    const paths = scopePaths(park.reason);
+    const allEphemeral = paths.length > 0 && paths.every(isEphemeralWorktreeArtifact);
+    const policy = contract?.automation.scopeMismatch ?? 'retry_ephemeral';
+    const maxRepairs = contract?.automation.maxRepairs ?? DEFAULT_MAX_REPAIRS;
+    if (allEphemeral && policy === 'retry_ephemeral' && input.attemptNo <= maxRepairs) {
+      return {
+        action: 'retry',
+        retryAt: (input.now ?? Date.now()) + EPHEMERAL_RETRY_DELAY_MS,
+        reason: `Only ephemeral artifacts remain in the publication-scope park (${paths.join(', ')}); the coordinator will retry once.`,
+      };
+    }
+  }
+
+  return { action: 'park', reason: park.reason };
+}
+
+export function coordinatorResolutionComment(resolution: CoordinatorResolution): string {
+  if (resolution.action === 'complete') {
+    return `Coordinator completed this run automatically.\n\n**Evidence:** ${resolution.reason}`;
+  }
+  if (resolution.action === 'retry') {
+    const when = new Date(resolution.retryAt).toISOString();
+    return `Coordinator repaired a deterministic blocker and scheduled one bounded retry at ${when}.\n\n**Evidence:** ${resolution.reason}`;
+  }
+  return `Coordinator left this run parked because it requires an external decision.\n\n**Reason:** ${resolution.reason}`;
+}

--- a/src/automation/dodContract.test.ts
+++ b/src/automation/dodContract.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { formatDoDContract, parseDoDContract } from './dodContract.js';
+
+describe('DoD contract', () => {
+  it('parses the bounded coordinator policy', () => {
+    const parsed = parseDoDContract([
+      'Task details',
+      formatDoDContract({
+        version: 1,
+        completion: { noChanges: 'complete' },
+        automation: { scopeMismatch: 'retry_ephemeral', maxRepairs: 1 },
+      }),
+    ].join('\n'));
+
+    expect(parsed).toEqual({
+      contract: {
+        version: 1,
+        completion: { noChanges: 'complete' },
+        automation: { scopeMismatch: 'retry_ephemeral', maxRepairs: 1 },
+      },
+    });
+  });
+
+  it('defaults omitted maxRepairs to 1', () => {
+    const parsed = parseDoDContract('```openswarm:dod\n{"version":1,"completion":{"noChanges":"park"},"automation":{"scopeMismatch":"park"}}\n```');
+    expect(parsed.contract?.automation.maxRepairs).toBe(1);
+  });
+
+  it('fails closed for malformed or out-of-range policy', () => {
+    expect(parseDoDContract('```openswarm:dod\n{"version":1}\n```').error).toContain('completion.noChanges');
+    expect(parseDoDContract('```openswarm:dod\nnot-json\n```').error).toContain('valid JSON');
+    expect(parseDoDContract('```openswarm:dod\n{"version":1,"completion":{"noChanges":"park"},"automation":{"scopeMismatch":"retry_ephemeral","maxRepairs":4}}\n```').error).toContain('0 to 3');
+    expect(parseDoDContract('```openswarm:dod\n{"version":1,"completion":{"noChanges":"park"},"automation":{"scopeMismatch":"retry_ephemeral","maxRepairs":1.5}}\n```').error).toContain('0 to 3');
+  });
+
+  it('ignores descriptions without a contract for legacy issues', () => {
+    expect(parseDoDContract('No machine policy here')).toEqual({});
+  });
+});

--- a/src/automation/dodContract.ts
+++ b/src/automation/dodContract.ts
@@ -1,0 +1,103 @@
+// ============================================
+// OpenSwarm — executable Definition of Done contract
+// ============================================
+//
+// Issue descriptions are untrusted input. This parser deliberately accepts a
+// small, versioned JSON policy and never executes commands from it. Commands
+// belong to the repository's trusted verify manifest; this contract only tells
+// the coordinator which deterministic outcomes it may resolve automatically.
+
+export type DoDNoChangesPolicy = 'park' | 'complete';
+export type DoDScopeMismatchPolicy = 'park' | 'retry_ephemeral';
+
+export interface DoDContract {
+  version: 1;
+  completion: {
+    noChanges: DoDNoChangesPolicy;
+  };
+  automation: {
+    scopeMismatch: DoDScopeMismatchPolicy;
+    maxRepairs: number;
+  };
+}
+
+export interface ParsedDoDContract {
+  contract?: DoDContract;
+  error?: string;
+}
+
+const FENCE = /```openswarm:dod\s*\n([\s\S]*?)\n```/i;
+const MAX_DESCRIPTION_CONTRACT_BYTES = 16_000;
+const MAX_REPAIRS = 3;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function boundedEnum<T extends string>(value: unknown, values: readonly T[]): T | undefined {
+  return typeof value === 'string' && values.includes(value as T) ? value as T : undefined;
+}
+
+function parseMaxRepairs(raw: unknown): { value?: number; error?: string } {
+  if (raw === undefined) return { value: 1 };
+  if (typeof raw !== 'number' || !Number.isSafeInteger(raw) || raw < 0 || raw > MAX_REPAIRS) {
+    return { error: `DoD contract automation.maxRepairs must be an integer from 0 to ${MAX_REPAIRS}` };
+  }
+  return { value: raw };
+}
+
+/**
+ * Parse the optional fenced contract from an issue description.
+ *
+ * An absent block is a legacy issue and remains fail-closed for business
+ * outcomes. A malformed block is also fail-closed, but is returned as an
+ * explicit error so the coordinator can report the authoring problem instead
+ * of silently ignoring it.
+ */
+export function parseDoDContract(description?: string): ParsedDoDContract {
+  if (!description) return {};
+  const match = description.match(FENCE);
+  if (!match) return {};
+  const source = match[1];
+  if (Buffer.byteLength(source, 'utf8') > MAX_DESCRIPTION_CONTRACT_BYTES) {
+    return { error: `DoD contract exceeds ${MAX_DESCRIPTION_CONTRACT_BYTES} bytes` };
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(source);
+  } catch {
+    return { error: 'DoD contract is not valid JSON' };
+  }
+  if (!isRecord(raw) || raw.version !== 1) {
+    return { error: 'DoD contract version must be 1' };
+  }
+  const completion = isRecord(raw.completion) ? raw.completion : undefined;
+  const automation = isRecord(raw.automation) ? raw.automation : undefined;
+  const noChanges = boundedEnum(completion?.noChanges, ['park', 'complete'] as const);
+  const scopeMismatch = boundedEnum(automation?.scopeMismatch, ['park', 'retry_ephemeral'] as const);
+  if (!noChanges || !scopeMismatch) {
+    return {
+      error: 'DoD contract requires completion.noChanges and automation.scopeMismatch',
+    };
+  }
+  const repairs = parseMaxRepairs(automation?.maxRepairs);
+  if (repairs.error || repairs.value === undefined) {
+    return { error: repairs.error ?? 'DoD contract automation.maxRepairs is invalid' };
+  }
+  return {
+    contract: {
+      version: 1,
+      completion: { noChanges },
+      automation: { scopeMismatch, maxRepairs: repairs.value },
+    },
+  };
+}
+
+export function formatDoDContract(contract: DoDContract): string {
+  return [
+    '```openswarm:dod',
+    JSON.stringify(contract, null, 2),
+    '```',
+  ].join('\n');
+}

--- a/src/automation/durableRunCoordinator.operatorPark.test.ts
+++ b/src/automation/durableRunCoordinator.operatorPark.test.ts
@@ -7,6 +7,8 @@ import type { PipelineResult } from '../agents/pairPipeline.js';
 import type { TaskItem } from '../orchestration/decisionEngine.js';
 import { DurableRunCoordinator } from './durableRunCoordinator.js';
 import { RunLedger } from './runLedger.js';
+import { formatDoDContract } from './dodContract.js';
+import { planCoordinatorResolution } from './coordinatorResolution.js';
 
 const roots: string[] = [];
 
@@ -69,6 +71,80 @@ describe('DurableRunCoordinator operatorPark', () => {
       .prepare("SELECT data_json FROM automation_events WHERE issue_id = 'scope' AND kind = 'operator_resumed' ORDER BY sequence DESC LIMIT 1")
       .get() as { data_json: string } | undefined;
     expect(JSON.parse(resumed?.data_json ?? '{}')).toMatchObject({ trigger: 'tracker_todo', parkedUnder: 'publication_scope_mismatch' });
+    coordinator.close();
+    ledger.close();
+  });
+
+  it('lets an explicit no-change DoD complete through the durable success path', async () => {
+    const ledgerPath = dbPath();
+    const ledger = new RunLedger(ledgerPath);
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', ledger });
+    const noChangeTask = {
+      ...task('no-change'),
+      description: formatDoDContract({
+        version: 1,
+        completion: { noChanges: 'complete' },
+        automation: { scopeMismatch: 'park', maxRepairs: 0 },
+      }),
+    };
+    const parked: PipelineResult = {
+      success: false,
+      sessionId: 's',
+      stages: [],
+      finalStatus: 'failed',
+      totalDuration: 1,
+      iterations: 1,
+      operatorPark: { code: 'worker_no_changes', reason: 'Worker finished without edits: already satisfied' },
+    };
+
+    const result = await coordinator.execute(noChangeTask, '/repo', async () => parked, {
+      resolveOperatorPark: (candidate, candidateResult, attemptNo) => planCoordinatorResolution({
+        task: candidate,
+        result: candidateResult,
+        attemptNo,
+      }),
+      successEffect: (_pipeline, claim) => ({
+        kind: 'tracker.complete',
+        dedupeKey: `no-change:${claim.attemptNo}`,
+        payload: { via: 'coordinator' },
+      }),
+    });
+
+    expect(result).toMatchObject({ success: true, finalStatus: 'approved', coordinatorResolution: { action: 'complete' } });
+    expect(ledger.getRun('no-change')).toMatchObject({ state: 'SYNC_PENDING' });
+    coordinator.close();
+    ledger.close();
+  });
+
+  it('defers an ephemeral-only fence without entering NEEDS_HUMAN', async () => {
+    const ledgerPath = dbPath();
+    const ledger = new RunLedger(ledgerPath);
+    const coordinator = new DurableRunCoordinator({ mode: 'primary', ledger });
+    const parked: PipelineResult = {
+      success: false,
+      sessionId: 's',
+      stages: [],
+      finalStatus: 'failed',
+      totalDuration: 1,
+      iterations: 1,
+      operatorPark: {
+        code: 'publication_scope_mismatch',
+        reason: 'publication-scope: branch contains files outside reserved write scope: pytest-local/case/output.txt',
+      },
+    };
+
+    const result = await coordinator.execute(task('ephemeral'), '/repo', async () => parked, {
+      resolveOperatorPark: (candidate, candidateResult, attemptNo) => planCoordinatorResolution({
+        task: candidate,
+        result: candidateResult,
+        attemptNo,
+        now: 1000,
+      }),
+    });
+
+    expect(result).toMatchObject({ success: false, finalStatus: 'deferred', coordinatorResolution: { action: 'retry' } });
+    expect(ledger.getRun('ephemeral')).toMatchObject({ state: 'RETRY_AT' });
+    expect(ledger.getRun('ephemeral')?.retryAt).toBeGreaterThan(Date.now());
     coordinator.close();
     ledger.close();
   });

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -25,6 +25,7 @@ import {
   OPERATOR_QUESTION_PARK_REASON,
 } from '../coordination/operatorAnswers.js';
 import { SANDBOX_OUTCOME_UNKNOWN_PARK_REASON } from '../sandboxExecutor/protocol.js';
+import type { CoordinatorResolution } from './coordinatorResolution.js';
 
 export interface DurableRunCoordinatorConfig {
   mode: RunLedgerMode;
@@ -64,6 +65,16 @@ export interface DurableExecuteOptions {
   /** Service shutdown is a resumable interruption, unlike an operator cancel. */
   retryCancellation?: (result: PipelineResult, claim: RunClaim) => boolean;
   admission?: RepositoryAdmissionPolicy;
+  /**
+   * Resolve a deterministic operator park before it is committed to
+   * NEEDS_HUMAN. The callback is pure policy; tracker/ledger side effects stay
+   * in this coordinator so a completion or bounded retry cannot split state.
+   */
+  resolveOperatorPark?: (
+    task: TaskItem,
+    result: PipelineResult,
+    attemptNo: number,
+  ) => CoordinatorResolution | undefined;
 }
 
 export interface RepositoryAdmissionPolicy {
@@ -626,6 +637,35 @@ export class DurableRunCoordinator {
     }
 
     if (leaseLost) return fencedResult(result);
+    // A deterministic park is normally terminal. A repository-authored DoD
+    // contract may, however, make two narrow outcomes coordinator-owned:
+    // explicitly accepted no-change work can complete through the normal
+    // outbox, and an ephemeral-only publication fence may receive one bounded
+    // retry. Resolve before recording the attempt so the durable row records
+    // the outcome that actually governs the next state.
+    if (result.operatorPark && options.resolveOperatorPark) {
+      const resolution = options.resolveOperatorPark(task, result, claim.attemptNo);
+      if (resolution?.action === 'complete') {
+        result = {
+          ...result,
+          success: true,
+          finalStatus: 'approved',
+          operatorPark: undefined,
+          coordinatorResolution: { action: 'complete', reason: resolution.reason },
+        };
+      } else if (resolution?.action === 'retry') {
+        result = {
+          ...result,
+          success: false,
+          finalStatus: 'deferred',
+          retryAt: resolution.retryAt,
+          operatorPark: undefined,
+          coordinatorResolution: { action: 'retry', reason: resolution.reason },
+          failureDetail: `coordinator: ${resolution.reason}`,
+        };
+      }
+    }
+
     // GitHub publication is an external side effect. If it succeeded but the
     // pipeline could not durably attach/finalize it, execution must stop here:
     // a normal RETRY_AT would allow another worker to mutate the published

--- a/src/automation/publishOnPark.ts
+++ b/src/automation/publishOnPark.ts
@@ -17,7 +17,7 @@ import { enforcedFileScope, type FileScopeSource } from '../orchestration/writeS
 import { PublicationScopeMismatchError } from '../support/publicationScopeFence.js';
 import { commitAndCreatePRWithHead, type WorktreeInfo } from '../support/worktreeManager.js';
 import type { PipelineResult } from '../agents/pairPipelineTypes.js';
-import { WORKER_NO_CHANGES_PARK_REASON } from '../agents/pairPipelineTypes.js';
+import { WORKER_NO_CHANGES_PARK_REASON, WORKER_NO_CHANGES_STATEMENT_PREFIX } from '../agents/pairPipelineTypes.js';
 
 import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
 
@@ -349,7 +349,7 @@ export async function publishApprovedWork(
             // commits"). Park with the worker's statement so the operator can
             // close the issue or send it back with what the worker missed.
             result.failureDetail = `publication: ${message} — worker: ${noChangesReason}`;
-            result.operatorPark = { code: WORKER_NO_CHANGES_PARK_REASON, reason: `Worker finished without edits: ${noChangesReason}` };
+            result.operatorPark = { code: WORKER_NO_CHANGES_PARK_REASON, reason: `${WORKER_NO_CHANGES_STATEMENT_PREFIX} ${noChangesReason}` };
           }
           // Otherwise the worker claimed edits that were only runtime
           // artifacts the stager drops. That is the attempt failing at its

--- a/src/cli/workCommand.ts
+++ b/src/cli/workCommand.ts
@@ -37,6 +37,7 @@ import {
   type ExecutionDurabilityHooks,
   type RepositoryAdmissionPolicy,
 } from '../automation/durableRunCoordinator.js';
+import { planCoordinatorResolution } from '../automation/coordinatorResolution.js';
 import type { EffectClaim } from '../automation/runLedger.js';
 import { setAutomationDbPath } from '../automation/automationDbPath.js';
 import { loadRepoMetadata, type RepoMetadata } from '../support/repoMetadata.js';
@@ -612,6 +613,11 @@ async function runWorkCommandInner(
             cancelEffect: (_result, claim) => buildWorkCancellationEffect(row.task, claim.attemptNo),
             // Interruptions are resumable — never turn Ctrl-C into a tracker cancel.
             retryCancellation: () => true,
+            resolveOperatorPark: (parkedTask, parkedResult, attemptNo) => planCoordinatorResolution({
+              task: parkedTask,
+              result: parkedResult,
+              attemptNo,
+            }),
           },
         );
       }, (settled) => {


### PR DESCRIPTION
## Summary
- Issue descriptions can declare a bounded `openswarm:dod` JSON policy. The coordinator applies it *before* a deterministic operator park is written as `NEEDS_HUMAN`.
- Proven no-change work (`Worker finished without edits: …`) completes through the durable outbox when the contract says so. A silent zero-diff stuck loop stays parked even with that contract.
- A residual ephemeral-only publication-scope park can retry once. Source/test/docs files still cannot widen write scope. Missing or malformed contracts fail closed for business outcomes.
- Wired on both the daemon and `openswarm work`.

## Test plan
- [x] `tsc --noEmit`
- [x] oxlint 0 errors
- [x] vitest: dodContract, coordinatorResolution, durableRunCoordinator.operatorPark, publishOnPark, autonomousRunner.coverage, workCommand (150 passed)
- [ ] `openswarm pr review --fresh` (Codex quota exhausted locally; independent reviewer ran as commit-gate layer 2)

AGT-4241