### PR TITLE
fix(guards): treat .test_venv as ephemeral so false parks do not idle the pool

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -42,6 +42,7 @@ import {
 // ExecutorResult used via execution.reportExecutionResult
 import { checkWorkAllowed } from '../support/timeWindow.js';
 import { shouldEarlyStuckForInfeasibility } from '../support/feasibilityDetector.js';
+import { citedPathsAreEphemeral } from '../support/worktreeEphemeral.js';
 import { recordTaskOutcome } from '../memory/repoKnowledge.js';
 import { updateProjectAfterTask } from '../linear/projectUpdater.js';
 import { TaskScheduler, initScheduler, normalizeProjectPath } from '../orchestration/taskScheduler.js';
@@ -1230,6 +1231,21 @@ export class AutonomousRunner {
             if (!isExactOperatorQuestionPark) {
               console.log(`[Scheduler] ${task.issueIdentifier ?? id} resumed from NEEDS_HUMAN (${task.explicitDispatch === true ? 'explicit dispatch' : `tracker state ${task.linearState}`}), parked under ${durableRun.lastErrorCode ?? 'unknown'}`);
             }
+            durableRun = this.durableRuns.getRun(id);
+            if (resumed === 'SYNC_PENDING') this.scheduleNextHeartbeat();
+          }
+        }
+        // AGT-4256: a guard/publication park that only named ephemeral paths
+        // (.test_venv, pytest-local) is not a human decision. Resume even when
+        // Linear is still In Progress so the next heartbeat can pick the work.
+        if (
+          durableRun?.state === 'NEEDS_HUMAN'
+          && !isOperatorQuestionPark
+          && citedPathsAreEphemeral(durableRun.lastErrorMessage ?? '')
+        ) {
+          const resumed = this.durableRuns.resumeNeedsHuman(id, Date.now(), 'unspecified');
+          if (resumed) {
+            console.log(`[Scheduler] ${task.issueIdentifier ?? id} resumed from NEEDS_HUMAN (ephemeral-only guard park)`);
             durableRun = this.durableRuns.getRun(id);
             if (resumed === 'SYNC_PENDING') this.scheduleNextHeartbeat();
           }

--- a/src/support/worktreeEphemeral.test.ts
+++ b/src/support/worktreeEphemeral.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { ephemeralPathspecRoots, isEphemeralWorktreeArtifact } from './worktreeEphemeral.js';
+import { citedPathsAreEphemeral, ephemeralPathspecRoots, isEphemeralWorktreeArtifact } from './worktreeEphemeral.js';
 
 describe('isEphemeralWorktreeArtifact', () => {
   // cgf-portal#207 (2026-09-02) shipped `apps/pipelines/.coverage`: the repo
@@ -52,6 +52,10 @@ describe('isEphemeralWorktreeArtifact', () => {
       '.venv.bak/bin/python',
       'venv/bin/python',
       'apps/pipelines/.venv/pyvenv.cfg',
+      '.test_venv/lib/python3.11/site-packages/_pytest/_code/code.py',
+      'test_venv/pyvenv.cfg',
+      '.test_venv',
+      'test_venv',
       '.venv',
       'venv',
     ]) {
@@ -74,5 +78,26 @@ describe('ephemeralPathspecRoots', () => {
     expect(ephemeralPathspecRoots([
       '.venv_test/bin/activate', '.venv_test/lib/python3.12/site-packages/a.py', 'apps/x/.venv/pyvenv.cfg', '.venv',
     ])).toEqual(['.venv', '.venv_test', 'apps/x/.venv']);
+  });
+});
+
+describe('citedPathsAreEphemeral', () => {
+  it('treats a BS-guard dump that only names .test_venv as ephemeral', () => {
+    const detail = 'Pipeline guard failed: [WARNING] .test_venv/lib/python3.11/site-packages/_pytest/_code/code.py:98 — TODO/FIXME';
+    expect(citedPathsAreEphemeral(detail)).toBe(true);
+  });
+
+  it('treats a publication-scope list that is only pytest-local as ephemeral', () => {
+    const detail = 'publication-scope: branch contains files outside reserved write scope: pytest-local/test_all_zero_token_samples_recurrent.py';
+    expect(citedPathsAreEphemeral(detail)).toBe(true);
+  });
+
+  it('does not treat a mixed source + venv failure as ephemeral', () => {
+    const detail = '[WARNING] src/ci_guard.py:12 — TODO/FIXME; [WARNING] .test_venv/lib/x.py:1 — TODO/FIXME';
+    expect(citedPathsAreEphemeral(detail)).toBe(false);
+  });
+
+  it('does not treat an operator-question park as ephemeral', () => {
+    expect(citedPathsAreEphemeral('[operator-question] asked 2 times with no answer — stopped retrying automatically')).toBe(false);
   });
 });

--- a/src/support/worktreeEphemeral.ts
+++ b/src/support/worktreeEphemeral.ts
@@ -3,15 +3,15 @@
 /** Test/runtime outputs are never task source, including on a resumed WIP branch. */
 /**
  * A Python virtualenv directory by name, at any depth: `.venv`, `venv`,
- * `.venv-verify`, `.venv.bak`, `.venv_test`, … The old list named the
+ * `.venv-verify`, `.venv.bak`, `.venv_test`, `.test_venv`, … The old list named the
  * worktree-level `.venv` link and two known siblings by exact string, so a
  * worker's `uv venv .venv_test` (cgf-portal AX-868, 2026-09-02) committed
  * 11,026 interpreter files that the purge then could not see, and the branch
  * failed the publication fence on every attempt after that.
  */
-const VENV_DIR = /(?:^|\/)\.?venv[\w.-]*\//;
-/** The worktree-level link/dir entry itself (`.venv`, `venv`, `.venv-verify`, `.venv.bak`) — never `venv_tools.py`. */
-const VENV_ENTRY = /^\.?venv(?:[\w-]*|\.bak)$/;
+const VENV_DIR = /(?:^|\/)(?:\.?venv[\w.-]*|\.?test_venv)\//;
+/** The worktree-level link/dir entry itself (`.venv`, `venv`, `.test_venv`, `.venv-verify`) — never `venv_tools.py`. */
+const VENV_ENTRY = /^(?:\.?venv(?:[\w-]*|\.bak)|\.?test_venv)$/;
 
 export function isEphemeralWorktreeArtifact(file: string): boolean {
   return VENV_DIR.test(file)
@@ -47,6 +47,26 @@ export function isEphemeralWorktreeArtifact(file: string): boolean {
     || /(?:^|\/)(?:\.pytest_cache|\.hypothesis|\.mypy_cache|\.ruff_cache|__pycache__|htmlcov)(?:\/|$)/.test(file);
 }
 
+
+const GUARD_PATH_RE = /\[(?:WARNING|CRITICAL|MINOR)\]\s+([^:\s]+):/g;
+const SCOPE_LIST_RE = /outside reserved write scope:\s*(.+)$/m;
+
+/**
+ * True when a pipeline-guard / publication-scope failure only cites
+ * ephemeral paths (`.test_venv/...`, `pytest-local/...`). Those parks are
+ * false positives — the next heartbeat should resume the run.
+ */
+export function citedPathsAreEphemeral(detail: string): boolean {
+  if (!detail) return false;
+  const cited = [...detail.matchAll(GUARD_PATH_RE)].map((match) => match[1]);
+  const scope = detail.match(SCOPE_LIST_RE)?.[1] ?? '';
+  const published = scope
+    ? scope.split(/,\s*/).map((part) => part.trim()).filter(Boolean)
+    : [];
+  const paths = [...cited, ...published];
+  return paths.length > 0 && paths.every((path) => isEphemeralWorktreeArtifact(path));
+}
+
 /** Collapse file paths to the shallowest directory (or file) git can rm -r. */
 export function ephemeralPathspecRoots(files: string[]): string[] {
   const roots: string[] = [];
@@ -61,7 +81,7 @@ export function ephemeralPathspecRoots(files: string[]): string[] {
       pathspec = root;
     } else {
       // One `git rm -r` per virtualenv or pytest basetemp, not one per file.
-      const m = file.match(/^(.*(?:^|\/)pytest-of-[^/]+)/) ?? file.match(/^(.*?(?:^|\/)\.?venv[\w.-]*)\//);
+      const m = file.match(/^(.*(?:^|\/)pytest-of-[^/]+)/) ?? file.match(/^(.*?(?:^|\/)(?:\.?venv[\w.-]*|\.?test_venv))\//);
       if (m) pathspec = m[1];
     }
     if (roots.some((r) => pathspec === r || pathspec.startsWith(`${r}/`))) continue;


### PR DESCRIPTION
## Summary
- VEGA's `.test_venv/site-packages` was not recognized as a venv, so the BS guard parked AGT-3827 as `NEEDS_HUMAN` and heartbeat had no in-scope work left.
- Resume `NEEDS_HUMAN` when every cited path is ephemeral. Operator-question parks stay parked.

## Test plan
- [x] `vitest run src/support/worktreeEphemeral.test.ts` (10 passed)
- [ ] vela: AGT-3827 Selected after deploy (card already moved to Todo so current daemon can resume even before this lands)