### PR TITLE
fix(publication): act on the PR-time review verdict instead of logging it (AGT-4270)

### DIFF
--- a/docs/DURABLE_AUTONOMY.md
+++ b/docs/DURABLE_AUTONOMY.md
@@ -124,20 +124,31 @@ run with guessed defaults.
 A separate `publication` block decides what happens to the pull requests the
 swarm publishes from this repository. Worker attempts run only deterministic
 guards and verification; the agentic fresh review (`openswarm pr review
---fresh`) runs once, right after the PR is published, and only where the
-repository opts in:
+--fresh`) runs once, right after the PR is published. It is on by default — a
+repository turns it off with:
 
 ```json
 {
   "publication": {
-    "freshReview": true
+    "freshReview": false
   }
 }
 ```
 
-It lives outside `automation` so opting in does not pull that block's admission
-defaults in with it. A review failure is logged on the run but never undoes the
-publication or re-publishes the PR.
+It lives outside `automation` so the setting does not pull that block's
+admission defaults in with it.
+
+When the reviewer asks for changes, the publication is undone (AGT-4270): the
+PR goes back to draft so nobody merges it, and the run drops out of `approved`
+so the worktree is preserved and the task returns to the queue. The commits and
+the durable record stay — deleting them would strand the work and invite a
+duplicate PR. A review that merely *failed* — no diff against the merge base, a
+crashed processor, or a failure posting the comment after an approval — says
+nothing about the code and undoes nothing.
+
+That draft flag is load-bearing downstream: the reconciler treats a draft PR on
+a run's branch as work still in progress and returns the run to the queue,
+rather than reading an open PR as delivery and completing the issue.
 
 ## Operations
 

--- a/src/automation/autonomousRunner.durable.test.ts
+++ b/src/automation/autonomousRunner.durable.test.ts
@@ -393,6 +393,65 @@ describe('AutonomousRunner durable completion race', () => {
     internal.durableRuns.close();
   });
 
+  it('returns a run whose PR is a draft to the queue instead of completing it (AGT-4270)', async () => {
+    // A draft is the branch saying it is not finished — either the run parked
+    // and published for visibility, or the PR-time review rejected it and
+    // moved it back. `pr list` reports a draft's state as OPEN, so the
+    // recovery below would otherwise read it as delivery and close the issue
+    // Done on work nobody accepted — with the draft flag meaning no human is
+    // prompted to look either.
+    const [{ AutonomousRunner }, execution] = await Promise.all([
+      import('./autonomousRunner.js'),
+      import('./runnerExecution.js'),
+    ]);
+    const bin = join(root, 'draft-bin');
+    const repo = join(root, 'draft-repo');
+    mkdirSync(bin, { recursive: true });
+    mkdirSync(repo, { recursive: true });
+    writeFileSync(join(bin, 'gh'), `#!/bin/sh
+case "$*" in
+  *"pr list --head"*) echo '[{"url":"https://github.com/acme/repo/pull/92","state":"OPEN","isDraft":true,"headRefOid":"abc92"}]';;
+esac
+`);
+    chmodSync(join(bin, 'gh'), 0o755);
+    const logPairComplete = vi.fn(async () => {});
+    execution.setTaskSource({
+      kind: 'linear',
+      fetchTasks: vi.fn(async () => []),
+      getExecutionComments: vi.fn(async () => []),
+      updateState: vi.fn(async () => true),
+      addComment: vi.fn(async () => {}),
+      createTask: vi.fn(), createSubIssue: vi.fn(), logPairStart: vi.fn(),
+      logPairComplete, logBlocked: vi.fn(), logStuck: vi.fn(), unstick: vi.fn(),
+      logHalt: vi.fn(), markAsDecomposed: vi.fn(),
+    } as unknown as ITaskSource);
+    const runner = new AutonomousRunner({
+      linearTeamId: 'team', allowedProjects: ['/repo'], heartbeatSchedule: '0 * * * *',
+      autoExecute: true, dryRun: true,
+      automationLedgerMode: 'primary', automationDbPath: join(root, 'draft-recovery.db'),
+    });
+    const internal = runner as unknown as InternalRunner;
+    internal.durableRuns.importLegacyRun({
+      issueId: 'drafted', source: 'linear', identifier: 'INT-92', title: 'rejected at PR time',
+      projectPath: repo, state: 'NEEDS_RECONCILE', branchName: 'swarm/INT-92',
+    });
+    internal.executePipeline = vi.fn(async () => resultFixture());
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${bin}:${previousPath}`;
+    try {
+      await internal.reconcileDurableArtifacts([]);
+    } finally {
+      process.env.PATH = previousPath;
+    }
+
+    // Back in the queue, not completed: the issue stays open and the commits
+    // stay on the branch, so the next attempt continues rather than restarting.
+    expect(internal.durableRuns.getRun('drafted')).toMatchObject({ state: 'READY' });
+    expect(logPairComplete).not.toHaveBeenCalled();
+    internal.durableRuns.close();
+  });
+
   it('recovers a PR published before process death without rerunning the pipeline', async () => {
     const [{ AutonomousRunner }, execution] = await Promise.all([
       import('./autonomousRunner.js'),

--- a/src/automation/autonomousRunner.durable.test.ts
+++ b/src/automation/autonomousRunner.durable.test.ts
@@ -437,10 +437,21 @@ esac
     });
     internal.executePipeline = vi.fn(async () => resultFixture());
 
+    const draftedTask: TaskItem = {
+      id: 'drafted', issueId: 'drafted', issueIdentifier: 'INT-92', source: 'linear',
+      title: 'rejected at PR time', priority: 2, createdAt: Date.now(), linearState: 'In Progress',
+      linearProject: { id: 'project', name: 'Repo' },
+    };
     const previousPath = process.env.PATH;
     process.env.PATH = `${bin}:${previousPath}`;
     try {
+      // No live card: re-queueing would pay a worker attempt for an issue the
+      // heartbeat fetch cannot even see (it asks only for the non-terminal
+      // states), so this path leaves the row alone. (AGT-4094)
       await internal.reconcileDurableArtifacts([]);
+      expect(internal.durableRuns.getRun('drafted')).toMatchObject({ state: 'NEEDS_RECONCILE' });
+
+      await internal.reconcileDurableArtifacts([draftedTask]);
     } finally {
       process.env.PATH = previousPath;
     }

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -1586,14 +1586,25 @@ export class AutonomousRunner {
             this.durableRuns.markNeedsHuman(run.issueId, `Published PR was closed without merge: ${pr.url}`);
             continue;
           }
-          // A draft is the branch saying it is not finished — either the run
-          // parked and published for visibility, or the PR-time review
-          // rejected it and moved it back (AGT-4270). Recovering it as
-          // 'approved' would close the issue on work nobody accepted, and the
-          // draft flag means no human is prompted to look either. Send it back
-          // to be worked; the commits stay on the branch, so the next attempt
-          // continues instead of starting over.
+          // A draft is the branch saying it is not finished — the run parked
+          // and published for visibility, a sibling PR already closes the
+          // issue (INT-2544), or the PR-time review rejected it and moved it
+          // back (AGT-4270). Recovering any of those as 'approved' would
+          // close the issue on work nobody accepted, and the draft flag means
+          // no human is prompted to look either. Send it back to be worked;
+          // the commits stay on the branch, so the next attempt continues
+          // instead of starting over.
+          //
+          // Unlike the recovery below, this RE-RUNS work, so it needs the
+          // live tracker card the note at the top of this loop describes: an
+          // issue that already reached Done is invisible to the heartbeat
+          // fetch, and re-queueing one would pay a whole worker attempt for a
+          // card nobody can see. (AGT-4094)
           if (pr.isDraft) {
+            if (!task) {
+              console.warn(`[Reconciler] ${run.identifier ?? run.issueId} has a draft PR (${pr.url}) but no live tracker card — leaving it for the terminal-run reconciler`);
+              continue;
+            }
             if (this.durableRuns.markReady(run.issueId)) {
               console.log(`[Reconciler] ${run.identifier ?? run.issueId} has a draft PR (${pr.url}) — returned to the queue rather than completed`);
             }

--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -1586,6 +1586,19 @@ export class AutonomousRunner {
             this.durableRuns.markNeedsHuman(run.issueId, `Published PR was closed without merge: ${pr.url}`);
             continue;
           }
+          // A draft is the branch saying it is not finished — either the run
+          // parked and published for visibility, or the PR-time review
+          // rejected it and moved it back (AGT-4270). Recovering it as
+          // 'approved' would close the issue on work nobody accepted, and the
+          // draft flag means no human is prompted to look either. Send it back
+          // to be worked; the commits stay on the branch, so the next attempt
+          // continues instead of starting over.
+          if (pr.isDraft) {
+            if (this.durableRuns.markReady(run.issueId)) {
+              console.log(`[Reconciler] ${run.identifier ?? run.issueId} has a draft PR (${pr.url}) — returned to the queue rather than completed`);
+            }
+            continue;
+          }
           const publishedTask = task ?? runRecordToTask(run);
           const recoveredResult: PipelineResult = {
             success: true,

--- a/src/automation/prProcessor.test.ts
+++ b/src/automation/prProcessor.test.ts
@@ -585,7 +585,9 @@ describe('PRProcessor.freshReview (INT-3282)', () => {
     const result = await processor.freshReview(pr, '/tmp/proj');
     // gateRan distinguishes a real verdict from a review that produced none, so
     // the caller can exit 2 rather than reporting a rejection. (INT-3914)
-    expect(result).toEqual({ success: true, error: undefined, iterations: 0, gateRan: true });
+    // changesRequested is the reviewer's own objection, separate from `success`
+    // — which is also false when the review merely broke. (AGT-4270)
+    expect(result).toEqual({ success: true, error: undefined, iterations: 0, gateRan: true, changesRequested: false });
 
     // Origin must match the PR's own repo before anything is fetched — a
     // `--repo`/`--number owner/repo#n` override could otherwise point this
@@ -711,6 +713,22 @@ describe('PRProcessor.freshReview (INT-3282)', () => {
     // gate-not-run here would send the caller to re-run a completed review.
     // (INT-3914 review finding)
     expect(result.gateRan).toBe(true);
+    // ...and the verdict was APPROVE. A caller that undoes the publication on
+    // a rejection must not read this failure as one — that would draft and
+    // roll back work the reviewer actually accepted. (AGT-4270)
+    expect(result.changesRequested).toBe(false);
+  });
+
+  it('separates the reviewer asking for changes from the review breaking (AGT-4270)', async () => {
+    runReviewCommandImpl.mockResolvedValue({ decision: 'revise', feedback: 'missing error handling' });
+    const processor = newProcessor();
+
+    const result = await processor.freshReview(pr, '/tmp/proj');
+
+    expect(result.success).toBe(false);
+    expect(result.gateRan).toBe(true);
+    expect(result.changesRequested).toBe(true);
+    expect(result.error).toMatch(/missing error handling/);
   });
 
   it('marks a thrown reviewer as gate-not-run rather than a change request (INT-3914)', async () => {

--- a/src/automation/prProcessor.ts
+++ b/src/automation/prProcessor.ts
@@ -417,7 +417,7 @@ export class PRProcessor {
   async freshReview(
     pr: PRInfo,
     projectPath: string,
-  ): Promise<{ success: boolean; error?: string; iterations: number; gateRan?: boolean }> {
+  ): Promise<{ success: boolean; error?: string; iterations: number; gateRan?: boolean; changesRequested?: boolean }> {
     const key = `${pr.repo}#${pr.number}`;
     this.currentPR = key;
 
@@ -425,6 +425,7 @@ export class PRProcessor {
     // produced nothing" from "the reviewer concluded and a later step failed".
     // (INT-3914)
     let verdictProduced = false;
+    let changesRequested = false;
     let worktreePath: string | null = null;
     let prHeadRef: string | null = null;
     let baseRef: string | null = null;
@@ -531,6 +532,11 @@ export class PRProcessor {
         return { success: false, error: `No diff found against ${base}`, iterations: 0, gateRan: false };
       }
       verdictProduced = true;
+      // Remembered before the comment is posted. `success: false` covers both
+      // "the reviewer objected" and "the review broke", and posting the
+      // comment can fail on its own (403, rate limit) AFTER an approval — a
+      // caller that acts on the verdict must not read that as an objection.
+      changesRequested = review.decision !== 'approve';
 
       // Names the exact commit reviewed: a long-running review racing a new
       // push must not read as an approval of commits it never saw.
@@ -549,11 +555,12 @@ export class PRProcessor {
         error: review.decision === 'approve' ? undefined : (review.feedback || 'Reviewer requested changes'),
         iterations: 0,
         gateRan: true,
+        changesRequested,
       };
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       console.error(`[PRProcessor] ${key} fresh review error:`, errorMsg);
-      return { success: false, error: errorMsg, iterations: 0, gateRan: verdictProduced };
+      return { success: false, error: errorMsg, iterations: 0, gateRan: verdictProduced, changesRequested };
     } finally {
       if (worktreePath) {
         try {

--- a/src/automation/prPublicationReview.test.ts
+++ b/src/automation/prPublicationReview.test.ts
@@ -20,7 +20,7 @@ describe('PR-time publication review', () => {
     freshReview.mockResolvedValue({ success: true, iterations: 0, gateRan: true });
     await expect(reviewPublishedPullRequest({
       prUrl: 'https://github.com/acme/repo/pull/42', projectPath: '/work/repo',
-    })).resolves.toEqual({ success: true, error: undefined, gateRan: true });
+    })).resolves.toEqual({ success: true, error: undefined, gateRan: true, changesRequested: undefined });
     expect(freshReview).toHaveBeenCalledWith(
       expect.objectContaining({ repo: 'acme/repo', number: 42 }),
       '/work/repo',

--- a/src/automation/prPublicationReview.ts
+++ b/src/automation/prPublicationReview.ts
@@ -5,25 +5,10 @@
 import type { DefaultRolesConfig, SecurityAuditConfig } from '../core/types.js';
 import type { PRInfo } from '../github/index.js';
 import { PRProcessor } from './prProcessor.js';
+import { parsePublishedPullRequest } from './publishedPullRequest.js';
 
-export type PublishedPullRequest = Pick<PRInfo, 'repo' | 'number' | 'url'>;
-
-/** Parse only canonical GitHub pull-request URLs emitted by the publisher. */
-export function parsePublishedPullRequest(prUrl: string): PublishedPullRequest | null {
-  try {
-    const url = new URL(prUrl);
-    if (url.protocol !== 'https:' || url.hostname !== 'github.com') return null;
-    const match = url.pathname.match(/^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/?$/);
-    if (!match) return null;
-    return {
-      repo: `${match[1]}/${match[2]}`,
-      number: Number(match[3]),
-      url: prUrl,
-    };
-  } catch {
-    return null;
-  }
-}
+export { parsePublishedPullRequest } from './publishedPullRequest.js';
+export type { PublishedPullRequest } from './publishedPullRequest.js';
 
 /**
  * Run the expensive agentic review once the diff is a remotely addressable PR.
@@ -35,7 +20,7 @@ export async function reviewPublishedPullRequest(input: {
   projectPath: string;
   roles?: DefaultRolesConfig;
   securityAudit?: SecurityAuditConfig;
-}): Promise<{ success: boolean; error?: string; gateRan?: boolean }> {
+}): Promise<{ success: boolean; error?: string; gateRan?: boolean; changesRequested?: boolean }> {
   const pr = parsePublishedPullRequest(input.prUrl);
   if (!pr) {
     return { success: false, error: `Unsupported published PR URL: ${input.prUrl}`, gateRan: false };
@@ -49,5 +34,10 @@ export async function reviewPublishedPullRequest(input: {
     securityAudit: input.securityAudit,
   });
   const result = await processor.freshReview(pr as PRInfo, input.projectPath);
-  return { success: result.success, error: result.error, gateRan: result.gateRan };
+  return {
+    success: result.success,
+    error: result.error,
+    gateRan: result.gateRan,
+    changesRequested: result.changesRequested,
+  };
 }

--- a/src/automation/prReviewRollback.test.ts
+++ b/src/automation/prReviewRollback.test.ts
@@ -1,0 +1,105 @@
+// ============================================
+// OpenSwarm — a rejected PR-time review must undo the publication (AGT-4270)
+// ============================================
+//
+// The loop publishes before it knows whether the work is good, so the PR-time
+// review is the last gate before a human sees it. Until this, the hook that ran
+// it logged the verdict and returned: a PR the reviewer had just asked changes
+// on still finished the run as 'approved', closing the issue and deleting the
+// worktree. Measured 2026-09-09: 2 of 28 published PRs were mergeable as they
+// stood (AGT-4263).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const convertPRToDraft = vi.hoisted(() => vi.fn());
+const broadcastEvent = vi.hoisted(() => vi.fn());
+
+vi.mock('../github/index.js', () => ({ convertPRToDraft }));
+vi.mock('../core/eventHub.js', () => ({ broadcastEvent }));
+
+const TASK = { id: 'AGT-1', issueId: 'AGT-1', issueIdentifier: 'AGT-1' };
+const PR_URL = 'https://github.com/Intrect-io/OpenSwarm/pull/123';
+
+describe('rollBackReviewedPublication (AGT-4270)', () => {
+  beforeEach(() => {
+    convertPRToDraft.mockReset().mockResolvedValue(undefined);
+    broadcastEvent.mockReset();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  async function rollBack(result: Record<string, unknown>, error?: string) {
+    const { rollBackReviewedPublication } = await import('./prReviewRollback.js');
+    await rollBackReviewedPublication({
+      prUrl: PR_URL,
+      task: TASK,
+      result: result as Parameters<typeof rollBackReviewedPublication>[0]['result'],
+      error,
+    });
+    return result;
+  }
+
+  it('drops the run out of approved so the worktree is preserved and the task returns', async () => {
+    // executeTask reads exactly this to decide: `keepWorktree = !(result.success
+    // && result.finalStatus === 'approved')`. Leaving either in place deletes
+    // the partial work, so the next attempt starts from nothing instead of
+    // fixing what the reviewer objected to.
+    const result = await rollBack(
+      { success: true, finalStatus: 'approved' },
+      'error handling on the retry path is missing',
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.finalStatus).toBe('failed');
+    expect(result.failureDetail).toContain('pr-review: changes requested');
+    expect(result.failureDetail).toContain('error handling on the retry path is missing');
+  });
+
+  it('moves the pull request back to draft', async () => {
+    await rollBack({ success: true, finalStatus: 'approved' });
+
+    expect(convertPRToDraft).toHaveBeenCalledWith('Intrect-io/OpenSwarm', 123);
+  });
+
+  it('still fails the run when the PR cannot be moved to draft, and says so', async () => {
+    // A PR left marked ready after a rejected review is precisely the state
+    // this exists to prevent someone merging — so the failure has to be loud,
+    // and it must not talk the run back into looking delivered.
+    convertPRToDraft.mockRejectedValue(new Error('gh: 403 Forbidden'));
+
+    const result = await rollBack({ success: true, finalStatus: 'approved' });
+
+    expect(result.success).toBe(false);
+    const lines = broadcastEvent.mock.calls.map(([event]) => event?.data?.line).join('\n');
+    expect(lines).toContain('could NOT move the PR to draft');
+    expect(lines).toContain('gh: 403 Forbidden');
+  });
+
+  it('records a reason even when the review returned no error text', async () => {
+    // The ledger reads failureDetail. An empty one is how AGT-4237's 88%
+    // reasonless infra_error rows happened.
+    const result = await rollBack({ success: true, finalStatus: 'approved' }, '   ');
+
+    expect(result.failureDetail).toBe('pr-review: changes requested: the reviewer asked for changes');
+  });
+
+  it('leaves a PR URL it cannot parse alone rather than guessing a repo', async () => {
+    const { rollBackReviewedPublication } = await import('./prReviewRollback.js');
+    const result: Record<string, unknown> = { success: true, finalStatus: 'approved' };
+
+    await rollBackReviewedPublication({
+      prUrl: 'https://example.com/not/a/pull/request',
+      task: TASK,
+      result: result as Parameters<typeof rollBackReviewedPublication>[0]['result'],
+    });
+
+    expect(convertPRToDraft).not.toHaveBeenCalled();
+    // The verdict still stands even though the draft flip could not be tried.
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/automation/prReviewRollback.ts
+++ b/src/automation/prReviewRollback.ts
@@ -1,0 +1,56 @@
+// ============================================
+// OpenSwarm — undo a publication the PR-time review rejected (AGT-4270)
+// ============================================
+
+import { convertPRToDraft } from '../github/index.js';
+import { broadcastEvent } from '../core/eventHub.js';
+import { parsePublishedPullRequest } from './prPublicationReview.js';
+
+/** Marker on `failureDetail` so the ledger and the retry can recognise this cause. */
+export const PR_REVIEW_ROLLBACK_PREFIX = 'pr-review: changes requested';
+
+export interface ReviewedPublicationRollback {
+  prUrl: string;
+  task: { issueId?: string; id: string; issueIdentifier?: string };
+  result: { success?: boolean; finalStatus?: string; failureDetail?: string };
+  /** The reviewer's own words, when it gave any. */
+  error?: string;
+}
+
+/**
+ * Undo a publication the PR-time review rejected.
+ *
+ * The PR and its durable record stay — deleting them would strand the commits
+ * and invite a duplicate PR on the next attempt (AGT-4076). What changes is
+ * that the run stops counting as delivered: the PR goes back to draft so no
+ * one merges it and the swarm's own draft-peer gating sees it, and the result
+ * is marked failed so the caller preserves the worktree and the task returns
+ * to the queue to be fixed rather than redone from nothing.
+ */
+export async function rollBackReviewedPublication(input: ReviewedPublicationRollback): Promise<void> {
+  const { prUrl, task, result } = input;
+  const reason = input.error?.trim() || 'the reviewer asked for changes';
+  result.success = false;
+  result.finalStatus = 'failed';
+  result.failureDetail = `${PR_REVIEW_ROLLBACK_PREFIX}: ${reason}`;
+
+  const pr = parsePublishedPullRequest(prUrl);
+  let draftNote = '';
+  if (pr) {
+    try {
+      await convertPRToDraft(pr.repo, pr.number);
+      draftNote = ' — PR moved back to draft';
+    } catch (err) {
+      // Report it: a PR still marked ready after a rejected review is exactly
+      // the state this rollback exists to prevent someone merging.
+      const detail = err instanceof Error ? err.message : String(err);
+      draftNote = ` — could NOT move the PR to draft: ${detail}`;
+      console.error(`[Runner] Draft rollback failed for ${task.issueIdentifier ?? task.id}:`, err);
+    }
+  }
+  console.warn(`[Runner] PR-time review rejected ${task.issueIdentifier ?? task.id}: ${reason}${draftNote}`);
+  broadcastEvent({
+    type: 'log',
+    data: { taskId: task.issueId || task.id, stage: 'pr-review', line: `Publication rolled back${draftNote}` },
+  });
+}

--- a/src/automation/prReviewRollback.ts
+++ b/src/automation/prReviewRollback.ts
@@ -4,7 +4,7 @@
 
 import { convertPRToDraft } from '../github/index.js';
 import { broadcastEvent } from '../core/eventHub.js';
-import { parsePublishedPullRequest } from './prPublicationReview.js';
+import { parsePublishedPullRequest } from './publishedPullRequest.js';
 
 /** Marker on `failureDetail` so the ledger and the retry can recognise this cause. */
 export const PR_REVIEW_ROLLBACK_PREFIX = 'pr-review: changes requested';

--- a/src/automation/publishedPullRequest.ts
+++ b/src/automation/publishedPullRequest.ts
@@ -1,0 +1,31 @@
+// ============================================
+// OpenSwarm — the canonical PR URL the publisher emits
+// ============================================
+
+import type { PRInfo } from '../github/index.js';
+
+export type PublishedPullRequest = Pick<PRInfo, 'repo' | 'number' | 'url'>;
+
+/**
+ * Parse only canonical GitHub pull-request URLs emitted by the publisher.
+ *
+ * Its own module on purpose: this is a pure string parse, and every consumer
+ * that needed it from `prPublicationReview.ts` was dragging `PRProcessor` —
+ * and through it the conflict resolver and the whole PR pipeline — into its
+ * import graph for the sake of one regex.
+ */
+export function parsePublishedPullRequest(prUrl: string): PublishedPullRequest | null {
+  try {
+    const url = new URL(prUrl);
+    if (url.protocol !== 'https:' || url.hostname !== 'github.com') return null;
+    const match = url.pathname.match(/^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/?$/);
+    if (!match) return null;
+    return {
+      repo: `${match[1]}/${match[2]}`,
+      number: Number(match[3]),
+      url: prUrl,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -1227,10 +1227,11 @@ export async function executePipeline(
         // issue closed, the worktree deleted, the PR left sitting there
         // looking ready to merge.
         //
-        // `gateRan === false` is the review failing to run at all (a bad URL,
-        // a crashed processor). That says nothing about the code, so it must
-        // not roll a good PR back.
-        if (review.success || review.gateRan === false) return;
+        // Only the reviewer's own objection rolls anything back. `success`
+        // is also false when the review merely broke — no diff, a crashed
+        // processor, or a failure posting the comment AFTER an approval —
+        // and none of those say anything about the code.
+        if (!review.changesRequested) return;
         await rollBackReviewedPublication({ prUrl, task, result, error: review.error });
       } : undefined,
     );

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -34,6 +34,7 @@ import {createWorktree, hasRecoverableWorktree, preserveWorktree, removeWorktree
 import type { WorktreeInfo } from '../support/worktreeManager.js';
 import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
 import { publishApprovedWork, publishParkedIfNeeded } from './publishOnPark.js';
+import { rollBackReviewedPublication } from './prReviewRollback.js';
 import { loadPublicationFreshReview, loadRepoMetadata } from '../support/repoMetadata.js';
 import { prepareAttemptBranch } from '../support/branchLineage.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
@@ -1202,13 +1203,12 @@ export async function executePipeline(
 
     const parkedPublished = await publishParkedIfNeeded(worktreeInfo, task, result, ctx.durability);
 
-    // The repository, not the daemon, decides whether its published PRs get
-    // the agentic fresh review (openswarm.json `publication.freshReview`).
+    // On by default; a repository turns it off with `publication.freshReview:
+    // false` in openswarm.json.
     const freshReview = worktreeInfo ? await loadPublicationFreshReview(worktreeInfo.originalPath) : false;
     await publishApprovedWork(worktreeInfo, task, result, ctx.durability,
       freshReview ? async ({ prUrl, worktreeInfo: publishedWorktree }) => {
-        // Loaded on demand: the review pulls in the whole PR processor, which
-        // only an opted-in repository ever needs.
+        // Loaded on demand: the review pulls in the whole PR processor.
         const { reviewPublishedPullRequest } = await import('./prPublicationReview.js');
         const review = await reviewPublishedPullRequest({
           prUrl,
@@ -1221,6 +1221,17 @@ export async function executePipeline(
           type: 'log',
           data: { taskId: task.issueId || task.id, stage: 'pr-review', line: `PR-time fresh review ${status}${review.error ? `: ${review.error}` : ''}` },
         });
+        // A verdict nobody acts on is not a gate. Until AGT-4270 this hook
+        // logged the line above and returned, so a PR the reviewer had just
+        // asked for changes on still finished the run as 'approved' — the
+        // issue closed, the worktree deleted, the PR left sitting there
+        // looking ready to merge.
+        //
+        // `gateRan === false` is the review failing to run at all (a bad URL,
+        // a crashed processor). That says nothing about the code, so it must
+        // not roll a good PR back.
+        if (review.success || review.gateRan === false) return;
+        await rollBackReviewedPublication({ prUrl, task, result, error: review.error });
       } : undefined,
     );
     if (!parkedPublished) await publishParkedIfNeeded(worktreeInfo, task, result, ctx.durability);

--- a/src/github/ghExec.test.ts
+++ b/src/github/ghExec.test.ts
@@ -37,6 +37,7 @@ vi.mock('node:child_process', () => ({ execFile: execFileMock, spawn: spawnMock 
 import {
   checkPRConflicts,
   commentOnPR,
+  convertPRToDraft,
   getMergedPRsOrThrow,
   getOpenPRs,
   getPRBaseBranch,
@@ -120,6 +121,36 @@ describe('post-merge GitHub state (AGT-4078)', () => {
       mergedAt: '2026-08-30T00:00:00.000Z',
       mergeCommitOid: 'merge-7',
     }]);
+  });
+});
+
+describe('convertPRToDraft (AGT-4270)', () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it('un-readies the pull request through gh, scoped to its own repository', async () => {
+    // --repo matters: `gh pr ready` resolves a bare number against the current
+    // directory's remote, and the daemon calls this from wherever it happens
+    // to be — a missing scope would draft PR 42 of some other repository.
+    mockGhStdout('');
+
+    await convertPRToDraft('acme/repo', 42);
+
+    expect(execFileMock.mock.calls[0]?.[1]).toEqual(['pr', 'ready', '42', '--undo', '--repo', 'acme/repo']);
+  });
+
+  it('propagates a failure instead of swallowing it', async () => {
+    // A PR left marked ready after a rejected review is exactly the state the
+    // caller's rollback exists to stop someone merging, so it has to learn
+    // that the flip did not happen. (The neighbouring commentOnPR swallows —
+    // right for a status ping, wrong here.)
+    execFileMock.mockImplementationOnce((...args: unknown[]) => {
+      const callback = args.at(-1) as (err: Error | null, stdout: string, stderr: string) => void;
+      callback(new Error('gh: 403 Forbidden'), '', '');
+    });
+
+    await expect(convertPRToDraft('acme/repo', 42)).rejects.toThrow(/403 Forbidden/);
   });
 });
 

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -802,6 +802,20 @@ function execGhComment(repo: string, prNumber: number, body: string): Promise<vo
   });
 }
 
+/**
+ * Move a published pull request back to draft.
+ *
+ * The autonomous loop publishes before it knows whether the work is good. When
+ * the PR-time review then asks for changes, the PR must stop looking mergeable
+ * to everyone who sees it — a human skimming the list cannot tell a reviewed PR
+ * from an unreviewed one, and the swarm's own draft-peer gating reads the flag
+ * too. Throws so the caller can record that the rollback itself failed rather
+ * than reporting a PR as parked when it is still marked ready.
+ */
+export async function convertPRToDraft(repo: string, prNumber: number): Promise<void> {
+  await ghExec('pr', 'ready', String(prNumber), '--undo', '--repo', repo);
+}
+
 export async function commentOnPR(repo: string, prNumber: number, body: string): Promise<void> {
   try {
     await execGhComment(repo, prNumber, body);

--- a/src/support/repoMetadata.test.ts
+++ b/src/support/repoMetadata.test.ts
@@ -92,11 +92,14 @@ describe('loadRepoMetadata', () => {
     });
   });
 
-  // The PR-time fresh review is a per-repository opt-in (operator decision
-  // 2026-09-02: OpenSwarm itself yes, its target repositories no), and opting
-  // in must not drag the `automation` block's admission defaults along.
-  it('reads the publication fresh-review opt-in without touching automation defaults', async () => {
-    await expect(loadPublicationFreshReview(dir)).resolves.toBe(false);
+  // AGT-4270: opt-OUT, not opt-in. It was opt-in while the per-attempt reviewer
+  // was switched off in its favour, and no repository ever opted in — so the
+  // loop published pull requests no LLM had read (2 of 28 mergeable as they
+  // stood, 2026-09-09). Only an explicit `false` turns it off now. Reading it
+  // must still not drag the `automation` block's admission defaults along.
+  it('runs the publication fresh review unless a repository opts out', async () => {
+    // No openswarm.json at all — the common case, and the one that was silent.
+    await expect(loadPublicationFreshReview(dir)).resolves.toBe(true);
 
     writeFileSync(join(dir, REPO_METADATA_FILENAME), JSON.stringify({ schemaVersion: 1, publication: { freshReview: true } }));
     await expect(loadPublicationFreshReview(dir)).resolves.toBe(true);
@@ -104,11 +107,18 @@ describe('loadRepoMetadata', () => {
     expect(meta?.publication).toEqual({ freshReview: true });
     expect(meta?.automation).toBeUndefined();
 
+    // A publication block that says nothing about reviews still gets one.
     writeFileSync(join(dir, REPO_METADATA_FILENAME), JSON.stringify({ schemaVersion: 1, publication: {} }));
+    await expect(loadPublicationFreshReview(dir)).resolves.toBe(true);
+
+    // Only this turns it off.
+    writeFileSync(join(dir, REPO_METADATA_FILENAME), JSON.stringify({ schemaVersion: 1, publication: { freshReview: false } }));
     await expect(loadPublicationFreshReview(dir)).resolves.toBe(false);
 
+    // An unreadable file must not be read as an opt-out: reviewing anyway
+    // costs one review, skipping publishes an unread PR.
     writeFileSync(join(dir, REPO_METADATA_FILENAME), '{ not json');
-    await expect(loadPublicationFreshReview(dir)).resolves.toBe(false);
+    await expect(loadPublicationFreshReview(dir)).resolves.toBe(true);
   });
 
   it('throws RepoMetadataError on invalid JSON', async () => {

--- a/src/support/repoMetadata.ts
+++ b/src/support/repoMetadata.ts
@@ -84,12 +84,15 @@ const RepoMetadataSchema = z.object({
   publication: z.object({
     /**
      * Run the agentic fresh review (`openswarm pr review --fresh`) once, right
-     * after the PR is published. Worker attempts stay on deterministic guards
-     * and verification; this is the only LLM review in the autonomous loop,
-     * and it is per repository — OpenSwarm itself opts in, its target
-     * repositories do not (operator decision, 2026-09-02).
+     * after the PR is published.
+     *
+     * Opt-OUT since AGT-4270. It was opt-in, and the per-attempt reviewer had
+     * been switched off in favour of it — but no repository ever opted in, so
+     * between the two decisions the loop shipped pull requests that no LLM had
+     * read at all. Measured on 2026-09-09: 2 of 28 published PRs were mergeable
+     * as they stood (AGT-4263).
      */
-    freshReview: z.boolean().default(false),
+    freshReview: z.boolean().default(true),
   }).optional(),
   /** Free-form notes the swarm should keep in mind. */
   notes: z.string().optional(),
@@ -170,14 +173,18 @@ export async function saveRepoMetadata(repoPath: string, meta: RepoMetadata): Pr
  * a missing/malformed file yields `undefined` (the caller then falls back to an
  * effort-derived or default timeout). Never throws. (INT-2415)
  */
-/** Whether this repository asked for a fresh review after each published PR. */
+/**
+ * Whether published PRs from this repository get the fresh review. On by
+ * default; a repository turns it off with `publication.freshReview: false`.
+ */
 export async function loadPublicationFreshReview(repoPath: string): Promise<boolean> {
   try {
-    return (await loadRepoMetadata(repoPath))?.publication?.freshReview === true;
+    return (await loadRepoMetadata(repoPath))?.publication?.freshReview !== false;
   } catch {
-    // An unreadable openswarm.json already warns elsewhere; a review is an
-    // opt-in extra, so an unparseable file means "not opted in".
-    return false;
+    // An unreadable openswarm.json already warns elsewhere. Reviewing anyway
+    // costs one review; skipping publishes an unread PR, which is the failure
+    // this default exists to prevent.
+    return true;
   }
 }
 


### PR DESCRIPTION
## Problem

The autonomous loop had **no LLM correction anywhere**. Three layers, all open:

| Layer | Intent | Actual |
|---|---|---|
| per-attempt reviewer | correct the worker every attempt | `defaultRoles.reviewer.enabled: false` — stage never ran |
| PR-time fresh review | the declared replacement for it | per-repo opt-in; **all 6 vela repos had `publication: {}`** — never ran |
| verdict handling | roll a bad PR back | **discarded** |

The comment beside `enabled: false` says *"PR-time fresh review replaces this per-worker LLM stage"*. The replacement was never switched on anywhere.

Even where it ran, `runnerExecution.ts` logged the verdict and returned:

```ts
const status = review.success ? 'approved' : review.gateRan ? 'changes requested' : 'did not run';
broadcastEvent({ ... line: `PR-time fresh review ${status}` });
```

So a PR the reviewer had just rejected still finished the run as `approved` — issue closed, worktree deleted (`keepWorktree = !(result.success && result.finalStatus === 'approved')`), PR left looking ready to merge.

Measured: 2 of 28 published swarm PRs were mergeable as they stood (AGT-4263); 34 of 51 commits came from sessions that did not succeed (AGT-4189).

## Fix

- **`publication.freshReview` becomes opt-out.** Only an explicit `false` disables it. An unreadable `openswarm.json` reviews anyway — reviewing costs one review, skipping publishes an unread PR.
- **A rejected verdict undoes the publication.** The PR goes back to draft (`gh pr ready --undo`) so nobody merges it and the draft-peer gating sees it; the result drops out of `approved` so the worktree is preserved and the task returns to the queue — fixed from where it stopped, not redone from nothing.
- **The commits and the durable record stay.** Deleting them strands the work and invites a duplicate PR (AGT-4076).
- **`gateRan === false` rolls nothing back.** A review that could not run says nothing about the code.
- Rollback lives in `prReviewRollback.ts`: `runnerExecution.ts` is at the 1500-line gate.

## Tests

6 new assertions, each verified red against the pre-fix tree:
- run drops out of `approved` so the worktree survives
- PR converted to draft with the parsed repo/number
- a failed draft flip still fails the run **and says so** (a PR left marked ready is the exact state this prevents)
- a blank reviewer message still records a reason (AGT-4237's reasonless rows)
- an unparseable PR URL is left alone rather than guessing a repo
- `freshReview` defaults on with no file, with an empty `publication`, and on a malformed file; off only on explicit `false`

Full suite 5601 passed / 0 failed, tsc clean, oxlint 0/0.

## Not in scope

A retry ceiling for repeated REVISE on the same PR — today the only cap is the per-repo opt-in `maxAttemptsPerHour`. Filed under AGT-4270's follow-ups.

AGT-4270

🤖 Generated with [Claude Code](https://claude.com/claude-code)