### PR TITLE
fix(worktree): stop the agent's own scratch from being staged into commits

### DIFF
--- a/src/support/worktreeEphemeral.test.ts
+++ b/src/support/worktreeEphemeral.test.ts
@@ -101,3 +101,36 @@ describe('citedPathsAreEphemeral', () => {
     expect(citedPathsAreEphemeral('[operator-question] asked 2 times with no answer — stopped retrying automatically')).toBe(false);
   });
 });
+
+describe('agent-runtime scratch (2026-09-10)', () => {
+  // Seven shapes reached main or an open PR before this existed. Each is
+  // something the AGENT wrote into the worktree it was handed, and each was
+  // swept in by a worker's `git add -A`.
+  it.each([
+    ['node_modules', 'symlink to the shared install; a checkout that gets it cannot npm ci'],
+    ['cli.json', 'cursor-agent permission allow-list granting Shell(**)'],
+    ['cursor/cli.json', 'the same, under its own directory'],
+    ['.run-tests.sh', 'generated runner with a hardcoded container worktree UUID'],
+    ['.tmp-run-dod-tests.sh', 'the same, different name'],
+    ['.run-targeted-tests.mjs', 'the same, different extension'],
+    ['.test-runner-tmp.sh', 'agent-written test runner'],
+    ['.cursor-review-git-dump.py', 'agent-written state dump'],
+  ])('treats %s as ephemeral (%s)', (file) => {
+    expect(isEphemeralWorktreeArtifact(file)).toBe(true);
+  });
+
+  it('does not swallow real source that merely resembles them', () => {
+    // The patterns are anchored on purpose: a repository may legitimately track
+    // a `src/cursor/` module, a `run-tests.sh` without the leading dot, or a
+    // `node_modules` path nested under a fixture directory.
+    for (const file of [
+      'run-tests.sh',
+      'scripts/run-deploy.sh',
+      'src/cursorTracker.ts',
+      'tests/fixtures/node_modules/pkg/index.js',
+      'src/cli.json.ts',
+    ]) {
+      expect(isEphemeralWorktreeArtifact(file)).toBe(false);
+    }
+  });
+});

--- a/src/support/worktreeEphemeral.ts
+++ b/src/support/worktreeEphemeral.ts
@@ -44,7 +44,35 @@ export function isEphemeralWorktreeArtifact(file: string): boolean {
     // reached the PR: cgf-portal#207 shipped `apps/pipelines/.coverage`.
     || /(?:^|\/)\.coverage(?:\.[^/]+)?$/.test(file)
     || /(?:^|\/)\.full-pytest\.status$/.test(file)
-    || /(?:^|\/)(?:\.pytest_cache|\.hypothesis|\.mypy_cache|\.ruff_cache|__pycache__|htmlcov)(?:\/|$)/.test(file);
+    || /(?:^|\/)(?:\.pytest_cache|\.hypothesis|\.mypy_cache|\.ruff_cache|__pycache__|htmlcov)(?:\/|$)/.test(file)
+    // The agent's own scratch, written INTO the worktree it was given. Seven
+    // shapes reached main or an open PR on 2026-09-10 before this existed:
+    //
+    //   node_modules              symlink to /work/<repo>/node_modules, created
+    //                             by worktreeManager to share one install. A
+    //                             checkout that receives it cannot `npm ci`.
+    //   cli.json, cursor/cli.json cursor-agent permission allow-lists granting
+    //                             `Shell(**)` and `Shell(rm*)` — a repository
+    //                             that ships one hands that to every checkout.
+    //                             One anchored `cli.json` rule covers both; a
+    //                             blanket `cursor/` rule would also swallow a
+    //                             project that legitimately tracks that name.
+    //   .run-tests.sh             generated runners that hardcode a container
+    //   .tmp-run-dod-tests.sh     worktree UUID and `rm -rf node_modules`.
+    //   .run-targeted-tests.mjs
+    //   .test-runner-tmp.sh
+    //   .cursor-review-git-dump.py
+    //
+    // `.gitignore` is the other half of this and was widened too (#601/#605/
+    // #606), but it only protects repositories that carry the pattern. This
+    // predicate is the daemon's own staging step, so it holds for every project
+    // the daemon touches, including ones it has never committed to before.
+    || file === 'node_modules'
+    || /(?:^|\/)cli\.json$/.test(file)
+    || /(?:^|\/)\.run-[^/]*\.(?:sh|mjs|js|py)$/.test(file)
+    || /(?:^|\/)\.tmp-run-[^/]*\.(?:sh|mjs|js|py)$/.test(file)
+    || /(?:^|\/)\.test-runner-tmp\.[^/]+$/.test(file)
+    || /(?:^|\/)\.cursor-review-[^/]+$/.test(file);
 }
 
 


### PR DESCRIPTION
## Why

The daemon hands each agent a git worktree, and the agent writes into it. A worker's `git add -A` then sweeps that in. **Seven shapes** reached main or an open pull request on 2026-09-10:

| file | consequence |
| --- | --- |
| `node_modules` | symlink to `/work/<repo>/node_modules`. A checkout that receives it cannot `npm ci` — measured: Docker build failed on `npm ci --include=dev`, exit 1 |
| `cli.json`, `cursor/cli.json` | cursor-agent permission allow-lists granting `Shell(**)` and `Shell(rm*)` |
| `.run-tests.sh`, `.tmp-run-dod-tests.sh`, `.run-targeted-tests.mjs`, `.test-runner-tmp.sh`, `.cursor-review-git-dump.py` | generated runners that hardcode a container worktree UUID and run `rm -rf node_modules` |

## Why here and not only in .gitignore

`isEphemeralWorktreeArtifact` already exists for exactly this — linked virtualenvs, pytest basetemps, coverage output — and the WIP checkpoint already consults it. The agent's own scratch simply was not on the list.

`.gitignore` is the other half and was widened too (#601, #605, #606), but **a pattern only protects a repository that carries it**. This predicate runs in the daemon's own staging step, so it holds for every project the daemon touches, including ones it has never committed to before.

## Verification

tsc 0 · full suite **5812 passed / 0 failed**.

Four mutants planted on the new patterns; the three non-redundant ones are killed. The fourth — a blanket `cursor/` rule — survived because `cli.json` already covers `cursor/cli.json`, so it was **removed rather than given a test**: it was redundant, and it would have swallowed a project that legitimately tracks that directory.

The negative case is pinned too. `run-tests.sh`, `scripts/run-deploy.sh`, `src/cursorTracker.ts`, `tests/fixtures/node_modules/pkg/index.js` and `src/cli.json.ts` must all stay stageable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)