### PR TITLE
fix(taskState): rotate dependency lookups past Canceled blockers (AGT-4253)

### DIFF
--- a/src/taskState/store.test.ts
+++ b/src/taskState/store.test.ts
@@ -393,6 +393,150 @@ describe('task state store', () => {
     expect(result.resolved).toBe(0);
     expect(result.released).toBe(0);
     expect(getTaskState('AGT-ERR-BLOCKER')?.linearState).toBe('In Review');
+    expect(getTaskState('AGT-ERR-BLOCKER')?.dependencyLookupFailed).toBe(true);
+
+    const retried: string[] = [];
+    const samePass = await reconcileDependencyBlockers({
+      source: { lookupIssueState: async (id) => { retried.push(id); return { ok: false as const, error: 'rate limited' }; } },
+      now: future,
+    });
+    expect(retried).toEqual([]);
+    expect(samePass.lookedUp).toBe(0);
+
+    const afterErrorWindow = await reconcileDependencyBlockers({
+      source: { lookupIssueState: async (id) => { retried.push(id); return { ok: false as const, error: 'rate limited' }; } },
+      now: future + 15 * 60_000,
+    });
+    expect(retried).toEqual(['AGT-ERR-BLOCKER']);
+    expect(afterErrorWindow.lookedUp).toBe(1);
+  });
+
+  it('treats a Canceled blocker as terminal so dependents are not waiting on dead work', () => {
+    // vela 2026-09-09: 20 locally-Canceled STO-* ids were the first
+    // reconcileDependencyBlockers candidates. isResolved ignored Canceled, so
+    // they never left the set and maxLookups never reached AGT-4207 (Done on
+    // Linear, 157th). DecisionEngine gates on getTaskReadiness, which must
+    // agree — otherwise even a perfect reconciler cannot unblock the queue.
+    upsertTaskState('STO-CANCELED', {
+      execution: { status: 'backlog', retryCount: 0 },
+      linearState: 'Canceled',
+    });
+    upsertTaskState('AGT-WAITING', {
+      dependencyIssueIds: ['STO-CANCELED'],
+      execution: { status: 'todo', retryCount: 0 },
+      linearState: 'Todo',
+    });
+
+    const waiting = {
+      id: 'AGT-WAITING', source: 'linear' as const, title: 'waiting', priority: 2,
+      createdAt: Date.now(), issueId: 'AGT-WAITING',
+    };
+    expect(getTaskReadiness(waiting).ready).toBe(true);
+    expect(getTaskReadiness(waiting).blockedBy).toEqual([]);
+  });
+
+  it('reconcileDependencyBlockers skips locally-Canceled blockers and looks up a later Done one under maxLookups', async () => {
+    const future = Date.now() + 2 * 60 * 60_000;
+    for (let i = 0; i < 20; i++) {
+      const id = `STO-CANCELED-${String(i).padStart(2, '0')}`;
+      upsertTaskState(id, {
+        execution: { status: 'blocked', retryCount: 0 },
+        linearState: 'Canceled',
+      });
+      upsertTaskState(`DEP-ON-CANCELED-${i}`, {
+        dependencyIssueIds: [id],
+        execution: { status: 'todo', retryCount: 0 },
+        linearState: 'Todo',
+      });
+    }
+    upsertTaskState('AGT-4207', {
+      execution: { status: 'in_progress', retryCount: 0 },
+      linearState: 'In Review',
+    });
+    upsertTaskState('AGT-4209', {
+      dependencyIssueIds: ['AGT-4207'],
+      execution: { status: 'todo', retryCount: 0 },
+      linearState: 'Todo',
+    });
+
+    const lookedUp: string[] = [];
+    const lookupIssueState = async (id: string) => {
+      lookedUp.push(id);
+      if (id === 'AGT-4207') return { ok: true as const, issue: { state: 'Done', stateType: 'completed' } };
+      throw new Error(`should not look up ${id}`);
+    };
+
+    const result = await reconcileDependencyBlockers({
+      source: { lookupIssueState },
+      now: future,
+      maxLookups: 20,
+    });
+
+    expect(lookedUp).toEqual(['AGT-4207']);
+    expect(result.eligible).toBe(1);
+    expect(result.lookedUp).toBe(1);
+    expect(result.resolved).toBe(1);
+    expect(result.released).toBe(1);
+    expect(getTaskReadiness({
+      id: 'AGT-4209', source: 'linear' as const, title: 'dependent', priority: 2,
+      createdAt: Date.now(), issueId: 'AGT-4209',
+    }).ready).toBe(true);
+  });
+
+  it('reconcileDependencyBlockers rotates past recently-checked open blockers on the next pass', async () => {
+    const future = Date.now() + 2 * 60 * 60_000;
+    for (let i = 0; i < 20; i++) {
+      const id = `OPEN-${String(i).padStart(2, '0')}`;
+      upsertTaskState(id, {
+        execution: { status: 'todo', retryCount: 0 },
+        linearState: 'Todo',
+      });
+      upsertTaskState(`DEP-ON-OPEN-${i}`, {
+        dependencyIssueIds: [id],
+        execution: { status: 'todo', retryCount: 0 },
+        linearState: 'Todo',
+      });
+    }
+    upsertTaskState('DONE-BLOCKER-ZZZ', {
+      execution: { status: 'in_progress', retryCount: 0 },
+      linearState: 'In Review',
+    });
+    upsertTaskState('DEP-ON-DONE', {
+      dependencyIssueIds: ['DONE-BLOCKER-ZZZ'],
+      execution: { status: 'todo', retryCount: 0 },
+      linearState: 'Todo',
+    });
+
+    const lookedUp: string[] = [];
+    const lookupIssueState = async (id: string) => {
+      lookedUp.push(id);
+      if (id === 'DONE-BLOCKER-ZZZ') return { ok: true as const, issue: { state: 'Done', stateType: 'completed' } };
+      return { ok: true as const, issue: { state: 'Todo', stateType: 'unstarted' } };
+    };
+
+    const first = await reconcileDependencyBlockers({
+      source: { lookupIssueState },
+      now: future,
+      maxLookups: 20,
+    });
+    expect(first.lookedUp).toBe(20);
+    expect(first.resolved).toBe(0);
+    expect(lookedUp).not.toContain('DONE-BLOCKER-ZZZ');
+
+    lookedUp.length = 0;
+    const second = await reconcileDependencyBlockers({
+      source: { lookupIssueState },
+      now: future,
+      maxLookups: 20,
+    });
+    expect(lookedUp).toEqual(['DONE-BLOCKER-ZZZ']);
+    expect(second.lookedUp).toBe(1);
+    expect(second.resolved).toBe(1);
+    expect(second.released).toBe(1);
+    expect(getTaskReadiness({
+      id: 'DEP-ON-DONE', source: 'linear' as const, title: 'dependent', priority: 2,
+      createdAt: Date.now(), issueId: 'DEP-ON-DONE',
+    }).ready).toBe(true);
   });
 
   it('reconciles stale in_progress against Linear state (R5)', () => {
@@ -480,6 +624,28 @@ describe('task state store', () => {
     expect(parent?.issueId).toBe('PARENT-1');
     expect(parent?.execution.status).toBe('done');
     expect(parent?.linearState).toBe('Done');
+  });
+
+  it('does not complete a parent when a child is Canceled — that is not Done', () => {
+    upsertTaskState('PARENT-CANCELED-CHILD', {
+      childIssueIds: ['CHILD-DONE', 'CHILD-CANCELED'],
+      execution: { status: 'decomposed', retryCount: 0 },
+      linearState: 'In Progress',
+    });
+    upsertTaskState('CHILD-DONE', {
+      parentIssueId: 'PARENT-CANCELED-CHILD',
+      execution: { status: 'done', retryCount: 0 },
+      linearState: 'Done',
+    });
+    upsertTaskState('CHILD-CANCELED', {
+      parentIssueId: 'PARENT-CANCELED-CHILD',
+      execution: { status: 'backlog', retryCount: 0 },
+      linearState: 'Canceled',
+    });
+
+    expect(completeParentIfChildrenDone('CHILD-DONE')).toBeNull();
+    expect(completeParentIfChildrenDone('CHILD-CANCELED')).toBeNull();
+    expect(getTaskState('PARENT-CANCELED-CHILD')?.execution.status).toBe('decomposed');
   });
 
   it('hydrates canonical state from the latest Linear sync comment', () => {

--- a/src/taskState/store.ts
+++ b/src/taskState/store.ts
@@ -72,6 +72,10 @@ export const OpenSwarmTaskStateSchema = z.object({
   execution: ExecutionStateSchema.default({ status: 'backlog', retryCount: 0 }),
   worktree: WorktreeStateSchema.default({}),
   updatedAt: z.string(),
+  /** Last time reconcileDependencyBlockers looked this id up. Distinct from
+   *  updatedAt so a worker touching the blocker does not look like a lookup. */
+  dependencyCheckedAt: z.string().optional(),
+  dependencyLookupFailed: z.boolean().optional(),
 });
 
 function createTaskMap(
@@ -648,6 +652,21 @@ function isResolved(state: OpenSwarmTaskState | undefined): boolean {
   return state.execution.status === 'done' || state.linearState === 'Done';
 }
 
+function isCanceledLinearState(linearState: string | undefined): boolean {
+  const name = linearState?.trim().toLowerCase();
+  return name === 'canceled' || name === 'cancelled';
+}
+
+/** A blocker that can no longer move work forward. Done is the historical
+ *  isResolved contract (parent-completion still uses that). Canceled is
+ *  terminal for dependencies — vela 2026-09-09: 20 locally-Canceled STO-*
+ *  ids sat at the front of reconcileDependencyBlockers' Set and consumed
+ *  maxLookups forever because isResolved ignored them. */
+function isDependencyTerminal(state: OpenSwarmTaskState | undefined): boolean {
+  if (isResolved(state)) return true;
+  return isCanceledLinearState(state?.linearState);
+}
+
 export function getTaskReadiness(task: TaskItem): {
   ready: boolean;
   blockedBy: string[];
@@ -683,7 +702,7 @@ export function getTaskReadiness(task: TaskItem): {
     return { ready: true, blockedBy: [] };
   }
 
-  const unresolved = dependencyIssueIds.filter((depId) => !isResolved(getTaskState(depId)));
+  const unresolved = dependencyIssueIds.filter((depId) => !isDependencyTerminal(getTaskState(depId)));
   if (unresolved.length > 0) {
     return {
       ready: false,
@@ -702,7 +721,7 @@ export function releaseDependentTasks(completedIssueId: string): OpenSwarmTaskSt
   for (const state of Object.values(store.tasks)) {
     if (!state.dependencyIssueIds.includes(completedIssueId)) continue;
 
-    const unresolved = state.dependencyIssueIds.filter((depId) => !isResolved(store.tasks[depId]));
+    const unresolved = state.dependencyIssueIds.filter((depId) => !isDependencyTerminal(store.tasks[depId]));
     if (unresolved.length > 0) {
       upsertTaskState(state.issueId, {
         execution: {
@@ -747,6 +766,11 @@ export interface DependencyBlockerReconcileOptions {
    *  a decomposition just created seconds ago is not yet stale. */
   staleAfterMs?: number;
   maxLookups?: number;
+  /** Skip a blocker looked up this recently — same role as
+   *  reconcileTrackerTerminalRuns' recheckAfterMs. Default 6h. */
+  recheckAfterMs?: number;
+  /** Failed lookups retry sooner than a confirmed-open skip. Default 15m. */
+  errorRecheckAfterMs?: number;
 }
 
 export interface DependencyBlockerReconcileResult {
@@ -771,9 +795,17 @@ export interface DependencyBlockerReconcileResult {
  * dependent forever. Terminal issues are invisible to the regular slim fetch
  * (Todo/In Progress/In Review/Backlog only), so this is the explicit per-issue
  * read that can see them — same shape as reconcileTrackerTerminalRuns, applied to
- * taskState instead of the durable ledger. (isResolved() only recognizes a literal
- * Done state, same pre-existing scope as releaseDependentTasks — a Cancelled
- * blocker is not covered here either.)
+ * taskState instead of the durable ledger.
+ *
+ * Canceled/Cancelled blockers are terminal for dependents (isDependencyTerminal)
+ * even though isResolved stays Done-only for completeParentIfChildrenDone.
+ * Live vela 2026-09-09: 20 locally-Canceled STO-* ids occupied maxLookups
+ * every heartbeat, so AGT-4207 (157th, Linear already Done) was never reached.
+ *
+ * Lookups are capped. Candidates are the blockers due for a check, sorted
+ * never-checked then oldest-checked (same rotation as reconcileTrackerTerminalRuns).
+ * A lookup — success or fail-closed — stamps dependencyCheckedAt so the same
+ * 20 cannot consume the cap on the next heartbeat.
  *
  * Only tasks still in a not-yet-executed phase (todo/ready/blocked) are
  * considered. dependencyIssueIds is never cleared once a task moves on (done,
@@ -788,6 +820,18 @@ export interface DependencyBlockerReconcileResult {
  */
 const DEPENDENCY_RECONCILE_ELIGIBLE_STATUSES = new Set<TaskExecutionStatus>(['todo', 'ready', 'blocked']);
 
+function blockerCheckedAtMs(state: OpenSwarmTaskState | undefined): number {
+  if (!state?.dependencyCheckedAt) return 0;
+  const ms = Date.parse(state.dependencyCheckedAt);
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+function blockerUpdatedAtMs(state: OpenSwarmTaskState | undefined): number {
+  if (!state?.updatedAt) return 0;
+  const ms = Date.parse(state.updatedAt);
+  return Number.isFinite(ms) ? ms : 0;
+}
+
 export async function reconcileDependencyBlockers(
   options: DependencyBlockerReconcileOptions,
 ): Promise<DependencyBlockerReconcileResult> {
@@ -797,24 +841,35 @@ export async function reconcileDependencyBlockers(
 
   const now = options.now ?? Date.now();
   const staleAfterMs = options.staleAfterMs ?? 60 * 60_000;
+  const recheckAfterMs = options.recheckAfterMs ?? 6 * 60 * 60_000;
+  const errorRecheckAfterMs = options.errorRecheckAfterMs ?? 15 * 60_000;
   const maxLookups = Math.max(1, Math.floor(options.maxLookups ?? 20));
   const knownTaskIds = options.knownTaskIds ?? new Set<string>();
 
-  const candidateDepIds = new Set<string>();
+  const byId = new Map<string, { depId: string; lastChecked: number; lastSeen: number }>();
   for (const state of listTaskStates()) {
     if (!DEPENDENCY_RECONCILE_ELIGIBLE_STATUSES.has(state.execution.status)) continue;
     if (state.dependencyIssueIds.length === 0) continue;
     const updatedAtMs = Date.parse(state.updatedAt);
     if (Number.isFinite(updatedAtMs) && now - updatedAtMs < staleAfterMs) continue;
     for (const depId of state.dependencyIssueIds) {
-      if (isResolved(getTaskState(depId))) continue;
+      if (isDependencyTerminal(getTaskState(depId))) continue;
       if (knownTaskIds.has(depId)) continue; // still open per this fetch — not stale
-      candidateDepIds.add(depId);
+      if (byId.has(depId)) continue;
+      const blocker = getTaskState(depId);
+      const lastChecked = blockerCheckedAtMs(blocker);
+      const skipFor = blocker?.dependencyLookupFailed ? errorRecheckAfterMs : recheckAfterMs;
+      if (lastChecked > 0 && now - lastChecked < skipFor) continue;
+      byId.set(depId, { depId, lastChecked, lastSeen: blockerUpdatedAtMs(blocker) });
     }
   }
-  result.eligible = candidateDepIds.size;
+  const candidates = [...byId.values()].sort(
+    (a, b) => a.lastChecked - b.lastChecked || a.lastSeen - b.lastSeen || a.depId.localeCompare(b.depId),
+  );
+  result.eligible = candidates.length;
 
-  for (const depId of candidateDepIds) {
+  const checkedAt = new Date(now).toISOString();
+  for (const { depId } of candidates) {
     if (result.lookedUp >= maxLookups) break;
     let lookup: Awaited<ReturnType<DependencyLookupSource['lookupIssueState']>>;
     try {
@@ -823,10 +878,15 @@ export async function reconcileDependencyBlockers(
       lookup = { ok: false, error: error instanceof Error ? error.message : String(error) };
     }
     result.lookedUp++;
-    if (!lookup.ok || !lookup.issue) continue; // fail closed — stays blocked, retried next pass
-
-    updateTaskLinearState(depId, lookup.issue.state);
-    if (isResolved(getTaskState(depId))) {
+    if (lookup.ok && lookup.issue) {
+      updateTaskLinearState(depId, lookup.issue.state);
+      upsertTaskState(depId, { dependencyCheckedAt: checkedAt, dependencyLookupFailed: false });
+    } else {
+      // Stamp on fail-closed so a persistent lookup error cannot monopolize
+      // the cap. Retries after errorRecheckAfterMs (15m), not recheckAfterMs (6h).
+      upsertTaskState(depId, { dependencyCheckedAt: checkedAt, dependencyLookupFailed: true });
+    }
+    if (isDependencyTerminal(getTaskState(depId))) {
       result.resolved++;
       result.released += releaseDependentTasks(depId).length;
     }


### PR DESCRIPTION
## Summary
- `reconcileDependencyBlockers` (AGT-4249) still left vela starved: every heartbeat looked up the same 20 locally-**Canceled** STO-* ids (`isResolved` is Done-only), so AGT-4207 (Linear Done, candidate #157) was never reached. Heartbeats after the 20:07 redeploy: `20 lookup / 0 resolved / 0 released` four times in a row.
- Treat Canceled/Cancelled as dependency-terminal for readiness/release/reconcile (`completeParentIfChildrenDone` stays Done-only). Stamp `dependencyCheckedAt` on each lookup and rotate the `maxLookups` cap the same way `reconcileTrackerTerminalRuns` does (6h open recheck, 15m error recheck).

## Test plan
- [x] `npx vitest run src/taskState/store.test.ts` — 43 passed / 3 skipped
- [x] `tsc --noEmit`, `oxlint` 0
- [ ] CI green
- [ ] After merge + vela redeploy: `[Dependency cache]` shows resolved>0 and AGT-4209/4208/4197 drop out of `Waiting on dependencies`