### PR TITLE
fix(memory): report an unopenable store once instead of on every recall (AGT-4267)

### DIFF
--- a/src/memory/memoryCore.ts
+++ b/src/memory/memoryCore.ts
@@ -249,13 +249,23 @@ let initInFlight: Promise<void> | null = null;
  * no restart. A latch would have kept it dark until someone noticed.
  */
 const RECALL_REPORT_WINDOW_MS = 10 * 60_000;
-type RecallPhase = 'open' | 'query';
+/**
+ * How many distinct messages one report may name. Errors that embed a varying
+ * detail — a byte range, a timestamped predicate — produce a new string every
+ * call, and an uncapped list turned one window's report into a single 131 KB
+ * line (measured, 2000 failures). Ninety-five stacks were at least greppable
+ * line by line; that is not.
+ */
+const RECALL_ALSO_SEEN_CAP = 5;
+type RecallPhase = 'open' | 'embed' | 'query';
 type RecallFailure = {
   phase: RecallPhase;
   message: string;
   reportedAt: number;
   suppressedCount: number;
   alsoSeen: Set<string>;
+  /** Occurrences of a differing message the cap kept out of `alsoSeen`. */
+  alsoSeenUnlisted: number;
 };
 let recallFailure: RecallFailure | null = null;
 
