### PR TITLE
fix(gitignore): widen the agent-artifact patterns to the rest of the family

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,5 +95,14 @@ plan.md
 # on main, #600 carried a third copy, and none of them belong in a checkout.
 cli.json
 cursor/
-.run-tests.sh
+# Generated runners and scratch the agent leaves in its worktree. Named
+# individually rather than by one broad glob so an intentional dotfile is not
+# swallowed: observed so far are .run-tests.sh, .tmp-run-dod-tests.sh (#600),
+# and .run-targeted-tests.mjs / .test-runner-tmp.sh / .cursor-review-git-dump.py
+# (#603). The shape is always "a script the agent wrote to run its own tests".
+.run-*.sh
+.run-*.mjs
+.run-*.js
 .tmp-run-*.sh
+.test-runner-tmp.*
+.cursor-review-*


### PR DESCRIPTION
## Why

#605 caught `cli.json`, `cursor/`, `.run-tests.sh` and `.tmp-run-*.sh`. #603 then arrived carrying three more of the same kind:

```
.cursor-review-git-dump.py
.run-targeted-tests.mjs
.test-runner-tmp.sh
```

The shape is consistent — a script the agent wrote into its worktree to run its own tests or dump state — but the filenames are not, so patterning them one at a time loses the race.

## What changes

```
.run-*.sh
.run-*.mjs
.run-*.js
.tmp-run-*.sh
.test-runner-tmp.*
.cursor-review-*
```

Named by form rather than one broad glob, so an intentional dotfile is not swallowed.

Verified with `git check-ignore -v` against all five known names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)