### PR TITLE
fix(admission): never skip enabled work when slots are free (AGT-4257)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,106 @@
+# Architecture
+
+> 이 문서는 다른 에이전트가 이 레포에 빠르게 온보딩하기 위한 구조 지도다.
+> 사람 독자용 개요는 [README.md](README.md)를 참조.
+> 실행 상태·리스·복구 불변식은 [docs/DURABLE_AUTONOMY.md](docs/DURABLE_AUTONOMY.md).
+
+## 시스템 개요
+
+OpenSwarm은 Linear(또는 로컬 이슈 스토어)에서 일을 집어와 worktree-isolated worker를 돌리는 자율 오케스트레이터다. 진실의 축은 둘이다.
+
+- **Intent**: Linear / local tracker (상태, 토론, Done/Canceled).
+- **Execution**: `~/.openswarm/automation.db` (`RunLedger`) — claim, lease, attempt, fileScope, outbox.
+
+Heartbeat(`AutonomousRunner`)가 이슈를 가져오고, `filterAlreadyProcessed`로 park/backoff를 열며, `DecisionEngine`이 실행 가능한 카드를 고르고, `detectSafeCandidateIds` + `RunLedger.claimRun`이 슬롯을 채운 뒤 `PairPipeline`이 Worker→Reviewer→Tester→Documenter를 돌린다.
+
+## 디렉토리 트리 (주요)
+
+```
+src/
+  automation/     — heartbeat, RunLedger, durable coordinator, PR processor
+  orchestration/  — DecisionEngine, TaskScheduler, conflictDetector, writeScope
+  taskState/      — JSON projection + getTaskReadiness / dependency reconcile
+  adapters/       — provider adapters (codex-responses, openrouter, …)
+  agents/         — pairPipeline, worker/reviewer/tester/documenter
+  linear/         — Linear fetch (Todo/In Progress/In Review/Backlog)
+  core/           — config Zod schema, service wiring
+  support/        — worktree, ephemeral paths, dashboard, time window
+  cli/            — openswarm work / review / pr
+docs/
+  DURABLE_AUTONOMY.md — ledger states, leases, reconcile
+  DOD_CONTRACT.md     — sandbox-achievable completion criteria
+```
+
+## 모듈 책임 (module → responsibility)
+
+| 모듈 | 책임 | 진입점 | 의존 |
+|------|------|--------|------|
+| `automation/autonomousRunner.ts` | 5분 heartbeat, idle_fill, enqueue | `heartbeat` / `heartbeatParallel` | DecisionEngine, RunLedger, scheduler |
+| `automation/runLedger.ts` | durable claim/lease/transition | `claimRun`, `resumeNeedsHuman`, `markReady` | `runLedgerScope.ts` |
+| `orchestration/decisionEngine.ts` | 선택·우선순위·umbrella/terminal 게이트 | `heartbeatMultiple` | `taskState/store.getTaskReadiness` |
+| `orchestration/conflictDetector.ts` | 예측 write-scope 비교 | `detectFileConflicts`, `describeScopeConflict` | `conflictScope.ts` |
+| `orchestration/taskScheduler.ts` | 슬롯·큐·worktree 병렬 | `enqueue`, `runAvailable` | worktreeManager |
+| `taskState/store.ts` | 의존성  readiness, Linear projection | `getTaskReadiness`, `reconcileDependencyBlockers` | Linear lookup |
+| `support/worktreeEphemeral.ts` | `.venv` / `.test_venv` / pytest-local | `citedPathsAreEphemeral` | publication fence |
+| `agents/pairPipeline.ts` | Worker↔Reviewer 루프 | `run` | adapters |
+
+## 데이터 흐름
+
+```mermaid
+graph LR
+  L[Linear fetch] --> F[filterAlreadyProcessed idle_fill]
+  F --> E[DecisionEngine]
+  E --> S[detectSafeCandidateIds]
+  S --> C[RunLedger.claimRun]
+  C --> P[PairPipeline in worktree]
+  P --> T[Linear / PR / outbox]
+```
+
+Admission under `unknownScopeAdmission: admit` (default, vela):
+
+1. `includeBacklog: true` — Backlog is a queue.
+2. `idle_fill` lifts `NEEDS_HUMAN` / `RETRY_AT` / legacy backoff when Linear still wants the card.
+3. Predicted file overlap does **not** defer. Worktrees isolate; merge later.
+4. Still skipped: Linear Done/Canceled, parent/EPIC umbrellas, live `CLAIMED`/`EXECUTING` leases, unresolved deps, unmapped/disabled projects.
+
+`serialize` restores Codex-era fail-closed overlap holds.
+
+## 주요 타입·스키마
+
+- `TaskItem` (`orchestration/decisionEngine.ts`) — `linearState`, `fileScope`, `blockedBy`, `explicitDispatch`.
+- `RunState` (`automation/runLedgerTypes.ts`) — `READY`…`DONE` plus `RETRY_AT`, `NEEDS_HUMAN`, `NEEDS_RECONCILE`.
+- `ParkResumeTrigger` — `idle_fill` | `explicit_dispatch` | `tracker_todo` | `sandbox_quarantine_dispatch` | `unspecified`.
+- `UnknownScopeAdmission` — `'admit' | 'serialize'`.
+- Config: `src/core/config.ts` `AutonomousConfigSchema` (`includeBacklog` default true, `unknownScopeAdmission` default admit).
+
+## 확장 지점
+
+- 새 provider: `src/adapters/` + `core/config` adapter enum.
+- Admission 정책: `runLedgerScope.admitsConflictScope`, `conflictDetector.detectFileConflicts`, `autonomousRunner.detectSafeCandidateIds` — 세 곳이 같은 정책을 읽어야 한다.
+- Linear fetch 상태: `src/linear/linear.ts` `getMyIssues` (이미 Backlog 포함).
+- Ephemeral 경로: `src/support/worktreeEphemeral.ts`.
+
+## 금기 / 지뢰
+
+- **vela compose는 이미지 태그를 pin한다.** `docker build`만으로는 recreate 안 됨. `docker-compose.yml`의 `openswarm:vela-YYYYMMDD-HHMM-amd64`를 바꾸고 `up -d --no-deps openswarm`.
+- **`vela-build.sh <sha>`는 `origin/main`만 fetch한다.** PR SHA는 `builds/4e8ba24`에서 `git fetch origin <branch>` 먼저.
+- **PR SHA를 돌리는 동안 `.last-deployed-sha`는 `origin/main` tip을 유지**하지 않으면 autodeploy cron이 main으로 롤백한다.
+- **`unknownScopeAdmission: admit`를 heartbeat만 바꾸고 claim 게이트를 안 바꾸면** 큐에는 들어가고 `claimRun`이 null — 슬롯이 다시 빈다.
+- **`isActionableLinearState(state)` 헬퍼 기본은 Backlog park.** 엔진/config 기본은 `includeBacklog: true`. `undefined`를 spread하면 DEFAULT true를 덮는다 — constructor가 `?? true`로 고정한다.
+- **AGT-4155 park loop**: Linear `In Progress`만으로 park를 열면 claim→exec→park가 heartbeat마다 돈다. 지금은 `idle_fill`이 의도적으로 연다 (싼 모델이 빈 슬롯을 씹도록). `serialize`/질문 대기를 되살릴 때 이 루프를 다시 열지 말 것.
+- **drafted `docs/integrations.md` 같은 광역 fileScope**는 한 레포의 카드를 전부 한 conflict group으로 묶는다. `admit`이 아니면 슬롯이 비어 있는 채로 1장만 산다.
+- 로컬 워크스페이스 `fix/agt-4220-…`의 dirty `store.ts` / `autonomousRunner.ts`는 이 스택과 섞지 말 것.
+
+## 테스트 전략
+
+```bash
+npx vitest run src/automation/autonomousRunner.operatorPark.test.ts \
+  src/automation/autonomousRunner.operatorQuestionPark.test.ts \
+  src/automation/runLedger.test.ts \
+  src/orchestration/conflictDetector.test.ts \
+  src/orchestration/decisionEngine.gating.test.ts \
+  src/core/config.test.ts
+npx tsc --noEmit
+```
+
+가드 테스트: `operatorQuestionPark` (idle_fill), `conflictDetector` (`admit` vs `serialize`), `runLedgerScope` / `runLedger.test.ts` claim overlap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **Heartbeat fills free slots instead of idling (AGT-4257).** Linear Backlog is a work queue by default (`autonomous.includeBacklog: true`). Parks (`NEEDS_HUMAN`, including unanswered `ask_human`), `RETRY_AT`, and legacy backoff are lifted via `idle_fill` when an enabled project still wants the card. Predicted file-scope overlap no longer `Decision: defer` under `unknownScopeAdmission: admit` (vela default) — worktrees isolate; `serialize` keeps the Codex-era hold.
+- **Codex-era spawn caps removed (AGT-4255).** `unknownScopeAdmission` defaults to `admit`, per-repo `maxConcurrent` no longer injects 1 or hard-caps at 10, and worker fan-out follows the candidate list.
+
+### Fixed
+
+- **`.test_venv` is ephemeral (AGT-4256).** The venv regex missed dotted test venvs, so a publication/BS guard park idled the pool (AGT-3827). Resume treats those paths as non-human parks.
+
+
 ## 0.22.1 — 2026-09-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ DISCORD_CHANNEL_ID=your-channel-id
 | `github` | Repos list for CI monitoring |
 | `agents` | Agent definitions (name, projectPath, heartbeat interval) |
 | `autonomous` | Schedule, pair mode, role models, decomposition settings |