@@ -286,19 +296,30 @@ function reportRecallFailure(error: unknown, phase: RecallPhase): void {
   const previous = recallFailure;
   if (previous && previous.phase === phase && now - previous.reportedAt < RECALL_REPORT_WINDOW_MS) {
     previous.suppressedCount += 1;
-    if (message !== previous.message) previous.alsoSeen.add(message);
+    if (message !== previous.message && !previous.alsoSeen.has(message)) {
+      if (previous.alsoSeen.size < RECALL_ALSO_SEEN_CAP) previous.alsoSeen.add(message);
+      else previous.alsoSeenUnlisted += 1;
+    }
     return;
   }
   const suppressed = previous?.suppressedCount ?? 0;
   const others = previous ? [...previous.alsoSeen, previous.message].filter(m => m !== message) : [];
+  const unlisted = previous?.alsoSeenUnlisted ?? 0;
   const parts = [
     suppressed > 0 ? `${suppressed} further failure(s) since the last report` : '',
-    others.length > 0 ? `also seen: ${others.join('; ')}` : '',
+    others.length > 0
+      ? `also seen: ${others.join('; ')}${unlisted > 0 ? `, and ${unlisted} more not listed` : ''}`
+      : '',
   ].filter(Boolean);
   const tail = parts.length > 0 ? ` (${parts.join(', ')})` : '';
-  const what = phase === 'open' ? 'the store could not be opened' : 'the store opened but recall failed';
+  const what = phase === 'open' ? 'the store could not be opened'
+    : phase === 'embed' ? 'the query could not be embedded'
+    : 'the store opened but recall failed';
   console.error(`[Memory] Long-term recall is UNAVAILABLE — ${what}${tail}: ${message}`);
-  recallFailure = { phase, message, reportedAt: now, suppressedCount: 0, alsoSeen: new Set() };
+  recallFailure = {
+    phase, message, reportedAt: now,
+    suppressedCount: 0, alsoSeen: new Set(), alsoSeenUnlisted: 0,
+  };
 }
 
 function clearRecallFailure(phase: RecallPhase): void {
@@ -1107,12 +1128,14 @@ export async function searchMemorySafe(
 
   try {
     if (!table) {
-      return {
-        success: false,
-        memories: [],
-        error: 'Database table not initialized',
-        errorCode: 'DB_INIT_FAILED',
-      };
+      // Unreachable today — a null handle throws inside the schema migration
+      // and is caught as an open failure — but if that ever changes, returning
+      // without reporting gives back a silent dead store while
+      // memoryRecallStatus() answers "available", which is the exact outcome
+      // this change exists to prevent.
+      const notInitialized = 'Database table not initialized';
+      reportRecallFailure(new Error(notInitialized), 'open');
+      return { success: false, memories: [], error: notInitialized, errorCode: 'DB_INIT_FAILED' };
     }
 
     const {
@@ -1128,7 +1151,14 @@ export async function searchMemorySafe(
     let queryVector: number[];
     try {
       queryVector = await embedQuery(query);
+      clearRecallFailure('embed');
     } catch (embeddingError) {
+      // The third way recall dies, and until now the only one left uncovered:
+      // a healthy store with a dead embedder returned early before either
+      // reporter, so 40 recalls printed 40 stacks (initEmbeddingPipeline nulls
+      // its promise on failure, so every call retries and re-logs) while
+      // memoryRecallStatus() still answered "available".
+      reportRecallFailure(embeddingError, 'embed');
       return {
         success: false,
         memories: [],

--- a/src/memory/memoryCore.ts
+++ b/src/memory/memoryCore.ts
@@ -302,13 +302,23 @@ function reportRecallFailure(error: unknown, phase: RecallPhase): void {
     }
     return;
   }
-  const suppressed = previous?.suppressedCount ?? 0;
-  const others = previous ? [...previous.alsoSeen, previous.message].filter(m => m !== message) : [];
-  const unlisted = previous?.alsoSeenUnlisted ?? 0;
+  // Only carry the tally when the phase is unchanged. A `query` outage followed
+  // by an embedding failure otherwise credits 39 broken queries to a report
+  // headed "the query could not be embedded", and names a lance error as
+  // something the embedder also saw. That transition skips a clear — the
+  // query-phase clear lives at the end of a successful search, which does not
+  // run here — so it is the one direction where a stale tally survives.
+  const sameAsBefore = previous?.phase === phase ? previous : null;
+  const suppressed = sameAsBefore?.suppressedCount ?? 0;
+  const others = sameAsBefore ? [sameAsBefore.message, ...sameAsBefore.alsoSeen].filter(m => m !== message) : [];
+  const unlisted = sameAsBefore?.alsoSeenUnlisted ?? 0;
   const parts = [
     suppressed > 0 ? `${suppressed} further failure(s) since the last report` : '',
     others.length > 0
-      ? `also seen: ${others.join('; ')}${unlisted > 0 ? `, and ${unlisted} more not listed` : ''}`
+      // "N more" would read as N further *messages*; this counts occurrences of
+      // messages the cap kept off the list, and `suppressedCount` above already
+      // carries the total.
+      ? `also seen: ${others.join('; ')}${unlisted > 0 ? `, and ${unlisted} further occurrence(s) of unlisted messages` : ''}`
       : '',
   ].filter(Boolean);
   const tail = parts.length > 0 ? ` (${parts.join(', ')})` : '';

--- a/src/memory/memoryCore.ts
+++ b/src/memory/memoryCore.ts
@@ -221,6 +221,66 @@ export interface SearchResult {
 // Singleton connection
 let db: Connection | null = null;
 let table: Table | null = null;
+/** The one open in progress, shared by every caller that arrives while it runs. */
+let initInFlight: Promise<void> | null = null;
+
+/**
+ * A store that cannot be opened fails on *every* recall, and each caller
+ * swallows the throw — so the same stack traced 95 times in five minutes on
+ * vela (AGT-4267), burying every other diagnostic line while the one fact that
+ * mattered ("recall is off") was never stated. Report the first occurrence and
+ * then only on a change or once a window has passed, carrying the count so the
+ * scale is still visible.
+ *
+ * Deliberately not a permanent disable: the vela outage was repaired by moving
+ * seven zero-byte manifests aside, and recall came back on the next call with
+ * no restart. A latch would have kept it dark until someone noticed.
+ */
+const DB_INIT_REPORT_WINDOW_MS = 10 * 60_000;
+let dbInitFailure: { message: string; reportedAt: number; suppressedCount: number } | null = null;
+
+/** Whether long-term recall is currently unavailable, and why. */
+export function memoryRecallStatus(): { available: boolean; error?: string; suppressedCount?: number } {
+  if (!dbInitFailure) return { available: true };
+  return {
+    available: false,
+    error: dbInitFailure.message,
+    suppressedCount: dbInitFailure.suppressedCount,
+  };
+}
+
+function reportDbInitFailure(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  const now = Date.now();
+  const previous = dbInitFailure;
+  if (previous && previous.message === message && now - previous.reportedAt < DB_INIT_REPORT_WINDOW_MS) {
+    previous.suppressedCount += 1;
+    return;
+  }
+  // Carry the count across a changed message too. Keying the credit on message
+  // equality means a store that alternates between two error strings reports
+  // "0 suppressed" forever while burying every occurrence of each.
+  const suppressed = previous?.suppressedCount ?? 0;
+  const priorNote = previous && previous.message !== message ? `, last reported: ${previous.message}` : '';
+  const tail = suppressed > 0 ? ` (${suppressed} failure(s) suppressed since the last report${priorNote})` : '';
+  console.error(`[Memory] Long-term recall is UNAVAILABLE — the store could not be opened${tail}: ${message}`);
+  dbInitFailure = { message, reportedAt: now, suppressedCount: 0 };
+}
+
+function clearDbInitFailure(): void {
+  if (!dbInitFailure) return;
+  // Deliberately stderr, matching the outage report. A daemon that captures the
+  // two streams separately would otherwise show an outage in its error log that
+  // never ends, which is the same unreadability this whole block exists to fix.
+  console.error(`${status.ok('[Memory] long-term recall restored')}`);
+  dbInitFailure = null;
+}
+
+/** Tests need the module's failure memory back at its initial state. */
+export function resetMemoryRecallStatusForTests(): void {
+  dbInitFailure = null;
+  initInFlight = null;
+}
 const LEGACY_SCHEMA_COLUMNS = new Set(['revisionCount', 'decay', 'stability', 'contradicts', 'supports']);
 
 // Singleton accessors (for memoryOps)
@@ -596,11 +656,24 @@ export function calculateImportance(
 }
 
 /**
- * Initialize database
+ * Open the store, at most once at a time.
+ *
+ * Sixteen concurrent reviewers each search memory (see the concurrency note in
+ * `searchMemorySafe`), and without this every one of them ran the whole open
+ * sequence: N connects, and on a first run N racing `createTable` calls. Once
+ * the catch below began nulling the handles on failure that stopped being mere
+ * duplicated work — a loser's failure destroyed the winner's live connection,
+ * and the next search died on `null.vectorSearch` while the freshly-set failure
+ * flag suppressed the log line that would have shown it. Sharing one in-flight
+ * open makes the call that nulls the handles the same call that assigned them.
  */
-export async function initDatabase(): Promise<void> {
-  if (db && table) return;
+export function initDatabase(): Promise<void> {
+  if (db && table) return Promise.resolve();
+  initInFlight ??= openDatabase().finally(() => { initInFlight = null; });
+  return initInFlight;
+}
 
+async function openDatabase(): Promise<void> {
   try {
     const fs = await import('fs/promises');
     await fs.mkdir(MEMORY_DIR, { recursive: true });
@@ -648,8 +721,13 @@ export async function initDatabase(): Promise<void> {
     }
 
     warnOnEmbeddingDrift();
+    clearDbInitFailure();
   } catch (error) {
-    console.error('[Memory] Database init error:', error);
+    // A half-open connection would make the next call report success and then
+    // fail on the table instead, which is how this looked like a query bug.
+    db = null;
+    table = null;
+    reportDbInitFailure(error);
     throw error;
   }
 }
@@ -1083,12 +1161,21 @@ export async function searchMemorySafe(
 
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
-    console.error('[Memory] Search error:', error);
+    const recall = memoryRecallStatus();
+    // An unopenable store surfaces here too, once per recall, because the throw
+    // from initDatabase lands in this catch. That duplicate is what made the log
+    // unreadable (AGT-4267) — but silence it by identity, not by "an outage is
+    // outstanding". The broader guard would also swallow a genuine query error
+    // that happened to coincide with one.
+    if (recall.error !== errorMsg) console.error('[Memory] Search error:', error);
     return {
       success: false,
       memories: [],
       error: errorMsg,
-      errorCode: 'QUERY_FAILED',
+      // `await initDatabase()` throws, so the DB_INIT_FAILED branch above never
+      // sees this case and callers were told a dead store was a failed query.
+      // repoKnowledge renders this code straight into the agent's prompt.
+      errorCode: recall.available ? 'QUERY_FAILED' : 'DB_INIT_FAILED',
     };
   }
 }

--- a/src/memory/memoryCore.ts
+++ b/src/memory/memoryCore.ts
@@ -262,7 +262,15 @@ type RecallFailure = {
   phase: RecallPhase;
   message: string;
   reportedAt: number;
+  /** Failures since the last report — reset every time one is emitted. */
   suppressedCount: number;
+  /**
+   * Failures in this outage, across every report the window forced. The two
+   * differ the moment an outage outlives one window, and vela's store was
+   * broken for nine days: `restored after N failure(s)` built on the
+   * window-scoped count would have answered with the last ten minutes.
+   */
+  totalCount: number;
   alsoSeen: Set<string>;
   /** Occurrences of a differing message the cap kept out of `alsoSeen`. */
   alsoSeenUnlisted: number;
@@ -296,6 +304,7 @@ function reportRecallFailure(error: unknown, phase: RecallPhase): void {
   const previous = recallFailure;
   if (previous && previous.phase === phase && now - previous.reportedAt < RECALL_REPORT_WINDOW_MS) {
     previous.suppressedCount += 1;
+    previous.totalCount += 1;
     if (message !== previous.message && !previous.alsoSeen.has(message)) {
       if (previous.alsoSeen.size < RECALL_ALSO_SEEN_CAP) previous.alsoSeen.add(message);
       else previous.alsoSeenUnlisted += 1;
@@ -320,8 +329,8 @@ function reportRecallFailure(error: unknown, phase: RecallPhase): void {
   const others = sameAsBefore ? [sameAsBefore.message, ...sameAsBefore.alsoSeen].filter(m => m !== message) : [];
   const unlisted = sameAsBefore?.alsoSeenUnlisted ?? 0;
   const parts = [
-    retired && retired.suppressedCount > 0
-      ? `ends a ${retired.phase}-phase outage of ${retired.suppressedCount + 1} failure(s)` : '',
+    retired && retired.totalCount > 1
+      ? `ends a ${retired.phase}-phase outage of ${retired.totalCount} failure(s)` : '',
     suppressed > 0 ? `${suppressed} further failure(s) since the last report` : '',
     others.length > 0
       // "N more" would read as N further *messages*; this counts occurrences of
@@ -337,7 +346,8 @@ function reportRecallFailure(error: unknown, phase: RecallPhase): void {
   console.error(`[Memory] Long-term recall is UNAVAILABLE — ${what}${tail}: ${message}`);
   recallFailure = {
     phase, message, reportedAt: now,
-    suppressedCount: 0, alsoSeen: new Set(), alsoSeenUnlisted: 0,
+    suppressedCount: 0, totalCount: (sameAsBefore?.totalCount ?? 0) + 1,
+    alsoSeen: new Set(), alsoSeenUnlisted: 0,
   };
 }
 
@@ -351,8 +361,8 @@ function clearRecallFailure(phase: RecallPhase): void {
   // Carry the blast radius. An outage that self-heals otherwise leaves no
   // record of its size anywhere — and "was memory dead during that run, and
   // how badly" is the question an operator actually asks afterwards.
-  const after = recallFailure.suppressedCount > 0
-    ? ` after ${recallFailure.suppressedCount + 1} failure(s)` : '';
+  const after = recallFailure.totalCount > 1
+    ? ` after ${recallFailure.totalCount} failure(s)` : '';
   // Deliberately stderr, matching the outage report. A daemon that captures the
   // two streams separately would otherwise show an outage in its error log that
   // never ends, which is the same unreadability this whole block exists to fix.

--- a/src/memory/memoryCore.ts
+++ b/src/memory/memoryCore.ts
@@ -309,10 +309,19 @@ function reportRecallFailure(error: unknown, phase: RecallPhase): void {
   // query-phase clear lives at the end of a successful search, which does not
   // run here — so it is the one direction where a stale tally survives.
   const sameAsBefore = previous?.phase === phase ? previous : null;
+  // A phase's first report always prints a count of zero — the record is fresh
+  // — and the tally is only ever printed by a LATER report of the same phase.
+  // A phase change destroys the record before that can happen, so without this
+  // the outgoing phase's scale is never stated anywhere: 40 failed queries
+  // followed by one embedding failure emitted two lines, neither of which said
+  // "forty". Name it, attributed to the phase it belongs to.
+  const retired = previous && previous.phase !== phase ? previous : null;
   const suppressed = sameAsBefore?.suppressedCount ?? 0;
   const others = sameAsBefore ? [sameAsBefore.message, ...sameAsBefore.alsoSeen].filter(m => m !== message) : [];
   const unlisted = sameAsBefore?.alsoSeenUnlisted ?? 0;
   const parts = [
+    retired && retired.suppressedCount > 0
+      ? `ends a ${retired.phase}-phase outage of ${retired.suppressedCount + 1} failure(s)` : '',
     suppressed > 0 ? `${suppressed} further failure(s) since the last report` : '',
     others.length > 0
       // "N more" would read as N further *messages*; this counts occurrences of
@@ -339,10 +348,15 @@ function clearRecallFailure(phase: RecallPhase): void {
   // clear it — which is why no test pins this; it is a guard against that
   // invariant changing, not against anything observed.
   if (recallFailure?.phase !== phase) return;
+  // Carry the blast radius. An outage that self-heals otherwise leaves no
+  // record of its size anywhere — and "was memory dead during that run, and
+  // how badly" is the question an operator actually asks afterwards.
+  const after = recallFailure.suppressedCount > 0
+    ? ` after ${recallFailure.suppressedCount + 1} failure(s)` : '';
   // Deliberately stderr, matching the outage report. A daemon that captures the
   // two streams separately would otherwise show an outage in its error log that
   // never ends, which is the same unreadability this whole block exists to fix.
-  console.error(`${status.ok('[Memory] long-term recall restored')}`);
+  console.error(`${status.ok('[Memory] long-term recall restored')}${after}`);
   recallFailure = null;
 }
 

--- a/src/memory/memoryCore.ts
+++ b/src/memory/memoryCore.ts
@@ -225,60 +225,99 @@ let table: Table | null = null;
 let initInFlight: Promise<void> | null = null;
 
 /**
- * A store that cannot be opened fails on *every* recall, and each caller
+ * Recall fails on *every* call once the store is broken, and each caller
  * swallows the throw — so the same stack traced 95 times in five minutes on
  * vela (AGT-4267), burying every other diagnostic line while the one fact that
- * mattered ("recall is off") was never stated. Report the first occurrence and
- * then only on a change or once a window has passed, carrying the count so the
- * scale is still visible.
+ * mattered ("recall is off") was never stated. Report the first occurrence,
+ * then suppress until the window passes, carrying the count and any other
+ * messages seen so the scale is still visible.
+ *
+ * Tracked by phase, because the two failures are genuinely different: `open`
+ * means the store could not be opened at all, `query` means it opened and then
+ * broke under us. A store can break either way — vela's corruption came from a
+ * single interrupted write, so whether the daemon met it at open time or
+ * mid-run was purely a matter of when it last restarted. Suppressing an open
+ * failure must not hide a query failure, or the second kind stays invisible
+ * exactly the way the first one used to be.
+ *
+ * Suppression is by phase and NOT by message. Keying it on the message means a
+ * store alternating between two error strings matches neither and reports on
+ * every single recall, which is the original unbounded logging wearing a hat.
  *
  * Deliberately not a permanent disable: the vela outage was repaired by moving
  * seven zero-byte manifests aside, and recall came back on the next call with
  * no restart. A latch would have kept it dark until someone noticed.
  */
-const DB_INIT_REPORT_WINDOW_MS = 10 * 60_000;
-let dbInitFailure: { message: string; reportedAt: number; suppressedCount: number } | null = null;
+const RECALL_REPORT_WINDOW_MS = 10 * 60_000;
+type RecallPhase = 'open' | 'query';
+type RecallFailure = {
+  phase: RecallPhase;
+  message: string;
+  reportedAt: number;
+  suppressedCount: number;
+  alsoSeen: Set<string>;
+};
+let recallFailure: RecallFailure | null = null;
 
-/** Whether long-term recall is currently unavailable, and why. */
-export function memoryRecallStatus(): { available: boolean; error?: string; suppressedCount?: number } {
-  if (!dbInitFailure) return { available: true };
+/**
+ * Whether long-term recall is currently working, and if not, why.
+ *
+ * `available: false` is the answer to a question callers could not previously
+ * ask: an empty result meant "nothing matched" and "the store is dead" alike.
+ */
+export function memoryRecallStatus(): {
+  available: boolean;
+  phase?: RecallPhase;
+  error?: string;
+  suppressedCount?: number;
+} {
+  if (!recallFailure) return { available: true };
   return {
     available: false,
-    error: dbInitFailure.message,
-    suppressedCount: dbInitFailure.suppressedCount,
+    phase: recallFailure.phase,
+    error: recallFailure.message,
+    suppressedCount: recallFailure.suppressedCount,
   };
 }
 
-function reportDbInitFailure(error: unknown): void {
+function reportRecallFailure(error: unknown, phase: RecallPhase): void {
   const message = error instanceof Error ? error.message : String(error);
   const now = Date.now();
-  const previous = dbInitFailure;
-  if (previous && previous.message === message && now - previous.reportedAt < DB_INIT_REPORT_WINDOW_MS) {
+  const previous = recallFailure;
+  if (previous && previous.phase === phase && now - previous.reportedAt < RECALL_REPORT_WINDOW_MS) {
     previous.suppressedCount += 1;
+    if (message !== previous.message) previous.alsoSeen.add(message);
     return;
   }
-  // Carry the count across a changed message too. Keying the credit on message
-  // equality means a store that alternates between two error strings reports
-  // "0 suppressed" forever while burying every occurrence of each.
   const suppressed = previous?.suppressedCount ?? 0;
-  const priorNote = previous && previous.message !== message ? `, last reported: ${previous.message}` : '';
-  const tail = suppressed > 0 ? ` (${suppressed} failure(s) suppressed since the last report${priorNote})` : '';
-  console.error(`[Memory] Long-term recall is UNAVAILABLE — the store could not be opened${tail}: ${message}`);
-  dbInitFailure = { message, reportedAt: now, suppressedCount: 0 };
+  const others = previous ? [...previous.alsoSeen, previous.message].filter(m => m !== message) : [];
+  const parts = [
+    suppressed > 0 ? `${suppressed} further failure(s) since the last report` : '',
+    others.length > 0 ? `also seen: ${others.join('; ')}` : '',
+  ].filter(Boolean);
+  const tail = parts.length > 0 ? ` (${parts.join(', ')})` : '';
+  const what = phase === 'open' ? 'the store could not be opened' : 'the store opened but recall failed';
+  console.error(`[Memory] Long-term recall is UNAVAILABLE — ${what}${tail}: ${message}`);
+  recallFailure = { phase, message, reportedAt: now, suppressedCount: 0, alsoSeen: new Set() };
 }
 
-function clearDbInitFailure(): void {
-  if (!dbInitFailure) return;
+function clearRecallFailure(phase: RecallPhase): void {
+  // Phase-scoped because an open that succeeds proves nothing about whether
+  // queries against that handle work. The two cannot cross today — a query
+  // failure leaves `db`/`table` set, so `openDatabase` never runs again to
+  // clear it — which is why no test pins this; it is a guard against that
+  // invariant changing, not against anything observed.
+  if (recallFailure?.phase !== phase) return;
   // Deliberately stderr, matching the outage report. A daemon that captures the
   // two streams separately would otherwise show an outage in its error log that
   // never ends, which is the same unreadability this whole block exists to fix.
   console.error(`${status.ok('[Memory] long-term recall restored')}`);
-  dbInitFailure = null;
+  recallFailure = null;
 }
 
 /** Tests need the module's failure memory back at its initial state. */
 export function resetMemoryRecallStatusForTests(): void {
-  dbInitFailure = null;
+  recallFailure = null;
   initInFlight = null;
 }
 const LEGACY_SCHEMA_COLUMNS = new Set(['revisionCount', 'decay', 'stability', 'contradicts', 'supports']);
@@ -668,6 +707,12 @@ export function calculateImportance(
  * open makes the call that nulls the handles the same call that assigned them.
  */
 export function initDatabase(): Promise<void> {
+  // The in-flight check comes FIRST. `openDatabase` assigns `table` and only
+  // then runs the schema migration, which rewrites that table with
+  // `mode: 'overwrite'` — so during the migration `db && table` are both
+  // truthy and a fast-pathing caller would query a handle whose storage is
+  // being replaced underneath it.
+  if (initInFlight) return initInFlight;
   if (db && table) return Promise.resolve();
   initInFlight ??= openDatabase().finally(() => { initInFlight = null; });
   return initInFlight;
@@ -721,13 +766,13 @@ async function openDatabase(): Promise<void> {
     }
 
     warnOnEmbeddingDrift();
-    clearDbInitFailure();
+    clearRecallFailure('open');
   } catch (error) {
     // A half-open connection would make the next call report success and then
     // fail on the table instead, which is how this looked like a query bug.
     db = null;
     table = null;
-    reportDbInitFailure(error);
+    reportRecallFailure(error, 'open');
     throw error;
   }
 }
@@ -1042,8 +1087,25 @@ export async function searchMemorySafe(
   query: string,
   options: SearchOptions = {}
 ): Promise<SearchResult> {
+  // Opening is its own phase. Folding it into the outer try reported a dead
+  // store as QUERY_FAILED — `await initDatabase()` throws, so the branch below
+  // written for exactly this case was unreachable — and made the outer catch
+  // guess which kind of failure it was holding. repoKnowledge renders this code
+  // straight into the agent's prompt, so the guess was visible to the model.
   try {
     await initDatabase();
+  } catch (error) {
+    // openDatabase already reported this under the rate limit; a second line
+    // per recall is what buried the log (AGT-4267).
+    return {
+      success: false,
+      memories: [],
+      error: error instanceof Error ? error.message : String(error),
+      errorCode: 'DB_INIT_FAILED',
+    };
+  }
+
+  try {
     if (!table) {
       return {
         success: false,
@@ -1156,26 +1218,21 @@ export async function searchMemorySafe(
       similarityScore: similarity,
     }));
 
+    clearRecallFailure('query');
     console.log(`${status.info(`[Memory] found ${formatted.length} memories`)} ${c.dim('hybrid retrieval')} ${c.dim(`query: "${query.slice(0, 30)}..."`)}`);
     return { success: true, memories: formatted };
 
   } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : String(error);
-    const recall = memoryRecallStatus();
-    // An unopenable store surfaces here too, once per recall, because the throw
-    // from initDatabase lands in this catch. That duplicate is what made the log
-    // unreadable (AGT-4267) — but silence it by identity, not by "an outage is
-    // outstanding". The broader guard would also swallow a genuine query error
-    // that happened to coincide with one.
-    if (recall.error !== errorMsg) console.error('[Memory] Search error:', error);
+    // A store that breaks AFTER a successful open never reaches openDatabase
+    // again — the `db && table` fast path holds forever — so before this every
+    // such recall printed a full stack, unbounded, while memoryRecallStatus()
+    // still answered "available". Same rate limit, own phase.
+    reportRecallFailure(error, 'query');
     return {
       success: false,
       memories: [],
-      error: errorMsg,
-      // `await initDatabase()` throws, so the DB_INIT_FAILED branch above never
-      // sees this case and callers were told a dead store was a failed query.
-      // repoKnowledge renders this code straight into the agent's prompt.
-      errorCode: recall.available ? 'QUERY_FAILED' : 'DB_INIT_FAILED',
+      error: error instanceof Error ? error.message : String(error),
+      errorCode: 'QUERY_FAILED',
     };
   }
 }

--- a/src/memory/recallStatus.test.ts
+++ b/src/memory/recallStatus.test.ts
@@ -1,0 +1,210 @@
+// ============================================
+// OpenSwarm — an unopenable memory store reports once, not per recall (AGT-4267)
+// ============================================
+//
+// Measured on vela 2026-09-10: seven zero-byte manifests left by a single
+// interrupted write on 2026-09-01 made every recall throw, and each caller
+// swallowed it — 95 identical stacks in five minutes, burying every other
+// diagnostic. The one fact nobody could read off that log was the only one
+// that mattered: long-term recall was off.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const connect = vi.hoisted(() => vi.fn());
+vi.mock('@lancedb/lancedb', () => ({ connect, Table: class {}, Connection: class {} }));
+// A usable extractor, so a search that gets past the store reaches the query
+// rather than stopping at EMBEDDING_FAILED.
+vi.mock('@huggingface/transformers', () => ({
+  pipeline: vi.fn(async () => async () => ({ data: Float32Array.from([1, 0, 0, 0]) })),
+  env: {},
+}));
+// vitest.setup.ts redirects four home-dir paths but not this one. MEMORY_DIR is
+// `resolve(homedir(), '.openswarm/memory')`, evaluated at module load, and the
+// operator's real store lives there — opening it reads their own embedding
+// signature and, on the create-table branch, writes to it.
+const testHome = vi.hoisted(() => `/tmp/openswarm-recall-status-${process.pid}`);
+vi.mock('os', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('os')>()),
+  homedir: () => testHome,
+}));
+
+describe('memory recall status (AGT-4267)', () => {
+  let errors: string[];
+
+  beforeEach(() => {
+    errors = [];
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args.map(a => (a instanceof Error ? a.message : String(a))).join(' '));
+    });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    connect.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  const corrupt = () => new Error('lance error: Invalid range 0..0 for object of size 0 bytes');
+  const openable = () => ({
+    tableNames: async () => ['cognitive_memory'],
+    openTable: async () => ({ schema: async () => ({ fields: [] }) }),
+  });
+  const reportsIn = (lines: string[]) => lines.filter(e => e.includes('recall is UNAVAILABLE'));
+
+  it('reports the first failure and suppresses the identical repeats', async () => {
+    connect.mockRejectedValue(corrupt());
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+
+    for (let i = 0; i < 20; i += 1) {
+      await expect(core.initDatabase()).rejects.toThrow();
+    }
+
+    expect(reportsIn(errors)).toHaveLength(1);
+    expect(reportsIn(errors)[0]).toContain('Invalid range 0..0');
+  });
+
+  it('says recall is unavailable, and how many failures it swallowed', async () => {
+    connect.mockRejectedValue(corrupt());
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+
+    await expect(core.initDatabase()).rejects.toThrow();
+    await expect(core.initDatabase()).rejects.toThrow();
+    await expect(core.initDatabase()).rejects.toThrow();
+
+    // "no memories found" and "recall is dead" were indistinguishable before.
+    const st = core.memoryRecallStatus();
+    expect(st.available).toBe(false);
+    expect(st.error).toContain('Invalid range 0..0');
+    expect(st.suppressedCount).toBe(2);
+  });
+
+  it('reports again once the window elapses, carrying the suppressed count', async () => {
+    // Suppression is a rate limit, not a mute. Without this a persistent outage
+    // would be announced once and then never mentioned again, which is how a
+    // store that stayed broken for nine days went unnoticed.
+    vi.useFakeTimers();
+    connect.mockRejectedValue(corrupt());
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+
+    for (let i = 0; i < 5; i += 1) await expect(core.initDatabase()).rejects.toThrow();
+    expect(reportsIn(errors)).toHaveLength(1);
+
+    vi.advanceTimersByTime(11 * 60_000);
+    await expect(core.initDatabase()).rejects.toThrow();
+
+    const reports = reportsIn(errors);
+    expect(reports).toHaveLength(2);
+    expect(reports[1]).toContain('4 failure(s) suppressed since the last report');
+    expect(core.memoryRecallStatus().suppressedCount).toBe(0);
+  });
+
+  it('reports again when the failure changes, and does not lose the earlier count', async () => {
+    connect.mockRejectedValue(corrupt());
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+    for (let i = 0; i < 4; i += 1) await expect(core.initDatabase()).rejects.toThrow();
+
+    connect.mockRejectedValue(new Error('ENOSPC: no space left on device'));
+    await expect(core.initDatabase()).rejects.toThrow();
+
+    const reports = reportsIn(errors);
+    expect(reports).toHaveLength(2);
+    expect(reports[1]).toContain('ENOSPC');
+    // Crediting the count only when the message matches would let two
+    // alternating errors report "0 suppressed" forever while burying both.
+    expect(reports[1]).toContain('3 failure(s) suppressed');
+    expect(reports[1]).toContain('Invalid range 0..0');
+  });
+
+  it('does not re-log the same failure a second time as a "Search error"', async () => {
+    // Two sites logged the same stack per recall: initDatabase's catch and
+    // searchMemorySafe's. Rate-limiting only the first would have halved the
+    // spam, not removed it.
+    connect.mockRejectedValue(corrupt());
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+
+    for (let i = 0; i < 12; i += 1) {
+      const res = await core.searchMemorySafe('anything');
+      expect(res.success).toBe(false);
+      // A dead store is not a failed query, and repoKnowledge renders this code
+      // straight into the agent's prompt.
+      expect(res.errorCode).toBe('DB_INIT_FAILED');
+    }
+
+    expect(reportsIn(errors)).toHaveLength(1);
+    expect(errors.filter(e => e.includes('Search error'))).toHaveLength(0);
+  });
+
+  it('still logs a genuine query error while an outage is outstanding', async () => {
+    // Guarding on "is an outage outstanding" instead of "is this the same
+    // error" would swallow a real defect that merely coincided with one — which
+    // is exactly how the concurrency bug below stayed invisible.
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+    connect.mockResolvedValue({
+      ...openable(),
+      openTable: async () => ({
+        schema: async () => ({ fields: [] }),
+        vectorSearch: () => { throw new Error('No field named expiresat'); },
+      }),
+    });
+
+    const res = await core.searchMemorySafe('anything');
+
+    expect(res.success).toBe(false);
+    expect(res.errorCode).toBe('QUERY_FAILED');
+    expect(errors.filter(e => e.includes('Search error'))).toHaveLength(1);
+  });
+
+  it('does not latch — an externally repaired store comes back without a restart', async () => {
+    // The vela fix was moving seven zero-byte manifests aside; recall returned
+    // on the next call with the daemon still running. A permanent disable
+    // would have kept it dark until someone noticed.
+    connect.mockRejectedValueOnce(corrupt());
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+    await expect(core.initDatabase()).rejects.toThrow();
+    expect(core.memoryRecallStatus().available).toBe(false);
+
+    connect.mockResolvedValue(openable());
+    await core.initDatabase();
+
+    expect(core.memoryRecallStatus().available).toBe(true);
+    // Announced on the same stream as the outage, or an error log shows a
+    // failure that never ends.
+    expect(errors.some(e => e.includes('long-term recall restored'))).toBe(true);
+  });
+
+  it('a failing concurrent open does not destroy the connection another caller just made', async () => {
+    // Sixteen reviewers each search memory (see searchMemorySafe's concurrency
+    // note). Nulling db/table in the catch made a loser's failure tear down the
+    // winner's live handles, and the next search died on `null.vectorSearch`
+    // while the fresh failure flag suppressed the log line that would have
+    // shown it. Reproduced by an independent reviewer, 2026-09-10.
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+    let call = 0;
+    connect.mockImplementation(async () => {
+      call += 1;
+      if (call > 1) throw new Error('Too many concurrent writers');
+      return openable();
+    });
+
+    const settled = await Promise.allSettled([core.initDatabase(), core.initDatabase()]);
+
+    expect(settled.map(s => s.status)).toEqual(['fulfilled', 'fulfilled']);
+    expect(core.getTable()).not.toBeNull();
+    expect(core.getDb()).not.toBeNull();
+    expect(core.memoryRecallStatus().available).toBe(true);
+    // One shared open, not one per caller — on a first run those were N racing
+    // createTable calls.
+    expect(call).toBe(1);
+  });
+});

--- a/src/memory/recallStatus.test.ts
+++ b/src/memory/recallStatus.test.ts
@@ -122,14 +122,20 @@ describe('memory recall status (AGT-4267)', () => {
     for (let i = 0; i < 5; i += 1) await expect(core.initDatabase()).rejects.toThrow();
     vi.advanceTimersByTime(11 * 60_000);
     for (let i = 0; i < 3; i += 1) await expect(core.initDatabase()).rejects.toThrow();
-    // Three reports, and the last one has only 2 failures behind it.
     expect(reportsIn(errors)).toHaveLength(3);
-    expect(core.memoryRecallStatus().suppressedCount).toBe(2);
+    // One more window holding a single failure, so the window count is 0 at the
+    // moment of recovery. Guarding the annotation on that count instead of the
+    // outage total drops the number entirely here — a long outage that happens
+    // to recover just after a window boundary reports nothing, which is the
+    // defect this pair of commits is about.
+    vi.advanceTimersByTime(11 * 60_000);
+    await expect(core.initDatabase()).rejects.toThrow();
+    expect(core.memoryRecallStatus().suppressedCount).toBe(0);
 
     connect.mockResolvedValue(openable());
     await core.initDatabase();
 
-    expect(errors.some(e => /long-term recall restored after 13 failure\(s\)/.test(e))).toBe(true);
+    expect(errors.some(e => /long-term recall restored after 14 failure\(s\)/.test(e))).toBe(true);
   });
 
   it('bounds reports even when the store alternates between two errors', async () => {
@@ -242,14 +248,17 @@ describe('memory recall status (AGT-4267)', () => {
       if (embedderBroken) throw new Error('failed to allocate tensor');
       return { data: Float32Array.from([1, 0, 0, 0]) };
     });
-    // Spans two windows on purpose: the suppressed count resets on the
-    // re-report, so it and the outage total diverge (19 vs 40) and the report
-    // has to name the second.
+    // Spans three windows on purpose, the last holding a single failure. The
+    // suppressed count resets on every re-report, so at the moment of the phase
+    // change it is 0 while the outage total is 40 — the report has to name the
+    // second, and must not gate itself on the first.
     vi.useFakeTimers();
     for (let i = 0; i < 20; i += 1) await core.searchMemorySafe('anything');
     vi.advanceTimersByTime(11 * 60_000);
-    for (let i = 0; i < 20; i += 1) await core.searchMemorySafe('anything');
-    expect(core.memoryRecallStatus().suppressedCount).toBe(19);
+    for (let i = 0; i < 19; i += 1) await core.searchMemorySafe('anything');
+    vi.advanceTimersByTime(11 * 60_000);
+    await core.searchMemorySafe('anything');
+    expect(core.memoryRecallStatus().suppressedCount).toBe(0);
 
     embedderBroken = true;
     expect((await core.searchMemorySafe('anything')).errorCode).toBe('EMBEDDING_FAILED');
@@ -285,7 +294,11 @@ describe('memory recall status (AGT-4267)', () => {
     expect((await core.searchMemorySafe('anything')).success).toBe(true);
 
     expect(core.memoryRecallStatus().available).toBe(true);
-    expect(errors.some(e => e.includes('long-term recall restored'))).toBe(true);
+    const restored = errors.filter(e => e.includes('long-term recall restored'));
+    expect(restored).toHaveLength(1);
+    // A single blip carries no count — annotating it is the noise the guard
+    // exists to prevent.
+    expect(restored[0]).not.toMatch(/after \d+ failure\(s\)/);
   });
 
   it('rate-limits a store that breaks AFTER it opened, and stops claiming it is available', async () => {

--- a/src/memory/recallStatus.test.ts
+++ b/src/memory/recallStatus.test.ts
@@ -226,6 +226,10 @@ describe('memory recall status (AGT-4267)', () => {
     expect(embedReport).toContain('the query could not be embedded');
     expect(embedReport).not.toContain('39 further failure(s)');
     expect(embedReport).not.toContain('query is broken');
+    // But the outgoing phase's scale is not simply dropped: a phase's FIRST
+    // report always prints a count of zero, so without naming it here the 40
+    // failed queries would never be stated anywhere at all.
+    expect(embedReport).toContain('ends a query-phase outage of 40 failure(s)');
   });
 
   it('clears an embed-phase outage once the embedder works again', async () => {
@@ -295,14 +299,17 @@ describe('memory recall status (AGT-4267)', () => {
         },
       }),
     });
-    await core.searchMemorySafe('anything');
-    expect(core.memoryRecallStatus().phase).toBe('query');
+    for (let i = 0; i < 3; i += 1) await core.searchMemorySafe('anything');
+    expect(core.memoryRecallStatus().suppressedCount).toBe(2);
 
     broken = false;
     await core.searchMemorySafe('anything');
 
     expect(core.memoryRecallStatus().available).toBe(true);
-    expect(errors.some(e => e.includes('long-term recall restored'))).toBe(true);
+    // An outage that self-heals must still say how big it was: "was memory dead
+    // during that run, and how badly" is what an operator asks afterwards, and
+    // the count died with the record before this.
+    expect(errors.some(e => /long-term recall restored after 3 failure\(s\)/.test(e))).toBe(true);
   });
 
   it('makes a caller arriving mid-open wait rather than reading a table being rewritten', async () => {

--- a/src/memory/recallStatus.test.ts
+++ b/src/memory/recallStatus.test.ts
@@ -168,7 +168,7 @@ describe('memory recall status (AGT-4267)', () => {
     expect(reports).toHaveLength(2);
     expect(reports[1].length).toBeLessThan(1500);
     // The ones it could not list are still counted, so the scale survives.
-    expect(reports[1]).toMatch(/and \d+ more not listed/);
+    expect(reports[1]).toMatch(/and \d+ further occurrence\(s\) of unlisted messages/);
     expect(reports[1]).toContain('399 further failure(s)');
   });
 
@@ -191,6 +191,41 @@ describe('memory recall status (AGT-4267)', () => {
     const st = core.memoryRecallStatus();
     expect(st.available).toBe(false);
     expect(st.phase).toBe('embed');
+  });
+
+  it('does not credit one phase\'s failures to another phase\'s report', async () => {
+    // query → embed is the one transition with no clear in between: the
+    // query-phase clear lives at the end of a successful search, which does not
+    // run when the embedder throws. Carrying the tally there tells an operator
+    // the embedder failed 40 times when it failed once and the store's query
+    // path failed 39.
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+    connect.mockResolvedValue({
+      ...openable(),
+      openTable: async () => ({
+        schema: async () => ({ fields: [] }),
+        vectorSearch: () => { throw new Error('lance: query is broken'); },
+      }),
+    });
+    // The extractor is cached after its first load, so a post-warm-up embed
+    // failure comes from the extractor throwing — tensor allocation under
+    // memory pressure — not from the pipeline failing to load.
+    let embedderBroken = false;
+    pipelineMock.mockImplementation(async () => async () => {
+      if (embedderBroken) throw new Error('failed to allocate tensor');
+      return { data: Float32Array.from([1, 0, 0, 0]) };
+    });
+    for (let i = 0; i < 40; i += 1) await core.searchMemorySafe('anything');
+    expect(core.memoryRecallStatus().suppressedCount).toBe(39);
+
+    embedderBroken = true;
+    expect((await core.searchMemorySafe('anything')).errorCode).toBe('EMBEDDING_FAILED');
+
+    const embedReport = reportsIn(errors).at(-1)!;
+    expect(embedReport).toContain('the query could not be embedded');
+    expect(embedReport).not.toContain('39 further failure(s)');
+    expect(embedReport).not.toContain('query is broken');
   });
 
   it('clears an embed-phase outage once the embedder works again', async () => {

--- a/src/memory/recallStatus.test.ts
+++ b/src/memory/recallStatus.test.ts
@@ -100,26 +100,136 @@ describe('memory recall status (AGT-4267)', () => {
 
     const reports = reportsIn(errors);
     expect(reports).toHaveLength(2);
-    expect(reports[1]).toContain('4 failure(s) suppressed since the last report');
+    expect(reports[1]).toContain('4 further failure(s) since the last report');
     expect(core.memoryRecallStatus().suppressedCount).toBe(0);
   });
 
-  it('reports again when the failure changes, and does not lose the earlier count', async () => {
-    connect.mockRejectedValue(corrupt());
+  it('bounds reports even when the store alternates between two errors', async () => {
+    // Suppressing only *identical* messages matches neither of an alternating
+    // pair, so every recall reports — the original unbounded logging wearing a
+    // hat. The window has to bound reports, not identical reports.
     const core = await import('./memoryCore.js');
     core.resetMemoryRecallStatusForTests();
-    for (let i = 0; i < 4; i += 1) await expect(core.initDatabase()).rejects.toThrow();
+    let n = 0;
+    connect.mockImplementation(async () => {
+      n += 1;
+      throw n % 2 === 0 ? new Error('Too many concurrent writers') : corrupt();
+    });
 
+    for (let i = 0; i < 20; i += 1) await expect(core.initDatabase()).rejects.toThrow();
+
+    const reports = reportsIn(errors);
+    expect(reports).toHaveLength(1);
+    expect(core.memoryRecallStatus().suppressedCount).toBe(19);
+  });
+
+  it('names the other errors it saw while suppressing, not just the last one', async () => {
+    vi.useFakeTimers();
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+    connect.mockRejectedValueOnce(corrupt());
+    await expect(core.initDatabase()).rejects.toThrow();
     connect.mockRejectedValue(new Error('ENOSPC: no space left on device'));
+    for (let i = 0; i < 3; i += 1) await expect(core.initDatabase()).rejects.toThrow();
+
+    vi.advanceTimersByTime(11 * 60_000);
     await expect(core.initDatabase()).rejects.toThrow();
 
     const reports = reportsIn(errors);
     expect(reports).toHaveLength(2);
     expect(reports[1]).toContain('ENOSPC');
-    // Crediting the count only when the message matches would let two
-    // alternating errors report "0 suppressed" forever while burying both.
-    expect(reports[1]).toContain('3 failure(s) suppressed');
+    expect(reports[1]).toContain('3 further failure(s)');
+    // The suppressed window held a different error; dropping it loses the only
+    // record that the store failed two distinct ways.
     expect(reports[1]).toContain('Invalid range 0..0');
+  });
+
+  it('rate-limits a store that breaks AFTER it opened, and stops claiming it is available', async () => {
+    // The `db && table` fast path holds for the process lifetime, so this never
+    // re-enters openDatabase: before, 40 recalls printed 40 stacks while
+    // memoryRecallStatus() answered available:true for a store failing 100% of
+    // recalls. vela's corruption came from one interrupted write, so meeting it
+    // mid-run rather than at startup was purely a matter of restart timing.
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+    connect.mockResolvedValue({
+      ...openable(),
+      openTable: async () => ({
+        schema: async () => ({ fields: [] }),
+        vectorSearch: () => { throw corrupt(); },
+      }),
+    });
+
+    for (let i = 0; i < 40; i += 1) {
+      const res = await core.searchMemorySafe('anything');
+      expect(res.errorCode).toBe('QUERY_FAILED');
+    }
+
+    expect(reportsIn(errors)).toHaveLength(1);
+    expect(reportsIn(errors)[0]).toContain('the store opened but recall failed');
+    const st = core.memoryRecallStatus();
+    expect(st.available).toBe(false);
+    expect(st.phase).toBe('query');
+    expect(st.suppressedCount).toBe(39);
+  });
+
+  it('clears a query-phase outage when a recall actually succeeds again', async () => {
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+    let broken = true;
+    connect.mockResolvedValue({
+      ...openable(),
+      openTable: async () => ({
+        schema: async () => ({ fields: [] }),
+        vectorSearch: () => {
+          if (broken) throw corrupt();
+          return { where: () => ({ limit: () => ({ toArray: async () => [] }) }) };
+        },
+      }),
+    });
+    await core.searchMemorySafe('anything');
+    expect(core.memoryRecallStatus().phase).toBe('query');
+
+    broken = false;
+    await core.searchMemorySafe('anything');
+
+    expect(core.memoryRecallStatus().available).toBe(true);
+    expect(errors.some(e => e.includes('long-term recall restored'))).toBe(true);
+  });
+
+  it('makes a caller arriving mid-open wait rather than reading a table being rewritten', async () => {
+    // openDatabase assigns `table` and only then runs the schema migration,
+    // which rewrites that table with mode:'overwrite'. Checking `db && table`
+    // before the in-flight promise let a second caller fast-path straight onto
+    // the handle whose storage was being replaced.
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+    let releaseMigration: () => void = () => {};
+    let migrationEntered: () => void = () => {};
+    const migrationGate = new Promise<void>(r => { releaseMigration = r; });
+    // Resolves the moment the migration starts reading the schema, i.e. exactly
+    // when `table` is assigned but its storage is about to be rewritten. Waiting
+    // a fixed number of ticks instead would let the second call arrive before
+    // `table` was set, where both orderings behave the same and pin nothing.
+    const migrationStarted = new Promise<void>(r => { migrationEntered = r; });
+    connect.mockResolvedValue({
+      tableNames: async () => ['cognitive_memory'],
+      openTable: async () => ({
+        schema: async () => { migrationEntered(); await migrationGate; return { fields: [] }; },
+      }),
+    });
+
+    const first = core.initDatabase();
+    await migrationStarted;
+    let secondSettled = false;
+    const second = core.initDatabase().then(() => { secondSettled = true; });
+
+    await new Promise(r => setTimeout(r, 5));
+    expect(secondSettled).toBe(false);
+
+    releaseMigration();
+    await Promise.all([first, second]);
+    expect(secondSettled).toBe(true);
   });
 
   it('does not re-log the same failure a second time as a "Search error"', async () => {
@@ -139,13 +249,11 @@ describe('memory recall status (AGT-4267)', () => {
     }
 
     expect(reportsIn(errors)).toHaveLength(1);
-    expect(errors.filter(e => e.includes('Search error'))).toHaveLength(0);
   });
 
-  it('still logs a genuine query error while an outage is outstanding', async () => {
-    // Guarding on "is an outage outstanding" instead of "is this the same
-    // error" would swallow a real defect that merely coincided with one — which
-    // is exactly how the concurrency bug below stayed invisible.
+  it('still reports a genuine query error on a healthy store', async () => {
+    // The two phases are tracked separately so that suppressing one kind of
+    // failure cannot hide the other.
     const core = await import('./memoryCore.js');
     core.resetMemoryRecallStatusForTests();
     connect.mockResolvedValue({
@@ -160,7 +268,8 @@ describe('memory recall status (AGT-4267)', () => {
 
     expect(res.success).toBe(false);
     expect(res.errorCode).toBe('QUERY_FAILED');
-    expect(errors.filter(e => e.includes('Search error'))).toHaveLength(1);
+    expect(reportsIn(errors)).toHaveLength(1);
+    expect(reportsIn(errors)[0]).toContain('No field named expiresat');
   });
 
   it('does not latch — an externally repaired store comes back without a restart', async () => {

--- a/src/memory/recallStatus.test.ts
+++ b/src/memory/recallStatus.test.ts
@@ -106,6 +106,32 @@ describe('memory recall status (AGT-4267)', () => {
     expect(core.memoryRecallStatus().suppressedCount).toBe(0);
   });
 
+  it('reports the whole outage on recovery, not just the last window', async () => {
+    // The suppressed count resets on every re-report the window forces, so an
+    // outage spanning three windows would have announced its last ten minutes
+    // as its size. vela's store was broken for nine days — the headline case
+    // for this ticket is exactly the one where that number is wrong by orders
+    // of magnitude.
+    vi.useFakeTimers();
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+    connect.mockRejectedValue(corrupt());
+
+    for (let i = 0; i < 5; i += 1) await expect(core.initDatabase()).rejects.toThrow();
+    vi.advanceTimersByTime(11 * 60_000);
+    for (let i = 0; i < 5; i += 1) await expect(core.initDatabase()).rejects.toThrow();
+    vi.advanceTimersByTime(11 * 60_000);
+    for (let i = 0; i < 3; i += 1) await expect(core.initDatabase()).rejects.toThrow();
+    // Three reports, and the last one has only 2 failures behind it.
+    expect(reportsIn(errors)).toHaveLength(3);
+    expect(core.memoryRecallStatus().suppressedCount).toBe(2);
+
+    connect.mockResolvedValue(openable());
+    await core.initDatabase();
+
+    expect(errors.some(e => /long-term recall restored after 13 failure\(s\)/.test(e))).toBe(true);
+  });
+
   it('bounds reports even when the store alternates between two errors', async () => {
     // Suppressing only *identical* messages matches neither of an alternating
     // pair, so every recall reports — the original unbounded logging wearing a
@@ -216,8 +242,14 @@ describe('memory recall status (AGT-4267)', () => {
       if (embedderBroken) throw new Error('failed to allocate tensor');
       return { data: Float32Array.from([1, 0, 0, 0]) };
     });
-    for (let i = 0; i < 40; i += 1) await core.searchMemorySafe('anything');
-    expect(core.memoryRecallStatus().suppressedCount).toBe(39);
+    // Spans two windows on purpose: the suppressed count resets on the
+    // re-report, so it and the outage total diverge (19 vs 40) and the report
+    // has to name the second.
+    vi.useFakeTimers();
+    for (let i = 0; i < 20; i += 1) await core.searchMemorySafe('anything');
+    vi.advanceTimersByTime(11 * 60_000);
+    for (let i = 0; i < 20; i += 1) await core.searchMemorySafe('anything');
+    expect(core.memoryRecallStatus().suppressedCount).toBe(19);
 
     embedderBroken = true;
     expect((await core.searchMemorySafe('anything')).errorCode).toBe('EMBEDDING_FAILED');

--- a/src/memory/recallStatus.test.ts
+++ b/src/memory/recallStatus.test.ts
@@ -12,12 +12,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const connect = vi.hoisted(() => vi.fn());
 vi.mock('@lancedb/lancedb', () => ({ connect, Table: class {}, Connection: class {} }));
-// A usable extractor, so a search that gets past the store reaches the query
-// rather than stopping at EMBEDDING_FAILED.
-vi.mock('@huggingface/transformers', () => ({
-  pipeline: vi.fn(async () => async () => ({ data: Float32Array.from([1, 0, 0, 0]) })),
-  env: {},
-}));
+const pipelineMock = vi.hoisted(() => vi.fn());
+vi.mock('@huggingface/transformers', () => ({ pipeline: pipelineMock, env: {} }));
 // vitest.setup.ts redirects four home-dir paths but not this one. MEMORY_DIR is
 // `resolve(homedir(), '.openswarm/memory')`, evaluated at module load, and the
 // operator's real store lives there — opening it reads their own embedding
@@ -39,6 +35,12 @@ describe('memory recall status (AGT-4267)', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     connect.mockReset();
+    // Reset rather than rely on restoreAllMocks: a mockRejectedValue set by one
+    // test outlives it and turns every later search into EMBEDDING_FAILED.
+    pipelineMock.mockReset();
+    // A usable extractor, so a search that gets past the store reaches the
+    // query rather than stopping at EMBEDDING_FAILED.
+    pipelineMock.mockImplementation(async () => async () => ({ data: Float32Array.from([1, 0, 0, 0]) }));
   });
 
   afterEach(() => {
@@ -142,6 +144,77 @@ describe('memory recall status (AGT-4267)', () => {
     // The suppressed window held a different error; dropping it loses the only
     // record that the store failed two distinct ways.
     expect(reports[1]).toContain('Invalid range 0..0');
+  });
+
+  it('caps how many distinct messages one report names', async () => {
+    // Errors that embed a varying detail — a byte range, a timestamped
+    // predicate — produce a new string every call. Uncapped, one window's
+    // report measured 131 KB on a single line. Ninety-five stacks were at
+    // least greppable line by line; that is not.
+    vi.useFakeTimers();
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+    let n = 0;
+    connect.mockImplementation(async () => {
+      n += 1;
+      throw new Error(`lance error: Invalid range ${n}..${n} for object of size 0 bytes`);
+    });
+
+    for (let i = 0; i < 400; i += 1) await expect(core.initDatabase()).rejects.toThrow();
+    vi.advanceTimersByTime(11 * 60_000);
+    await expect(core.initDatabase()).rejects.toThrow();
+
+    const reports = reportsIn(errors);
+    expect(reports).toHaveLength(2);
+    expect(reports[1].length).toBeLessThan(1500);
+    // The ones it could not list are still counted, so the scale survives.
+    expect(reports[1]).toMatch(/and \d+ more not listed/);
+    expect(reports[1]).toContain('399 further failure(s)');
+  });
+
+  it('rate-limits a dead embedder too, instead of leaving it the one uncovered path', async () => {
+    // A healthy store with a broken embedder returned early before either
+    // reporter: 40 recalls, 40 stacks, and memoryRecallStatus() answering
+    // available:true while every recall failed.
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+    connect.mockResolvedValue(openable());
+    pipelineMock.mockRejectedValue(new Error('model weights are corrupt'));
+
+    for (let i = 0; i < 40; i += 1) {
+      const res = await core.searchMemorySafe('anything');
+      expect(res.errorCode).toBe('EMBEDDING_FAILED');
+    }
+
+    expect(reportsIn(errors)).toHaveLength(1);
+    expect(reportsIn(errors)[0]).toContain('the query could not be embedded');
+    const st = core.memoryRecallStatus();
+    expect(st.available).toBe(false);
+    expect(st.phase).toBe('embed');
+  });
+
+  it('clears an embed-phase outage once the embedder works again', async () => {
+    // Without this the outage sticks forever: the clear at the end of a
+    // successful search is phase-scoped to 'query', so it would never match an
+    // 'embed' failure and recall would report dead for the process lifetime.
+    const core = await import('./memoryCore.js');
+    core.resetMemoryRecallStatusForTests();
+    connect.mockResolvedValue({
+      ...openable(),
+      openTable: async () => ({
+        schema: async () => ({ fields: [] }),
+        vectorSearch: () => ({ where: () => ({ limit: () => ({ toArray: async () => [] }) }) }),
+      }),
+    });
+    pipelineMock.mockRejectedValueOnce(new Error('model weights are corrupt'));
+
+    expect((await core.searchMemorySafe('anything')).errorCode).toBe('EMBEDDING_FAILED');
+    expect(core.memoryRecallStatus().phase).toBe('embed');
+
+    expect((await core.searchMemorySafe('anything')).success).toBe(true);
+
+    expect(core.memoryRecallStatus().available).toBe(true);
+    expect(errors.some(e => e.includes('long-term recall restored'))).toBe(true);
   });
 
   it('rate-limits a store that breaks AFTER it opened, and stops claiming it is available', async () => {


### PR DESCRIPTION
## The incident

Seven zero-byte manifests, left by a single interrupted write on 2026-09-01, made every long-term recall on vela throw. `initDatabase` logged the stack and rethrew; `searchMemorySafe` caught it and logged the same stack again; every caller swallowed the throw. **95 identical stacks in five minutes**, burying every other diagnostic line — and none of them stated the one fact that mattered. From outside, "no memories found" and "recall is dead" looked the same.

## What changes

Recall failures go through one rate limiter, tracked by **phase**:

| phase | meaning |
|---|---|
| `open` | the store could not be opened at all |
| `embed` | the store is fine, the encoder is not |
| `query` | it opened and then broke under us |

The first failure is reported, repeats are suppressed for ten minutes while the count and the other messages seen are carried, and it reports again when the window elapses. `memoryRecallStatus()` exposes the state so callers can tell dead from empty, and `searchMemorySafe` now returns `DB_INIT_FAILED` for a store that never opened — `await initDatabase()` throws, so the branch written for that case was unreachable and `repoKnowledge` rendered "failed query" into the agent's prompt for a store that was never opened.

Deliberately **not** a latch. The vela outage was repaired by moving the zero-byte manifests aside and recall returned on the next call with the daemon still running; a permanent disable would have kept it dark until someone noticed.

## What five review rounds found

Each of these was measured by an independent reviewer, not reasoned about. Most of them are defects the fix itself introduced.

1. **The catch nulled a concurrently-successful open's handles.** A losing `initDatabase` destroyed the winner's live connection; the next search died on `null.vectorSearch`, and the freshly-set failure flag suppressed the line that would have shown it. Reproduced deterministically. Opening is now memoized — one in-flight open, shared — which also removes N racing `createTable` calls on a first run.
2. **Three of the first tests pinned nothing.** Setting the window to `Number.MAX_SAFE_INTEGER` — a permanent latch — left a test literally named *"does not latch"* green.
3. **A store that broke *after* opening bypassed the whole fix.** The `db && table` fast path holds for the process lifetime, so `openDatabase` never runs again: 40 recalls, 40 stacks, and `memoryRecallStatus()` answering `available: true` for a store failing 100% of recalls.
4. **The suppressed-message list was unbounded — one report measured 131,090 characters.** Errors that embed a varying detail produce a new string per call, and the search predicate interpolates `Date.now()`. Ninety-five stacks were at least greppable line by line; a 131 KB line is not. Capped at five distinct messages, now 601 characters, with the rest counted.
5. **The dead embedder was a third uncovered path** — `initEmbeddingPipeline` nulls its promise on failure, so every recall retried and re-logged.
6. **`query → embed` credited one phase's failures to another.** 39 broken queries appeared under "the query could not be embedded"; an operator reads that as the embedder failing 40 times.
7. **And then the fix for 6 dropped the number entirely.** A phase's first report always prints zero, so a phase change destroyed the tally before it was ever printed. The superseding report now names it. Recovery had the same sink from the start — an outage that self-healed left no record of its size.

## Verification

- `tsc` 0, `oxlint` 0, full suite **5621 passed / 10 skipped**, statements 90.08%.
- Coverage carries no signal here: `memoryCore.ts` is in `integrationBoundaryCoverageExcludes`. **Mutation is the evidence.** Every claim above fails the suite when reverted — the memoization, the fast-path reorder, the message cap (at 20 and above), the phase split, the embed report and its clear, the cross-phase carry, the retired-phase tally, and the restored line's count.

Closes AGT-4267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)