### PR TITLE
fix(publication): review every publication, and make the checks fail loudly (AGT-4277, AGT-4278)

### DIFF
--- a/src/automation/deletedTestGuard.test.ts
+++ b/src/automation/deletedTestGuard.test.ts
@@ -1,0 +1,123 @@
+// ============================================
+// OpenSwarm — deleting a passing test must not be free (AGT-4277)
+// ============================================
+//
+// PR #580 removed four tests from planCommand.test.ts and passed 8/8 CI. The
+// originals pass unmodified against that PR's own production code, so they were
+// not deleted because they broke — and three mutations of planCommand.ts that
+// main's suite kills survive without them.
+
+import { describe, expect, it } from 'vitest';
+import { collectTestCaseDeltas, countTestCases, deletedTestNotice, findDeletedTests } from './deletedTestGuard.js';
+
+const FOUR_CASES = `
+describe('planCommand', () => {
+  it('does not dispatch on no', () => {});
+  it('drops a sub-task on edit, then dispatches the remainder', () => {});
+  test('uses the single-task path when no decomposition is needed', () => {});
+  it.each([1, 2])('dispatches the approved sub-tasks on yes %i', () => {});
+});
+`;
+const ONE_CASE = `
+describe('planCommand', () => {
+  it('dispatches the approved sub-tasks on yes', () => {});
+});
+`;
+
+describe('deleted test guard (AGT-4277)', () => {
+  it('counts declarations, including it.each and test', () => {
+    expect(countTestCases(FOUR_CASES)).toBe(4);
+    expect(countTestCases(ONE_CASE)).toBe(1);
+  });
+
+  it('does not count a word that merely ends in "it"', () => {
+    // `submit(`, `edit(`, `await it` — a naive /it\(/ would flag all three.
+    expect(countTestCases('submit(x); audit(y); const edit = () => {};')).toBe(0);
+  });
+
+  it('reports the loss PR #580 made, with the file and the counts', () => {
+    const finding = findDeletedTests([
+      { file: 'src/support/planCommand.test.ts', before: FOUR_CASES, after: ONE_CASE },
+    ]);
+
+    expect(finding.removed).toBe(3);
+    expect(finding.files).toEqual([
+      { file: 'src/support/planCommand.test.ts', before: 4, after: 1 },
+    ]);
+  });
+
+  it('counts a deleted test file as losing every case it held', () => {
+    const finding = findDeletedTests([
+      { file: 'src/support/planCommand.test.ts', before: FOUR_CASES, after: null },
+    ]);
+
+    expect(finding.removed).toBe(4);
+  });
+
+  it('says nothing about a change that only adds tests', () => {
+    const finding = findDeletedTests([
+      { file: 'src/support/planCommand.test.ts', before: ONE_CASE, after: FOUR_CASES },
+      { file: 'src/support/planCommand.ts', before: 'it(', after: '' },
+    ]);
+
+    expect(finding.removed).toBe(0);
+    expect(finding.files).toEqual([]);
+  });
+
+  it('ignores production files, whose "it(" is not a test', () => {
+    // planCommand.ts itself contains `submit(`; a guard that read production
+    // files would fire on every refactor and be turned off within a day.
+    const finding = findDeletedTests([
+      { file: 'src/support/planCommand.ts', before: 'it("x", () => {}); it("y", () => {});', after: '' },
+    ]);
+
+    expect(finding.removed).toBe(0);
+  });
+
+  it('puts the worst file first, so a long list still leads with the point', () => {
+    const finding = findDeletedTests([
+      { file: 'a.test.ts', before: ONE_CASE, after: '' },
+      { file: 'b.test.ts', before: FOUR_CASES, after: '' },
+    ]);
+
+    expect(finding.files.map(f => f.file)).toEqual(['b.test.ts', 'a.test.ts']);
+  });
+
+  it('writes a notice that names the count, the file, and what to do', () => {
+    const notice = deletedTestNotice(findDeletedTests([
+      { file: 'src/support/planCommand.test.ts', before: FOUR_CASES, after: ONE_CASE },
+    ]));
+
+    expect(notice).toContain('removes 3 test case(s)');
+    expect(notice).toContain('src/support/planCommand.test.ts');
+    expect(notice).toContain('| 4 | 1 | −3 |');
+    // Not a block — a gate that refused legitimate deletions would be routed
+    // around. It asks the change to say why.
+    expect(notice).toContain('restore them');
+    expect(notice).toContain('say so in the description');
+  });
+
+  it('reads the delta out of git, treating an absent side as zero', async () => {
+    const run = async (args: string[]) => {
+      if (args[0] === 'merge-base') return 'base-sha\n';
+      if (args[0] === 'diff') return 'src/a.test.ts\nsrc/prod.ts\nsrc/gone.test.ts\n';
+      const ref = args[1];
+      if (ref === 'base-sha:src/a.test.ts') return FOUR_CASES;
+      if (ref === 'HEAD:src/a.test.ts') return ONE_CASE;
+      if (ref === 'base-sha:src/gone.test.ts') return ONE_CASE;
+      throw new Error(`fatal: path does not exist in ${ref}`);
+    };
+
+    const finding = await collectTestCaseDeltas('origin/HEAD', run);
+
+    // 3 from the rewritten file, 1 from the deleted one. prod.ts never read.
+    expect(finding.removed).toBe(4);
+    expect(finding.files.map(f => f.file)).toEqual(['src/a.test.ts', 'src/gone.test.ts']);
+  });
+
+  it('says nothing when the branch shares no history to compare against', async () => {
+    const run = async () => { throw new Error('fatal: no merge base'); };
+
+    await expect(collectTestCaseDeltas('origin/HEAD', run)).resolves.toEqual({ files: [], removed: 0 });
+  });
+});

