### PR TITLE
chore(release): 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 ## [Unreleased]
 
 
+## 0.24.0 — 2026-09-10
+
+Everything the loop published still had to get past a gate, and three of them
+were not looking. CI failed every pull request for a reason none of them
+caused, the reviewer saw 22% of what shipped, and a store that had been broken
+for nine days was reported once per recall instead of once.
+
+### Fixed
+
+- **One dead apt repository no longer fails every pull request (AGT-4274).** `apt-get update && apt-get install -y bubblewrap` let *any* configured repository gate the sandbox install. The google-chrome repo the runner image ships served a mismatched index, `update` exited non-zero, the `&&` short-circuited, and bubblewrap was never installed — every open PR died seven lines later at `bwrap: command not found`, `Tests` and `Verify sandbox` red on all four while `main` was green. `set -e` does not fire on a non-final command of an AND-OR list, so the step ran past the real cause instead of stopping at it and nothing in the error named apt. `update` failing is now a warning; the **install** is the gate and still fails closed, with `bwrap --version` catching an unpacked-but-unusable binary. The line existed in three places — `ci.yml` Tests, `ci.yml` verify-sandbox, and `release.yml`, so the release publish path carried the same mine — and is now one composite action.
+- **Every publication is reviewed, not 22% of them (AGT-4278).** Of nine published pull requests, two carried a reviewer verdict. Draft publications never reached the gate at all: `publishParkedIfNeeded` opens a draft PR and took no review hook, so the output of runs that *stopped* — the least finished work the daemon emits — was the only thing nobody reviewed. Both park sides now get the same reviewer, without the rollback a draft has no use for. And a review that dies no longer fails open silently: two PRs ended at `openrouter timeout after 300000ms` and were published anyway, leaving an unreviewed PR indistinguishable from a reviewed one. A publication with no verdict now says so on the PR, with the reason. Reviews are deduplicated per PR **and head sha** on the park path only — never on the approved path, where skipping one would disarm the rollback for exactly the changes a reviewer had already rejected.
+- **A change that removes test cases says so on the pull request (AGT-4277).** A loop-authored PR green on all eight checks deleted four passing tests; three mutations of the file they covered survive without them, one of which would dispatch a sub-task the user had explicitly dropped. No gate could see it — the coverage threshold is a repository-wide ratio, so four tests in one file move it by nothing, and the reviewer reads added code. The check is deterministic, notes rather than blocks (renames, merges and genuinely obsolete coverage are legitimate; a gate that refused them would be routed around), and runs before the review so it survives a reviewer that times out or throws.
+- **An unopenable memory store is reported once, not on every recall (AGT-4267).** Seven zero-byte manifests from a single interrupted write made every long-term recall throw; `initDatabase` logged the stack and rethrew, `searchMemorySafe` logged it again, and callers swallowed it — 95 identical stacks in five minutes, none of which said that recall was off. Failures are now tracked by phase (`open` / `embed` / `query`) through one rate limiter, so suppressing one kind cannot hide another; opening the store is memoized, which also removes the racing `createTable` calls a first run made under concurrency; and `searchMemorySafe` returns `DB_INIT_FAILED` rather than `QUERY_FAILED` for a store that never opened, which `repoKnowledge` renders straight into the agent's prompt. Not a latch: the outage was repaired externally and recall returned on the next call. Measured after deployment: 34 init errors per three minutes → 0, and 192 successful recalls in four minutes.
+- **`coordinationTools` test asserts through chalk's colouring (AGT-4153).** Green in CI, red on every developer machine.
+
+
 ## 0.23.0 — 2026-09-10
 
 The autonomous loop was shipping pull requests that no LLM had read, and its

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intrect/openswarm",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.72.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intrect/openswarm",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Autonomous AI agent orchestrator — Claude, GPT, Codex, and local models (Ollama/LMStudio/llama.cpp)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Six fixes, all measured on the running daemon rather than reasoned about.

## What this release is about

Everything the loop publishes has to get past a gate. Three of them were not looking.

- **CI failed every pull request for a reason none of them caused.** Four open PRs, identical failure signature, `main` green — one dead third-party apt repository, short-circuiting the bubblewrap install through a `&&`. `set -e` does not fire on a non-final command of an AND-OR list, so the step died seven lines later at `bwrap: command not found` and nothing in the error named apt. The release publish path carried the same line.
- **The reviewer saw 22% of what shipped.** Of nine published PRs, two carried a verdict. Draft publications — the output of runs that *stopped* — never reached the gate at all, and the reviewed path failed open silently on a 300 s timeout. One of the PRs that shipped unreviewed contained a no-op fix for something closed two months earlier plus four deleted passing tests.
- **A memory store broken for nine days was reported once per recall.** 95 identical stacks in five minutes, none of which said that long-term recall was off.

## Verified

`tsc` 0, `oxlint` 0, full suite **5650 passed / 10 skipped**, statements 90.10%.

AGT-4267's fix is already deployed and measured on vela: init errors went from 34 per three minutes to **0**, and successful recalls from 11 per three minutes to **192 per four**.

Each behavioural claim in the changelog is mutation-pinned — reverting it fails the suite. That standard came out of this cycle: an independent review deleted the central line of one of these fixes and found 5628 tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)