### PR TITLE
refactor(admission): drop Codex-era spawn caps so cheap models fill the pool (AGT-4255)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -75,10 +75,9 @@ autonomous:
   worktreeMode: true  # Required for same-project parallel tasks
   allowSameProjectConcurrent: true
   # What durable admission does with a task whose write scope could not be
-  # resolved while another run in the same repository is live. serialize
-  # (default) fails closed; admit relies on isolated worktrees and post-merge
-  # integration requeue to surface a branch conflict at PR time instead.
-  # unknownScopeAdmission: serialize
+  # resolved while another run in the same repository is live. admit (default)
+  # relies on isolated worktrees; serialize is the Codex-era fail-closed hold.
+  # unknownScopeAdmission: admit
   # An infrastructure failure is not the task's fault and is never counted
   # toward STUCK — but the same infrastructure failure on this many consecutive
   # attempts is not a blip. Park the run for the operator with the cause named

--- a/src/agents/workerFanoutGate.test.ts
+++ b/src/agents/workerFanoutGate.test.ts
@@ -181,6 +181,7 @@ describe('runWorkerWithOptionalFanout — candidate building and no-winner fallb
     expect(runWorkerFanout).toHaveBeenCalledTimes(1);
     const passedCandidates = runWorkerFanout.mock.calls[0][0].candidates;
     expect(passedCandidates.map((c: { id: string }) => c.id)).toEqual(['custom-a', 'custom-b']);
+    expect(runWorkerFanout.mock.calls[0][0].concurrency).toBe(2);
     // The single-worker fallback must not run when fan-out already found a winner.
     expect(runWorker).not.toHaveBeenCalled();
   });

--- a/src/agents/workerFanoutGate.ts
+++ b/src/agents/workerFanoutGate.ts
@@ -189,7 +189,7 @@ export async function runWorkerWithOptionalFanout(input: {
       projectPath: input.projectPath,
       baseWorkerOptions: workerOptions,
       candidates,
-      concurrency: fanoutConfig.concurrency ?? Math.min(candidates.length, 3),
+      concurrency: fanoutConfig.concurrency ?? candidates.length,
       keepSandboxes: fanoutConfig.keepSandboxes,
       linkSharedPaths: fanoutConfig.linkSharedPaths,
       guards: input.guards,

--- a/src/automation/autonomousRunner.coverage.test.ts
+++ b/src/automation/autonomousRunner.coverage.test.ts
@@ -278,7 +278,9 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
 
       expect(safe).toEqual(new Set(['alias-first', 'alias-second']));
       expect(detectFileConflictsMock).toHaveBeenCalledTimes(1);
-      expect(detectFileConflictsMock).toHaveBeenCalledWith([first, second], '/repo');
+      expect(detectFileConflictsMock).toHaveBeenCalledWith([first, second], '/repo', {
+        unknownScopeAdmission: 'admit',
+      });
     });
 
     it('defers overlapping scopes even when each issue runs in its own worktree', async () => {
@@ -305,7 +307,7 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
       // Third argument is the admission policy the durable gate also reads;
       // passing it is the fix for AGT-4233.
       expect(describeScopeConflictMock)
-        .toHaveBeenCalledWith(candidate.fileScope, activeTask.fileScope, 'serialize');
+        .toHaveBeenCalledWith(candidate.fileScope, activeTask.fileScope, 'admit');
       expect(detectFileConflictsMock).not.toHaveBeenCalled();
     });
 
@@ -324,7 +326,9 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
       ]);
 
       expect(safe).toEqual(new Set(['first', 'second']));
-      expect(detectFileConflictsMock).toHaveBeenCalledWith([first, second], '/repo');
+      expect(detectFileConflictsMock).toHaveBeenCalledWith([first, second], '/repo', {
+        unknownScopeAdmission: 'admit',
+      });
     });
 
     it('repays a known-first deferred unknown as the next exclusive idle wave', async () => {
@@ -351,6 +355,7 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
       expect(detectFileConflictsMock).toHaveBeenLastCalledWith([known, unknown], '/repo', {
         preferUnknownExclusive: true,
         preferredUnknownTaskId: 'unknown',
+        unknownScopeAdmission: 'admit',
       });
     });
 
