### PR TITLE
ci: run CodeQL weekly and on release tags, not on every worker edit

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: CodeQL
+
+# AGT-4160 moved CodeQL out of the autonomous pipeline, and it was right to:
+# a whole-database scan per worker edit costs up to 20 minutes per language and
+# parked runs as `security-audit-infra`, so pull requests stopped coming out.
+#
+# But that left the analysis running nowhere. `review-gate.yml` only *uploads*
+# SARIF from `openswarm review` — `codeql-action/upload-sarif` is the ingestion
+# endpoint, not the scanner — so after that change nothing analysed this
+# repository at all. A capability that quietly stops running is the failure
+# this repository spent 2026-09-10 removing from three other gates.
+#
+# So: not per edit, and not never. Weekly, plus on demand, plus on a release
+# tag — the triggers where a 20-minute scan is affordable and the finding is
+# still actionable before it reaches users.
+
+on:
+  schedule:
+    # 04:17 Monday UTC. Off the hour: every repository that asks for "weekly"
+    # gets :00, and the shared runner pool feels it.
+    - cron: '17 4 * * 1'
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          # `security-extended` over the default suite: the default is tuned to
+          # keep false positives near zero on any repository, and this one is
+          # an agent runtime that spawns processes and writes files under
+          # instructions from a model.
+          queries: security-extended
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:javascript-typescript


### PR DESCRIPTION
## Why

#589 (AGT-4160) removed CodeQL from the autonomous pipeline. That was correct — a whole-database scan per worker edit costs up to 20 minutes per language and parked runs as `security-audit-infra`, so pull requests stopped coming out. A security control paid for with the throughput of the thing it protects is not a good trade.

**But it left the analysis running nowhere.** I checked before merging:

- `.github/` contains no `codeql-action/init` or `analyze` step. `review-gate.yml` uses `codeql-action/upload-sarif`, which is the *ingestion* endpoint for any SARIF — it publishes `openswarm review`'s findings, it does not scan.
- The only `codeql database` invocation in the tree is `src/verify/securityAudit.ts`, reached from `pairPipeline.ts:178` behind `securityAudit?.enabled` — now defaulting to false.

So after #589 this repository is analysed by nothing.

## What this adds

CodeQL on a weekly schedule, on `v*` tags, and on demand — the points where 20 minutes is affordable and a finding is still actionable before it reaches users. Not per edit, and not never.

`security-extended` rather than the default suite: the default is tuned to keep false positives near zero on *any* repository, and this one is an agent runtime that spawns processes and writes files under a model's instructions.

The cron is `17 4 * * 1` rather than `0 4` — every repository that asks for "weekly" lands on `:00`, and the shared runner pool feels it.

## The pattern

A capability that quietly stops running is the failure this repository spent today removing from three other gates: a CI install that silently skipped (#588), a reviewer that saw 22% of publications (#592), and a deleted-test check that returned "nothing found" when it could not compare (#592). Turning CodeQL off without putting it anywhere would have been the fourth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)