### PR TITLE
fix(taskState): look up this heartbeat's blockers before the rest of the store (AGT-4254)

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -2408,13 +2408,18 @@ export class AutonomousRunner {
         this.syslog(`✓ Tracker cache: ${trackerReconcile.fromFetch} bulk hit(s), ${trackerReconcile.lookedUp} explicit lookup(s), ${trackerReconcile.terminal} terminal ledger row(s) reconciled`);
       }
       const knownTaskIds = new Set<string>();
+      const priorityDepIds = new Set<string>();
       for (const t of tasks) {
         if (t.issueId) knownTaskIds.add(t.issueId);
         if (t.id) knownTaskIds.add(t.id);
+        for (const depId of t.blockedBy ?? []) priorityDepIds.add(depId);
+        const cached = getTaskState(t.issueId || t.id);
+        for (const depId of cached?.dependencyIssueIds ?? []) priorityDepIds.add(depId);
       }
       const depReconcile = await reconcileDependencyBlockers({
         source: getTaskSource(),
         knownTaskIds,
+        priorityDepIds,
       });
       if (depReconcile.lookedUp > 0) {
         this.syslog(`✓ Dependency cache: ${depReconcile.lookedUp} explicit lookup(s), ${depReconcile.resolved} blocker(s) confirmed done, ${depReconcile.released} dependent task(s) released`);

--- a/src/taskState/store.test.ts
+++ b/src/taskState/store.test.ts
@@ -539,6 +539,68 @@ describe('task state store', () => {
     }).ready).toBe(true);
   });
 
