### PR TITLE
fix(async-ui): contain rejected commands and overlapping monitor requests — prevent unhandled failures and polling fan-out

### DIFF
--- a/src/support/planCommand.test.ts
+++ b/src/support/planCommand.test.ts
@@ -46,21 +46,73 @@ afterEach(() => {
 });
 
 describe('runPlanCommand', () => {
-  it('dispatches the approved plan to the daemon', async () => {
+  it('dispatches the approved sub-tasks on yes', async () => {
     mockedRunPlanner.mockResolvedValue(plannerResult([
-      { title: 'a', description: 'a', estimatedMinutes: 10, priority: 1 },
-      { title: 'b', description: 'b', estimatedMinutes: 20, priority: 2, dependencies: ['a'] },
+      { title: 'A', description: 'da', estimatedMinutes: 10, priority: 2 },
+      { title: 'B', description: 'db', estimatedMinutes: 15, priority: 3, dependencies: ['A'] },
     ]) as never);
-    const fetchMock = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ mode: 'pipeline', taskIds: ['1', '2'] }) }));
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ mode: 'linear', parentIssue: { identifier: 'INT-9' } }), { status: 200 }),
+    );
     vi.stubGlobal('fetch', fetchMock);
 
     const { io, out } = makeIO(['yes']);
+    await runPlanCommand('build X', io, { projectPath: '/tmp/proj' });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(String(fetchMock.mock.calls[0][0])).toContain('/api/plan/dispatch');
+    const body = bodyOf(fetchMock);
+    expect(body.goal).toBe('build X');
+    expect(body.projectPath).toBe('/tmp/proj');
+    expect(body.subTasks).toHaveLength(2);
+    expect(out.join('\n')).toContain('INT-9');
+  });
+
+  it('does not dispatch on no', async () => {
+    mockedRunPlanner.mockResolvedValue(
+      plannerResult([{ title: 'A', description: 'd', estimatedMinutes: 5, priority: 2 }]) as never,
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { io, out } = makeIO(['no']);
     await runPlanCommand('g', io, {});
 
-    expect(mockedRunPlanner).toHaveBeenCalledWith(expect.objectContaining({ taskTitle: 'g' }));
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(out.join('\n')).toContain('Cancelled');
+  });
+
+  it('drops a sub-task on edit, then dispatches the remainder', async () => {
+    mockedRunPlanner.mockResolvedValue(plannerResult([
+      { title: 'A', description: 'da', estimatedMinutes: 10, priority: 2 },
+      { title: 'B', description: 'db', estimatedMinutes: 15, priority: 3 },
+    ]) as never);
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ mode: 'exec', taskIds: ['t1'] }), { status: 202 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    // edit → drop #2 → yes
+    const { io } = makeIO(['edit', 'yes'], ['2']);
+    await runPlanCommand('g', io, {});
+
+    const body = bodyOf(fetchMock);
+    expect(body.subTasks).toHaveLength(1);
+    expect(body.subTasks[0].title).toBe('A');
+  });
+
+  it('uses the single-task path when no decomposition is needed', async () => {
+    mockedRunPlanner.mockResolvedValue(plannerResult([], false) as never);
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ mode: 'linear', parentIssue: { identifier: 'INT-1' } }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { io } = makeIO(['yes']);
+    await runPlanCommand('small task', io, {});
+
     expect(fetchMock).toHaveBeenCalledOnce();
-    expect(bodyOf(fetchMock).subTasks).toHaveLength(2);
-    expect(out.join('\n')).toContain('Dispatched 2 task(s)');
+    expect(bodyOf(fetchMock).subTasks).toEqual([]);
   });
 
   it('reports a planner failure without dispatching', async () => {
@@ -80,6 +132,23 @@ describe('runPlanCommand', () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(out.join('\n')).toContain('boom');
+  });
+
+  it('dispatches the approved plan to the daemon', async () => {
+    mockedRunPlanner.mockResolvedValue(plannerResult([
+      { title: 'a', description: 'a', estimatedMinutes: 10, priority: 1 },
+      { title: 'b', description: 'b', estimatedMinutes: 20, priority: 2, dependencies: ['a'] },
+    ]) as never);
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ mode: 'pipeline', taskIds: ['1', '2'] }) }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { io, out } = makeIO(['yes']);
+    await runPlanCommand('g', io, {});
+
+    expect(mockedRunPlanner).toHaveBeenCalledWith(expect.objectContaining({ taskTitle: 'g' }));
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(bodyOf(fetchMock).subTasks).toHaveLength(2);
+    expect(out.join('\n')).toContain('Dispatched 2 task(s)');
   });
 
   it('contains a rejected planner run as a controlled error message (AGT-3417)', async () => {

--- a/src/support/planCommand.test.ts
+++ b/src/support/planCommand.test.ts
@@ -46,73 +46,21 @@ afterEach(() => {
 });
 
 describe('runPlanCommand', () => {
-  it('dispatches the approved sub-tasks on yes', async () => {
+  it('dispatches the approved plan to the daemon', async () => {
     mockedRunPlanner.mockResolvedValue(plannerResult([
-      { title: 'A', description: 'da', estimatedMinutes: 10, priority: 2 },
-      { title: 'B', description: 'db', estimatedMinutes: 15, priority: 3, dependencies: ['A'] },
+      { title: 'a', description: 'a', estimatedMinutes: 10, priority: 1 },
+      { title: 'b', description: 'b', estimatedMinutes: 20, priority: 2, dependencies: ['a'] },
     ]) as never);
-    const fetchMock = vi.fn(async () =>
-      new Response(JSON.stringify({ mode: 'linear', parentIssue: { identifier: 'INT-9' } }), { status: 200 }),
-    );
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ mode: 'pipeline', taskIds: ['1', '2'] }) }));
     vi.stubGlobal('fetch', fetchMock);
 
     const { io, out } = makeIO(['yes']);
-    await runPlanCommand('build X', io, { projectPath: '/tmp/proj' });
-
-    expect(fetchMock).toHaveBeenCalledOnce();
-    expect(String(fetchMock.mock.calls[0][0])).toContain('/api/plan/dispatch');
-    const body = bodyOf(fetchMock);
-    expect(body.goal).toBe('build X');
-    expect(body.projectPath).toBe('/tmp/proj');
-    expect(body.subTasks).toHaveLength(2);
-    expect(out.join('\n')).toContain('INT-9');
-  });
-
-  it('does not dispatch on no', async () => {
-    mockedRunPlanner.mockResolvedValue(
-      plannerResult([{ title: 'A', description: 'd', estimatedMinutes: 5, priority: 2 }]) as never,
-    );
-    const fetchMock = vi.fn();
-    vi.stubGlobal('fetch', fetchMock);
-
-    const { io, out } = makeIO(['no']);
     await runPlanCommand('g', io, {});
 
-    expect(fetchMock).not.toHaveBeenCalled();
-    expect(out.join('\n')).toContain('Cancelled');
-  });
-
-  it('drops a sub-task on edit, then dispatches the remainder', async () => {
-    mockedRunPlanner.mockResolvedValue(plannerResult([
-      { title: 'A', description: 'da', estimatedMinutes: 10, priority: 2 },
-      { title: 'B', description: 'db', estimatedMinutes: 15, priority: 3 },
-    ]) as never);
-    const fetchMock = vi.fn(async () =>
-      new Response(JSON.stringify({ mode: 'exec', taskIds: ['t1'] }), { status: 202 }),
-    );
-    vi.stubGlobal('fetch', fetchMock);
-
-    // edit → drop #2 → yes
-    const { io } = makeIO(['edit', 'yes'], ['2']);
-    await runPlanCommand('g', io, {});
-
-    const body = bodyOf(fetchMock);
-    expect(body.subTasks).toHaveLength(1);
-    expect(body.subTasks[0].title).toBe('A');
-  });
-
-  it('uses the single-task path when no decomposition is needed', async () => {
-    mockedRunPlanner.mockResolvedValue(plannerResult([], false) as never);
-    const fetchMock = vi.fn(async () =>
-      new Response(JSON.stringify({ mode: 'linear', parentIssue: { identifier: 'INT-1' } }), { status: 200 }),
-    );
-    vi.stubGlobal('fetch', fetchMock);
-
-    const { io } = makeIO(['yes']);
-    await runPlanCommand('small task', io, {});
-
+    expect(mockedRunPlanner).toHaveBeenCalledWith(expect.objectContaining({ taskTitle: 'g' }));
     expect(fetchMock).toHaveBeenCalledOnce();
-    expect(bodyOf(fetchMock).subTasks).toEqual([]);
+    expect(bodyOf(fetchMock).subTasks).toHaveLength(2);
+    expect(out.join('\n')).toContain('Dispatched 2 task(s)');
   });
 
   it('reports a planner failure without dispatching', async () => {
@@ -132,5 +80,24 @@ describe('runPlanCommand', () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(out.join('\n')).toContain('boom');
+  });
+
+  it('contains a rejected planner run as a controlled error message (AGT-3417)', async () => {
+    mockedRunPlanner.mockRejectedValue(new Error('RateLimitError: slow down'));
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { io, out } = makeIO([]);
+    await expect(runPlanCommand('g', io, {})).resolves.toBeUndefined();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(out.join('\n')).toContain('✖ Planner failed: RateLimitError: slow down');
+  });
+
+  it('stringifies non-Error planner rejections (AGT-3417)', async () => {
+    mockedRunPlanner.mockRejectedValue('plain string failure');
+    const { io, out } = makeIO([]);
+    await expect(runPlanCommand('g', io, {})).resolves.toBeUndefined();
+    expect(out.join('\n')).toContain('✖ Planner failed: plain string failure');
   });
 });