+| `autonomous.includeBacklog` | Treat Linear Backlog as a work queue (default `true`) |
+| `autonomous.unknownScopeAdmission` | `admit` (default): worktrees isolate — predicted file overlap does not defer. `serialize`: Codex-era fail-closed |
 | `prProcessor` | PR auto-improvement schedule, retry limits, conflict resolver config |
 
 ### CLI Adapter (Provider)
@@ -687,6 +689,8 @@ Notes:
 
 ## Architecture
 
+Agent-oriented module map, admission gates, and landmines: **[ARCHITECTURE.md](ARCHITECTURE.md)**.
+
 ```
                          ┌──────────────────────────┐
                          │       Linear API          │
@@ -756,9 +760,11 @@ Notes:
 ## How It Works
 
 ```
-Linear (Todo/In Progress)
+Linear (Todo / In Progress / In Review / Backlog)
   → Fetch assigned issues
-  → DecisionEngine filters & prioritizes
+  → filterAlreadyProcessed (idle_fill parks/backoff when slots are free)
+  → DecisionEngine filters & prioritizes (still skips Done/Canceled, parent/EPIC, unresolved deps)
+  → detectSafeCandidateIds (`admit` does not defer on predicted file overlap)
   → Resolve project path via projectMapper
   → PairPipeline.run()
     → Worker generates code (via the configured adapter)
@@ -880,6 +886,8 @@ and the harness defects the benchmark uncovered.
 
 ## Project Structure
 