+  it('treats a Duplicate blocker as terminal so dependents are not waiting on it', () => {
+    upsertTaskState('AGT-4115', {
+      execution: { status: 'in_progress', retryCount: 0 },
+      linearState: 'Duplicate',
+    });
+    upsertTaskState('AGT-4121', {
+      dependencyIssueIds: ['AGT-4115'],
+      execution: { status: 'todo', retryCount: 0 },
+      linearState: 'Todo',
+    });
+    expect(getTaskReadiness({
+      id: 'AGT-4121', source: 'linear' as const, title: 'waiting', priority: 2,
+      createdAt: Date.now(), issueId: 'AGT-4121',
+    }).ready).toBe(true);
+  });
+
+  it('reconcileDependencyBlockers looks up heartbeat-priority deps before older out-of-scope ones', async () => {
+    const future = Date.now() + 2 * 60 * 60_000;
+    for (let i = 0; i < 20; i++) {
+      const id = `OLD-${String(i).padStart(2, '0')}`;
+      upsertTaskState(id, {
+        execution: { status: 'todo', retryCount: 0 },
+        linearState: 'Todo',
+      });
+      upsertTaskState(`DEP-ON-OLD-${i}`, {
+        dependencyIssueIds: [id],
+        execution: { status: 'todo', retryCount: 0 },
+        linearState: 'Todo',
+      });
+    }
+    upsertTaskState('AGT-4114', {
+      execution: { status: 'backlog', retryCount: 0 },
+      linearState: 'Backlog',
+    });
+    upsertTaskState('AGT-4121-LIVE', {
+      dependencyIssueIds: ['AGT-4114'],
+      execution: { status: 'todo', retryCount: 0 },
+      linearState: 'Todo',
+    });
+
+    const lookedUp: string[] = [];
+    const lookupIssueState = async (id: string) => {
+      lookedUp.push(id);
+      if (id === 'AGT-4114') return { ok: true as const, issue: { state: 'Done', stateType: 'completed' } };
+      return { ok: true as const, issue: { state: 'Todo', stateType: 'unstarted' } };
+    };
+
+    const result = await reconcileDependencyBlockers({
+      source: { lookupIssueState },
+      now: future,
+      maxLookups: 20,
+      priorityDepIds: new Set(['AGT-4114']),
+    });
+
+    expect(lookedUp[0]).toBe('AGT-4114');
+    expect(result.resolved).toBe(1);
+    expect(getTaskReadiness({
+      id: 'AGT-4121-LIVE', source: 'linear' as const, title: 'live', priority: 2,
+      createdAt: Date.now(), issueId: 'AGT-4121-LIVE',
+    }).ready).toBe(true);
+  });
+
   it('reconciles stale in_progress against Linear state (R5)', () => {
     // Operator parks an actively-running issue → local in_progress is stale.
     markTaskInProgress('KT-400', { linearState: 'In Progress' });

--- a/src/taskState/store.ts
+++ b/src/taskState/store.ts
@@ -652,19 +652,19 @@ function isResolved(state: OpenSwarmTaskState | undefined): boolean {
   return state.execution.status === 'done' || state.linearState === 'Done';
 }
 
-function isCanceledLinearState(linearState: string | undefined): boolean {
+function isDependencyTerminalLinearState(linearState: string | undefined): boolean {
   const name = linearState?.trim().toLowerCase();
-  return name === 'canceled' || name === 'cancelled';
+  return name === 'canceled' || name === 'cancelled' || name === 'duplicate';
 }
 
 /** A blocker that can no longer move work forward. Done is the historical
- *  isResolved contract (parent-completion still uses that). Canceled is
- *  terminal for dependencies — vela 2026-09-09: 20 locally-Canceled STO-*
- *  ids sat at the front of reconcileDependencyBlockers' Set and consumed
- *  maxLookups forever because isResolved ignored them. */
+ *  isResolved contract (parent-completion still uses that). Canceled/Duplicate
+ *  are terminal for dependencies — vela 2026-09-09: Canceled STO-* ids occupied
+ *  maxLookups, and AGT-4115 (Duplicate on Linear, In Progress locally) kept
+ *  AGT-4121 blocked after AGT-4253. Matches trackerTerminalReconciler. */
 function isDependencyTerminal(state: OpenSwarmTaskState | undefined): boolean {
   if (isResolved(state)) return true;
-  return isCanceledLinearState(state?.linearState);
+  return isDependencyTerminalLinearState(state?.linearState);
 }
 
 export function getTaskReadiness(task: TaskItem): {
@@ -771,6 +771,10 @@ export interface DependencyBlockerReconcileOptions {
   recheckAfterMs?: number;
   /** Failed lookups retry sooner than a confirmed-open skip. Default 15m. */
   errorRecheckAfterMs?: number;
+  /** Dependency ids blocking tasks in this heartbeat's Linear fetch.
+   *  Looked up before the rest of the store so a live queue cannot starve
+   *  behind July KT-* Backlog from projects this daemon does not run. */
+  priorityDepIds?: ReadonlySet<string>;
 }
 
 export interface DependencyBlockerReconcileResult {
@@ -802,8 +806,8 @@ export interface DependencyBlockerReconcileResult {
  * Live vela 2026-09-09: 20 locally-Canceled STO-* ids occupied maxLookups
  * every heartbeat, so AGT-4207 (157th, Linear already Done) was never reached.
  *
- * Lookups are capped. Candidates are the blockers due for a check, sorted
- * never-checked then oldest-checked (same rotation as reconcileTrackerTerminalRuns).
+ * Lookups are capped. Candidates due for a check are sorted heartbeat-priority
+ * first (deps of tasks in this fetch), then never-checked, then oldest-checked.
  * A lookup — success or fail-closed — stamps dependencyCheckedAt so the same
  * 20 cannot consume the cap on the next heartbeat.
  *
@@ -845,8 +849,9 @@ export async function reconcileDependencyBlockers(
   const errorRecheckAfterMs = options.errorRecheckAfterMs ?? 15 * 60_000;
   const maxLookups = Math.max(1, Math.floor(options.maxLookups ?? 20));
   const knownTaskIds = options.knownTaskIds ?? new Set<string>();
+  const priorityDepIds = options.priorityDepIds ?? new Set<string>();
 
-  const byId = new Map<string, { depId: string; lastChecked: number; lastSeen: number }>();
+  const byId = new Map<string, { depId: string; lastChecked: number; lastSeen: number; priority: number }>();
   for (const state of listTaskStates()) {
     if (!DEPENDENCY_RECONCILE_ELIGIBLE_STATUSES.has(state.execution.status)) continue;
     if (state.dependencyIssueIds.length === 0) continue;
@@ -860,11 +865,16 @@ export async function reconcileDependencyBlockers(
       const lastChecked = blockerCheckedAtMs(blocker);
       const skipFor = blocker?.dependencyLookupFailed ? errorRecheckAfterMs : recheckAfterMs;
       if (lastChecked > 0 && now - lastChecked < skipFor) continue;
-      byId.set(depId, { depId, lastChecked, lastSeen: blockerUpdatedAtMs(blocker) });
+      byId.set(depId, {
+        depId,
+        lastChecked,
+        lastSeen: blockerUpdatedAtMs(blocker),
+        priority: priorityDepIds.has(depId) ? 1 : 0,
+      });
     }
   }
   const candidates = [...byId.values()].sort(
-    (a, b) => a.lastChecked - b.lastChecked || a.lastSeen - b.lastSeen || a.depId.localeCompare(b.depId),
+    (a, b) => b.priority - a.priority || a.lastChecked - b.lastChecked || a.lastSeen - b.lastSeen || a.depId.localeCompare(b.depId),
   );
   result.eligible = candidates.length;
 


### PR DESCRIPTION
## Summary
- After AGT-4253, workers finished AGT-4209/4208/4197 then went idle (`4 enabled / skip 0 executable`, 12 free slots). AGT-4121 is blocked by 6 children that are already **Done or Duplicate on Linear**; local cache still says Backlog/In Progress.
- `maxLookups` 20 was spent on July KT-* Backlog from projects this daemon does not run. This PR looks up deps of the current Linear fetch first, and treats Duplicate as dependency-terminal (same as the tracker reconciler).

## Test plan
- [x] `npx vitest run src/taskState/store.test.ts` — 45 passed / 3 skipped
- [x] `tsc --noEmit`, `oxlint` 0
- [ ] CI green
- [ ] vela: AGT-4121 drops `Waiting on dependencies` and `Selected > 0`