### PR TITLE
fix(ci): stop an unrelated apt repository from blocking the bubblewrap install (AGT-4274)

### DIFF
--- a/.github/actions/install-bubblewrap/action.yml
+++ b/.github/actions/install-bubblewrap/action.yml
@@ -1,0 +1,31 @@
+name: Install bubblewrap
+description: >
+  Install the bubblewrap OS sandbox on an Ubuntu runner, tolerating index
+  failures from apt repositories that have nothing to do with the package.
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+        # `apt-get update` exits non-zero when ANY configured repository fails,
+        # including third-party ones the runner image ships and we never use.
+        # On 2026-09-09 the google-chrome repository served an index whose hash
+        # did not match, and because the install was chained as
+        # `apt-get update && apt-get install`, bubblewrap was simply never
+        # installed. Every open PR then died seven lines later at
+        # `bwrap: command not found`, with nothing in the error naming apt —
+        # and `set -e` does not fire on a failed AND-OR list, so the step ran on
+        # instead of stopping at the real cause (AGT-4274).
+        #
+        # bubblewrap comes from the Ubuntu archive, whose indexes fetched fine
+        # throughout that outage, so an unrelated repository must not gate it.
+        # The install below is the real gate and still fails closed.
+        if ! sudo apt-get update; then
+          echo "::warning::apt-get update reported an error (usually a third-party repository index); continuing, since the bubblewrap install below is the real gate"
+        fi
+        sudo apt-get install -y bubblewrap
+        # Prove the binary is actually usable rather than merely unpacked, so a
+        # broken install is reported here instead of at the first sandboxed test.
+        bwrap --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,9 @@ jobs:
       # runner image does not ship, so without this every verify test reports
       # "OS verification sandbox is unavailable". macOS uses built-in
       # sandbox-exec and needs no install.
-      - name: Install the Linux verification sandbox
+      - uses: ./.github/actions/install-bubblewrap
+      - name: Lift the AppArmor user-namespace restriction
         run: |
-          sudo apt-get update && sudo apt-get install -y bubblewrap
           # ubuntu-24.04 images restrict unprivileged user namespaces through
           # AppArmor; without lifting it bwrap cannot set up the network
           # namespace and every sandboxed command dies with
@@ -142,10 +142,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-bubblewrap
       - name: Bubblewrap alone must not be assumed sufficient
         run: |
           set -uo pipefail
-          sudo apt-get update && sudo apt-get install -y bubblewrap
           if bwrap --ro-bind / / --unshare-net --dev /dev --proc /proc -- /usr/bin/true 2>/dev/null; then
             echo "::warning::The sandbox now works without lifting the AppArmor restriction — the README's sysctl step may be obsolete on this image"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,11 @@ jobs:
       # through AppArmor, which bwrap needs for its network namespace. Same setup
       # as the Tests job in ci.yml — without it the release gate fails on every
       # src/verify test.
-      - name: Install the Linux verification sandbox
+      - uses: ./.github/actions/install-bubblewrap
+        if: steps.ver.outputs.exists == 'false'
+      - name: Lift the AppArmor user-namespace restriction
         if: steps.ver.outputs.exists == 'false'
         run: |
-          sudo apt-get update && sudo apt-get install -y bubblewrap
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
           bwrap --ro-bind / / --unshare-net --dev /dev --proc /proc -- /bin/sh -lc 'echo sandbox-ok'
 


### PR DESCRIPTION
## What was broken

Every open pull request was red — #579, #580, #583, #585 all showed the same
signature: `Tests` FAILURE + `Verify sandbox` FAILURE, every other job SUCCESS,
while `main` itself was green. That is not four bad changes; it is one bad line.

From `gh run view 34384809513 --log-failed`:

```
Err:24 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
  Hash Sum mismatch
E: Some index files failed to download. They have been ignored, or old ones used instead.
kernel.apparmor_restrict_unprivileged_userns = 0        <- the NEXT line still ran
/home/runner/work/_temp/....sh: line 7: bwrap: command not found
##[error]Process completed with exit code 127
```

Two defects overlap in `sudo apt-get update && sudo apt-get install -y bubblewrap`:

1. **`&&` short-circuit.** `apt-get update` exits non-zero when *any* configured
   repository fails, including third-party ones the runner image ships and we
   never use. bubblewrap lives in the Ubuntu archive, whose indexes fetched
   fine — but the install never ran.
2. **`set -e` does not catch it.** POSIX exempts a non-final command of an
   AND-OR list from errexit, so the step continued and died seven lines later
   with an error that never mentions apt:

   ```
   $ bash -e -c 'false && echo installed; echo continued; command -v bwrap || echo "bwrap missing"'
   continued
   bwrap missing
   exit=0
   ```

## What this changes

`apt-get update` failing is now a `::warning::`; the **install is the gate** and
still fails closed, with `bwrap --version` proving the binary is usable rather
than merely unpacked.

The line existed in three places (`ci.yml` Tests, `ci.yml` verify-sandbox,
`release.yml` — so the release publish path had the same failure mode). They now
share one composite action, `.github/actions/install-bubblewrap`. The AppArmor
sysctl and the namespace probe stay at each call site, because their semantics
genuinely differ there: `verify-sandbox` deliberately probes *before* lifting the
restriction to assert that bubblewrap alone is insufficient.

## Verification

- YAML parses for all three files (`yaml.safe_load`).
- No `apt-get update &&` pattern remains under `.github/` except inside the
  comment that explains the bug.
- The real proof is this PR's own CI: the `Tests` and `Verify sandbox` jobs must
  come back green on the same runner image that has been failing.

Closes AGT-4274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)