+Full module responsibilities and data flow: **[ARCHITECTURE.md](ARCHITECTURE.md)**.
+
 ```
 src/
 ├── index.ts                 # Entry point
@@ -983,11 +991,9 @@ the CLI (fire-and-forget with a short timeout, and failures are silently ignored
 Full version history lives in **[CHANGELOG.md](CHANGELOG.md)** and the
 [GitHub Releases](https://github.com/unohee/OpenSwarm/releases) page.
 
-Latest — **v0.17.7**: `openswarm stop` now actually stops a launchd-managed
-daemon, a dashboard project disable survives a daemon restart, failed-session
-partial work is committed to its branch before the worktree is preserved, and
-Lance memory writes retry instead of colliding under `review --max`. Adds the
-Atlas Cloud provider adapter. See CHANGELOG.md for the rest.
+Latest shipping line is **v0.22.1**. Unreleased work (AGT-4257) fills free
+heartbeat slots instead of skipping enabled Backlog / parked / overlapping
+cards. See CHANGELOG.md for the rest.
 
 ---
 

--- a/src/automation/autonomousRunner.operatorPark.test.ts
+++ b/src/automation/autonomousRunner.operatorPark.test.ts
@@ -99,11 +99,11 @@ describe('operator park without an authoritative ledger (AGT-4033)', () => {
     expect(defaultAutomationDbPath()).toBe(configured);
   });
 
-  it('holds a parked task on its backoff until the answer is there', async () => {
+  it('idle-fills a parked backoff so free slots do not sit empty (AGT-4257)', async () => {
     const { internal, park } = await makeRunner();
     park(true);
 
-    expect(internal.filterAlreadyProcessed([TASK])).toEqual([]);
+    expect(internal.filterAlreadyProcessed([TASK])).toEqual([TASK]);
   });
 
   it('cuts the backoff short once the operator answers, and spends the park doing it', async () => {
@@ -131,7 +131,7 @@ describe('operator park without an authoritative ledger (AGT-4033)', () => {
 
     // Now it fails for its own reasons and backs off again.
     internal.failedTaskRetryTimes.set('AGT-1', Date.now() + 3_600_000);
-    expect(internal.filterAlreadyProcessed([TASK])).toEqual([]);
+    expect(internal.filterAlreadyProcessed([TASK])).toEqual([TASK]);
   });
 });
 
@@ -225,16 +225,12 @@ describe('operator park on the run ledger (AGT-4033)', () => {
     internal.durableRuns.close();
   });
 
-  it('leaves an ordinary failure on its backoff, answered question or not', async () => {
-    // The park has to expire with the attempt that caused it. Here the run backed
-    // off for its own reasons, so the answer still on the board says nothing about
-    // it — and the ledger, which overwrites the code on every transition, is what
-    // makes that distinction without anyone maintaining a flag.
+  it('idle-fills an ordinary RETRY_AT failure so free slots chew the backoff (AGT-4257)', async () => {
     const internal = await parkedRunner('failed');
     answered = true;
 
-    expect(internal.filterAlreadyProcessed([TASK])).toEqual([]);
-    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('RETRY_AT');
+    expect(internal.filterAlreadyProcessed([TASK])).toEqual([TASK]);
+    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('READY');
     internal.durableRuns.close();
   });
 });

--- a/src/automation/autonomousRunner.operatorQuestionPark.test.ts
+++ b/src/automation/autonomousRunner.operatorQuestionPark.test.ts
@@ -321,6 +321,9 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
     // re-claimed, re-executed, re-published and re-parked, once per cycle,
     // holding a slot the whole time. Observed in production at attempt 20.
     const internal = await makeRunner();
+    // Through a real claim: a park is always reached by attempting the task, and
+    // the attempt counter is what marks the row as this daemon's own work.
+    await seedConsecutiveUnansweredAttempts(1);
     internal.durableRuns.markNeedsHuman('AGT-1', 'Reviewer rejected 4 attempts: still failing lint');
     const stillParked: TaskItem = { ...TASK, linearState: 'In Progress' };
     // The slot the park was holding has to go somewhere: an unrelated task in
@@ -388,16 +391,53 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
     // A bare Linear 'In Progress' with only the row observeTask wrote is
     // someone else's work — a human, or another daemon. Admitting it
     // re-decomposes work already in progress (INT-1980: duplicate sub-issues
-    // and a redundant PR). This daemon's own parks reach here as READY after
-    // idle fill and still pass.
+    // and a redundant PR). observeTask registers every fetched card as READY,
+    // so the row existing proves nothing; the attempt counter does.
     const internal = await makeRunner();
     const external: TaskItem = { ...TASK, linearState: 'In Progress' };
+    expect(internal.durableRuns.getRun('AGT-1')?.attemptNo).toBe(0);
 
     expect(internal.filterAlreadyProcessed([external])).toEqual([]);
     internal.durableRuns.close();
   });
 
-  it('idle-fills a finished run whose card is In Progress, but never one In Review (AGT-4257)', async () => {
+  it('admits an In Progress card this daemon has claimed before (INT-1979 guard)', async () => {
+    // The other side of the same gate: once claimRun has bumped the attempt,
+    // the card being In Progress is this run's own doing — parking never moves
+    // it back — so its backoff and parks must still reach the pipeline.
+    const internal = await makeRunner();
+    await seedConsecutiveUnansweredAttempts(1);
+    expect(internal.durableRuns.getRun('AGT-1')?.attemptNo).toBeGreaterThan(0);
+    internal.durableRuns.markNeedsHuman('AGT-1', 'Reviewer rejected 4 attempts: still failing lint');
+
+    const claimed: TaskItem = { ...TASK, linearState: 'In Progress' };
+    expect(internal.filterAlreadyProcessed([claimed])).toEqual([claimed]);
+    internal.durableRuns.close();
+  });
+
+  it('admits a legacy-imported row whose local claim marker says it is ours (INT-1979 guard)', async () => {
+    // migrateLegacyRunState imports a card in flight at cutover from the very
+    // marker markTaskInProgress writes, and importRun inserts at attempt 0.
+    // attempt_no only grows inside claimRun, which this filter gates, so
+    // judging that row by the counter alone would deadlock it with no path
+    // back except a manual move to Todo.
+    const internal = await makeRunner();
+    const store = await import('../taskState/store.js');
+    store.upsertTaskState('AGT-1', {
+      execution: { status: 'in_progress', retryCount: 0 },
+    } as Parameters<typeof store.upsertTaskState>[1]);
+    expect(internal.durableRuns.getRun('AGT-1')?.attemptNo).toBe(0);
+
+    const inFlight: TaskItem = { ...TASK, linearState: 'In Progress' };
+    expect(internal.filterAlreadyProcessed([inFlight])).toEqual([inFlight]);
+    internal.durableRuns.close();
+  });
+
+  it('reopens a finished run from Backlog only — never In Progress or In Review (AGT-4257)', async () => {
+    // durableRunCoordinator.observeTask states the rule this mirrors: a terminal
+    // run reopens on Todo or an explicit dispatch, never on In Progress, which
+    // a human or another daemon may own. In Review is a published PR waiting on
+    // the merge gate — re-running it makes a duplicate PR.
     const internal = await makeRunner();
     const { RunLedger } = await import('./runLedger.js');
     const ledger = new RunLedger(dbPath);
@@ -409,14 +449,14 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
     ledger.close();
     expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('DONE');
 
-    // In Review: its PR is waiting on the merge gate. Re-executing makes a
-    // duplicate PR, so a finished run there is not work to fill a slot with.
-    expect(internal.filterAlreadyProcessed([{ ...TASK, linearState: 'In Review' }])).toEqual([]);
-    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('DONE');
+    for (const linearState of ['In Review', 'In Progress'] as const) {
+      expect(internal.filterAlreadyProcessed([{ ...TASK, linearState }])).toEqual([]);
+      expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('DONE');
+    }
 
-    // In Progress with a free slot is idle fill of this daemon's own run.
-    const inProgress: TaskItem = { ...TASK, linearState: 'In Progress' };
-    expect(internal.filterAlreadyProcessed([inProgress])).toEqual([inProgress]);
+    // Backlog with a free slot is idle fill: nobody is working that card.
+    const backlog: TaskItem = { ...TASK, linearState: 'Backlog' };
+    expect(internal.filterAlreadyProcessed([backlog])).toEqual([backlog]);
     expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('READY');
     internal.durableRuns.close();
   });

--- a/src/automation/autonomousRunner.operatorQuestionPark.test.ts
+++ b/src/automation/autonomousRunner.operatorQuestionPark.test.ts
@@ -180,20 +180,13 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
     });
 
     expect(internal.failedTaskRetryTimes.has('AGT-1')).toBe(false);
-    expect(internal.filterAlreadyProcessed([TASK])).toEqual([]);
-    expect(internal.durableRuns.getRun('AGT-1')).toMatchObject({
-      state: 'NEEDS_HUMAN',
-      lastErrorCode: 'execution_outcome_unknown',
-      retryAt: undefined,
-    });
-
-    const explicit = { ...TASK, explicitDispatch: true };
-    expect(internal.filterAlreadyProcessed([explicit])).toEqual([explicit]);
+    // AGT-4257: idle_fill resumes even a sandbox-quarantine park so slots work.
+    expect(internal.filterAlreadyProcessed([TASK])).toEqual([TASK]);
     expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('READY');
     internal.durableRuns.close();
   });
 
-  it('does not resume a parked, unanswered ask just because the Linear card never left Todo', async () => {
+  it('idle-fills a parked unanswered ask so the enabled pool does not sit empty (AGT-4257)', async () => {
     // The bug this pins closed: an ask_human park never touches the Linear
     // card, so the pre-existing Todo/In Progress/In Review resume condition
     // was almost always already true for an actively-worked task — reviving
@@ -213,8 +206,8 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
 
     const selected = internal.filterAlreadyProcessed([TASK]); // TASK.linearState === 'Todo'
 
-    expect(selected).toEqual([]);
-    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('NEEDS_HUMAN');
+    expect(selected).toEqual([TASK]);
+    expect(internal.durableRuns.getRun('AGT-1')?.state).not.toBe('NEEDS_HUMAN');
     internal.durableRuns.close();
   });
 
@@ -291,21 +284,19 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
       expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('NEEDS_HUMAN');
     });
 
-    // Answer A is durable but cannot satisfy the exact question-B park.
-    expect(internal.filterAlreadyProcessed([TASK])).toEqual([]);
-    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('NEEDS_HUMAN');
+    // AGT-4257: idle_fill resumes question-B without waiting for its answer.
+    expect(internal.filterAlreadyProcessed([TASK])).toEqual([TASK]);
+    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('READY');
 
     await store.publish({
       repository: REPO, taskId: 'AGT-1', actor: 'operator', recipient: 'worker-x',
       kind: 'human-answer', status: 'completed', correlationId: 'hq-b', summary: 'answered B',
       detail: 'Use monthly_cutoff; do not create due_date.', timestamp: resumedAt + 200,
     });
-    expect(internal.filterAlreadyProcessed([TASK])).toEqual([TASK]);
-    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('READY');
     internal.durableRuns.close();
   });
 
-  it('does not resume a NEEDS_HUMAN park from an unrelated reason just because no question was ever asked', async () => {
+  it('idle-fills an unrelated NEEDS_HUMAN park so Backlog still occupies a slot (AGT-4257)', async () => {
     // A rejection-limit or PR-closed-without-merge park shares NEEDS_HUMAN but
     // has nothing to do with ask_human — openQuestionCount is legitimately 0
     // for it, and that must not read as "answered". Modeled with the ticket out
@@ -318,12 +309,12 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
 
     const selected = internal.filterAlreadyProcessed([parkedElsewhere]);
 
-    expect(selected).toEqual([]);
-    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('NEEDS_HUMAN');
+    expect(selected).toEqual([parkedElsewhere]);
+    expect(internal.durableRuns.getRun('AGT-1')?.state).not.toBe('NEEDS_HUMAN');
     internal.durableRuns.close();
   });
 
-  it('leaves an unrelated NEEDS_HUMAN park alone while its card sits In Progress (AGT-4155)', async () => {
+  it('idle-fills an In Progress NEEDS_HUMAN park together with its sibling (AGT-4257)', async () => {
     // 'In Progress' is where THIS run put the card when it claimed the task,
     // and parking does not move it back. Treating that level as "the operator
     // reopened it" re-admitted the park on the very next heartbeat: it
@@ -340,8 +331,8 @@ describe('stop re-dispatching a repeatedly-unanswered ask_human (AGT-4042)', () 
 
     const selected = internal.filterAlreadyProcessed([stillParked, sibling]);
 
-    expect(selected).toEqual([sibling]);
-    expect(internal.durableRuns.getRun('AGT-1')?.state).toBe('NEEDS_HUMAN');
+    expect(selected).toEqual([stillParked, sibling]);
+    expect(internal.durableRuns.getRun('AGT-1')?.state).not.toBe('NEEDS_HUMAN');
     internal.durableRuns.close();
   });
 

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -1173,13 +1173,14 @@ export class AutonomousRunner {
         )
       ) {
         // 'Todo' (or an explicit dispatch) is the operator reopening a finished
-        // run — never gated. Backlog / In Progress are idle fill under AGT-4257
-        // and spend budget. 'In Review' is a published PR waiting on the merge
-        // gate: re-executing it makes a duplicate PR, so it is not work to fill.
+        // run — never gated. 'Backlog' is idle fill under AGT-4257 and spends
+        // budget. 'In Progress' and 'In Review' are excluded on purpose, the
+        // same rule durableRunCoordinator.observeTask states for this exact
+        // transition: In Progress may be owned by a human or another daemon,
+        // and In Review is a published PR waiting on the merge gate. Reopening
+        // either re-decomposes or re-publishes work that already exists.
         const operatorReopened = task.linearState === 'Todo' || task.explicitDispatch === true;
-        const idleReopen = !operatorReopened
-          && (task.linearState === 'Backlog' || task.linearState === 'In Progress')
-          && idleFillBudget > 0;
+        const idleReopen = !operatorReopened && task.linearState === 'Backlog' && idleFillBudget > 0;
         if ((operatorReopened || idleReopen) && this.durableRuns.markReady(id)) {
           if (idleReopen) {
             idleFillBudget--;
@@ -1327,7 +1328,6 @@ export class AutonomousRunner {
           && (this.completedTaskIds.has(id) || (this.failedTaskCounts.get(id) ?? 0) >= AutonomousRunner.MAX_RETRY_COUNT)) {
         if (idleFillBudget <= 0) return false;
         idleFillBudget--;
-        idleLifted = true;
         this.completedTaskIds.delete(id);
         this.failedTaskCounts.delete(id);
         recovered++;
@@ -1343,16 +1343,20 @@ export class AutonomousRunner {
       // with no local claim record is skipped. An explicit dispatch is the
       // operator handing it over and passes.
       //
-      // Under the ledger the ownership signal is the attempt counter, not the
-      // state: observeTask registers every fetched card as READY (attempt 0),
-      // so a state test admitted every external card. A row this daemon has
-      // claimed at least once (attempt ≥ 1) is its own work — a backoff, a
-      // finished run reopened — and passes; so does a row idle fill lifted in
-      // this very pass, since only this daemon's own parks are lifted.
-      if (task.linearState === 'In Progress' && task.explicitDispatch !== true && !idleLifted) {
+      // Under the ledger, state alone cannot answer "is this ours": observeTask
+      // registers every fetched card as READY and cacheTrackerObservation writes
+      // DONE/CANCELLED straight from tracker state, both without a claim. Two
+      // signals do:
+      //   - attemptNo >= 1: claimRun is the only writer of that counter.
+      //   - the legacy in_progress marker, which markTaskInProgress writes when
+      //     WE claim. It is also what migrateLegacyRunState read to import an
+      //     in-flight card at cutover, so it keeps that row — imported at
+      //     attempt 0 — from deadlocking behind a counter only claimRun grows.
+      if (task.linearState === 'In Progress' && task.explicitDispatch !== true) {
+        const locallyClaimed = getTaskState(id)?.execution?.status === 'in_progress';
         if (this.durableRuns.isPrimary) {
-          if (!durableRun || durableRun.attemptNo === 0) return false;
-        } else if (getTaskState(id)?.execution?.status !== 'in_progress') {
+          if (!durableRun || (durableRun.attemptNo === 0 && !locallyClaimed)) return false;
+        } else if (!locallyClaimed) {
           return false;
         }
       }

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -551,7 +551,7 @@ export class AutonomousRunner {
       linearTeamId: config.linearTeamId,
       autoExecute: config.autoExecute,
       dryRun: config.dryRun,
-      includeBacklog: config.includeBacklog,
+      includeBacklog: config.includeBacklog ?? true,
       // Same-project parallel selection only makes sense when the scheduler can
       // actually run those tasks concurrently (worktree isolation). (INT-2318)
       sameProjectParallel: (config.allowSameProjectConcurrent ?? true) && (config.worktreeMode ?? false),
@@ -1173,70 +1173,38 @@ export class AutonomousRunner {
           || durableRun.state === 'DECOMPOSED'
           || durableRun.state === 'CANCELLED'
         )
-        && task.linearState === 'Todo'
+        && (task.linearState === 'Todo' || task.linearState === 'Backlog'
+          || task.linearState === 'In Progress' || task.linearState === 'In Review')
         && this.durableRuns.markReady(id)
       ) {
         durableRun = this.durableRuns.getRun(id);
       }
 
       if (this.durableRuns.isPrimary && durableRun?.state === 'NEEDS_HUMAN') {
-        const isSandboxOutcomeQuarantine = durableRun.lastErrorCode === SANDBOX_OUTCOME_UNKNOWN_PARK_REASON;
-        if (isSandboxOutcomeQuarantine) {
-          if (task.explicitDispatch === true) {
-            const resumed = this.durableRuns.resumeNeedsHuman(id, Date.now(), 'sandbox_quarantine_dispatch');
-            if (resumed) durableRun = this.durableRuns.getRun(id);
-          }
-          if (durableRun?.state === 'NEEDS_HUMAN') return false;
-          if (!durableRun) return false;
-        }
-        // The resume conditions are mutually exclusive by why the run was
-        // parked, not layered as "either one fires it." An ask_human park
-        // (marker prefix) resumes only when its own questions are answered;
-        // every other park resumes only when the operator dispatches it again.
-        // Neither reads the Linear card's state, because an active task's card
-        // is routinely 'Todo' or 'In Progress' for reasons the pipeline itself
-        // created — see the note on `operatorRedispatched` below.
-        const isExactOperatorQuestionPark = durableRun.lastErrorCode === OPERATOR_QUESTION_PARK_REASON;
-        const isLegacyOperatorQuestionPark = durableRun.lastErrorMessage?.startsWith(OPERATOR_QUESTION_PARK_MARKER) ?? false;
-        const isOperatorQuestionPark = isExactOperatorQuestionPark || isLegacyOperatorQuestionPark;
-        // A park is terminal for the autonomous loop, so re-admission needs an
-        // operator ACT. 'In Progress' and 'In Review' are not one: this run put
-        // the card there when it claimed the task and parking does not move it
-        // back, so the old `['Todo','In Progress','In Review']` test was true on
-        // the very next heartbeat for every park that leaves the card alone.
-        // Each cycle re-claimed, re-executed, re-published and re-parked while
-        // holding a slot — AX-1030 reached attempt 20, AX-1027 16, AX-873 15,
-        // and 6 parked runs sat in 'In Progress' feeding this loop with none in
-        // 'Todo' (AGT-4155).
-        //
-        // 'Todo' survives because the pipeline never parks a card there — it is
-        // the operator-reopen surface `observeTask` already documents, reached
-        // by moving a STUCK issue back. `explicitDispatch` is the same act via
-        // the issue board or the `work` CLI.
-        const operatorReopened = !isOperatorQuestionPark
-          && (task.explicitDispatch === true || task.linearState === 'Todo');
-        // Read from the durable trace, not the live board: a busy task's own
-        // traffic can push its unanswered question out of a board window, and
-        // `openQuestionCount` would then read that as "no questions open" —
-        // resuming a run that is still genuinely waiting.
-        const legacyQuestionAnswered = isLegacyOperatorQuestionPark && getCoordinationStore().allQuestionsAnswered(id);
-        if (operatorReopened || legacyQuestionAnswered || isExactOperatorQuestionPark) {
-          const resumed = isExactOperatorQuestionPark
-            ? this.durableRuns.resumeNeedsHumanForQuestions(id)
-            : this.durableRuns.resumeNeedsHuman(id, Date.now(), task.explicitDispatch === true ? 'explicit_dispatch' : 'tracker_todo');
-          if (resumed) {
-            // Say it out loud: a park is meant to hold until a person acts, so
-            // every re-admission is either that person or a leak.
-            if (!isExactOperatorQuestionPark) {
-              console.log(`[Scheduler] ${task.issueIdentifier ?? id} resumed from NEEDS_HUMAN (${task.explicitDispatch === true ? 'explicit dispatch' : `tracker state ${task.linearState}`}), parked under ${durableRun.lastErrorCode ?? 'unknown'}`);
-            }
-            durableRun = this.durableRuns.getRun(id);
-            if (resumed === 'SYNC_PENDING') this.scheduleNextHeartbeat();
-          }
+        const idleResumed = this.durableRuns.resumeNeedsHuman(id, Date.now(), 'idle_fill');
+        if (idleResumed) {
+          console.log(`[Scheduler] ${task.issueIdentifier ?? id} resumed from NEEDS_HUMAN (idle_fill)`);
+          const lifted = this.durableRuns.getRun(id);
+          if (lifted) durableRun = lifted;
+          if (idleResumed === 'SYNC_PENDING') this.scheduleNextHeartbeat();
         }
       }
 
       if (this.durableRuns.isPrimary && durableRun) {
+        // AGT-4257: a parked/backoff row is still work. Lift it so claimRun
+        // can take the slot instead of the heartbeat returning skip.
+        if (
+          durableRun.state === 'RETRY_AT'
+          || durableRun.state === 'WAITING_EXTERNAL'
+          || durableRun.state === 'NEEDS_SPEC'
+          || durableRun.state === 'NEEDS_ENV'
+        ) {
+          if (this.durableRuns.markReady(id)) {
+            const lifted = this.durableRuns.getRun(id);
+            if (lifted) durableRun = lifted;
+          }
+        }
+        if (!durableRun) return false;
         if (['DONE', 'DECOMPOSED', 'CANCELLED', 'NEEDS_HUMAN'].includes(durableRun.state)) return false;
         if (['CLAIMED', 'EXECUTING', 'VERIFYING', 'PUBLISHING', 'SYNC_PENDING', 'NEEDS_RECONCILE'].includes(durableRun.state)) return false;
         if (durableRun.state === 'RETRY_AT' && (durableRun.retryAt ?? 0) > Date.now()) {
@@ -1303,31 +1271,31 @@ export class AutonomousRunner {
         return true;
       }
       if (stuckDecision === 'skip-stuck') {
-        // Durable across restarts: the label lives on the Linear issue, not in the
-        // in-memory counters that a restart would lose.
-        stuckSkipped++;
-        return false;
+        // AGT-4257: a stuck label must not idle an enabled pool. Linear still
+        // showing the card means the work is wanted.
+        this.completedTaskIds.delete(id);
+        this.failedTaskCounts.delete(id);
+        clearRejection(id);
+        clearRetryTime(id, this.failedTaskRetryTimes);
+        if (isStuck) toUnstick.push(id);
+        recovered++;
+        return true;
       }
 
-      if (legacyIsAuthority && this.completedTaskIds.has(id)) return false;
-      if (legacyIsAuthority && (this.failedTaskCounts.get(id) ?? 0) >= AutonomousRunner.MAX_RETRY_COUNT) return false;
-
-      // External-claim guard (INT-1979 dup): an issue set to 'In Progress' that THIS
-      // daemon never claimed is owned by a human or another agent — picking it up
-      // would re-decompose work someone is already doing (that spawned duplicate
-      // INT-1980 sub-issues + a redundant PR). markTaskInProgress writes
-      // execution.status='in_progress' when WE claim, so our own in-flight work
-      // (incl. resumption after a restart) still passes; a bare Linear 'In Progress'
-      // with no local claim record is skipped.
-      if (task.linearState === 'In Progress') {
-        if (this.durableRuns.isPrimary) {
-          // Comments/local JSON are context, not ownership authority. Only a
-          // durable crashed-run record may resume an externally In Progress card.
-          if (!durableRun || !['NEEDS_RECONCILE', 'READY', 'RETRY_AT'].includes(durableRun.state)) return false;
-        } else if (getTaskState(id)?.execution?.status !== 'in_progress') {
-          return false;
-        }
+      if (legacyIsAuthority && this.completedTaskIds.has(id)) {
+        this.completedTaskIds.delete(id);
+        this.failedTaskCounts.delete(id);
+        recovered++;
+        return true;
       }
+      if (legacyIsAuthority && (this.failedTaskCounts.get(id) ?? 0) >= AutonomousRunner.MAX_RETRY_COUNT) {
+        this.failedTaskCounts.delete(id);
+        recovered++;
+        return true;
+      }
+
+      // AGT-4257: In Progress without a local claim is still work. Skipping it
+      // idled the enabled pool while Linear cards sat in In Progress.
 
       if (legacyIsAuthority) {
         // Check if task is in exponential backoff period — unless the only thing
@@ -1335,12 +1303,9 @@ export class AutonomousRunner {
         // an `ask_human` park, so left alone it makes the operator's reply land
         // up to two hours after they sent it.
         if (!canRetryNow(id, this.failedTaskRetryTimes)) {
-          if (!this.answerArrivedFor(id)) {
-            backoffSkipped++;
-            return false; // Skip tasks still in backoff period
-          }
+          // AGT-4257: free slots chew the backoff instead of sitting idle.
           clearRetryTime(id, this.failedTaskRetryTimes);
-          answered++;
+          recovered++;
         }
         // Admitted, so the park is spent — retire it here and it expires with the
         // attempt that caused it, the way the ledger's error code does. Left set,
@@ -2517,8 +2482,11 @@ export class AutonomousRunner {
 
     // Pre-filter tasks to enabled projects only (before DecisionEngine selection)
     // This prevents DecisionEngine from wasting its max-slot budget on non-enabled projects.
-    // Only execute Todo tasks; Backlog is fetched for dashboard display only
-    const executableTasks = tasks.filter(t => t.linearState !== 'Backlog');
+    // AGT-4257: Backlog is a queue when slots are free. Terminal Linear
+    // states are still dropped later by the decision engine.
+    const executableTasks = (this.config.includeBacklog ?? true)
+      ? tasks
+      : tasks.filter(t => t.linearState !== 'Backlog');
 
     let tasksForEngine = executableTasks;
     if (this.shouldFilterByEnabled()) {

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -198,18 +198,6 @@ export function decisionSelectionBudget(availableSlots: number, candidateCount: 
 }
 
 /**
- * Prefix stamped on a NEEDS_HUMAN run's `lastErrorMessage` when this file
- * parked it for a repeated, unanswered `ask_human` question (AGT-4042).
- *
- * `markNeedsHuman` is shared with unrelated parks (a rejection limit, a PR
- * closed without merge — see the other call sites in this file), each with its
- * own resume condition. This is how the filter below tells "this one resumes
- * when the operator answers" from "this one resumes when Linear state changes"
- * without adding a second column or state for what is still one ledger state.
- */
-const OPERATOR_QUESTION_PARK_MARKER = '[operator-question]';
-
-/**
  * Record, or retire, the stand-in park signal for a task whose park cannot be
  * carried by the run ledger.
  *

--- a/src/automation/runLedger.test.ts
+++ b/src/automation/runLedger.test.ts
@@ -261,6 +261,28 @@ describe('RunLedger operator re-admission (AGT-4033)', () => {
     ledger.close();
   });
 
+  it('idle_fill is the only generic trigger that lifts an unanswered ask_human park (AGT-4257)', () => {
+    const ledger = new RunLedger(createDbPath());
+    register(ledger, 'AX-4257');
+    const claimed = claim(ledger, 'AX-4257', 'daemon');
+    expect(ledger.transition(claimed, 'RETRY_AT', {
+      retryAt: 99_000,
+      errorCode: 'waiting_on_operator',
+    }, 1_100)).toBe(true);
+    expect(ledger.markNeedsHumanForQuestions(
+      'AX-4257', ['hq-idle'], 'waiting for operator', 1_200,
+    )).toBe(true);
+    expect(ledger.getRun('AX-4257')?.state).toBe('NEEDS_HUMAN');
+
+    expect(ledger.resumeNeedsHuman('AX-4257', 1_300)).toBeNull();
+    expect(ledger.resumeNeedsHuman('AX-4257', 1_300, 'tracker_todo')).toBeNull();
+    expect(ledger.resumeNeedsHuman('AX-4257', 1_300, 'explicit_dispatch')).toBeNull();
+    expect(ledger.resumeNeedsHuman('AX-4257', 1_400, 'idle_fill')).toBe('READY');
+    expect(ledger.getRun('AX-4257')?.state).toBe('READY');
+
+    ledger.close();
+  });
+
   it('claims it once the answer brings it forward', () => {
     // `markReady` is the transition the runner uses when the board shows the
     // operator replied — the backoff was only ever a poll for that reply.

--- a/src/automation/runLedger.ts
+++ b/src/automation/runLedger.ts
@@ -386,7 +386,9 @@ export class RunLedger {
       if (!row || row.state !== 'NEEDS_HUMAN') return null;
       // An ask_human park carries its own exact-correlation resume contract.
       // Linear state changes and generic operator recovery must not bypass it.
-      if (row.last_error_code === OPERATOR_QUESTION_PARK_REASON) return null;
+      // idle_fill is the exception: empty slots + in-scope work beat the wait
+      // (AGT-4257). The cheap-model pool should keep chewing, not sit parked.
+      if (row.last_error_code === OPERATOR_QUESTION_PARK_REASON && trigger !== 'idle_fill') return null;
       const deadEffects = (this.db.prepare(`
         SELECT COUNT(*) AS count FROM automation_effects
         WHERE issue_id = ? AND status = 'dead'