--- a/src/support/planCommand.ts
+++ b/src/support/planCommand.ts
@@ -53,12 +53,21 @@ export async function runPlanCommand(
   io.print(`🧭 Planning: ${trimmed}`);
   io.print('   (running the Planner — may take up to ~2 min; requires the claude CLI)');
 
-  const result = await runPlanner({
-    taskTitle: trimmed,
-    taskDescription: trimmed,
-    projectPath,
-    model: opts.model,
-  });
+  let result: Awaited<ReturnType<typeof runPlanner>>;
+  try {
+    result = await runPlanner({
+      taskTitle: trimmed,
+      taskDescription: trimmed,
+      projectPath,
+      model: opts.model,
+    });
+  } catch (err) {
+    // The planner can reject (e.g. RateLimitError, CLI missing) — contain it so
+    // the command surface never surfaces an unhandled promise rejection.
+    const message = err instanceof Error ? err.message : String(err);
+    io.print(`✖ Planner failed: ${message}`);
+    return;
+  }
 
   if (!result.success) {
     io.print(`✖ Planner failed: ${result.error ?? 'unknown error'}`);

--- a/src/tui/hooks/useMonitor.test.tsx
+++ b/src/tui/hooks/useMonitor.test.tsx
@@ -1,0 +1,104 @@
+// Purpose: useMonitor contains timed-out fetches and clamps the poll interval
+// (AGT-3417). The hook is the network/effect boundary for the monitor tabs.
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render } from 'ink-testing-library';
+import { act } from 'react';
+import { Text } from 'ink';
+import { useMonitor, clampPollIntervalMs } from './useMonitor.js';
+import type { Table } from '../monitorRows.js';
+
+const table: Table = { columns: ['name'], rows: [['a']] };
+
+// Let the effect run / React flush state updates.
+const tick = () => new Promise((r) => setTimeout(r, 5));
+
+function Probe({ port, fetcher, intervalMs }: {
+  port?: number;
+  fetcher: (port: number, signal?: AbortSignal) => Promise<Table>;
+  intervalMs?: number;
+}) {
+  const { table, error, loading } = useMonitor(port, fetcher, intervalMs);
+  if (error) return <Text>{`err:${error}`}</Text>;
+  if (!table) return <Text>{loading ? 'loading' : 'idle'}</Text>;
+  return <Text>{`rows:${table.rows.length}`}</Text>;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('clampPollIntervalMs', () => {
+  it('clamps below the 100ms floor and above the 5min ceiling', () => {
+    expect(clampPollIntervalMs(10)).toBe(100);
+    expect(clampPollIntervalMs(1_000_000)).toBe(300_000);
+    expect(clampPollIntervalMs(5000)).toBe(5000);
+  });
+
+  it('replaces non-finite values with the 5000ms default', () => {
+    expect(clampPollIntervalMs(Number.NaN)).toBe(5000);
+    expect(clampPollIntervalMs(Number.POSITIVE_INFINITY)).toBe(5000);
+    expect(clampPollIntervalMs(undefined)).toBe(5000);
+  });
+});
+
+describe('useMonitor', () => {
+  it('renders fetched rows and clears the error on success', async () => {
+    const fetcher = vi.fn(async () => table);
+    const r = render(<Probe port={3847} fetcher={fetcher} />);
+    await act(tick);
+    expect(r.lastFrame()).toContain('rows:1');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a rejected fetch as an error string', async () => {
+    const fetcher = vi.fn(async () => { throw new Error('boom'); });
+    const r = render(<Probe port={3847} fetcher={fetcher} />);
+    await act(tick);
+    expect(r.lastFrame()).toContain('err:boom');
+  });
+
+  it('aborts a timed-out fetch and lets the next interval start a fresh request', async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const aborts: Array<() => void> = [];
+    const fetcher = vi.fn((_port: number, signal?: AbortSignal) => new Promise<Table>((_, reject) => {
+      calls += 1;
+      signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+      aborts.push(() => reject(new Error('never settles on its own')));
+    }));
+    const r = render(<Probe port={3847} fetcher={fetcher} intervalMs={100} />);
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(calls).toBe(1);
+
+    // First request hangs; the 15s timeout aborts it, the race rejects, and the
+    // finally block clears inFlight so the next tick can start a new request.
+    await act(async () => { await vi.advanceTimersByTimeAsync(15_000); });
+    expect(r.lastFrame()).toContain('timed out');
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+    expect(calls).toBe(2); // no fan-out: exactly one new request after the drain
+    r.unmount();
+  });
+
+  it('does not start a second request while one is in flight', async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const fetcher = vi.fn(async () => { calls += 1; await new Promise(() => {}); });
+    const r = render(<Probe port={3847} fetcher={fetcher} intervalMs={100} />);
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(500); });
+    expect(calls).toBe(1); // inFlight guard held across several ticks
+    r.unmount();
+  });
+
+  it('aborts the in-flight request on unmount', async () => {
+    let aborted = false;
+    const fetcher = vi.fn((_port: number, signal?: AbortSignal) => new Promise<Table>(() => {
+      signal?.addEventListener('abort', () => { aborted = true; }, { once: true });
+    }));
+    const r = render(<Probe port={3847} fetcher={fetcher} intervalMs={100} />);
+    await act(tick);
+    r.unmount();
+    expect(aborted).toBe(true);
+  });
+});

