### PR TITLE
fix(adapters): give every HTTPS adapter the HTTP/1.1 dispatcher, not just codex

### DIFF
--- a/src/adapters/atlascloud.test.ts
+++ b/src/adapters/atlascloud.test.ts
@@ -8,6 +8,20 @@ import { AtlasCloudCliAdapter, createApiCaller } from './atlascloud.js';
 import { RateLimitError } from './rateLimitError.js';
 import { getAdapter } from './index.js';
 
+// Adapters send HTTPS traffic through undici's own fetch with a shared HTTP/1.1
+// dispatcher (AGT-4220), so `vi.stubGlobal('fetch', ...)` alone no longer
+// intercepts it. Delegating the module's fetch to the global keeps every
+// existing stub in this file meaningful, and the init object — `dispatcher`
+// included — still reaches the stub, so it stays assertable.
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: (url: unknown, init: unknown) => (globalThis.fetch as unknown as (u: unknown, i: unknown) => unknown)(url, init),
+  };
+});
+
+
 describe('AtlasCloudCliAdapter', () => {
   const originalEnv = { ...process.env };
 

--- a/src/adapters/atlascloud.ts
+++ b/src/adapters/atlascloud.ts
@@ -32,6 +32,7 @@ import {
   resolveDefaultModel,
   type CatalogSpec,
 } from './modelCatalog.js';
+import { adapterFetch } from './httpDispatcher.js';
 
 /** Model listing must never block a run for long — it is advisory metadata. */
 const MODEL_LIST_TIMEOUT_MS = 10_000;
@@ -66,7 +67,7 @@ function catalogSpec(): CatalogSpec {
     fetchLive: async () => {
       const apiKey = getEnvApiKey();
       if (!apiKey) return [];
-      const res = await fetch(`${ATLASCLOUD_API_BASE}/models`, {
+      const res = await adapterFetch(`${ATLASCLOUD_API_BASE}/models`, {
         headers: { Authorization: `Bearer ${apiKey}` },
         signal: AbortSignal.timeout(MODEL_LIST_TIMEOUT_MS),
       });
@@ -224,7 +225,7 @@ export function createApiCaller(apiKey: string, model: string, opts: AtlasCloudA
     }
     const attempt = async (): Promise<ReturnType<typeof consumeChatCompletionsStream>> => {
       const request = prepareApprovedModelRequest(`${ATLASCLOUD_API_BASE}/chat/completions`, body);
-      const res = await fetch(request.url, {
+      const res = await adapterFetch(request.url, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${apiKey}`,

--- a/src/adapters/codexModels.test.ts
+++ b/src/adapters/codexModels.test.ts
@@ -4,6 +4,20 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { addForwardCompatModels, getCodexModelIds, DEFAULT_CODEX_MODELS } from './codexModels.js';
 
+// Adapters send HTTPS traffic through undici's own fetch with a shared HTTP/1.1
+// dispatcher (AGT-4220), so `vi.stubGlobal('fetch', ...)` alone no longer
+// intercepts it. Delegating the module's fetch to the global keeps every
+// existing stub in this file meaningful, and the init object — `dispatcher`
+// included — still reaches the stub, so it stays assertable.
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: (url: unknown, init: unknown) => (globalThis.fetch as unknown as (u: unknown, i: unknown) => unknown)(url, init),
+  };
+});
+
+
 describe('addForwardCompatModels', () => {
   it('de-dupes while preserving order', () => {
     expect(addForwardCompatModels(['a', 'b', 'a', 'c', 'b'])).toEqual(['a', 'b', 'c']);

--- a/src/adapters/codexResponses.ts
+++ b/src/adapters/codexResponses.ts
@@ -5,7 +5,7 @@
 // (unlike the codex `exec` CLI, which is a black box). INT-1586.
 // ============================================
 
-import { Agent, fetch as undiciFetch } from 'undici';
+import { adapterFetch } from './httpDispatcher.js';
 
 import type {
   CliAdapter,
@@ -51,27 +51,9 @@ type ResponsesInputItem =
   | { type: 'function_call'; call_id: string; name: string; arguments: string }
   | { type: 'function_call_output'; call_id: string; output: string };
 
-/**
- * Dedicated dispatcher for Codex Responses traffic, pinned to HTTP/1.1.
- *
- * Node's global fetch negotiates h2 with this origin, and undici then carries
- * several concurrent requests as streams over a couple of connections. The
- * server admits only a few concurrent streams per connection, so with N
- * reviewers in one process a request sat in undici waiting for a stream slot:
- * measured at concurrency 4, `create -> sendHeaders` was 17.30s median while
- * the server itself answered in 1.07s. Splitting the same work across four
- * processes was fast purely because each got its own connection.
- *
- * One connection per in-flight request restores that, without needing a
- * process boundary. undici's own `fetch` is required — a dispatcher built from
- * the npm package is rejected by the copy bundled inside Node's global fetch
- * (same constraint as support/outboundUrl.ts). (AGT-4220)
- */
-let codexDispatcher: Agent | undefined;
-function getCodexDispatcher(): Agent {
-  codexDispatcher ??= new Agent({ allowH2: false, connections: 64, pipelining: 1 });
-  return codexDispatcher;
-}
+// The dispatcher rationale now lives in httpDispatcher.ts, shared with every
+// other HTTPS adapter: they run in the same process at the same concurrency and
+// hit the same stall. (AGT-4220)
 
 /**
  * Resolve the reasoning effort for a Responses API request. An explicit effort
@@ -513,11 +495,7 @@ export class CodexResponsesAdapter implements CliAdapter {
       // NOTE: never set max_output_tokens — the Codex backend rejects it with HTTP 400.
       const doCall = async (accessToken: string): Promise<ChatLikeResponse> => {
         const request = this.prepareRequest(body);
-        // undici's Response is spec-compatible with the global one; the DOM lib
-        // types are structurally distinct, so cross the boundary once, here —
-        // same bridge support/outboundUrl.ts makes.
-        const res = await undiciFetch(request.url, {
-          dispatcher: getCodexDispatcher(),
+        const res = await adapterFetch(request.url, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -530,7 +508,7 @@ export class CodexResponsesAdapter implements CliAdapter {
           body: request.body,
           // The caller's signal AND this call's own deadline. Either aborts.
           signal: abortSignalWithDeadline(signal, timeoutMs),
-        } as never) as unknown as Response;
+        } as never);
 
         if (!res.ok) {
           const errText = await res.text().catch(() => '');

--- a/src/adapters/gpt.ts
+++ b/src/adapters/gpt.ts
@@ -28,6 +28,7 @@ import {
   resolveDefaultModel,
   type CatalogSpec,
 } from './modelCatalog.js';
+import { adapterFetch } from './httpDispatcher.js';
 
 const OPENAI_API_BASE = 'https://api.openai.com/v1';
 // Was pinned to `gpt-4o` long after the GPT-5 line shipped — the exact staleness
@@ -57,7 +58,7 @@ function catalogSpec(): CatalogSpec {
     fetchLive: async () => {
       const apiKey = process.env.OPENAI_API_KEY?.trim();
       if (!apiKey) return [];
-      const res = await fetch(`${OPENAI_API_BASE}/models`, {
+      const res = await adapterFetch(`${OPENAI_API_BASE}/models`, {
         headers: { Authorization: `Bearer ${apiKey}` },
         signal: AbortSignal.timeout(MODEL_LIST_TIMEOUT_MS),
       });
@@ -220,7 +221,7 @@ export class GptCliAdapter implements CliAdapter {
       }
       const doCall = async (accessToken: string) => {
         const request = prepareApprovedModelRequest(`${OPENAI_API_BASE}/chat/completions`, body);
-        const res = await fetch(request.url, {
+        const res = await adapterFetch(request.url, {
           method: 'POST',
           headers: {
             'Authorization': `Bearer ${accessToken}`,

--- a/src/adapters/httpDispatcher.test.ts
+++ b/src/adapters/httpDispatcher.test.ts
@@ -1,0 +1,74 @@
+// ============================================
+// OpenSwarm — the dispatcher that keeps concurrent adapters off one h2 connection
+// ============================================
+//
+// The failure this guards against is invisible in a single-request test: h2
+// stream starvation only appears under concurrency, and it appears as latency
+// rather than as an error. So what is asserted here is the CONFIGURATION that
+// prevents it and the fact that every call carries it — the measurement itself
+// lives in the module's comment (AGT-4220, and vela 2026-09-10: 50 openrouter
+// timeouts and 34 `fetch failed` in one hour at 48 active runs).
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const undiciFetch = vi.hoisted(() => vi.fn(async () => new Response('ok')));
+const agentArgs = vi.hoisted(() => [] as unknown[]);
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  class RecordingAgent extends actual.Agent {
+    constructor(opts?: unknown) { super(opts as never); agentArgs.push(opts); }
+  }
+  return { ...actual, fetch: undiciFetch, Agent: RecordingAgent };
+});
+
+import { adapterFetch, getAdapterDispatcher, resetAdapterDispatcherForTests } from './httpDispatcher.js';
+
+afterEach(() => {
+  undiciFetch.mockClear();
+  agentArgs.length = 0;
+  resetAdapterDispatcherForTests();
+});
+
+describe('adapter HTTP dispatcher', () => {
+  it('pins HTTP/1.1 so concurrent requests do not queue for a stream slot', () => {
+    // `allowH2: false` is the whole fix. With h2 the server admits only a few
+    // streams per connection, and the daemon runs dozens of adapters in one
+    // process — measured at concurrency 4, create -> sendHeaders was 17.30s
+    // median against a server answering in 1.07s.
+    getAdapterDispatcher();
+
+    expect(agentArgs).toHaveLength(1);
+    expect(agentArgs[0]).toMatchObject({ allowH2: false });
+  });
+
+  it('reuses one dispatcher, because the connection ceiling is process-wide', () => {
+    // A second Agent would add a second pool to the same origin and make the
+    // ceiling a function of how many callers happened to build one.
+    expect(getAdapterDispatcher()).toBe(getAdapterDispatcher());
+    // Constructed once, not once per caller.
+    expect(agentArgs).toHaveLength(1);
+  });
+
+  it('sends every request through it, not through the global fetch', () => {
+    // The global negotiates h2 with these origins; that is the state being
+    // avoided. A call that forgets the dispatcher silently rejoins it.
+    void adapterFetch('https://example.test/v1/chat', { method: 'POST' });
+
+    expect(undiciFetch).toHaveBeenCalledTimes(1);
+    const init = undiciFetch.mock.calls[0][1] as { dispatcher?: unknown; method?: string };
+    expect(init.dispatcher).toBe(getAdapterDispatcher());
+    expect(init.method).toBe('POST');
+  });
+
+  it('keeps the caller init rather than replacing it', () => {
+    const signal = AbortSignal.timeout(1_000);
+    void adapterFetch('https://example.test/v1/models', {
+      headers: { Authorization: 'Bearer k' },
+      signal,
+    });
+
+    const init = undiciFetch.mock.calls[0][1] as { headers?: Record<string, string>; signal?: unknown };
+    expect(init.headers).toEqual({ Authorization: 'Bearer k' });
+    expect(init.signal).toBe(signal);
+  });
+});

--- a/src/adapters/httpDispatcher.ts
+++ b/src/adapters/httpDispatcher.ts
@@ -1,0 +1,63 @@
+// ============================================
+// OpenSwarm — one HTTP/1.1 connection per in-flight adapter request
+// ============================================
+//
+// Node's global fetch negotiates h2 with these origins, and undici then carries
+// several concurrent requests as streams over a couple of connections. The
+// server admits only a few concurrent streams per connection, so with N agents
+// in one process a request sits in undici waiting for a stream slot: measured
+// on codex-responses at concurrency 4, `create -> sendHeaders` was 17.30s
+// median while the server itself answered in 1.07s. Splitting the same work
+// across four processes was fast purely because each got its own connection.
+// (AGT-4220)
+//
+// That fix shipped for codex-responses alone. The daemon runs every HTTPS
+// adapter the same way — in-process, dozens at a time — so the same stall
+// reaches them: measured on vela 2026-09-10 with 48 active runs, one hour
+// produced 50 `openrouter timeout after 90000ms` and 34 undici `fetch failed`
+// while the endpoint answered a direct probe in 0.07s.
+//
+// undici's own `fetch` is required: a dispatcher built from the npm package is
+// rejected by the copy bundled inside Node's global fetch (the same constraint
+// as support/outboundUrl.ts).
+
+import { Agent, fetch as undiciFetch } from 'undici';
+
+/**
+ * Shared across adapters on purpose. undici pools per ORIGIN, so one Agent
+ * still gives each provider its own connection pool; a second Agent would only
+ * add a second pool to the same origin and make the ceiling unpredictable.
+ *
+ * The bound is fixed at construction rather than passed per call: it is a
+ * process-wide resource limit, and a caller that could raise it per request
+ * would make the ceiling a function of whoever asked last.
+ */
+let dispatcher: Agent | undefined;
+
+export function getAdapterDispatcher(): Agent {
+  dispatcher ??= new Agent({ allowH2: false, connections: 64, pipelining: 1 });
+  return dispatcher;
+}
+
+/** Tests need a fresh dispatcher rather than one carrying another test's pool. */
+export function resetAdapterDispatcherForTests(): void {
+  dispatcher = undefined;
+}
+
+/**
+ * `fetch`, pinned to HTTP/1.1 with one connection per in-flight request.
+ *
+ * Drop-in for the global: same arguments, and undici's Response is
+ * spec-compatible with the DOM one.
+ */
+export async function adapterFetch(
+  url: string,
+  init?: Parameters<typeof undiciFetch>[1],
+): Promise<Response> {
+  const res = await undiciFetch(url, { ...init, dispatcher: getAdapterDispatcher() });
+  // undici's Response is spec-compatible with the global one; the DOM lib types
+  // are structurally distinct. Cross that boundary HERE, once, so no adapter
+  // has to carry a cast of its own — the same bridge support/outboundUrl.ts
+  // makes.
+  return res as unknown as Response;
+}

--- a/src/adapters/openrouter.test.ts
+++ b/src/adapters/openrouter.test.ts
@@ -12,6 +12,20 @@ import { RateLimitError } from './rateLimitError.js';
 import { getAdapter } from './index.js';
 import type { ChatMessage } from './agenticLoop.js';
 
+// Adapters send HTTPS traffic through undici's own fetch with a shared HTTP/1.1
+// dispatcher (AGT-4220), so `vi.stubGlobal('fetch', ...)` alone no longer
+// intercepts it. Delegating the module's fetch to the global keeps every
+// existing stub in this file meaningful, and the init object — `dispatcher`
+// included — still reaches the stub, so it stays assertable.
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: (url: unknown, init: unknown) => (globalThis.fetch as unknown as (u: unknown, i: unknown) => unknown)(url, init),
+  };
+});
+
+
 describe('OpenRouterCliAdapter', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/src/adapters/openrouter.ts
+++ b/src/adapters/openrouter.ts
@@ -34,6 +34,7 @@ import {
   resolveDefaultModel,
   type CatalogSpec,
 } from './modelCatalog.js';
+import { adapterFetch } from './httpDispatcher.js';
 
 const OPENROUTER_API_BASE = 'https://openrouter.ai/api/v1';
 // Picked from the Atlas pool benchmark (benchmarks/, INT-3106): v4-flash passed
@@ -77,7 +78,7 @@ function catalogSpec(): CatalogSpec {
         }
       }
       if (!apiKey) return [];
-      const res = await fetch(`${OPENROUTER_API_BASE}/models`, {
+      const res = await adapterFetch(`${OPENROUTER_API_BASE}/models`, {
         headers: { Authorization: `Bearer ${apiKey}` },
         signal: AbortSignal.timeout(MODEL_LIST_TIMEOUT_MS),
       });
@@ -294,7 +295,7 @@ export function createApiCaller(apiKey: string, model: string, opts: ApiCallerOp
     }
     const attempt = async (): Promise<ReturnType<typeof consumeChatCompletionsStream>> => {
       const request = prepareApprovedModelRequest(`${OPENROUTER_API_BASE}/chat/completions`, body);
-      const res = await fetch(request.url, {
+      const res = await adapterFetch(request.url, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${apiKey}`,


### PR DESCRIPTION
## Why

AGT-4220 measured this stall and fixed it **for one adapter**. Node's global `fetch` negotiates h2 with these origins; undici then carries several concurrent requests as streams over a couple of connections, and the server admits only a few streams per connection. At concurrency 4, `create -> sendHeaders` was **17.30s median** while the server itself answered in **1.07s**.

`codex-responses` got a dedicated `allowH2: false` dispatcher. `openrouter`, `atlascloud` and `gpt` kept the global fetch — and the daemon runs them the same way, in-process, dozens at a time.

## Measured on vela (2026-09-10, 48 active runs, one hour of drafter traffic)

| message | count |
| --- | ---: |
| `cursor timeout after 90000ms` | 72 |
| `openrouter timeout after 90000ms` | 50 |
| `fetch failed` | 34 |

A direct probe from the same container answered in **0.074s**, and DNS resolved fine. The network is not the problem; the stream ceiling is.

## What changes

- New `src/adapters/httpDispatcher.ts` — one shared `Agent({ allowH2: false, connections: 64, pipelining: 1 })` plus `adapterFetch`. undici pools per origin, so one Agent still gives each provider its own pool; a second would only make the ceiling unpredictable.
- `openrouter`, `atlascloud`, `gpt` route their 6 fetch calls through it.
- `codex-responses` uses the shared module instead of keeping a second copy of the same Agent and rationale.
- The undici/DOM `Response` type bridge moves into the module, so it is crossed **once** rather than cast at each call site.

## Test seam moved with the code

Adapter tests mocked `global.fetch`, which this bypasses — without a shim they were reaching the **real API and getting 401s**. The same `vi.mock('undici', …)` delegation `codexResponses.test.ts` already used is now in the three other suites, so every existing `vi.stubGlobal('fetch', …)` keeps working unchanged.

## Verification

tsc 0 · oxlint 0 · full suite **5719 passed / 0 failed**.

Three mutants planted on the new module — `allowH2` flipped to true, memoisation removed, dispatcher dropped from the init — **all three killed**.

**Not covered:** `gpt.ts` has no test file of its own, so its two swapped call sites are exercised only through typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)