### PR TITLE
fix(gitignore): stop a node_modules symlink from being committable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Dependencies
-node_modules/
+node_modules
 
 # Build output
 dist/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/work/OpenSwarm/node_modules


### PR DESCRIPTION
## Why

PR #595 was opened by an autonomous run whose **entire diff** was one symlink at the repository root:

```
node_modules -> /work/OpenSwarm/node_modules
```

That path exists only inside the daemon's container. Merging it would have given every checkout a dangling symlink where its dependencies go.

## Root cause, measured

A trailing slash restricts a gitignore pattern to **directories**, and git records a symlink as a file — so `node_modules/` never matched it:

| pattern | result for a `node_modules` symlink |
| --- | --- |
| `node_modules/` | `A  node_modules` — staged |
| `node_modules` | ignored |

## What changes

One character. Dropping the slash still ignores the directory at any depth, and now also ignores the symlink.

Worktree flows that create these symlinks deliberately (sharing one install across many worktrees) are unaffected — they need the link to exist, not to be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)