### PR TITLE
[Bug] coordinationTools test asserts an uncoloured substring — green in CI, red on every developer machine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1300,9 +1300,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1318,9 +1315,6 @@
       "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1338,9 +1332,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1356,9 +1347,6 @@
       "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1376,9 +1364,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1394,9 +1379,6 @@
       "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1414,9 +1396,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1433,9 +1412,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1451,9 +1427,6 @@
       "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1477,9 +1450,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1501,9 +1471,6 @@
       "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1527,9 +1494,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1551,9 +1515,6 @@
       "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1577,9 +1538,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1602,9 +1560,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1626,9 +1581,6 @@
       "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/src/coordination/coordinationTools.test.ts
+++ b/src/coordination/coordinationTools.test.ts
@@ -560,10 +560,20 @@ describe('a wait keeps its process alive until it settles', () => {
     ].join('\n'), 'utf-8');
 
     try {
+      // CI captures the child's stdout through a pipe (no TTY), so chalk leaves
+      // `true` bare; on a developer terminal the same line arrives wrapped in
+      // ANSI colour (e.g. \x1B[33mtrue\x1B[39m) and the bare-substring match
+      // fails. Force colour off in the child so the captured text is identical
+      // in both environments and the assertion tests the behaviour (the wait
+      // settled) rather than how the child rendered it.
       const { stdout } = await run(
         process.execPath,
         [join(process.cwd(), 'node_modules/tsx/dist/cli.mjs'), script],
-        { cwd: process.cwd(), timeout: 60_000 },
+        {
+          cwd: process.cwd(),
+          timeout: 60_000,
+          env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+        },
       );
       // Without the fix the child exits silently and this never appears.
       expect(stdout).toContain('SETTLED [] true');


### PR DESCRIPTION
## Summary
## Problem

`src/coordination/coordinationTools.test.ts` → *"a wait keeps its process alive until it settles > resolves in a child process with nothing else pending"* fails locally:

```
AssertionError: expected 'SETTLED [] <ESC>[33mtrue<ESC>[39m\n' to contain 'SETTLED [] true'
```

The child process writes `true` wrapped in a yellow ANSI colour code. The assertion looks
for the bare substring, so it only passes where stdout is **not** a TTY — which is exactly
CI. The result is a test that is permanently green in CI and permanently red for anyone
running the suite on their own machine.

## Evidence it is pre-existing, not from any current branch

Reproduced on pristine `origin/main` at `9704ffe` by stashing all local changes in a fresh
worktree and running only that file: **1 failed | 22 passed**. It reproduces the same way
with an unrelated locale-only patch applied, so nothing in flight causes it.

## Why it matters more than one red test

It trains people to ignore a failing suite. This session lost time twice deciding whether
a failure belonged to the change in hand — which is precisely the cost a test suite exists
to avoid. It also means the assertion is not actually testing what it reads as: it passes
in CI for the wrong reason.

## Scope

* Make the assertion independent of colour — strip ANSI from the captured output before
  matching, or spawn the child with colour disabled (`FORCE_COLOR=0` / `NO_COLOR=1`) so the
  captured text is stable in both environments.
* Prefer whichever keeps the test asserting the *behaviour* (the wait settled) rather than
  the exact rendering.
* Check for sibling tests in this file that capture child-process stdout and would fail the
  same way once someone runs them on a TTY.

## Done

* The test passes both with and without a TTY.
* The assertion no longer depends on whether colour is enabled.
* A short comment records why, so it is not "simplified" back.

## ⚠️ File overlap with in-flight work

This branch changes files that other open PRs / active branches also touch. Coordinate before merging to avoid divergent parallel edits (INT-2388 #3):

- **PR #584 (swarm/AGT-4059-bug-dashboard-s-latestaddressable-can-ta)** — 1 file(s): `package-lock.json`
- **PR #583 (swarm/AGT-4079-bug-api-health-spikes-past-the-10s-healt)** — 1 file(s): `package-lock.json`
- **PR #581 (swarm/AGT-4008-feature-implement-authenticated-github-r)** — 1 file(s): `package-lock.json`
- **PR #580 (swarm/AGT-3417-fix-async-ui-contain-rejected-commands-a)** — 1 file(s): `package-lock.json`
- **PR #579 (swarm/AGT-3492-fix-network-access-restrict-notification)** — 1 file(s): `package-lock.json`
- **PR #549 (dependabot/npm_and_yarn/npm_and_yarn-8839a8980a)** — 1 file(s): `package-lock.json`

## Linear
Closes AGT-4153

---
🤖 Generated with [OpenSwarm](https://github.com/Intrect-io/OpenSwarm)