--- a/src/tui/hooks/useMonitor.ts
+++ b/src/tui/hooks/useMonitor.ts
@@ -9,6 +9,21 @@ import type { Table } from '../monitorRows.js';
 
 const MONITOR_REQUEST_TIMEOUT_MS = 15_000;
 
+// Clamp the poll interval to safe finite bounds: below 100ms the polling loop
+// can starve the TUI render loop, and non-finite values (NaN/Infinity) would
+// make setInterval fire immediately/never. Above 5 min a stale tab just polls
+// rarely — still valid, so it is the upper bound.
+const MIN_POLL_INTERVAL_MS = 100;
+const MAX_POLL_INTERVAL_MS = 300_000;
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+
+export function clampPollIntervalMs(intervalMs: number | undefined): number {
+  const raw = typeof intervalMs === 'number' && Number.isFinite(intervalMs)
+    ? intervalMs
+    : DEFAULT_POLL_INTERVAL_MS;
+  return Math.max(MIN_POLL_INTERVAL_MS, Math.min(raw, MAX_POLL_INTERVAL_MS));
+}
+
 export interface MonitorResult {
   table: Table | null;
   error: string | null;
@@ -64,7 +79,7 @@ export function useMonitor(
       }
     };
     void load();
-    const timer = setInterval(() => void load(), intervalMs);
+    const timer = setInterval(() => void load(), clampPollIntervalMs(intervalMs));
     return () => {
       cancelled = true;
       activeController?.abort();


### PR DESCRIPTION
## Summary
## Background

Async command and monitor flows do not consistently contain rejected work or enforce one active request. A timeout may race with an underlying fetch that continues while future intervals start additional requests.

## Included follow-ups

* Handle rejected planner executions in the /plan command flow (src/support/planCommand.ts:51)
* Prevent timed-out monitor fetches from allowing overlapping underlying requests (src/tui/hooks/useMonitor.ts:37-67)
* Validate or clamp the monitor polling interval before creating setInterval (src/tui/hooks/useMonitor.ts:67)

## Completion criteria

* Planner rejection is caught and converted into a controlled command result.
* Monitor polling aborts, drains, or otherwise accounts for timed-out fetches before another request starts.
* Poll intervals are validated and clamped to safe finite bounds before scheduling.

## ⚠️ File overlap with in-flight work

This branch changes files that other open PRs / active branches also touch. Coordinate before merging to avoid divergent parallel edits (INT-2388 #3):

- **PR #579 (swarm/AGT-3492-fix-network-access-restrict-notification)** — 1 file(s): `package-lock.json`
- **PR #549 (dependabot/npm_and_yarn/npm_and_yarn-8839a8980a)** — 1 file(s): `package-lock.json`
- **⚠️ MERGED PR #578 (chore/release-0.23.0) — not in this branch's history, verify its fix wasn't dropped** — 1 file(s): `package-lock.json`

## Linear
Closes AGT-3417

---
🤖 Generated with [OpenSwarm](https://github.com/Intrect-io/OpenSwarm)