--- a/src/automation/deletedTestGuard.test.ts
+++ b/src/automation/deletedTestGuard.test.ts
@@ -7,7 +7,7 @@
 // not deleted because they broke — and three mutations of planCommand.ts that
 // main's suite kills survive without them.
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { collectTestCaseDeltas, countTestCases, deletedTestNotice, findDeletedTests } from './deletedTestGuard.js';
 
 const FOUR_CASES = `
@@ -115,9 +115,14 @@ describe('deleted test guard (AGT-4277)', () => {
     expect(finding.files.map(f => f.file)).toEqual(['src/a.test.ts', 'src/gone.test.ts']);
   });
 
-  it('says nothing when the branch shares no history to compare against', async () => {
+  it('says nothing when the branch shares no history — but says THAT, out loud', async () => {
+    // A check that quietly never fires is the failure it exists to catch.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const run = async () => { throw new Error('fatal: no merge base'); };
 
     await expect(collectTestCaseDeltas('origin/HEAD', run)).resolves.toEqual({ files: [], removed: 0 });
+
+    expect(warn.mock.calls.some(c => String(c[0]).includes('skipping the check'))).toBe(true);
+    warn.mockRestore();
   });
 });

--- a/src/automation/deletedTestGuard.ts
+++ b/src/automation/deletedTestGuard.ts
@@ -99,11 +99,17 @@ export async function collectTestCaseDeltas(
   let base: string;
   try {
     base = (await run(['merge-base', baseRef, 'HEAD'])).trim();
-  } catch {
-    // No shared history to compare against says nothing about deleted tests.
+  } catch (err) {
+    // No shared history says nothing about deleted tests — but say that it did
+    // not run. A check that quietly never fires is the failure it exists to
+    // catch, wearing the check's own badge.
+    console.warn(`[DeletedTests] No merge base with ${baseRef}; skipping the check:`, err);
     return { files: [], removed: 0 };
   }
-  if (!base) return { files: [], removed: 0 };
+  if (!base) {
+    console.warn(`[DeletedTests] Empty merge base with ${baseRef}; skipping the check`);
+    return { files: [], removed: 0 };
+  }
 
   const names = (await run(['diff', '--name-only', `${base}..HEAD`])).split('\n')
     .map(n => n.trim())

--- a/src/automation/deletedTestGuard.ts
+++ b/src/automation/deletedTestGuard.ts
@@ -1,0 +1,120 @@
+// ============================================
+// OpenSwarm — a diff that removes test cases has to say why (AGT-4277)
+// ============================================
+//
+// PR #580, written by the loop and green on all eight CI checks, deleted four
+// tests from `planCommand.test.ts`. They had not broken: main's originals pass
+// unmodified against that PR's own production code. Three mutations of
+// `planCommand.ts` — dropping the `decision === 'no'` early return, neutering
+// the drop filter, disabling the `mode === 'linear'` branch — survived the
+// PR's suite and died against main's.
+//
+// No gate saw it. The coverage threshold is a repository-wide ratio, so four
+// tests in one file move it by nothing, and the reviewer reads added code.
+// This check is deterministic on purpose: "the diff removes test cases" is a
+// property of the text, and does not need a model to have an opinion about it.
+
+/** A test file's `it(`/`test(` case count, before and after. */
+export interface TestCaseDelta {
+  file: string;
+  before: number;
+  after: number;
+}
+
+export interface DeletedTestFinding {
+  /** Files that lost cases, worst first. */
+  files: TestCaseDelta[];
+  /** Total cases removed across the diff. */
+  removed: number;
+}
+
+// `it(`, `test(`, `it.each(`, `test.only(`, … but not `it.skip` being counted
+// twice via `describe`. Deliberately loose: this counts declarations, and the
+// only thing it has to get right is the DIRECTION of the change between two
+// versions of the same file, which a consistent undercount preserves.
+const TEST_CASE = /(?:^|[\s;{}])(?:it|test)(?:\.\w+)*\s*(?:\(|`)/g;
+
+/** How many test cases a file declares. */
+export function countTestCases(source: string): number {
+  return source.match(TEST_CASE)?.length ?? 0;
+}
+
+/**
+ * Report the test cases a change removes.
+ *
+ * A file that disappears entirely counts all of its cases as removed — that is
+ * the same loss, arrived at by a bigger deletion.
+ */
+export function findDeletedTests(
+  changed: Array<{ file: string; before: string | null; after: string | null }>,
+): DeletedTestFinding {
+  const files: TestCaseDelta[] = [];
+  for (const { file, before, after } of changed) {
+    if (!/\.(test|spec)\.[cm]?[jt]sx?$/.test(file)) continue;
+    const from = before === null ? 0 : countTestCases(before);
+    const to = after === null ? 0 : countTestCases(after);
+    if (to < from) files.push({ file, before: from, after: to });
+  }
+  files.sort((a, b) => (b.before - b.after) - (a.before - a.after));
+  return { files, removed: files.reduce((n, f) => n + (f.before - f.after), 0) };
+}
+
+/**
+ * The note that goes on the pull request.
+ *
+ * Not a block: renaming a suite, merging two cases, or deleting genuinely
+ * obsolete coverage are all legitimate, and a gate that refused them would be
+ * routed around within a day. What was missing was anyone *noticing* — so this
+ * states the loss, in the one place a reviewer is already looking, and puts
+ * the burden of saying why on the change.
+ */
+export function deletedTestNotice(finding: DeletedTestFinding): string {
+  const rows = finding.files
+    .map(f => `| \`${f.file}\` | ${f.before} | ${f.after} | −${f.before - f.after} |`)
+    .join('\n');
+  return `## ⚠️ This change removes ${finding.removed} test case(s)\n\n`
+    + '| File | Before | After | Change |\n| --- | ---: | ---: | ---: |\n'
+    + `${rows}\n\n`
+    + 'Deleting a test is a legitimate thing to do — a rename, a merge, coverage '
+    + 'that is genuinely obsolete. It is also the cheapest way to make a suite '
+    + 'pass, and a repository-wide coverage threshold does not move enough to '
+    + 'notice.\n\n'
+    + '**If these were removed to get green, restore them.** If they were '
+    + 'removed deliberately, say so in the description — a later reader cannot '
+    + 'tell the two apart from the diff alone.';
+}
+
+/**
+ * Read the test-case delta a branch introduces, from the worktree that holds it.
+ *
+ * Runs against the branch's own worktree, which still exists at publication
+ * time (cleanup is the caller's `finally`), so no fetch or scratch checkout is
+ * needed — the daemon already paid for this checkout.
+ */
+export async function collectTestCaseDeltas(
+  baseRef: string,
+  /** `git` in the branch's worktree. Injected so this stays testable and cwd-explicit. */
+  run: (args: string[]) => Promise<string>,
+): Promise<DeletedTestFinding> {
+  let base: string;
+  try {
+    base = (await run(['merge-base', baseRef, 'HEAD'])).trim();
+  } catch {
+    // No shared history to compare against says nothing about deleted tests.
+    return { files: [], removed: 0 };
+  }
+  if (!base) return { files: [], removed: 0 };
+
+  const names = (await run(['diff', '--name-only', `${base}..HEAD`])).split('\n')
+    .map(n => n.trim())
+    .filter(n => /\.(test|spec)\.[cm]?[jt]sx?$/.test(n));
+
+  const changed: Array<{ file: string; before: string | null; after: string | null }> = [];
+  for (const file of names) {
+    // A file absent on one side is a genuine outcome (added, or deleted), not
+    // an error — `git show` exits non-zero for both.
+    const at = async (ref: string) => { try { return await run(['show', `${ref}:${file}`]); } catch { return null; } };
+    changed.push({ file, before: await at(base), after: await at('HEAD') });
+  }
+  return findDeletedTests(changed);
+}

--- a/src/automation/publicationReviewHook.test.ts
+++ b/src/automation/publicationReviewHook.test.ts
@@ -122,6 +122,46 @@ describe('publication review hook (AGT-4278)', () => {
     expect(commentOnPR).toHaveBeenCalledTimes(1);
   });
 
+  it('re-reviews an approved republication at the same sha, so the rollback still fires', async () => {
+    // A rolled-back run resumes the preserved worktree, commits nothing new —
+    // the implementation is already there and looks finished — and
+    // republishes the SAME PR at the SAME sha. Skipping the review there
+    // finishes it `approved` with the reviewer's objection unaddressed, which
+    // is AGT-4270's failure arriving through a cache.
+    reviewPublishedPullRequest.mockResolvedValue({
+      success: false, gateRan: true, changesRequested: true, error: 'still wrong',
+    });
+
+    await hook(true)(ctx);
+    await hook(true)(ctx);
+
+    expect(reviewPublishedPullRequest).toHaveBeenCalledTimes(2);
+    expect(rollBackReviewedPublication).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not let a draft review suppress the approved review of the same sha', async () => {
+    // Same key, two different contracts: one may roll back, the other may not.
+    reviewPublishedPullRequest.mockResolvedValue({
+      success: false, gateRan: true, changesRequested: true, error: 'still wrong',
+    });
+
+    await hook(false)(ctx);
+    await hook(true)(ctx);
+
+    expect(rollBackReviewedPublication).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not mark a sha reviewed when the review never produced anything', async () => {
+    reviewPublishedPullRequest.mockRejectedValueOnce(new Error('import failed'));
+
+    await expect(hook(false)(ctx)).rejects.toThrow('import failed');
+
+    reviewPublishedPullRequest.mockResolvedValue({ success: true, gateRan: true, changesRequested: false });
+    await hook(false)(ctx);
+
+    expect(reviewPublishedPullRequest).toHaveBeenCalledTimes(2);
+  });
+
   it('reviews again when the branch moved on', async () => {
     reviewPublishedPullRequest.mockResolvedValue({ success: false, gateRan: false, error: 'timeout' });
 

--- a/src/automation/publicationReviewHook.test.ts
+++ b/src/automation/publicationReviewHook.test.ts
@@ -1,0 +1,116 @@
+// ============================================
+// OpenSwarm — every publication gets a verdict, or says why it did not (AGT-4278)
+// ============================================
+//
+// Measured on vela 2026-09-10: of nine published pull requests, two carried a
+// reviewer verdict. The gate was not weak, it was narrow. Draft publications —
+// the output of runs that STOPPED, i.e. the least finished work the daemon
+// emits — never reached it at all, and the ones that did failed open silently
+// when the reviewer timed out.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const reviewPublishedPullRequest = vi.hoisted(() => vi.fn());
+vi.mock('./prPublicationReview.js', () => ({ reviewPublishedPullRequest }));
+const commentOnPR = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock('../github/github.js', () => ({ commentOnPR }));
+const rollBackReviewedPublication = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock('./prReviewRollback.js', () => ({ rollBackReviewedPublication }));
+vi.mock('../core/eventHub.js', () => ({ broadcastEvent: vi.fn() }));
+
+import { buildPublicationReviewHook } from './publicationReviewHook.js';
+
+const PR = 'https://github.com/Intrect-io/OpenSwarm/pull/580';
+const ctx = { prUrl: PR, headSha: 'abc1234', worktreeInfo: { originalPath: '/work/OpenSwarm' } };
+
+function hook(rollbackOnRejection: boolean) {
+  return buildPublicationReviewHook({
+    task: { id: 't1', issueId: 'AGT-1', issueIdentifier: 'AGT-1', title: 'x' },
+    result: { success: true, finalStatus: 'approved' },
+    rollbackOnRejection,
+  } as Parameters<typeof buildPublicationReviewHook>[0]);
+}
+
+describe('publication review hook (AGT-4278)', () => {
+  beforeEach(() => {
+    reviewPublishedPullRequest.mockReset();
+    commentOnPR.mockClear();
+    rollBackReviewedPublication.mockClear();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('says on the PR when the reviewer produced no verdict, naming the reason', async () => {
+    // #579 and #580 both died on `openrouter timeout after 300000ms` and were
+    // published anyway. An unreviewed PR looked exactly like a reviewed one.
+    reviewPublishedPullRequest.mockResolvedValue({
+      success: false, gateRan: false, error: 'openrouter timeout after 300000ms',
+    });
+
+    await hook(true)(ctx);
+
+    expect(commentOnPR).toHaveBeenCalledTimes(1);
+    const [repo, number, body] = commentOnPR.mock.calls[0];
+    expect(repo).toBe('Intrect-io/OpenSwarm');
+    expect(number).toBe(580);
+    expect(body).toContain('without a reviewer verdict');
+    expect(body).toContain('openrouter timeout after 300000ms');
+    // A review that never ran said nothing about the code, so nothing rolls back.
+    expect(rollBackReviewedPublication).not.toHaveBeenCalled();
+  });
+
+  it('does not roll back a draft, but still gets it reviewed', async () => {
+    // The verdict cannot undo a draft — it is already a draft, and the run
+    // already parked. It is the starting point for whoever picks it up.
+    reviewPublishedPullRequest.mockResolvedValue({
+      success: false, gateRan: true, changesRequested: true, error: 'drops four passing tests',
+    });
+
+    await hook(false)(ctx);
+
+    expect(reviewPublishedPullRequest).toHaveBeenCalledTimes(1);
+    expect(rollBackReviewedPublication).not.toHaveBeenCalled();
+    expect(commentOnPR).not.toHaveBeenCalled();
+  });
+
+  it('rolls back a ready publication the reviewer rejected', async () => {
+    reviewPublishedPullRequest.mockResolvedValue({
+      success: false, gateRan: true, changesRequested: true, error: 'drops four passing tests',
+    });
+
+    await hook(true)(ctx);
+
+    expect(rollBackReviewedPublication).toHaveBeenCalledTimes(1);
+    expect(rollBackReviewedPublication.mock.calls[0][0]).toMatchObject({
+      prUrl: PR, error: 'drops four passing tests',
+    });
+  });
+
+  it('stays quiet when the reviewer approved', async () => {
+    reviewPublishedPullRequest.mockResolvedValue({ success: true, gateRan: true, changesRequested: false });
+
+    await hook(true)(ctx);
+
+    expect(commentOnPR).not.toHaveBeenCalled();
+    expect(rollBackReviewedPublication).not.toHaveBeenCalled();
+  });
+
+  it('does not fail the run when it cannot post the did-not-run notice', async () => {
+    // The reviewer already failed; failing to say so must not also fail the
+    // run. Guarded at this call site rather than relying on `commentOnPR`'s
+    // own swallow, so swapping it for `commentOnPROrThrow` cannot turn a
+    // courtesy note into a run failure.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    reviewPublishedPullRequest.mockResolvedValue({ success: false, gateRan: false, error: 'boom' });
+    commentOnPR.mockRejectedValueOnce(new Error('403 from GitHub'));
+
+    await expect(hook(true)(ctx)).resolves.toBeUndefined();
+  });
+
+  it('reviews an unparseable PR URL nowhere rather than crashing', async () => {
+    reviewPublishedPullRequest.mockResolvedValue({ success: false, gateRan: false, error: 'boom' });
+
+    await hook(true)({ ...ctx, prUrl: 'not-a-pr-url' });
+
+    expect(commentOnPR).not.toHaveBeenCalled();
+  });
+});

--- a/src/automation/publicationReviewHook.test.ts
+++ b/src/automation/publicationReviewHook.test.ts
@@ -18,7 +18,7 @@ const rollBackReviewedPublication = vi.hoisted(() => vi.fn(async () => {}));
 vi.mock('./prReviewRollback.js', () => ({ rollBackReviewedPublication }));
 vi.mock('../core/eventHub.js', () => ({ broadcastEvent: vi.fn() }));
 
-import { buildPublicationReviewHook } from './publicationReviewHook.js';
+import { buildPublicationReviewHook, resetReviewedPublicationsForTests } from './publicationReviewHook.js';
 
 const PR = 'https://github.com/Intrect-io/OpenSwarm/pull/580';
 const ctx = { prUrl: PR, headSha: 'abc1234', worktreeInfo: { originalPath: '/work/OpenSwarm' } };
@@ -36,6 +36,7 @@ describe('publication review hook (AGT-4278)', () => {
     reviewPublishedPullRequest.mockReset();
     commentOnPR.mockClear();
     rollBackReviewedPublication.mockClear();
+    resetReviewedPublicationsForTests();
   });
   afterEach(() => vi.restoreAllMocks());
 
@@ -104,6 +105,30 @@ describe('publication review hook (AGT-4278)', () => {
     commentOnPR.mockRejectedValueOnce(new Error('403 from GitHub'));
 
     await expect(hook(true)(ctx)).resolves.toBeUndefined();
+  });
+
+  it('reviews a given PR+sha once, however many times the run re-parks on it', async () => {
+    // A parked run resumes on the same branch and reuses the open PR, so a task
+    // that parks five times paid five full reviews of an unchanged diff and
+    // appended five identical notices.
+    reviewPublishedPullRequest.mockResolvedValue({ success: false, gateRan: false, error: 'timeout' });
+
+    const h = hook(false);
+    await h(ctx);
+    await h(ctx);
+    await hook(false)(ctx);
+
+    expect(reviewPublishedPullRequest).toHaveBeenCalledTimes(1);
+    expect(commentOnPR).toHaveBeenCalledTimes(1);
+  });
+
+  it('reviews again when the branch moved on', async () => {
+    reviewPublishedPullRequest.mockResolvedValue({ success: false, gateRan: false, error: 'timeout' });
+
+    await hook(false)(ctx);
+    await hook(false)({ ...ctx, headSha: 'def5678' });
+
+    expect(reviewPublishedPullRequest).toHaveBeenCalledTimes(2);
   });
 
   it('reviews an unparseable PR URL nowhere rather than crashing', async () => {

--- a/src/automation/publicationReviewHook.test.ts
+++ b/src/automation/publicationReviewHook.test.ts
@@ -162,6 +162,36 @@ describe('publication review hook (AGT-4278)', () => {
     expect(reviewPublishedPullRequest).toHaveBeenCalledTimes(2);
   });
 
+  it('collapses concurrent reviews of the same draft into one', async () => {
+    // The key goes in before the review, not after, so two callers arriving in
+    // the same tick do not both pay for it.
+    let release: (v: unknown) => void = () => {};
+    reviewPublishedPullRequest.mockImplementation(() => new Promise(r => { release = r; }));
+
+    const h = hook(false);
+    const both = Promise.all([h(ctx), h(ctx)]);
+    // Both callers must actually REACH the mock before it resolves, or the
+    // test would pass on ordering rather than on the dedup.
+    await vi.waitFor(() => expect(reviewPublishedPullRequest).toHaveBeenCalled());
+    release({ success: true, gateRan: true, changesRequested: false });
+    await both;
+
+    expect(reviewPublishedPullRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets the next park say what this one could not', async () => {
+    // The notice failing to post is the mirror of the review throwing: a sha
+    // marked done over a PR nobody told anything.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    reviewPublishedPullRequest.mockResolvedValue({ success: false, gateRan: false, error: 'timeout' });
+    commentOnPR.mockRejectedValueOnce(new Error('403'));
+
+    await hook(false)(ctx);
+    await hook(false)(ctx);
+
+    expect(commentOnPR).toHaveBeenCalledTimes(2);
+  });
+
   it('reviews again when the branch moved on', async () => {
     reviewPublishedPullRequest.mockResolvedValue({ success: false, gateRan: false, error: 'timeout' });
 

--- a/src/automation/publicationReviewHook.ts
+++ b/src/automation/publicationReviewHook.ts
@@ -1,0 +1,90 @@
+// ============================================
+// OpenSwarm — PR-time review coverage for every publication, not just some
+// ============================================
+//
+// Measured on vela 2026-09-10 (AGT-4278): of nine published pull requests, two
+// carried a reviewer verdict. The gate was not weak, it was narrow — draft
+// publications never reached it at all, and the ones that did failed open when
+// the reviewer timed out, leaving an unreviewed PR indistinguishable from a
+// reviewed one.
+
+import { broadcastEvent } from '../core/eventHub.js';
+import { commentOnPR } from '../github/github.js';
+import { parsePublishedPullRequest } from './publishedPullRequest.js';
+import { rollBackReviewedPublication } from './prReviewRollback.js';
+import type { DefaultRolesConfig, SecurityAuditConfig } from '../core/types.js';
+import type { PublishableResult, PublishableTask } from './publishOnPark.js';
+
+export interface PublicationReviewHookInput {
+  task: PublishableTask;
+  result: PublishableResult & { success?: boolean; finalStatus?: string; prUrl?: string };
+  roles?: DefaultRolesConfig;
+  securityAudit?: SecurityAuditConfig;
+  /**
+   * Whether a "changes requested" verdict may undo the publication.
+   *
+   * False for a draft: it is already a draft, the run already parked, and
+   * there is nothing to roll back. The verdict is still worth having — it is
+   * the starting point for whoever picks the draft up.
+   */
+  rollbackOnRejection: boolean;
+}
+
+/** Why the reviewer produced no verdict, said on the PR instead of only in a log nobody keeps. */
+function couldNotRunNotice(error: string | undefined): string {
+  return '## 🔍 Fresh review did not run\n\n'
+    + 'This pull request was published **without a reviewer verdict**. The review '
+    + 'was attempted and failed to produce one, so nothing here has been checked '
+    + 'beyond CI.\n\n'
+    + `**Reason:** ${error || 'the reviewer produced no parseable verdict'}\n\n`
+    + '_An unreviewed publication used to look exactly like a reviewed one; this '
+    + 'note exists so it does not._';
+}
+
+/**
+ * Build the hook that reviews a freshly published pull request.
+ *
+ * The reviewer's own objection is the only thing that rolls a publication back.
+ * `success` is also false when the review merely broke — no diff, a crashed
+ * processor, a failure posting the comment after an approval — and none of
+ * those say anything about the code. But "it broke" must not be silent either,
+ * so a run that produced no verdict says so on the PR.
+ */
+export function buildPublicationReviewHook(
+  input: PublicationReviewHookInput,
+): (ctx: { prUrl: string; headSha: string; worktreeInfo: { originalPath: string } }) => Promise<void> {
+  const { task, result, roles, securityAudit, rollbackOnRejection } = input;
+  return async ({ prUrl, worktreeInfo }) => {
+    // Loaded on demand: the review pulls in the whole PR processor.
+    const { reviewPublishedPullRequest } = await import('./prPublicationReview.js');
+    const review = await reviewPublishedPullRequest({
+      prUrl, projectPath: worktreeInfo.originalPath, roles, securityAudit,
+    });
+    const status = review.success ? 'approved' : review.gateRan ? 'changes requested' : 'did not run';
+    broadcastEvent({
+      type: 'log',
+      data: {
+        taskId: task.issueId || task.id,
+        stage: 'pr-review',
+        line: `PR-time fresh review ${status}${review.error ? `: ${review.error}` : ''}`,
+      },
+    });
+
+    if (!review.gateRan) {
+      const pr = parsePublishedPullRequest(prUrl);
+      // Best-effort, and defensively so. `commentOnPR` swallows today, but a
+      // caller whose whole job is a courtesy note must not be the reason a run
+      // fails if that ever changes to `commentOnPROrThrow`.
+      if (pr) {
+        try {
+          await commentOnPR(pr.repo, pr.number, couldNotRunNotice(review.error));
+        } catch (err) {
+          console.warn('[Runner] Could not post the "review did not run" notice:', err);
+        }
+      }
+      return;
+    }
+    if (!review.changesRequested || !rollbackOnRejection) return;
+    await rollBackReviewedPublication({ prUrl, task, result, error: review.error });
+  };
+}

--- a/src/automation/publicationReviewHook.ts
+++ b/src/automation/publicationReviewHook.ts
@@ -15,6 +15,22 @@ import { rollBackReviewedPublication } from './prReviewRollback.js';
 import type { DefaultRolesConfig, SecurityAuditConfig } from '../core/types.js';
 import type { PublishableResult, PublishableTask } from './publishOnPark.js';
 
+/**
+ * PR + head sha pairs already reviewed by this process.
+ *
+ * A parked run resumes on the same branch, and `commitAndCreatePRWithHead`
+ * reuses an open PR rather than opening a second one — so a task that parks
+ * five times used to pay five full reviews of an unchanged diff and append up
+ * to five byte-identical "did not run" notices. The sha the publication
+ * already hands us is the key that makes the work once-per-diff.
+ */
+const reviewedPublications = new Set<string>();
+
+/** Tests need the once-per-sha memory back at its initial state. */
+export function resetReviewedPublicationsForTests(): void {
+  reviewedPublications.clear();
+}
+
 export interface PublicationReviewHookInput {
   task: PublishableTask;
   result: PublishableResult & { success?: boolean; finalStatus?: string; prUrl?: string };
@@ -54,7 +70,10 @@ export function buildPublicationReviewHook(
   input: PublicationReviewHookInput,
 ): (ctx: { prUrl: string; headSha: string; worktreeInfo: { originalPath: string } }) => Promise<void> {
   const { task, result, roles, securityAudit, rollbackOnRejection } = input;
-  return async ({ prUrl, worktreeInfo }) => {
+  return async ({ prUrl, headSha, worktreeInfo }) => {
+    const alreadyReviewed = `${prUrl}@${headSha}`;
+    if (reviewedPublications.has(alreadyReviewed)) return;
+    reviewedPublications.add(alreadyReviewed);
     // Loaded on demand: the review pulls in the whole PR processor.
     const { reviewPublishedPullRequest } = await import('./prPublicationReview.js');
     const review = await reviewPublishedPullRequest({
@@ -70,6 +89,12 @@ export function buildPublicationReviewHook(
       },
     });
 
+    // A verdict that was reached but could not be POSTED (`commentOnPROrThrow`
+    // refusing after the decision) also leaves the PR without it, and on a
+    // draft nothing else records it. Not handled here: `error` carries the
+    // reviewer's feedback on a clean rejection too (prProcessor.ts:555), so
+    // this layer cannot tell the two apart. Distinguishing them needs a
+    // `verdictPosted` flag from the processor — filed rather than guessed.
     if (!review.gateRan) {
       const pr = parsePublishedPullRequest(prUrl);
       // Best-effort, and defensively so. `commentOnPR` swallows today, but a

--- a/src/automation/publicationReviewHook.ts
+++ b/src/automation/publicationReviewHook.ts
@@ -11,6 +11,7 @@
 import { broadcastEvent } from '../core/eventHub.js';
 import { commentOnPR } from '../github/github.js';
 import { parsePublishedPullRequest } from './publishedPullRequest.js';
+import { collectTestCaseDeltas, deletedTestNotice } from './deletedTestGuard.js';
 import { rollBackReviewedPublication } from './prReviewRollback.js';
 import type { DefaultRolesConfig, SecurityAuditConfig } from '../core/types.js';
 import type { PublishableResult, PublishableTask } from './publishOnPark.js';
@@ -57,6 +58,23 @@ function couldNotRunNotice(error: string | undefined): string {
     + 'note exists so it does not._';
 }
 
+/** Say on the PR when a change removes test cases. Best-effort, never fatal. */
+async function noteDeletedTests(prUrl: string, worktreePath: string | undefined): Promise<void> {
+  if (!worktreePath) return;
+  const pr = parsePublishedPullRequest(prUrl);
+  if (!pr) return;
+  try {
+    const { execFile } = await import('node:child_process');
+    const { promisify } = await import('node:util');
+    const exec = promisify(execFile);
+    const run = async (args: string[]) => (await exec('git', ['-C', worktreePath, ...args])).stdout;
+    const finding = await collectTestCaseDeltas('origin/HEAD', run);
+    if (finding.removed > 0) await commentOnPR(pr.repo, pr.number, deletedTestNotice(finding));
+  } catch (err) {
+    console.warn('[Runner] Could not check the change for deleted tests:', err);
+  }
+}
+
 /**
  * Build the hook that reviews a freshly published pull request.
  *
@@ -68,7 +86,11 @@ function couldNotRunNotice(error: string | undefined): string {
  */
 export function buildPublicationReviewHook(
   input: PublicationReviewHookInput,
-): (ctx: { prUrl: string; headSha: string; worktreeInfo: { originalPath: string } }) => Promise<void> {
+): (ctx: {
+  prUrl: string;
+  headSha: string;
+  worktreeInfo: { originalPath: string; worktreePath?: string };
+}) => Promise<void> {
   const { task, result, roles, securityAudit, rollbackOnRejection } = input;
   return async ({ prUrl, headSha, worktreeInfo }) => {
     const alreadyReviewed = `${prUrl}@${headSha}`;
@@ -79,6 +101,11 @@ export function buildPublicationReviewHook(
     const review = await reviewPublishedPullRequest({
       prUrl, projectPath: worktreeInfo.originalPath, roles, securityAudit,
     });
+    // Before the verdict, because it does not depend on one and must survive a
+    // reviewer that times out — which is exactly the state PR #580 shipped in.
+    // Deterministic: "the diff removes test cases" is a property of the text.
+    await noteDeletedTests(prUrl, worktreeInfo.worktreePath);
+
     const status = review.success ? 'approved' : review.gateRan ? 'changes requested' : 'did not run';
     broadcastEvent({
       type: 'log',

--- a/src/automation/publicationReviewHook.ts
+++ b/src/automation/publicationReviewHook.ts
@@ -68,7 +68,12 @@ async function noteDeletedTests(prUrl: string, worktreePath: string | undefined)
     const { promisify } = await import('node:util');
     const exec = promisify(execFile);
     const run = async (args: string[]) => (await exec('git', ['-C', worktreePath, ...args])).stdout;
-    const finding = await collectTestCaseDeltas('origin/HEAD', run);
+    // Resolved, not hardcoded (INT-2545): `origin/HEAD` is unset on a repo
+    // added without a clone and stale after a default-branch rename, and this
+    // check failing quietly is this change's own thesis failure.
+    const { resolveBaseRef } = await import('../support/worktreeManager.js');
+    const base = await resolveBaseRef(worktreePath);
+    const finding = await collectTestCaseDeltas(base.ref, run);
     if (finding.removed > 0) await commentOnPR(pr.repo, pr.number, deletedTestNotice(finding));
   } catch (err) {
     console.warn('[Runner] Could not check the change for deleted tests:', err);
@@ -101,6 +106,12 @@ export function buildPublicationReviewHook(
     // and republishes the same PR at the same sha; a cache hit would then
     // finish it `approved` with the objection unaddressed. That is AGT-4270's
     // failure — a verdict nobody acts on — reintroduced.
+    // Before the review, and outside its try, because it depends on nothing the
+    // reviewer produces and must survive a reviewer that times out OR throws.
+    // A timeout is exactly the state PR #580 shipped in. Deterministic: "the
+    // diff removes test cases" is a property of the text.
+    await noteDeletedTests(prUrl, worktreeInfo.worktreePath);
+
     const dedupKey = rollbackOnRejection ? null : `${prUrl}@${headSha}`;
     if (dedupKey) {
       if (reviewedPublications.has(dedupKey)) return;
@@ -120,11 +131,6 @@ export function buildPublicationReviewHook(
       if (dedupKey) reviewedPublications.delete(dedupKey);
       throw err;
     }
-    // Before the verdict, because it does not depend on one and must survive a
-    // reviewer that times out — which is exactly the state PR #580 shipped in.
-    // Deterministic: "the diff removes test cases" is a property of the text.
-    await noteDeletedTests(prUrl, worktreeInfo.worktreePath);
-
     const status = review.success ? 'approved' : review.gateRan ? 'changes requested' : 'did not run';
     broadcastEvent({
       type: 'log',
@@ -150,6 +156,9 @@ export function buildPublicationReviewHook(
         try {
           await commentOnPR(pr.repo, pr.number, couldNotRunNotice(review.error));
         } catch (err) {
+          // Mirror of the throw case: a sha left marked done over a PR nobody
+          // told anything means the next park says nothing either.
+          if (dedupKey) reviewedPublications.delete(dedupKey);
           console.warn('[Runner] Could not post the "review did not run" notice:', err);
         }
       }

--- a/src/automation/publicationReviewHook.ts
+++ b/src/automation/publicationReviewHook.ts
@@ -93,14 +93,33 @@ export function buildPublicationReviewHook(
 }) => Promise<void> {
   const { task, result, roles, securityAudit, rollbackOnRejection } = input;
   return async ({ prUrl, headSha, worktreeInfo }) => {
-    const alreadyReviewed = `${prUrl}@${headSha}`;
-    if (reviewedPublications.has(alreadyReviewed)) return;
-    reviewedPublications.add(alreadyReviewed);
+    // Only the park path may skip. The approved path's whole job is to ACT on
+    // the verdict, and this cache remembers "seen", not what was decided — so
+    // skipping there disarms the rollback exactly where a reviewer already
+    // objected. A rolled-back run resumes the preserved worktree, commits
+    // nothing new (the implementation is already there and looks finished),
+    // and republishes the same PR at the same sha; a cache hit would then
+    // finish it `approved` with the objection unaddressed. That is AGT-4270's
+    // failure — a verdict nobody acts on — reintroduced.
+    const dedupKey = rollbackOnRejection ? null : `${prUrl}@${headSha}`;
+    if (dedupKey) {
+      if (reviewedPublications.has(dedupKey)) return;
+      reviewedPublications.add(dedupKey);
+    }
     // Loaded on demand: the review pulls in the whole PR processor.
-    const { reviewPublishedPullRequest } = await import('./prPublicationReview.js');
-    const review = await reviewPublishedPullRequest({
-      prUrl, projectPath: worktreeInfo.originalPath, roles, securityAudit,
-    });
+    let review: Awaited<ReturnType<typeof import('./prPublicationReview.js')['reviewPublishedPullRequest']>>;
+    try {
+      const { reviewPublishedPullRequest } = await import('./prPublicationReview.js');
+      review = await reviewPublishedPullRequest({
+        prUrl, projectPath: worktreeInfo.originalPath, roles, securityAudit,
+      });
+    } catch (err) {
+      // The key goes in before the review so concurrent callers collapse; a
+      // review that never produced a verdict must not leave the sha marked
+      // done, or the draft is never reviewed and nothing says why.
+      if (dedupKey) reviewedPublications.delete(dedupKey);
+      throw err;
+    }
     // Before the verdict, because it does not depend on one and must survive a
     // reviewer that times out — which is exactly the state PR #580 shipped in.
     // Deterministic: "the diff removes test cases" is a property of the text.

--- a/src/automation/publishOnPark.test.ts
+++ b/src/automation/publishOnPark.test.ts
@@ -161,6 +161,19 @@ describe('parked publication is reviewed too (AGT-4278)', () => {
     expect(hook).not.toHaveBeenCalled();
   });
 
+  it('does not review a publication that never happened', async () => {
+    commitAndCreatePRWithHead.mockRejectedValue(new Error('No commits to create PR from'));
+    const durability = {
+      beforePublish: vi.fn(async () => true),
+      onPublication: vi.fn(async () => true),
+    } as unknown as ExecutionDurabilityHooks;
+    const hook = vi.fn(async () => {});
+
+    await publishParkedIfNeeded(info, publishable, parked, durability, hook);
+
+    expect(hook).not.toHaveBeenCalled();
+  });
+
   it('reports a throwing reviewer as a review failure, not as a failed publication', async () => {
     commitAndCreatePRWithHead.mockResolvedValue({ prUrl: 'https://github.com/o/r/pull/44', headSha: 'head-44' });
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/src/automation/publishOnPark.test.ts
+++ b/src/automation/publishOnPark.test.ts
@@ -109,6 +109,75 @@ describe('afterPublication hook (per-repository fresh review)', () => {
   });
 });
 
+// Measured 2026-09-10 (AGT-4278): 5 of 5 draft publications carried no reviewer
+// verdict, because this path took no hook at all. Drafts are what runs that
+// STOPPED emit — the least finished work the daemon produces.
+describe('parked publication is reviewed too (AGT-4278)', () => {
+  const info = { worktreePath: '/tmp/w', originalPath: '/tmp/r', branchName: 'swarm/AGT-1', issueId: 'AGT-1' };
+  const publishable = { id: 'task-1', issueIdentifier: 'AGT-1', title: 'Parked' };
+  const parked = { operatorPark: { code: 'ask_human', reason: 'needs a decision' } };
+
+  it('hands the reviewer the published draft, with the sha it can dedup on', async () => {
+    commitAndCreatePRWithHead.mockResolvedValue({ prUrl: 'https://github.com/o/r/pull/42', headSha: 'head-42' });
+    const durability = {
+      beforePublish: vi.fn(async () => true),
+      onPublication: vi.fn(async () => true),
+    } as unknown as ExecutionDurabilityHooks;
+    const hook = vi.fn(async () => {});
+
+    const published = await publishParkedIfNeeded(info, publishable, parked, durability, hook);
+
+    expect(published).toBe(true);
+    expect(hook).toHaveBeenCalledTimes(1);
+    expect(hook.mock.calls[0][0]).toMatchObject({
+      prUrl: 'https://github.com/o/r/pull/42', headSha: 'head-42',
+    });
+  });
+
+  it('does not review what the lease fence refused to publish', async () => {
+    const durability = {
+      beforePublish: vi.fn(async () => false),
+      onPublication: vi.fn(async () => true),
+    } as unknown as ExecutionDurabilityHooks;
+    const hook = vi.fn(async () => {});
+
+    await publishParkedIfNeeded(info, publishable, parked, durability, hook);
+
+    expect(commitAndCreatePRWithHead).not.toHaveBeenCalled();
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it('does not review a publication the durable attach rejected', async () => {
+    // A stale executor's PR exists but is not ours to speak for.
+    commitAndCreatePRWithHead.mockResolvedValue({ prUrl: 'https://github.com/o/r/pull/43', headSha: 'head-43' });
+    const durability = {
+      beforePublish: vi.fn(async () => true),
+      onPublication: vi.fn(async () => false),
+    } as unknown as ExecutionDurabilityHooks;
+    const hook = vi.fn(async () => {});
+
+    await publishParkedIfNeeded(info, publishable, parked, durability, hook);
+
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it('reports a throwing reviewer as a review failure, not as a failed publication', async () => {
+    commitAndCreatePRWithHead.mockResolvedValue({ prUrl: 'https://github.com/o/r/pull/44', headSha: 'head-44' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const durability = {
+      beforePublish: vi.fn(async () => true),
+      onPublication: vi.fn(async () => true),
+    } as unknown as ExecutionDurabilityHooks;
+    const hook = vi.fn(async () => { throw new Error('reviewer exploded'); });
+
+    await expect(publishParkedIfNeeded(info, publishable, parked, durability, hook)).resolves.toBe(true);
+
+    const lines = warn.mock.calls.map(c => String(c[0]));
+    expect(lines.some(l => l.includes('Post-publication review failed'))).toBe(true);
+    expect(lines.some(l => l.includes('Could not publish parked work'))).toBe(false);
+  });
+});
+
 describe('approved publish, lease fence rejection (cgf-portal AX-1020, 2026-08-31)', () => {
   // Losing beforePublish did not set failureDetail. pickPipelineFailureDetail
   // then fell back to lastReviewFeedback — a reviewer's APPROVAL text recorded

--- a/src/automation/publishOnPark.ts
+++ b/src/automation/publishOnPark.ts
@@ -37,7 +37,7 @@ export const PUBLICATION_SCOPE_PARK_REASON = 'publication_scope_mismatch';
 export { WORKER_NO_CHANGES_PARK_REASON } from '../agents/pairPipelineTypes.js';
 
 /** The fields these paths read; narrower than the full pipeline result. */
-interface PublishableResult {
+export interface PublishableResult {
   success?: boolean;
   finalStatus?: string;
   prUrl?: string;
@@ -46,7 +46,7 @@ interface PublishableResult {
 }
 
 /** The fields these paths read off the task. */
-interface PublishableTask {
+export interface PublishableTask {
   /** Required: the broadcast events key on `issueId || id`. */
   id: string;
   issueId?: string;
@@ -96,6 +96,7 @@ export async function publishParkedWork(
   worktreeInfo: WorktreeInfo,
   task: PublishableTask,
   durability: ExecutionDurabilityHooks | undefined,
+  afterPublication?: ApprovedPublicationHook,
 ): Promise<void> {
   // The same lease fence the approved path uses. Without it an executor that
   // already lost its claim — expired lease, a newer generation now owning the
@@ -136,6 +137,12 @@ export async function publishParkedWork(
     const attached = await durability?.onPublication(prUrl, headSha) ?? true;
     if (attached) {
       console.log(`[Runner] Parked run published as draft for ${task.issueIdentifier}: ${prUrl}`);
+      // A draft is the *least* reviewed thing this daemon emits — the run
+      // stopped because it could not finish — and until AGT-4278 it was also
+      // the only publication no reviewer ever looked at. The verdict cannot
+      // roll anything back here (it is already a draft), but it is the
+      // starting point for whoever picks the draft up.
+      if (afterPublication) await afterPublication({ prUrl, headSha, worktreeInfo });
     } else {
       console.warn(`[Runner] Parked publication for ${task.issueIdentifier} was not durably attached (lease fence); the PR exists at ${prUrl} and will be reused by branch name`);
     }
@@ -163,9 +170,10 @@ export async function publishParkedIfNeeded(
   task: PublishableTask,
   result: PublishableResult,
   durability: ExecutionDurabilityHooks | undefined,
+  afterPublication?: ApprovedPublicationHook,
 ): Promise<boolean> {
   if (!worktreeInfo || !shouldPublishParkedWork(true, result)) return false;
-  await publishParkedWork(worktreeInfo, task, durability);
+  await publishParkedWork(worktreeInfo, task, durability, afterPublication);
   return true;
 }
 

--- a/src/automation/publishOnPark.ts
+++ b/src/automation/publishOnPark.ts
@@ -107,6 +107,7 @@ export async function publishParkedWork(
     console.warn(`[Runner] Parked publication fenced for ${task.issueIdentifier}; leaving the branch unpublished`);
     return;
   }
+  let published: { prUrl: string; headSha: string } | null = null;
   try {
     const publication = await commitAndCreatePRWithHead(
       worktreeInfo,
@@ -137,12 +138,7 @@ export async function publishParkedWork(
     const attached = await durability?.onPublication(prUrl, headSha) ?? true;
     if (attached) {
       console.log(`[Runner] Parked run published as draft for ${task.issueIdentifier}: ${prUrl}`);
-      // A draft is the *least* reviewed thing this daemon emits — the run
-      // stopped because it could not finish — and until AGT-4278 it was also
-      // the only publication no reviewer ever looked at. The verdict cannot
-      // roll anything back here (it is already a draft), but it is the
-      // starting point for whoever picks the draft up.
-      if (afterPublication) await afterPublication({ prUrl, headSha, worktreeInfo });
+      published = { prUrl, headSha };
     } else {
       console.warn(`[Runner] Parked publication for ${task.issueIdentifier} was not durably attached (lease fence); the PR exists at ${prUrl} and will be reused by branch name`);
     }
@@ -153,6 +149,22 @@ export async function publishParkedWork(
     const detail = err instanceof Error ? err.message : String(err);
     if (!/No commits to create PR from/.test(detail)) {
       console.warn(`[Runner] Could not publish parked work for ${task.issueIdentifier}: ${detail}`);
+    }
+  }
+
+  // A draft is the *least* reviewed thing this daemon emits — the run stopped
+  // because it could not finish — and until AGT-4278 it was also the only
+  // publication no reviewer ever looked at. The verdict cannot roll anything
+  // back here (it is already a draft), but it is the starting point for
+  // whoever picks the draft up.
+  //
+  // Outside the try above on purpose: a hook that throws must not be reported
+  // as "could not publish parked work" when the PR exists and was attached.
+  if (published && afterPublication) {
+    try {
+      await afterPublication({ ...published, worktreeInfo });
+    } catch (err) {
+      console.warn(`[Runner] Post-publication review failed for ${task.issueIdentifier}:`, err);
     }
   }
 }

--- a/src/automation/runnerExecution.ts
+++ b/src/automation/runnerExecution.ts
@@ -34,7 +34,7 @@ import {createWorktree, hasRecoverableWorktree, preserveWorktree, removeWorktree
 import type { WorktreeInfo } from '../support/worktreeManager.js';
 import type { ExecutionDurabilityHooks } from './durableRunCoordinator.js';
 import { publishApprovedWork, publishParkedIfNeeded } from './publishOnPark.js';
-import { rollBackReviewedPublication } from './prReviewRollback.js';
+import { buildPublicationReviewHook } from './publicationReviewHook.js';
 import { loadPublicationFreshReview, loadRepoMetadata } from '../support/repoMetadata.js';
 import { prepareAttemptBranch } from '../support/branchLineage.js';
 import { RateLimitError } from '../adapters/rateLimitError.js';
@@ -1201,41 +1201,25 @@ export async function executePipeline(
       result.failureDetail = lifecycleFailure.message;
     }
 
-    const parkedPublished = await publishParkedIfNeeded(worktreeInfo, task, result, ctx.durability);
-
     // On by default; a repository turns it off with `publication.freshReview:
     // false` in openswarm.json.
     const freshReview = worktreeInfo ? await loadPublicationFreshReview(worktreeInfo.originalPath) : false;
-    await publishApprovedWork(worktreeInfo, task, result, ctx.durability,
-      freshReview ? async ({ prUrl, worktreeInfo: publishedWorktree }) => {
-        // Loaded on demand: the review pulls in the whole PR processor.
-        const { reviewPublishedPullRequest } = await import('./prPublicationReview.js');
-        const review = await reviewPublishedPullRequest({
-          prUrl,
-          projectPath: publishedWorktree.originalPath,
-          roles,
-          securityAudit: ctx.securityAudit,
-        });
-        const status = review.success ? 'approved' : review.gateRan ? 'changes requested' : 'did not run';
-        broadcastEvent({
-          type: 'log',
-          data: { taskId: task.issueId || task.id, stage: 'pr-review', line: `PR-time fresh review ${status}${review.error ? `: ${review.error}` : ''}` },
-        });
-        // A verdict nobody acts on is not a gate. Until AGT-4270 this hook
-        // logged the line above and returned, so a PR the reviewer had just
-        // asked for changes on still finished the run as 'approved' — the
-        // issue closed, the worktree deleted, the PR left sitting there
-        // looking ready to merge.
-        //
-        // Only the reviewer's own objection rolls anything back. `success`
-        // is also false when the review merely broke — no diff, a crashed
-        // processor, or a failure posting the comment AFTER an approval —
-        // and none of those say anything about the code.
-        if (!review.changesRequested) return;
-        await rollBackReviewedPublication({ prUrl, task, result, error: review.error });
-      } : undefined,
-    );
-    if (!parkedPublished) await publishParkedIfNeeded(worktreeInfo, task, result, ctx.durability);
+    // A verdict nobody acts on is not a gate (AGT-4270), and a gate that only
+    // half the publications reach is not one either (AGT-4278): drafts get the
+    // same reviewer, minus the rollback they have no use for. Built before the
+    // pre-approve park publish so BOTH park sides are covered — a run parks
+    // either before the approved publish or during it, and the earlier side is
+    // the one that carries the 42-commit outcomes.
+    const reviewHook = (rollbackOnRejection: boolean) => freshReview
+      ? buildPublicationReviewHook({ task, result, roles, securityAudit: ctx.securityAudit, rollbackOnRejection })
+      : undefined;
+
+    const parkedPublished = await publishParkedIfNeeded(worktreeInfo, task, result, ctx.durability, reviewHook(false));
+
+    await publishApprovedWork(worktreeInfo, task, result, ctx.durability, reviewHook(true));
+    if (!parkedPublished) {
+      await publishParkedIfNeeded(worktreeInfo, task, result, ctx.durability, reviewHook(false));
+    }
 
     keepWorktree = !(result.success && result.finalStatus === 'approved');
     return result;


### PR DESCRIPTION
## The measurement

Of nine pull requests the daemon published, **two carried a reviewer verdict**.

```
#579  freshReview=0  +588/-500   (ready)   openrouter timeout after 300000ms
#580  freshReview=0  +161/-114   (ready)   openrouter timeout after 300000ms
#581  freshReview=0  +292/-12    (draft)
#582  freshReview=0  +1/-0       (draft)
#583  freshReview=1  +526/-706   (ready)
#584  freshReview=0  +47/-276    (draft)
#585  freshReview=1  +11/-49     (ready)
#586  freshReview=0  +20/-52     (draft)
#587  freshReview=0  +32/-53     (draft)
```

Not correlated with size — the largest got one, the smallest did not. The axis is **draft**, and the cause is structural: `publishParkedIfNeeded` opens a draft PR and took no review hook. Drafts are what runs that *stopped* emit, so the least finished work the daemon produces was the only output nobody reviewed. The reviewed path then failed open silently when the reviewer timed out, leaving an unreviewed PR indistinguishable from a reviewed one.

#580 is what that costs. It passed 8/8 CI, and an independent review found: the half of its title about "overlapping monitor requests" was a **no-op** — that containment landed on `main` two months earlier — and it **deleted four passing tests**, after which three mutations of `planCommand.ts` survive that `main`'s suite kills.

## What changes

**Every publication is reviewed** (AGT-4278). Both park sides get the same reviewer, with `rollbackOnRejection: false` — the PR is already a draft and the run already parked, but the verdict is the starting point for whoever picks it up. A review that produces no verdict now says so **on the PR**, with the reason.

**A change that removes test cases says so** (AGT-4277). Deterministic — "the diff removes test cases" is a property of the text and needs no model to have an opinion. It notes rather than blocks: renaming a suite, merging two cases, deleting genuinely obsolete coverage are all legitimate, and a gate that refused them would be routed around within a day. What was missing was anyone *noticing* — the coverage threshold is a repository-wide ratio, so four tests in one file move it by nothing, and the reviewer reads added code. It runs before the review and depends on nothing it produces, so it survives a reviewer that times out or throws.

## What three review rounds found

Every one of these was measured, and most are defects this change introduced.

1. **The headline line was pinned by nothing.** Deleting the call that hands a draft to the reviewer left **5628 tests green**. The internal branch was covered; the call site, where the behaviour lives, was not.
2. **The dedup I added could disarm the rollback.** A rejected publication rolls back to draft and the run retries on the preserved worktree; with no new commits it republishes the *same PR at the same sha*, hit the cache, skipped the review, and finished `approved` — AGT-4270's "a verdict nobody acts on is not a gate", reintroduced, landing precisely on PRs a reviewer had already rejected. The dedup is now scoped to the park path.
3. **Checks that fail quietly.** `origin/HEAD` hardcoded against this repo's own INT-2545 convention, `merge-base` throwing into a silent catch; a did-not-run notice that failed to post leaving the sha marked done. A check that never fires is this change's own thesis failure.

## Deliberately not done

A verdict that was *reached* but could not be **posted** leaves a draft with nothing recording it. `error` carries the reviewer's feedback on a clean rejection too (`prProcessor.ts:555`), so this layer cannot tell the two apart — my first attempt fired on every rejection and my own test caught it. It needs a `verdictPosted` flag from the processor. Named rather than guessed.

## Verification

`tsc` 0, `oxlint` 0, full suite **5650 passed / 10 skipped**, statements 90.10%.

Mutation is the evidence, per round 1's lesson. Each of these fails the suite when reverted: never calling the hook; calling it past the lease fence or a rejected durable attach; reviewing a publication that never happened; applying the dedup to the approved path; keeping the key after a failed review or a failed notice; adding the key after the review instead of before; counting a deleted test file as no loss; reading production files; a naive `/it\(/` that matches `submit(`; counting additions as removals; a silent no-merge-base.

Closes AGT-4277, AGT-4278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)