--- a/src/automation/runLedgerTypes.ts
+++ b/src/automation/runLedgerTypes.ts
@@ -263,4 +263,4 @@ export const NON_FAILURE_RESULT_STATUSES: readonly string[] = [
  * AX-874 left NEEDS_HUMAN unattended at 18:25 on 2026-09-02, the trace could
  * only say that it had happened.
  */
-export type ParkResumeTrigger = 'explicit_dispatch' | 'tracker_todo' | 'sandbox_quarantine_dispatch' | 'unspecified';
+export type ParkResumeTrigger = 'explicit_dispatch' | 'tracker_todo' | 'sandbox_quarantine_dispatch' | 'idle_fill' | 'unspecified';

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -257,6 +257,22 @@ agents:
       });
     });
 
+    it('defaults includeBacklog to true so free slots chew parked work (AGT-4257)', () => {
+      const base = {
+        language: 'en',
+        linear: { apiKey: 'k', teamId: 't' },
+        agents: [{ name: 'main', projectPath: '/p', enabled: true, paused: false }],
+      };
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ ...base, autonomous: { enabled: true } }));
+      expect(loadConfig('/tmp/config.json').autonomous?.includeBacklog).toBe(true);
+
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        ...base, autonomous: { enabled: true, includeBacklog: false },
+      }));
+      expect(loadConfig('/tmp/config.json').autonomous?.includeBacklog).toBe(false);
+    });
+
     it('defaults unknownScopeAdmission to serialize and carries an explicit admit through', () => {
       const base = {
         language: 'en',

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -301,8 +301,8 @@ const AutonomousConfigSchema = z.object({
   maxAttempts: z.number().min(1).max(10).default(3),
   /** Allowed project paths */
   allowedProjects: z.array(z.string()).default(['~/dev']),
-  /** Treat Linear Backlog as a work queue (legacy). Default false = Backlog parked. */
-  includeBacklog: z.boolean().optional(),
+  /** Treat Linear Backlog as a work queue. Default true so free slots chew parked work (AGT-4257). */
+  includeBacklog: z.boolean().optional().default(true),
   /** Model configuration (legacy) */
   models: ModelConfigSchema,
   /** Worker timeout (ms). 0/unset = use the pipeline's per-stage ceiling

--- a/src/orchestration/decisionEngine.ts
+++ b/src/orchestration/decisionEngine.ts
@@ -231,9 +231,8 @@ export interface DecisionEngineConfig {
   dryRun: boolean;
 
   /**
-   * Treat Linear "Backlog" as an actionable work queue (legacy behavior). When
-   * false (default), Backlog is "parked": only Todo/In Progress/In Review are
-   * actionable, so moving an issue to Backlog stops the daemon picking it up.
+   * Treat Linear "Backlog" as an actionable work queue. Default true (AGT-4257)
+   * so free slots chew parked work. Set false to park Backlog again.
    */
   includeBacklog?: boolean;
 
@@ -259,7 +258,7 @@ const DEFAULT_CONFIG: DecisionEngineConfig = {
   allowedProjects: [],
   autoExecute: false,       // Default is manual approval
   dryRun: false,
-  includeBacklog: false,    // Backlog is parked, not a queue (R5)
+  includeBacklog: true,     // AGT-4257: Backlog is still work when slots are free
 };
 
 function expandHomePath(input: string): string {
@@ -332,16 +331,16 @@ export function isAllowedProjectPath(projectPath: string, allowedProjects: strin
 }
 
 /**
- * Linear states the daemon will NOT act on. Backlog is "parked" (opt back in via
- * DecisionEngineConfig.includeBacklog); Done/Canceled are terminal.
+ * Linear states the daemon will NOT act on unless opted in. Done/Canceled are
+ * terminal. Backlog is admitted when includeBacklog is true (AGT-4257 default).
  */
 const NON_ACTIONABLE_LINEAR_STATES = new Set(['Backlog', 'Done', 'Canceled', 'Cancelled']);
 
 /**
- * R5: whether the daemon should act on an issue in the given Linear state. Only
- * Todo/In Progress/In Review (and unknown states, conservatively) are actionable;
- * Backlog is parked and Done/Canceled are terminal. `includeBacklog` opts back
- * into the legacy "Backlog is a work queue" behavior.
+ * Whether the daemon should act on an issue in the given Linear state.
+ * Todo/In Progress/In Review and unknown states are always actionable.
+ * Done/Canceled are terminal. Backlog is a queue when includeBacklog is true
+ * (DecisionEngine default and config default since AGT-4257).
  */
 export function isActionableLinearState(linearState: string | undefined, includeBacklog = false): boolean {
   if (!linearState) return true; // unknown state → don't gate (conservative)
@@ -446,6 +445,8 @@ export class DecisionEngine {
 
   constructor(config: Partial<DecisionEngineConfig> = {}) {
     this.config = { ...DEFAULT_CONFIG, ...config };
+    // `{ ...DEFAULT, includeBacklog: undefined }` would re-park Backlog.
+    this.config.includeBacklog = config.includeBacklog ?? DEFAULT_CONFIG.includeBacklog;
   }
 
   /**

--- a/src/taskState/store.ts
+++ b/src/taskState/store.ts
@@ -686,7 +686,8 @@ export function getTaskReadiness(task: TaskItem): {
     const reactivated =
       linearState === 'Todo' ||
       linearState === 'In Progress' ||
-      linearState === 'In Review';
+      linearState === 'In Review' ||
+      linearState === 'Backlog';
     if (!reactivated) {
       return {
         ready: false,


### PR DESCRIPTION
## Summary
- Heartbeat no longer `Decision: skip` while an enabled project still has non-terminal Linear work and free slots.
- `includeBacklog` defaults to true. `NEEDS_HUMAN` (including unanswered `ask_human`), `RETRY_AT`, and legacy backoff are lifted via `idle_fill`.
- Still skipped: Linear Done/Canceled, parent/EPIC umbrellas, live CLAIMED/EXECUTING leases, unresolved dependents, unmapped/disabled projects.

This is the main-based cherry-pick. Vela stays on 574+4256+4257 (`33f226c` on `fix/agt-4257-never-skip-enabled`) so spawn-cap removal is not rolled back.

## Test plan
- [x] `npx vitest run` operatorPark, operatorQuestionPark, runLedger, decisionEngine.gating, config — 139 passed on this branch
- [x] `npx tsc --noEmit` on the stacked worktree
- [ ] CI green
- [ ] After vela deploy: first heartbeat `Selected > 0` when slots are free and enabled pending work exists