@@ -407,7 +412,7 @@ describe('AutonomousRunner coverage — safely-reachable helpers', () => {
       // Third argument is the admission policy the durable gate also reads;
       // passing it is the fix for AGT-4233.
       expect(describeScopeConflictMock)
-        .toHaveBeenCalledWith(candidate.fileScope, activeTask.fileScope, 'serialize');
+        .toHaveBeenCalledWith(candidate.fileScope, activeTask.fileScope, 'admit');
       expect(detectFileConflictsMock).not.toHaveBeenCalled();
     });
 

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -2748,7 +2748,7 @@ export class AutonomousRunner {
         // `unknownScopeAdmission: admit` was live on vela yet one running task
         // still deferred every other candidate — 11 of 12 slots idle with 126
         // executable tasks waiting (AGT-4233).
-        const admission = this.config.unknownScopeAdmission ?? 'serialize';
+        const admission = this.config.unknownScopeAdmission ?? 'admit';
         const runnable = group.filter(candidate => {
           let blockedBy: { label: string; reason: ScopeConflictReason } | undefined;
           for (const running of active) {
@@ -2786,8 +2786,11 @@ export class AutonomousRunner {
           ? await detectFileConflicts(runnableTasks, projPath, {
             preferUnknownExclusive: true,
             preferredUnknownTaskId: debtTask.task.id,
+            unknownScopeAdmission: admission,
           })
-          : await detectFileConflicts(runnableTasks, projPath);
+          : await detectFileConflicts(runnableTasks, projPath, {
+            unknownScopeAdmission: admission,
+          });
 
         for (const t of result.safe) {
           safeTasks.add(t.id);

--- a/src/automation/durableRunCoordinator.ts
+++ b/src/automation/durableRunCoordinator.ts
@@ -81,7 +81,7 @@ export interface RepositoryAdmissionPolicy {
   maxConcurrent?: number;
   /** Predicted repository-relative write set used for atomic conflict admission. */
   conflictScope?: string[];
-  /** Whether an unknown scope serializes against live same-repo runs (default) or is admitted. */
+  /** Whether an unknown scope serializes against live same-repo runs or is admitted (default admit). */
   unknownScopeAdmission?: 'serialize' | 'admit';
   maxAttemptsPerHour?: number;
   maxFailuresPerHour?: number;

--- a/src/automation/runLedger.test.ts
+++ b/src/automation/runLedger.test.ts
@@ -448,7 +448,7 @@ describe('RunLedger claim and fencing races', () => {
     ledger.close();
   });
 
-  it('fails closed when a parallel claim explicitly supplies an unknown scope', () => {
+  it('fails closed when a parallel claim supplies an unknown scope under serialize', () => {
     const ledger = new RunLedger(createDbPath());
     register(ledger, 'KNOWN', '/same-repo', ['src/known.ts']);
     register(ledger, 'UNKNOWN', '/same-repo');
@@ -458,7 +458,7 @@ describe('RunLedger claim and fencing races', () => {
     })).not.toBeNull();
     expect(ledger.claimRun('UNKNOWN', {
       ownerInstanceId: 'unknown', leaseMs: 1_000, now: 2_001,
-      maxActiveForProject: 2, conflictScope: [],
+      maxActiveForProject: 2, conflictScope: [], unknownScopeAdmission: 'serialize',
     })).toBeNull();
     ledger.close();
   });

--- a/src/automation/runLedgerScope.ts
+++ b/src/automation/runLedgerScope.ts
@@ -32,15 +32,16 @@ export function scopesOverlap(left: Set<string>, right: Set<string>): boolean {
  * Decide whether a claim may join the runs already live in one repository.
  *
  * The cap controls capacity; this controls safety inside that capacity.
- * Unknown scope on either side fails closed — worktrees isolate filesystem
- * writes, but they do not make two unknown write sets safe to merge.
+ * Unknown scope on either side is not a conflict under the default `admit`
+ * policy — worktrees isolate live edits. Known overlapping write sets still
+ * refuse. Pass `serialize` to restore the Codex-era fail-closed hold.
  */
 export type UnknownScopeAdmission = 'serialize' | 'admit';
 
 export function admitsConflictScope(
   requested: unknown,
   activeScopes: readonly unknown[],
-  unknownScope: UnknownScopeAdmission = 'serialize',
+  unknownScope: UnknownScopeAdmission = 'admit',
 ): boolean {
   if (activeScopes.length === 0) return true;
   const requestedScope = normalizeConflictScope(requested);

--- a/src/automation/runLedgerTypes.ts
+++ b/src/automation/runLedgerTypes.ts
@@ -148,7 +148,7 @@ export interface ClaimOptions {
   maxActiveForProject?: number;
   /** Normalized predicted write set. Unknown scope serializes against live same-repo claims. */
   conflictScope?: string[];
-  /** How an unknown scope (empty on either side) is admitted. Default 'serialize'. */
+  /** How an unknown scope (empty on either side) is admitted. Default 'admit'. */
   unknownScopeAdmission?: 'serialize' | 'admit';
   maxAttemptsPerHour?: number;
   maxFailuresPerHour?: number;

--- a/src/automation/runnerTypes.ts
+++ b/src/automation/runnerTypes.ts
@@ -49,9 +49,9 @@ export interface AutonomousConfig {
   allowSameProjectConcurrent?: boolean;
   /**
    * Durable admission for a task whose write scope could not be resolved
-   * while another run in the same repository is live. 'serialize' (default)
-   * fails closed; 'admit' relies on isolated worktrees plus post-merge
-   * integration requeue to surface any branch conflict at PR time instead.
+   * while another run in the same repository is live. 'admit' (default)
+   * relies on isolated worktrees plus post-merge integration requeue;
+   * 'serialize' is the Codex-era fail-closed hold.
    */
   unknownScopeAdmission?: 'serialize' | 'admit';
   /** Identical-fingerprint infra_error attempts that park a run for the operator (0 disables, default 6). */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -538,7 +538,7 @@ program
   .description('Pick Linear issues and deploy an agent pipeline per issue into isolated git worktrees')
   .argument('[issueIds...]', 'Issue ids/identifiers (e.g. INT-123); omit for the interactive picker')
   .option('--path <path>', 'Repository path (default: cwd)')
-  .option('--concurrency <n>', 'Max issues in flight (default: min(selected, config autonomous.maxConcurrentTasks ?? 4))', parsePositiveIntegerOption)
+  .option('--concurrency <n>', 'Max issues in flight (default: min(selected, config autonomous.maxConcurrentTasks ?? 64))', parsePositiveIntegerOption)
   .option('--dry-run', 'Print the execution plan (issue → branch/worktree/resume) and exit')
   .option('--yes', 'Skip the confirmation prompt')
   .option('--adapter <name>', 'Adapter override for the worker/reviewer')

--- a/src/cli/workCommand.test.ts
+++ b/src/cli/workCommand.test.ts
@@ -688,7 +688,7 @@ describe('runWorkCommand — options plumbing', () => {
     expect(deps.logs.join('\n')).toContain('2 non-overlapping wave(s)');
   });
 
-  it('defaults concurrency to min(selected, autonomous.maxConcurrentTasks ?? 4)', async () => {
+  it('defaults concurrency to min(selected, autonomous.maxConcurrentTasks ?? 64)', async () => {
     const createCoordinator = vi.fn(() => fakeCoordinator());
     const deps = baseDeps({
       createCoordinator,
@@ -835,7 +835,7 @@ describe('pure helpers', () => {
     ];
 
     expect(buildConflictFreeWaves(rows).map((wave) => wave.map(({ task }) => task.id)))
-      .toEqual([['a', 'b'], ['c'], ['unknown']]);
+      .toEqual([['a', 'b', 'unknown'], ['c']]);
   });
 
   it('summarizeSettled maps approved success to a removed worktree', () => {

--- a/src/cli/workCommand.ts
+++ b/src/cli/workCommand.ts
@@ -43,7 +43,7 @@ import { setAutomationDbPath } from '../automation/automationDbPath.js';
 import { loadRepoMetadata, type RepoMetadata } from '../support/repoMetadata.js';
 import { hasRecoverableWorktree } from '../support/worktreeManager.js';
 import { runPool } from '../support/concurrencyPool.js';
-import { fileScopesConflict, resolveTaskFileScope } from '../orchestration/conflictDetector.js';
+import { describeScopeConflict, resolveTaskFileScope } from '../orchestration/conflictDetector.js';
 import { buildConflictFreeWaves as partitionConflictFreeWaves } from '../orchestration/conflictAdmission.js';
 import { resolveTaskSource, describeTaskSourceFailure, type TaskSourceResult } from './reviewCommand.js';
 import { filterRepoIssues, selectIssuesInteractive, WORK_SKIP_STATES } from './workSelect.js';
@@ -85,7 +85,7 @@ export interface WorkCommandOptions {
   issueIds?: string[];
   /** Repository path (default: cwd). */
   path?: string;
-  /** Max issues in flight (default: min(selected, autonomous.maxConcurrentTasks ?? 4)). */
+  /** Max issues in flight (default: min(selected, autonomous.maxConcurrentTasks ?? 64)). */
   concurrency?: number;
   /** Print the execution plan and exit. */
   dryRun?: boolean;
@@ -155,15 +155,13 @@ interface PlanRow {
 
 /**
  * Partition a priority-ordered plan into pairwise-disjoint execution waves.
- * Unknown scopes conflict with everything, so they each get a serial wave.
- * The durable ledger repeats the same check atomically across processes; this
- * local partition prevents siblings from merely losing a claim and being
- * reported as superseded instead of running in the next safe wave.
+ * Known overlapping write sets still serialize. Unknown scope is not a
+ * conflict under the default admit policy (worktrees isolate live edits).
  */
 export function buildConflictFreeWaves<T extends { task: TaskItem }>(rows: readonly T[]): T[][] {
   return partitionConflictFreeWaves(
     rows,
-    (left, right) => fileScopesConflict(left.task.fileScope, right.task.fileScope),
+    (left, right) => describeScopeConflict(left.task.fileScope, right.task.fileScope) !== null,
   );
 }
 
@@ -474,7 +472,7 @@ async function runWorkCommandInner(
   });
 
   const concurrency = opts.concurrency
-    ?? Math.min(tasks.length, config.autonomous?.maxConcurrentTasks ?? 4);
+    ?? Math.min(tasks.length, config.autonomous?.maxConcurrentTasks ?? 64);
 
   // ---- Plan ----------------------------------------------------------------
   const recoverable = deps.hasRecoverableWorktree ?? hasRecoverableWorktree;

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -257,7 +257,7 @@ agents:
       });
     });
 
-    it('defaults unknownScopeAdmission to serialize and carries an explicit admit through', () => {
+    it('defaults unknownScopeAdmission to admit and carries an explicit serialize through', () => {
       const base = {
         language: 'en',
         linear: { apiKey: 'k', teamId: 't' },
@@ -265,12 +265,12 @@ agents:
       };
       vi.mocked(existsSync).mockReturnValue(true);
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ ...base, autonomous: { enabled: true } }));
-      expect(loadConfig('/tmp/config.json').autonomous?.unknownScopeAdmission).toBe('serialize');
+      expect(loadConfig('/tmp/config.json').autonomous?.unknownScopeAdmission).toBe('admit');
 
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
-        ...base, autonomous: { enabled: true, unknownScopeAdmission: 'admit' },
+        ...base, autonomous: { enabled: true, unknownScopeAdmission: 'serialize' },
       }));
-      expect(loadConfig('/tmp/config.json').autonomous?.unknownScopeAdmission).toBe('admit');
+      expect(loadConfig('/tmp/config.json').autonomous?.unknownScopeAdmission).toBe('serialize');
 
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
         ...base, autonomous: { enabled: true, unknownScopeAdmission: 'yolo' },

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -132,7 +132,7 @@ const RoleConfigSchema = z.object({
     enabled: z.boolean().optional(),
     mode: z.enum(['report', 'execute']).optional(),
     minScore: z.number().min(1).max(10).optional(),
-    concurrency: z.number().int().min(1).max(3).optional(),
+    concurrency: z.number().int().min(1).max(256).optional(),
     keepSandboxes: z.boolean().optional(),
     linkSharedPaths: z.boolean().optional(),
     candidates: z.array(z.object({
@@ -337,11 +337,11 @@ const AutonomousConfigSchema = z.object({
   /** Allow concurrent tasks on the same repo (requires worktreeMode). (INT-1975) */
   allowSameProjectConcurrent: z.boolean().default(true),
   /**
-   * 'serialize' (default) refuses a claim with no resolvable write scope while
-   * another same-repo run is live. 'admit' lets it through and leaves branch
-   * conflicts to post-merge integration requeue.
+   * 'admit' (default) lets a claim with no resolvable write scope join other
+   * same-repo runs; worktrees isolate live edits and known file-scope overlap
+   * still refuses. 'serialize' is the Codex-era fail-closed holdover.
    */
-  unknownScopeAdmission: z.enum(['serialize', 'admit']).default('serialize'),
+  unknownScopeAdmission: z.enum(['serialize', 'admit']).default('admit'),
   /**
    * Consecutive infra_error attempts with one failure fingerprint after which a
    * run parks for the operator instead of backing off again. 0 disables.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -353,7 +353,7 @@ export type RoleConfig = {
     mode?: 'report' | 'execute';
     /** Minimum signal score required to recommend fan-out (default 2). */
     minScore?: number;
-    /** Max candidate workers in flight (default candidates length, capped at 3). */
+    /** Max candidate workers in flight (default: all candidates). */
     concurrency?: number;
     /** Keep temporary candidate repos for debugging. */
     keepSandboxes?: boolean;

--- a/src/orchestration/conflictDetector.coverage.test.ts
+++ b/src/orchestration/conflictDetector.coverage.test.ts
@@ -157,20 +157,27 @@ describe('detectFileConflicts Knowledge Graph fallback (no declared fileScope)',
     expect(draftTask).toHaveBeenCalledTimes(1);
   });
 
-  it('serializes KG scopes that reduce to unknown after volatile paths are removed', async () => {
+  it('admits KG scopes that reduce to unknown after volatile paths are removed', async () => {
     // Both tasks resolve to a non-null impact, but every module normalizes
     // away (node_modules / dist are filtered as volatile), so `modules.size`
     // is 0 and the code falls through to unknownScopeIndices instead of
-    // recording a real scope.
+    // recording a real scope. Default admit does not serialize that uncertainty.
     mockAnalyzeIssue.mockResolvedValue(impact(['node_modules/pkg/index.js'], ['dist/bundle.js']));
 
-    const result = await detectFileConflicts(
+    const admitted = await detectFileConflicts(
       [task('A', 2), task('B', 2)],
       project,
     );
+    expect(new Set(admitted.safe.map((candidate) => candidate.id))).toEqual(new Set(['A', 'B']));
+    expect(admitted.conflictGroups).toHaveLength(0);
 
-    expect(result.conflictGroups).toHaveLength(1);
-    expect(result.safe).toHaveLength(1);
+    const serialized = await detectFileConflicts(
+      [task('A', 2), task('B', 2)],
+      project,
+      { unknownScopeAdmission: 'serialize' },
+    );
+    expect(serialized.conflictGroups).toHaveLength(1);
+    expect(serialized.safe).toHaveLength(1);
   });
 
   it('treats a failed KG lookup as unknown scope and logs a warning instead of throwing', async () => {
@@ -187,14 +194,21 @@ describe('detectFileConflicts Knowledge Graph fallback (no declared fileScope)',
         project,
       );
 
-      // Task A's failure makes its scope unknown, so admission fails closed
-      // against B until a later heartbeat can prove the write sets disjoint.
-      expect(result.conflictGroups).toHaveLength(1);
-      expect(result.safe).toHaveLength(1);
+      // Unknown from a failed lookup is not evidence of overlap under admit.
+      expect(new Set(result.safe.map((candidate) => candidate.id))).toEqual(new Set(['A', 'B']));
+      expect(result.conflictGroups).toHaveLength(0);
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('[ConflictDetector] Impact analysis failed for A:'),
         expect.any(Error),
       );
+
+      const serialized = await detectFileConflicts(
+        [task('A', 2), task('B', 2)],
+        project,
+        { unknownScopeAdmission: 'serialize' },
+      );
+      expect(serialized.conflictGroups).toHaveLength(1);
+      expect(serialized.safe).toHaveLength(1);
     } finally {
       warnSpy.mockRestore();
     }

--- a/src/orchestration/conflictDetector.test.ts
+++ b/src/orchestration/conflictDetector.test.ts
@@ -121,7 +121,7 @@ describe('detectFileConflicts (planner-declared file scope)', () => {
     expect(result.conflictGroups).toHaveLength(0);
   });
 
-  it('runs the known maximal wave before an unknown scope', async () => {
+  it('lets unknown scopes run with disjoint known work under the default admit policy', async () => {
     const result = await detectFileConflicts(
       [
         task('unknown', 1, ['unknown-file-scope']),
@@ -131,26 +131,45 @@ describe('detectFileConflicts (planner-declared file scope)', () => {
       PROJECT,
     );
 
+    expect(new Set(result.safe.map((t) => t.id))).toEqual(new Set(['unknown', 'known-a', 'known-b']));
+    expect(result.conflictGroups).toHaveLength(0);
+  });
+
+  it('still serializes unknown scopes when the caller asks for the Codex-era hold', async () => {
+    const result = await detectFileConflicts(
+      [
+        task('unknown', 1, ['unknown-file-scope']),
+        task('known-a', 2, ['src/a.ts']),
+        task('known-b', 2, ['src/b.ts']),
+      ],
+      PROJECT,
+      { unknownScopeAdmission: 'serialize' },
+    );
+
     expect(result.safe.map((t) => t.id)).toEqual(['known-a', 'known-b']);
     expect(result.conflictGroups).toHaveLength(1);
     expect(result.conflictGroups[0].sharedModules).toEqual(['unknown-file-scope']);
   });
 
-  it('admits exactly one task when every scope is unknown', async () => {
+  it('admits every unknown-scope task concurrently by default', async () => {
     const result = await detectFileConflicts(
       [task('first', 2), task('second', 1), task('third', 3)],
       PROJECT,
     );
 
-    expect(result.safe.map((t) => t.id)).toEqual(['second']);
-    expect(result.conflictGroups).toHaveLength(1);
+    expect(new Set(result.safe.map((t) => t.id))).toEqual(new Set(['first', 'second', 'third']));
+    expect(result.conflictGroups).toHaveLength(0);
   });
 
-  it('can repay a deferred unknown as an exclusive wave', async () => {
+  it('can repay a deferred unknown as an exclusive wave under serialize', async () => {
     const result = await detectFileConflicts(
       [task('known', 1, ['src/known.ts']), task('unknown', 4)],
       PROJECT,
-      { preferUnknownExclusive: true, preferredUnknownTaskId: 'unknown' },
+      {
+        preferUnknownExclusive: true,
+        preferredUnknownTaskId: 'unknown',
+        unknownScopeAdmission: 'serialize',
+      },
     );
 
     expect(result.safe.map((t) => t.id)).toEqual(['unknown']);
@@ -204,8 +223,8 @@ describe('describeScopeConflict', () => {
     expect(describeScopeConflict(['src/a.ts'], ['src/b.ts'], 'admit')).toBeNull();
   });
 
-  it('defaults to serialize when no policy is passed', () => {
-    expect(describeScopeConflict(undefined, ['src/a.ts'])).toEqual({ kind: 'unknown-candidate' });
+  it('defaults to admit when no policy is passed', () => {
+    expect(describeScopeConflict(undefined, ['src/a.ts'])).toBeNull();
   });
 });
 

--- a/src/orchestration/conflictDetector.ts
+++ b/src/orchestration/conflictDetector.ts
@@ -89,6 +89,8 @@ export interface ConflictDetectionOptions {
   /** Repay one deferred unknown task by admitting it alone on an idle repository. */
   preferUnknownExclusive?: boolean;
   preferredUnknownTaskId?: string;
+  /** Candidate-vs-candidate unknown-scope policy. Default admit (cheap-model fan-out). */
+  unknownScopeAdmission?: 'serialize' | 'admit';
 }
 
 function pairKey(left: number, right: number): string {
@@ -210,7 +212,7 @@ function sharedScopeEntries(candidate: Set<string>, active: Set<string>): string
 export function describeScopeConflict(
   candidate: string[] | undefined,
   active: string[] | undefined,
-  unknownScopeAdmission: 'serialize' | 'admit' = 'serialize',
+  unknownScopeAdmission: 'serialize' | 'admit' = 'admit',
 ): ScopeConflictReason | null {
   const a = normalizeScope(candidate);
   const b = normalizeScope(active);
@@ -263,11 +265,12 @@ export async function detectFileConflicts(
     for (let j = i + 1; j < tasks.length; j++) {
       const modulesJ = taskImpacts.get(j);
       if (unknownScopeIndices.has(i) || unknownScopeIndices.has(j)) {
-        // Worktrees isolate filesystem writes, but they do not make two unknown
-        // write sets safe to merge. Serialize uncertainty and retry after the
-        // known owner exits.
-        pairShared.set(`${i}:${j}`, new Set([UNKNOWN_SCOPE]));
-        uf.union(i, j);
+        // Codex-era fail-closed: one unknown serialized the whole repository.
+        // Cheap-model default is admit — unknown is not evidence of overlap.
+        if (options.unknownScopeAdmission === 'serialize') {
+          pairShared.set(`${i}:${j}`, new Set([UNKNOWN_SCOPE]));
+          uf.union(i, j);
+        }
         continue;
       }
 

--- a/src/orchestration/conflictScope.test.ts
+++ b/src/orchestration/conflictScope.test.ts
@@ -40,9 +40,10 @@ describe('canonical conflict scope policy', () => {
     ['C:\\repo\\file.ts'],
     ['../outside.ts'],
     ['unknown-file-scope'],
-  ])('fails closed for unsafe or unknown scope %j', (requested) => {
+  ])('treats unsafe or unknown scope %j as empty; durable admission defaults to admit', (requested) => {
     expect(normalizeConflictScope(requested)).toEqual(new Set());
     expect(fileScopesConflict(requested, ['src/safe.ts'])).toBe(true);
-    expect(admitsConflictScope(requested, [{ fileScope: ['src/safe.ts'] }])).toBe(false);
+    expect(admitsConflictScope(requested, [{ fileScope: ['src/safe.ts'] }])).toBe(true);
+    expect(admitsConflictScope(requested, [{ fileScope: ['src/safe.ts'] }], 'serialize')).toBe(false);
   });
 });

--- a/src/support/repoMetadata.test.ts
+++ b/src/support/repoMetadata.test.ts
@@ -66,10 +66,29 @@ describe('loadRepoMetadata', () => {
     expect(meta?.automation).toEqual({
       enabled: true,
       maxConcurrent: 2,
-      maxAttemptsPerHour: 12,
       maxFailuresPerHour: 6,
       maxCostUsdPerDay: 5,
       circuitCooldownMinutes: 60,
+    });
+  });
+
+  it('does not inject a hidden maxConcurrent of 1 when the key is omitted', async () => {
+    writeFileSync(
+      join(dir, REPO_METADATA_FILENAME),
+      JSON.stringify({ schemaVersion: 1, automation: { enabled: true } }),
+    );
+    const meta = await loadRepoMetadata(dir);
+    expect(meta?.automation?.maxConcurrent).toBeUndefined();
+    expect(meta?.automation?.maxAttemptsPerHour).toBeUndefined();
+  });
+
+  it('accepts a per-repo cap up to the daemon global maximum', async () => {
+    writeFileSync(
+      join(dir, REPO_METADATA_FILENAME),
+      JSON.stringify({ schemaVersion: 1, automation: { maxConcurrent: 64 } }),
+    );
+    await expect(loadRepoMetadata(dir)).resolves.toMatchObject({
+      automation: { maxConcurrent: 64 },
     });
   });
 

--- a/src/support/repoMetadata.ts
+++ b/src/support/repoMetadata.ts
@@ -57,10 +57,10 @@ const RepoMetadataSchema = z.object({
   automation: z.object({
     /** Explicit kill switch for issue-driven execution in this repository. */
     enabled: z.boolean().default(true),
-    /** Same-repository active leases. Default one; raise only with isolated worktrees. */
-    maxConcurrent: z.number().int().min(1).max(10).default(1),
-    /** Rolling attempt budget. */
-    maxAttemptsPerHour: z.number().int().min(1).max(100).default(12),
+    /** Same-repository active leases. Omit to inherit the daemon global cap. */
+    maxConcurrent: z.number().int().min(1).max(256).optional(),
+    /** Rolling attempt budget. Omit to skip the attempts-per-hour circuit. */
+    maxAttemptsPerHour: z.number().int().min(1).max(1000).optional(),
     /**
      * Rolling circuit breaker threshold: how many attempts in the last hour may
      * end unsuccessfully before this repository is taken out of admission until
@@ -79,7 +79,7 @@ const RepoMetadataSchema = z.object({
   /**
    * What happens to a pull request the swarm publishes from this repository.
    * Kept outside `automation` so opting in does not pull that block's
-   * admission defaults (maxConcurrent 1, …) in with it.
+   * admission defaults (legacy maxConcurrent 1, …) in with it.
    */
   publication: z.object({
     /**

--- a/src/taskState/store.test.ts
+++ b/src/taskState/store.test.ts
@@ -374,6 +374,34 @@ describe('task state store', () => {
     expect(result.lookedUp).toBe(0);
   });
 
+  it('reconcileDependencyBlockers still looks up blockers of a current-fetch dependent that was just upserted', async () => {
+    upsertTaskState('AGT-4114', {
+      execution: { status: 'todo', retryCount: 0 },
+      linearState: 'Backlog',
+    });
+    upsertTaskState('AGT-4121', {
+      dependencyIssueIds: ['AGT-4114'],
+      execution: { status: 'todo', retryCount: 0 },
+      linearState: 'Todo',
+    });
+
+    const lookupIssueState = async (id: string) => id === 'AGT-4114'
+      ? { ok: true as const, issue: { state: 'Done', stateType: 'completed' } }
+      : { ok: false as const, error: 'unexpected id' };
+
+    const result = await reconcileDependencyBlockers({
+      source: { lookupIssueState },
+      knownTaskIds: new Set(['AGT-4121']),
+    });
+
+    expect(result.lookedUp).toBe(1);
+    expect(result.resolved).toBe(1);
+    expect(getTaskReadiness({
+      id: 'AGT-4121', source: 'linear' as const, title: 'waiting', priority: 2,
+      createdAt: Date.now(), issueId: 'AGT-4121',
+    }).ready).toBe(true);
+  });
+
   it('reconcileDependencyBlockers fails closed when the lookup errors', async () => {
     upsertTaskState('AGT-ERR-BLOCKER', {
       execution: { status: 'in_progress', retryCount: 0 },

--- a/src/taskState/store.ts
+++ b/src/taskState/store.ts
@@ -856,7 +856,11 @@ export async function reconcileDependencyBlockers(
     if (!DEPENDENCY_RECONCILE_ELIGIBLE_STATUSES.has(state.execution.status)) continue;
     if (state.dependencyIssueIds.length === 0) continue;
     const updatedAtMs = Date.parse(state.updatedAt);
-    if (Number.isFinite(updatedAtMs) && now - updatedAtMs < staleAfterMs) continue;
+    // Current-fetch dependents are upserted this heartbeat, so updatedAt is
+    // always fresh. Skipping them is why AGT-4121 stayed blocked after AGT-4254
+    // shipped: its six Linear-Done blockers were never eligible for lookup.
+    const fromCurrentFetch = knownTaskIds.has(state.issueId);
+    if (!fromCurrentFetch && Number.isFinite(updatedAtMs) && now - updatedAtMs < staleAfterMs) continue;
     for (const depId of state.dependencyIssueIds) {
       if (isDependencyTerminal(getTaskState(depId))) continue;
       if (knownTaskIds.has(depId)) continue; // still open per this fetch — not stale


### PR DESCRIPTION
## Summary
- Remove Codex-era hidden spawn caps: `unknownScopeAdmission` defaults to `admit`, per-repo `maxConcurrent` no longer injects 1 or hard-caps at 10, worker fan-out concurrency follows the candidate list instead of `min(3)`.
- Candidate-vs-candidate unknown scopes no longer serialize the whole repository under the default policy. Known file-scope overlap still refuses.
- `openswarm work` default concurrency fallback is 64 (schema default), not 4.

## Test plan
- [x] `npx vitest run` on repoMetadata, config, conflictDetector, conflictScope, workCommand, workerFanoutGate, autonomousRunner.coverage, runLedger, durableRunCoordinator — 342 passed
- [x] `npx tsc --noEmit`
- [ ] CI green
- [ ] After merge: vela `maxConcurrentTasks` 12→64 and `/work/*/openswarm.json` `automation.maxConcurrent` 10→64, then heartbeat `Selected > 0` / runningTasks rise