### PR TITLE
fix(web): give the browser a way to authenticate — the dashboard could not send a token at all (AGT-4280)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,9 @@ openswarm.orb-*.json
 # Subprojects
 openclaw/
 plan.md
+# Agent working plans (§2.5). Scratch, never repo content — and an
+# untracked directory here is exactly what `git add -A` swept into commits.
+.plans/
 
 # Agent-runtime droppings. The daemon runs agents inside each git worktree, and
 # they write their own scratch there: `cli.json`/`cursor/cli.json` are

--- a/src/issues/graphql/server.ts
+++ b/src/issues/graphql/server.ts
@@ -125,7 +125,9 @@ export async function handleGraphQL(
 ): Promise<void> {
   if (applyCors(req, res)) return;
   if (!isGraphQLTransportAuthorized(req)) {
-    res.writeHead(403, { 'Content-Type': 'application/json' });
+    // Same marker the REST gate sets: this 403 is about the credential, not
+    // about what was asked for. (AGT-4280)
+    res.writeHead(403, { 'Content-Type': 'application/json', 'X-OpenSwarm-Auth': 'token-required' });
     res.end(JSON.stringify({ errors: [{ message: 'Unauthorized GraphQL request' }] }));
     return;
   }

--- a/src/issues/issueBoardHtml.ts
+++ b/src/issues/issueBoardHtml.ts
@@ -11,6 +11,7 @@ export const ISSUE_BOARD_HTML = `<!DOCTYPE html>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>OpenSwarm :: Issues</title>
   <script src="/static/js/themeBoot.js"></script>
+  <script src="/static/js/webToken.js"></script>
   <link rel="stylesheet" href="/static/css/tokens.css">
   <style>
     /* Colour comes from /static/css/tokens.css (AGT-4201); the legacy names

--- a/src/support/dashboardHtml.ts
+++ b/src/support/dashboardHtml.ts
@@ -6,6 +6,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>OpenSwarm :: Supervisor</title>
   <script src="/static/js/themeBoot.js"></script>
+  <script src="/static/js/webToken.js"></script>
   <link rel="stylesheet" href="/static/css/tokens.css">
   <link rel="stylesheet" href="/static/css/shell.css">
   <link rel="stylesheet" href="/static/css/supervisor.css">

--- a/src/support/web.ts
+++ b/src/support/web.ts
@@ -25,13 +25,16 @@ import { getAllProcesses, killProcess, startHealthChecker, stopHealthChecker } f
 import { setDefaultAdapter, isKnownAdapter, listAdapterNames } from '../adapters/index.js';
 import { writeProviderOverride } from '../core/providerOverride.js';
 import * as memory from '../memory/index.js';
-import { PairPipeline, type PipelineResult } from '../agents/pairPipeline.js';
-import type { TaskItem } from '../orchestration/decisionEngine.js';
-import type { PipelineStage, RoleConfig } from '../core/types.js';
-import { detectTailscaleIP, isLoopbackAddress, isTailscaleAddress, isAuthorizedTailscalePeer } from './tailscaleNetwork.js';
+import { detectTailscaleIP, isTailscaleAddress } from './tailscaleNetwork.js';
 export { detectTailscaleIP, isTailscaleAddress, isAuthorizedTailscalePeer } from './tailscaleNetwork.js';
 import { runChatCompletion, getDefaultChatModel } from './chatBackend.js';
 import { handleGraphQL, isGraphQLRequest } from '../issues/graphql/server.js';
+import {
+  isAllowedOrigin, isAuthorizedLocalRead, isAuthorizedMutation,
+  isMutatingApiRequest, isMutatingGraphQLRequest,
+  writeAuthRequired, writeJson,
+} from './webAuth.js';
+import { execTasks, startExecTask } from './webExecTasks.js';
 import { ISSUE_BOARD_HTML } from '../issues/issueBoardHtml.js';
 import { createSubIssuesWithDependencies, getTaskSource } from '../automation/runnerExecution.js';
 import { refuseForChildCap } from '../automation/decompositionLimits.js';
@@ -68,29 +71,7 @@ let server: ReturnType<typeof createServer> | null = null;
 let runnerRef: AutonomousRunner | undefined;
 let gitStatusPoller: NodeJS.Timeout | null = null;
 
-// CORS origin allowlist — hostname-strict match (no substring/prefix pitfalls)
-function isAllowedOrigin(origin: string): boolean {
-  let url: URL;
-  try {
-    url = new URL(origin);
-  } catch {
-    return false;
-  }
-  const { protocol, hostname } = url;
-  if (protocol !== 'http:' && protocol !== 'https:') return false;
 
-  // Exact hostname matches
-  if (hostname === 'localhost' || hostname === '127.0.0.1') return true;
-  if (hostname === 'tauri.localhost') return true;
-
-  // Tailscale CGNAT range: 100.64.0.0/10 → first octet 100, second 64–127
-  const tailscaleMatch = hostname.match(/^100\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/);
-  if (tailscaleMatch) {
-    const second = Number(tailscaleMatch[1]);
-    if (second >= 64 && second <= 127) return true;
-  }
-  return false;
-}
 
 // `systemctl` talking to a wedged user service manager can hang past any
 // caller's patience; bound it so a stuck call surfaces as a controlled error
@@ -106,197 +87,32 @@ function safeErrorMessage(err: unknown): string {
   return 'Internal error';
 }
 
-function isTrustedTailscaleRequest(req: IncomingMessage): boolean {
-  return process.env.OPENSWARM_TRUST_TAILSCALE === 'true'
-    // Range membership is not trust: the peer must be explicitly allowlisted.
-    && isAuthorizedTailscalePeer(req.socket.remoteAddress)
-    && isTrustedLocalOrigin(req);
-}
 
-function isLoopbackHostname(hostname: string): boolean {
-  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
-}
 
-function extractBearerToken(header: string | undefined): string | null {
-  if (!header) return null;
-  // Linear-time parse (no regex): 'Bearer' + one space/tab + token. A
-  // backtracking /^Bearer\s+(.+)$/ is polynomial on adversarial whitespace runs.
-  const prefix = header.slice(0, 7).toLowerCase();
-  if (prefix !== 'bearer ' && prefix !== 'bearer\t') return null;
-  return header.slice(7).trim() || null;
-}
 
-function hasValidWebToken(req: IncomingMessage): boolean {
-  const configuredToken = process.env.OPENSWARM_WEB_TOKEN?.trim();
-  if (!configuredToken) return false;
 
-  const presentedToken =
-    extractBearerToken(req.headers.authorization) ||
-    (Array.isArray(req.headers['x-openswarm-token'])
-      ? req.headers['x-openswarm-token'][0]
-      : req.headers['x-openswarm-token']);
-  return presentedToken === configuredToken;
-}
 
-function getEffectivePort(url: URL): string {
-  if (url.port) return url.port;
-  return url.protocol === 'https:' ? '443' : '80';
-}
 
-function isTrustedLocalOrigin(req: IncomingMessage): boolean {
-  const origin = req.headers.origin;
-  if (!origin) return true;
 
-  if (!isAllowedOrigin(origin)) return false;
 
-  let originUrl: URL;
-  try {
-    originUrl = new URL(origin);
-  } catch {
-    return false;
-  }
 
-  if (originUrl.hostname === 'tauri.localhost') return true;
 
-  const host = req.headers.host;
-  if (!host) return false;
 
-  let hostUrl: URL;
-  try {
-    hostUrl = new URL(`${originUrl.protocol}//${host}`);
-  } catch {
-    return false;
-  }
 
-  const sameHost = originUrl.hostname === hostUrl.hostname;
-  const loopbackAlias = isLoopbackHostname(originUrl.hostname) && isLoopbackHostname(hostUrl.hostname);
-  return (sameHost || loopbackAlias) && getEffectivePort(originUrl) === getEffectivePort(hostUrl);
-}
 
-function isAuthorizedMutation(req: IncomingMessage): boolean {
-  if (hasValidWebToken(req)) return true;
-  return (isLoopbackAddress(req.socket.remoteAddress) && isTrustedLocalOrigin(req))
-    || isTrustedTailscaleRequest(req);
-}
 
-function isAuthorizedLocalRead(req: IncomingMessage): boolean {
-  if (hasValidWebToken(req)) return true;
-  return (isLoopbackAddress(req.socket.remoteAddress) && isTrustedLocalOrigin(req))
-    || isTrustedTailscaleRequest(req);
-}
 
-function isMutatingApiRequest(pathname: string, method: string | undefined): boolean {
-  return pathname.startsWith('/api/') && ['DELETE', 'PATCH', 'POST', 'PUT'].includes(method ?? '');
-}
 
-function isMutatingGraphQLRequest(requestUrl: URL, method: string | undefined): boolean {
-  if (!isGraphQLRequest(requestUrl.pathname)) return false;
-  if (['DELETE', 'PATCH', 'POST', 'PUT'].includes(method ?? '')) return true;
-  if (method !== 'GET') return false;
 
-  const query = requestUrl.searchParams.get('query') ?? '';
-  return query.includes('mutation');
-}
 
-function writeJson(res: ServerResponse, statusCode: number, body: unknown): void {
-  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
-  res.end(JSON.stringify(body));
-}
 
-// Exec task store (in-memory)
 
-interface ExecTaskEntry {
-  taskId: string;
-  status: 'queued' | 'running' | 'completed' | 'failed';
-  currentStage?: string;
-  result?: {
-    success: boolean;
-    summary?: string;
-    finalStatus?: string;
-  };
-  error?: string;
-  createdAt: number;
-}
 
-const execTasks = new Map<string, ExecTaskEntry>();
 
-function cleanupExecTask(taskId: string): void {
-  setTimeout(() => { execTasks.delete(taskId); }, 3600000); // 1 hour
-}
 
-/**
- * Create an in-memory exec task and run it through PairPipeline asynchronously.
- * Shared by `POST /api/exec` and the `/api/plan/dispatch` fallback (Path B) so a
- * fix to the exec lifecycle applies to both. Returns the taskId immediately;
- * status is pollable via GET /api/exec/:taskId.
- */
-function startExecTask(
-  prompt: string,
-  opts: { projectPath?: string; pipeline?: boolean; workerOnly?: boolean; model?: string } = {},
-): string {
-  const taskId = `exec-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const resolvedPath = opts.projectPath ?? process.cwd();
 
-  const entry: ExecTaskEntry = { taskId, status: 'queued', createdAt: Date.now() };
-  execTasks.set(taskId, entry);
 
-  // Run pipeline asynchronously
-  (async () => {
-    try {
-      entry.status = 'running';
 
-      let stages: PipelineStage[];
-      if (opts.workerOnly) {
-        stages = ['worker'];
-      } else if (opts.pipeline) {
-        stages = ['worker', 'reviewer', 'tester', 'documenter'];
-      } else {
-        stages = ['worker', 'reviewer'];
-      }
-
-      const roles: Record<string, RoleConfig> = {};
-      if (opts.model) {
-        roles.worker = { enabled: true, model: opts.model, timeoutMs: 0 };
-      }
-
-      const task: TaskItem = {
-        id: taskId,
-        source: 'local',
-        title: prompt,
-        description: prompt,
-        priority: 3,
-        projectPath: resolvedPath,
-        createdAt: Date.now(),
-      };
-
-      const pipelineInstance = new PairPipeline({
-        stages,
-        maxIterations: 3,
-        roles: Object.keys(roles).length > 0 ? roles as any : undefined,
-      });
-
-      pipelineInstance.on('stage:start', ({ stage }: { stage: string }) => {
-        entry.currentStage = stage;
-      });
-
-      const result: PipelineResult = await pipelineInstance.run(task, resolvedPath);
-
-      entry.status = 'completed';
-      entry.result = {
-        success: result.success,
-        summary: result.workerResult?.summary,
-        finalStatus: result.finalStatus,
-      };
-    } catch (err) {
-      entry.status = 'failed';
-      entry.error = err instanceof Error ? err.message : String(err);
-    } finally {
-      cleanupExecTask(taskId);
-    }
-  })();
-
-  return taskId;
-}
 
 // Pinned + enabled repos persistence
 const REPOS_FILE = join(homedir(), '.claude', 'openswarm-repos.json');
@@ -519,6 +335,7 @@ export async function startWebServer(port: number = 3847): Promise<void> {
         res.setHeader('Access-Control-Allow-Origin', origin);
         res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE');
         res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-OpenSwarm-Token');
+        res.setHeader('Access-Control-Expose-Headers', 'X-OpenSwarm-Auth');
       }
       if (req.method === 'OPTIONS') {
         res.writeHead(204);
@@ -529,11 +346,11 @@ export async function startWebServer(port: number = 3847): Promise<void> {
       // authentication"), and the desktop shell polls it token-less. (INT-3388)
       if (url === '/api/health' && req.method === 'GET') { writeJson(res, 200, getCachedHealthPayload()); return; }
       if ((isMutatingApiRequest(url, req.method) || isMutatingGraphQLRequest(requestUrl, req.method)) && !isAuthorizedMutation(req)) {
-        writeJson(res, 403, { error: 'Forbidden' });
+        writeAuthRequired(res);
         return;
       }
       if (req.method === 'GET' && (url.startsWith('/api/') || isGraphQLRequest(url)) && !isAuthorizedLocalRead(req)) {
-        writeJson(res, 403, { error: 'Forbidden' });
+        writeAuthRequired(res);
         return;
       }
 
@@ -1383,7 +1200,7 @@ export async function startWebServer(port: number = 3847): Promise<void> {
       // Returns: { path, parent, entries: [{name, isDir}] } — dotfiles excluded, dirs first.
       } else if (url.startsWith('/api/fs/list') && req.method === 'GET') {
         if (!isAuthorizedLocalRead(req)) {
-          writeJson(res, 403, { error: 'Forbidden' });
+          writeAuthRequired(res);
           return;
         }
 

--- a/src/support/webAuth.test.ts
+++ b/src/support/webAuth.test.ts
@@ -1,0 +1,218 @@
+// ============================================
+// OpenSwarm — who the HTTP API lets in (AGT-4280)
+// ============================================
+//
+// This surface had no tests of its own. It was extracted from web.ts, which is
+// excluded from coverage as an effectful boundary — so these pure predicates,
+// the ones that decide whether a request is authorized at all, were never
+// exercised directly.
+//
+// The gap was not theoretical. `isAllowedOrigin` accepts a Tailscale CGNAT
+// Origin (100.64/10), while `isTailscaleAddress` — narrowed in #579 — rejects
+// a CGNAT socket address outright. One half of the check expects CGNAT
+// browsing and the other calls it impossible, so neither Tailscale address
+// worked for a mutation: CGNAT was refused by the socket check, and the ULA
+// form was refused here, because a bracketed IPv6 hostname matched none of the
+// allowed shapes. A test on either function alone would have passed.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { IncomingMessage } from 'node:http';
+
+import {
+  extractBearerToken, getEffectivePort, hasValidWebToken, isAllowedOrigin,
+  isAuthorizedLocalRead, isAuthorizedMutation, isMutatingApiRequest,
+  isMutatingGraphQLRequest, isTrustedLocalOrigin,
+} from './webAuth.js';
+
+/** A request shaped like the parts these predicates read. */
+function req(opts: {
+  origin?: string; host?: string; auth?: string; token?: string; remote?: string;
+} = {}): IncomingMessage {
+  const headers: Record<string, string> = {};
+  if (opts.origin) headers.origin = opts.origin;
+  if (opts.host) headers.host = opts.host;
+  if (opts.auth) headers.authorization = opts.auth;
+  if (opts.token) headers['x-openswarm-token'] = opts.token;
+  return { headers, socket: { remoteAddress: opts.remote ?? '127.0.0.1' } } as unknown as IncomingMessage;
+}
+
+const ORIGINAL = process.env.OPENSWARM_WEB_TOKEN;
+beforeEach(() => { delete process.env.OPENSWARM_WEB_TOKEN; });
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.OPENSWARM_WEB_TOKEN;
+  else process.env.OPENSWARM_WEB_TOKEN = ORIGINAL;
+});
+
+describe('isAllowedOrigin', () => {
+  it('accepts loopback and the desktop shell', () => {
+    expect(isAllowedOrigin('http://localhost:3847')).toBe(true);
+    expect(isAllowedOrigin('http://127.0.0.1:3847')).toBe(true);
+    expect(isAllowedOrigin('https://tauri.localhost')).toBe(true);
+  });
+
+  it('accepts the Tailscale CGNAT range, and only its second octet 64-127', () => {
+    expect(isAllowedOrigin('http://100.95.200.28:3847')).toBe(true);
+    expect(isAllowedOrigin('http://100.64.0.1:3847')).toBe(true);
+    expect(isAllowedOrigin('http://100.127.255.255:3847')).toBe(true);
+    // 100.0.0.0/10 and 100.128.0.0/9 are ordinary public space.
+    expect(isAllowedOrigin('http://100.63.0.1:3847')).toBe(false);
+    expect(isAllowedOrigin('http://100.128.0.1:3847')).toBe(false);
+  });
+
+  it('accepts the Tailscale ULA, which a URL hostname keeps in brackets', () => {
+    // Without this the IPv6 address — the one #579 left as the only trusted
+    // socket shape — could pass the socket check and then fail here.
+    expect(isAllowedOrigin('http://[fd7a:115c:a1e0::bc01:c823]:3847')).toBe(true);
+    expect(isAllowedOrigin('http://[fd7a:115c:a1e0::b601:f469]:3847')).toBe(true);
+    // A different ULA is not Tailscale's.
+    expect(isAllowedOrigin('http://[fd00::1]:3847')).toBe(false);
+    expect(isAllowedOrigin('http://[::1]:3847')).toBe(false);
+  });
+
+  it('rejects other hosts, other schemes, and unparseable values', () => {
+    expect(isAllowedOrigin('http://evil.com')).toBe(false);
+    expect(isAllowedOrigin('http://localhost.evil.com')).toBe(false);
+    expect(isAllowedOrigin('file:///etc/passwd')).toBe(false);
+    expect(isAllowedOrigin('javascript:alert(1)')).toBe(false);
+    expect(isAllowedOrigin('not a url')).toBe(false);
+  });
+});
+
+describe('isTrustedLocalOrigin', () => {
+  it('allows a request that sends no Origin at all', () => {
+    // Same-origin GETs do not send one; refusing them would break every read.
+    expect(isTrustedLocalOrigin(req())).toBe(true);
+  });
+
+  it('refuses an Origin that is not on the allowlist', () => {
+    expect(isTrustedLocalOrigin(req({ origin: 'http://evil.com', host: 'localhost:3847' }))).toBe(false);
+  });
+
+  it('refuses an unparseable Origin', () => {
+    expect(isTrustedLocalOrigin(req({ origin: 'http://', host: 'localhost:3847' }))).toBe(false);
+  });
+
+  it('requires a Host header to compare against', () => {
+    expect(isTrustedLocalOrigin(req({ origin: 'http://localhost:3847' }))).toBe(false);
+  });
+
+  it('matches Origin against Host, treating loopback spellings as one host', () => {
+    expect(isTrustedLocalOrigin(req({ origin: 'http://localhost:3847', host: 'localhost:3847' }))).toBe(true);
+    expect(isTrustedLocalOrigin(req({ origin: 'http://127.0.0.1:3847', host: 'localhost:3847' }))).toBe(true);
+    // A cross-host Origin that happens to be allowlisted must still not pass:
+    // this is the CSRF check, not a second allowlist.
+    expect(isTrustedLocalOrigin(req({ origin: 'http://100.95.200.28:3847', host: 'localhost:3847' }))).toBe(false);
+  });
+
+  it('always accepts the desktop shell, whose Host never matches', () => {
+    expect(isTrustedLocalOrigin(req({ origin: 'https://tauri.localhost', host: 'localhost:3847' }))).toBe(true);
+  });
+});
+
+describe('getEffectivePort', () => {
+  it('uses the explicit port when there is one', () => {
+    expect(getEffectivePort(new URL('http://localhost:3847'))).toBe('3847');
+  });
+
+  it('falls back to the scheme default, so :80 and no port compare equal', () => {
+    expect(getEffectivePort(new URL('http://localhost'))).toBe('80');
+    expect(getEffectivePort(new URL('https://localhost'))).toBe('443');
+  });
+});
+
+describe('extractBearerToken', () => {
+  it('reads the token after either separator the header allows', () => {
+    expect(extractBearerToken('Bearer abc123')).toBe('abc123');
+    expect(extractBearerToken('bearer abc123')).toBe('abc123');
+    expect(extractBearerToken('Bearer\tabc123')).toBe('abc123');
+  });
+
+  it('rejects anything that is not a bearer credential', () => {
+    expect(extractBearerToken(undefined)).toBeNull();
+    expect(extractBearerToken('Basic abc123')).toBeNull();
+    expect(extractBearerToken('Bearer')).toBeNull();
+    expect(extractBearerToken('Bearer    ')).toBeNull();
+  });
+
+  it('does not backtrack on a long whitespace run', () => {
+    // The parse is linear on purpose: /^Bearer\s+(.+)$/ is polynomial here.
+    const started = Date.now();
+    expect(extractBearerToken(`Bearer ${' '.repeat(50_000)}`)).toBeNull();
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+});
+
+describe('hasValidWebToken', () => {
+  it('is false when the daemon configures no token, whatever is presented', () => {
+    expect(hasValidWebToken(req({ token: 'anything' }))).toBe(false);
+  });
+
+  it('accepts the configured token through either header', () => {
+    process.env.OPENSWARM_WEB_TOKEN = 'secret';
+    expect(hasValidWebToken(req({ token: 'secret' }))).toBe(true);
+    expect(hasValidWebToken(req({ auth: 'Bearer secret' }))).toBe(true);
+  });
+
+  it('rejects a wrong or absent token', () => {
+    process.env.OPENSWARM_WEB_TOKEN = 'secret';
+    expect(hasValidWebToken(req({ token: 'wrong' }))).toBe(false);
+    expect(hasValidWebToken(req())).toBe(false);
+  });
+});
+
+describe('isMutatingApiRequest', () => {
+  it('counts every write verb under /api/', () => {
+    for (const m of ['POST', 'PUT', 'PATCH', 'DELETE']) {
+      expect(isMutatingApiRequest('/api/provider', m)).toBe(true);
+    }
+    expect(isMutatingApiRequest('/api/stats', 'GET')).toBe(false);
+    expect(isMutatingApiRequest('/static/x.js', 'POST')).toBe(false);
+    expect(isMutatingApiRequest('/api/x', undefined)).toBe(false);
+  });
+});
+
+describe('isMutatingGraphQLRequest', () => {
+  const at = (q?: string) => new URL(`http://localhost:3847/graphql${q ? `?query=${encodeURIComponent(q)}` : ''}`);
+
+  it('treats any write verb on /graphql as mutating', () => {
+    expect(isMutatingGraphQLRequest(at(), 'POST')).toBe(true);
+    expect(isMutatingGraphQLRequest(at(), 'DELETE')).toBe(true);
+  });
+
+  it('reads the query string on GET, because a GET can carry a mutation', () => {
+    expect(isMutatingGraphQLRequest(at('mutation { x }'), 'GET')).toBe(true);
+    expect(isMutatingGraphQLRequest(at('query { x }'), 'GET')).toBe(false);
+    expect(isMutatingGraphQLRequest(at(), 'GET')).toBe(false);
+  });
+
+  it('ignores verbs that write nothing, and other paths', () => {
+    expect(isMutatingGraphQLRequest(at('mutation { x }'), 'HEAD')).toBe(false);
+    expect(isMutatingGraphQLRequest(new URL('http://localhost:3847/api/stats'), 'POST')).toBe(false);
+  });
+});
+
+describe('isAuthorizedMutation / isAuthorizedLocalRead', () => {
+  it('accept a valid token from anywhere', () => {
+    process.env.OPENSWARM_WEB_TOKEN = 'secret';
+    const r = req({ token: 'secret', remote: '192.168.50.99', origin: 'http://evil.com', host: 'x' });
+    expect(isAuthorizedMutation(r)).toBe(true);
+    expect(isAuthorizedLocalRead(r)).toBe(true);
+  });
+
+  it('accept loopback with a trusted origin', () => {
+    const r = req({ remote: '127.0.0.1', origin: 'http://localhost:3847', host: 'localhost:3847' });
+    expect(isAuthorizedMutation(r)).toBe(true);
+    expect(isAuthorizedLocalRead(r)).toBe(true);
+  });
+
+  it('refuse a LAN address with no credential — the case that read as a dead daemon', () => {
+    const r = req({ remote: '192.168.50.99', host: '192.168.50.43:3847' });
+    expect(isAuthorizedMutation(r)).toBe(false);
+    expect(isAuthorizedLocalRead(r)).toBe(false);
+  });
+
+  it('refuse loopback when the Origin is not trusted', () => {
+    const r = req({ remote: '127.0.0.1', origin: 'http://evil.com', host: 'localhost:3847' });
+    expect(isAuthorizedMutation(r)).toBe(false);
+  });
+});

--- a/src/support/webAuth.ts
+++ b/src/support/webAuth.ts
@@ -33,6 +33,13 @@ export function isAllowedOrigin(origin: string): boolean {
     const second = Number(tailscaleMatch[1]);
     if (second >= 64 && second <= 127) return true;
   }
+  // Tailscale ULA, as a URL hostname: `new URL('http://[fd7a:…]:3847').hostname`
+  // keeps the brackets. Without this, browsing to the IPv6 address passed the
+  // socket check and then failed here — so neither Tailscale address worked for
+  // a mutation: CGNAT was refused by the socket check, ULA by this one.
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    if (hostname.slice(1, -1).toLowerCase().startsWith('fd7a:115c:a1e0:')) return true;
+  }
   return false;
 }
 

--- a/src/support/webAuth.ts
+++ b/src/support/webAuth.ts
@@ -1,0 +1,154 @@
+// ============================================
+// OpenSwarm — who is allowed to call the HTTP API
+// ============================================
+//
+// Split out of support/web.ts while adding the browser's own way to
+// authenticate (AGT-4280). These functions decide, for every request, whether
+// the caller presented an accepted credential or arrived from a network
+// position the daemon trusts — one concern, previously interleaved with route
+// handling in a 1650-line file, and the surface most worth reading on its own.
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { isLoopbackAddress, isAuthorizedTailscalePeer } from './tailscaleNetwork.js';
+import { isGraphQLRequest } from '../issues/graphql/server.js';
+
+// CORS origin allowlist — hostname-strict match (no substring/prefix pitfalls)
+export function isAllowedOrigin(origin: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch {
+    return false;
+  }
+  const { protocol, hostname } = url;
+  if (protocol !== 'http:' && protocol !== 'https:') return false;
+
+  // Exact hostname matches
+  if (hostname === 'localhost' || hostname === '127.0.0.1') return true;
+  if (hostname === 'tauri.localhost') return true;
+
+  // Tailscale CGNAT range: 100.64.0.0/10 → first octet 100, second 64–127
+  const tailscaleMatch = hostname.match(/^100\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/);
+  if (tailscaleMatch) {
+    const second = Number(tailscaleMatch[1]);
+    if (second >= 64 && second <= 127) return true;
+  }
+  return false;
+}
+
+export function isTrustedTailscaleRequest(req: IncomingMessage): boolean {
+  return process.env.OPENSWARM_TRUST_TAILSCALE === 'true'
+    // Range membership is not trust: the peer must be explicitly allowlisted.
+    && isAuthorizedTailscalePeer(req.socket.remoteAddress)
+    && isTrustedLocalOrigin(req);
+}
+
+export function isLoopbackHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
+}
+
+export function extractBearerToken(header: string | undefined): string | null {
+  if (!header) return null;
+  // Linear-time parse (no regex): 'Bearer' + one space/tab + token. A
+  // backtracking /^Bearer\s+(.+)$/ is polynomial on adversarial whitespace runs.
+  const prefix = header.slice(0, 7).toLowerCase();
+  if (prefix !== 'bearer ' && prefix !== 'bearer\t') return null;
+  return header.slice(7).trim() || null;
+}
+
+export function hasValidWebToken(req: IncomingMessage): boolean {
+  const configuredToken = process.env.OPENSWARM_WEB_TOKEN?.trim();
+  if (!configuredToken) return false;
+
+  const presentedToken =
+    extractBearerToken(req.headers.authorization) ||
+    (Array.isArray(req.headers['x-openswarm-token'])
+      ? req.headers['x-openswarm-token'][0]
+      : req.headers['x-openswarm-token']);
+  return presentedToken === configuredToken;
+}
+
+export function getEffectivePort(url: URL): string {
+  if (url.port) return url.port;
+  return url.protocol === 'https:' ? '443' : '80';
+}
+
+export function isTrustedLocalOrigin(req: IncomingMessage): boolean {
+  const origin = req.headers.origin;
+  if (!origin) return true;
+
+  if (!isAllowedOrigin(origin)) return false;
+
+  let originUrl: URL;
+  try {
+    originUrl = new URL(origin);
+  } catch {
+    return false;
+  }
+
+  if (originUrl.hostname === 'tauri.localhost') return true;
+
+  const host = req.headers.host;
+  if (!host) return false;
+
+  let hostUrl: URL;
+  try {
+    hostUrl = new URL(`${originUrl.protocol}//${host}`);
+  } catch {
+    return false;
+  }
+
+  const sameHost = originUrl.hostname === hostUrl.hostname;
+  const loopbackAlias = isLoopbackHostname(originUrl.hostname) && isLoopbackHostname(hostUrl.hostname);
+  return (sameHost || loopbackAlias) && getEffectivePort(originUrl) === getEffectivePort(hostUrl);
+}
+
+export function isAuthorizedMutation(req: IncomingMessage): boolean {
+  if (hasValidWebToken(req)) return true;
+  return (isLoopbackAddress(req.socket.remoteAddress) && isTrustedLocalOrigin(req))
+    || isTrustedTailscaleRequest(req);
+}
+
+export function isAuthorizedLocalRead(req: IncomingMessage): boolean {
+  if (hasValidWebToken(req)) return true;
+  return (isLoopbackAddress(req.socket.remoteAddress) && isTrustedLocalOrigin(req))
+    || isTrustedTailscaleRequest(req);
+}
+
+export function isMutatingApiRequest(pathname: string, method: string | undefined): boolean {
+  return pathname.startsWith('/api/') && ['DELETE', 'PATCH', 'POST', 'PUT'].includes(method ?? '');
+}
+
+export function isMutatingGraphQLRequest(requestUrl: URL, method: string | undefined): boolean {
+  if (!isGraphQLRequest(requestUrl.pathname)) return false;
+  if (['DELETE', 'PATCH', 'POST', 'PUT'].includes(method ?? '')) return true;
+  if (method !== 'GET') return false;
+
+  const query = requestUrl.searchParams.get('query') ?? '';
+  return query.includes('mutation');
+}
+
+export function writeJson(res: ServerResponse, statusCode: number, body: unknown): void {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+/**
+ * Refuse a request because it carried no accepted credential.
+ *
+ * Marked, because 403 is not only ever about authentication: the warehouse
+ * routes answer 403 for path containment ("Path escapes the warehouse",
+ * "Symbolic-link targets are not accepted"), which says nothing about who the
+ * caller is. A browser that treats every 403 as "you need a token" asks a
+ * loopback operator — already authorized, possibly on a daemon with no token
+ * configured at all — to paste a credential for a symlink refusal, and
+ * overwrites the token it already had. The header lets the client tell the
+ * gate's own refusal from every other 403. (AGT-4280)
+ */
+const AUTH_REQUIRED_HEADER = 'X-OpenSwarm-Auth';
+
+export function writeAuthRequired(res: ServerResponse): void {
+  res.setHeader(AUTH_REQUIRED_HEADER, 'token-required');
+  writeJson(res, 403, { error: 'Forbidden' });
+}
+

--- a/src/support/webExecTasks.ts
+++ b/src/support/webExecTasks.ts
@@ -1,0 +1,108 @@
+// ============================================
+// OpenSwarm — in-memory exec task lifecycle
+// ============================================
+//
+// Moved verbatim out of support/web.ts (AGT-4280). Nothing here changed: the
+// file it came from was already 150 lines over the repository's size gate
+// before this change, so any edit to it was blocked, and this block is
+// self-contained — it touches no module state of the server it used to live in.
+
+import { PairPipeline, type PipelineResult } from '../agents/pairPipeline.js';
+import type { TaskItem } from '../orchestration/decisionEngine.js';
+import type { PipelineStage, RoleConfig } from '../core/types.js';
+
+// Exec task store (in-memory)
+
+export interface ExecTaskEntry {
+  taskId: string;
+  status: 'queued' | 'running' | 'completed' | 'failed';
+  currentStage?: string;
+  result?: {
+    success: boolean;
+    summary?: string;
+    finalStatus?: string;
+  };
+  error?: string;
+  createdAt: number;
+}
+
+/** Read by the GET /api/exec/:taskId route in web.ts. */
+export const execTasks = new Map<string, ExecTaskEntry>();
+
+export function cleanupExecTask(taskId: string): void {
+  setTimeout(() => { execTasks.delete(taskId); }, 3600000); // 1 hour
+}
+
+/**
+ * Create an in-memory exec task and run it through PairPipeline asynchronously.
+ * Shared by `POST /api/exec` and the `/api/plan/dispatch` fallback (Path B) so a
+ * fix to the exec lifecycle applies to both. Returns the taskId immediately;
+ * status is pollable via GET /api/exec/:taskId.
+ */
+export function startExecTask(
+  prompt: string,
+  opts: { projectPath?: string; pipeline?: boolean; workerOnly?: boolean; model?: string } = {},
+): string {
+  const taskId = `exec-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const resolvedPath = opts.projectPath ?? process.cwd();
+
+  const entry: ExecTaskEntry = { taskId, status: 'queued', createdAt: Date.now() };
+  execTasks.set(taskId, entry);
+
+  // Run pipeline asynchronously
+  (async () => {
+    try {
+      entry.status = 'running';
+
+      let stages: PipelineStage[];
+      if (opts.workerOnly) {
+        stages = ['worker'];
+      } else if (opts.pipeline) {
+        stages = ['worker', 'reviewer', 'tester', 'documenter'];
+      } else {
+        stages = ['worker', 'reviewer'];
+      }
+
+      const roles: Record<string, RoleConfig> = {};
+      if (opts.model) {
+        roles.worker = { enabled: true, model: opts.model, timeoutMs: 0 };
+      }
+
+      const task: TaskItem = {
+        id: taskId,
+        source: 'local',
+        title: prompt,
+        description: prompt,
+        priority: 3,
+        projectPath: resolvedPath,
+        createdAt: Date.now(),
+      };
+
+      const pipelineInstance = new PairPipeline({
+        stages,
+        maxIterations: 3,
+        roles: Object.keys(roles).length > 0 ? roles as any : undefined,
+      });
+
+      pipelineInstance.on('stage:start', ({ stage }: { stage: string }) => {
+        entry.currentStage = stage;
+      });
+
+      const result: PipelineResult = await pipelineInstance.run(task, resolvedPath);
+
+      entry.status = 'completed';
+      entry.result = {
+        success: result.success,
+        summary: result.workerResult?.summary,
+        finalStatus: result.finalStatus,
+      };
+    } catch (err) {
+      entry.status = 'failed';
+      entry.error = err instanceof Error ? err.message : String(err);
+    } finally {
+      cleanupExecTask(taskId);
+    }
+  })();
+
+  return taskId;
+}

--- a/src/support/webTokenBrowser.test.ts
+++ b/src/support/webTokenBrowser.test.ts
@@ -1,0 +1,510 @@
+// @vitest-environment jsdom
+//
+// The dashboard could not authenticate from a browser at all (AGT-4280): 36
+// bare `fetch("/api/…")` call sites, a server that reads only the
+// `X-OpenSwarm-Token` / `Authorization` headers, and no UI to supply one. The
+// page worked solely from a network position the server already trusts, so an
+// operator on a LAN address saw every data endpoint return 403 while
+// `/api/health` — which sits in front of the gate — kept answering 200. The
+// dashboard rendered, showed nothing, and read as a dead daemon.
+//
+// These tests pin the two properties that make the seam worth having: it
+// cannot be bypassed by a call site that forgets it, and it never sends the
+// token anywhere but this origin's gated endpoints.
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Installer = (scope: { fetch: typeof fetch }) => typeof fetch;
+interface WebTokenApi {
+  TOKEN_KEY: string;
+  HEADER: string;
+  readToken(): string;
+  storeToken(token: string): void;
+  isGatedRequest(input: unknown): boolean;
+  resetForTests(): void;
+  install: Installer;
+  installEventSource(scope: Record<string, unknown>): void;
+}
+
+let api: WebTokenApi;
+
+beforeAll(async () => {
+  vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })));
+  await import('../../web/static/js/webToken.js');
+  api = (window as unknown as { OpenSwarmWebToken: WebTokenApi }).OpenSwarmWebToken;
+});
+
+/** A scope with its own mocked transport, so each test observes only its own calls. */
+function scopeWith(responder: (input: RequestInfo | URL, init?: RequestInit) => Response) {
+  const transport = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => responder(input, init));
+  const scope = { fetch: transport as unknown as typeof fetch };
+  api.install(scope);
+  return { scope, transport };
+}
+
+/** A 403 shaped like the gate's own refusal — the only kind that may prompt. */
+function authRefusal(): Response {
+  return new Response('{"error":"Forbidden"}', {
+    status: 403,
+    headers: { 'X-OpenSwarm-Auth': 'token-required' },
+  });
+}
+
+function headerOf(call: [RequestInfo | URL, RequestInit?] | undefined): string | null {
+  if (!call) return null;
+  return new Headers(call[1]?.headers).get('X-OpenSwarm-Token');
+}
+
+/** Fill in and submit the prompt the wrapper appends on a 403. */
+async function answerPrompt(token: string): Promise<void> {
+  const input = await vi.waitFor(() => {
+    const el = document.querySelector<HTMLInputElement>('#openswarm-token-input');
+    expect(el).toBeTruthy();
+    return el!;
+  });
+  input.value = token;
+  input.form!.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+}
+
+describe('browser access token seam (AGT-4280)', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    document.body.innerHTML = '';
+    api.resetForTests();
+  });
+
+  it('attaches the stored token to same-origin API requests', async () => {
+    sessionStorage.setItem(api.TOKEN_KEY, 'secret-token');
+    const { scope, transport } = scopeWith(() => new Response('{}', { status: 200 }));
+
+    await scope.fetch('/api/stats');
+
+    expect(headerOf(transport.mock.calls[0])).toBe('secret-token');
+  });
+
+  it('covers a call site that never asked for authentication', async () => {
+    // This is the whole point of wrapping `fetch` instead of editing 36 call
+    // sites: `api.mjs` and the dashboard's inline script both call the global
+    // with no headers of their own, and both are still authorized.
+    sessionStorage.setItem(api.TOKEN_KEY, 'secret-token');
+    const { scope, transport } = scopeWith(() => new Response('{}', { status: 200 }));
+
+    await scope.fetch('/api/projects', { method: 'POST', body: '{}' });
+
+    expect(headerOf(transport.mock.calls[0])).toBe('secret-token');
+    expect(transport.mock.calls[0][1]?.method).toBe('POST');
+  });
+
+  it('preserves headers the caller set', async () => {
+    sessionStorage.setItem(api.TOKEN_KEY, 'secret-token');
+    const { scope, transport } = scopeWith(() => new Response('{}', { status: 200 }));
+
+    await scope.fetch('/api/provider', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const sent = new Headers(transport.mock.calls[0][1]?.headers);
+    expect(sent.get('Content-Type')).toBe('application/json');
+    expect(sent.get('X-OpenSwarm-Token')).toBe('secret-token');
+  });
+
+  it('never sends the token to another origin', async () => {
+    // The token authorizes this daemon. A page that also talks to GitHub or a
+    // CDN must not hand it over.
+    sessionStorage.setItem(api.TOKEN_KEY, 'secret-token');
+    const { scope, transport } = scopeWith(() => new Response('{}', { status: 200 }));
+
+    await scope.fetch('https://example.com/api/stats');
+
+    expect(headerOf(transport.mock.calls[0])).toBeNull();
+    expect(api.isGatedRequest('https://example.com/api/stats')).toBe(false);
+  });
+
+  it('leaves same-origin non-API requests alone', async () => {
+    sessionStorage.setItem(api.TOKEN_KEY, 'secret-token');
+    const { scope, transport } = scopeWith(() => new Response('', { status: 200 }));
+
+    await scope.fetch('/static/js/theme.mjs');
+
+    expect(headerOf(transport.mock.calls[0])).toBeNull();
+  });
+
+  it('asks for a token on 403 and retries the same request with it', async () => {
+    const { scope, transport } = scopeWith((_input, init) => {
+      const presented = new Headers(init?.headers).get('X-OpenSwarm-Token');
+      return presented === 'entered-token'
+        ? new Response('{"ok":true}', { status: 200 })
+        : authRefusal();
+    });
+
+    const pending = scope.fetch('/api/stats');
+    await answerPrompt('entered-token');
+    const res = await pending;
+
+    expect(res.status).toBe(200);
+    expect(transport).toHaveBeenCalledTimes(2);
+    expect(sessionStorage.getItem(api.TOKEN_KEY)).toBe('entered-token');
+  });
+
+  it('asks once however many requests were refused at the same time', async () => {
+    // The dashboard fires several requests in one Promise.all, so a 403 storm
+    // is the normal case. One prompt per in-flight request would be unusable.
+    const { scope, transport } = scopeWith((_input, init) => {
+      const presented = new Headers(init?.headers).get('X-OpenSwarm-Token');
+      return presented === 'entered-token'
+        ? new Response('{}', { status: 200 })
+        : authRefusal();
+    });
+
+    const all = Promise.all([
+      scope.fetch('/api/stats'),
+      scope.fetch('/api/projects'),
+      scope.fetch('/api/tasks'),
+    ]);
+    await vi.waitFor(() => expect(transport).toHaveBeenCalledTimes(3));
+    expect(document.querySelectorAll('#openswarm-token-prompt')).toHaveLength(1);
+
+    await answerPrompt('entered-token');
+    const results = await all;
+
+    expect(results.every(r => r.status === 200)).toBe(true);
+    expect(transport).toHaveBeenCalledTimes(6);
+  });
+
+  it('hands back the original 403 when the prompt is dismissed, without retrying', async () => {
+    // An operator who does not have the token needs a way out. Without one,
+    // every refused request stays pending forever and the page just stops —
+    // worse than the 403, because nothing on screen reports anything. And a
+    // retry with no token would fail identically and ask again forever.
+    const { scope, transport } = scopeWith(() => authRefusal());
+
+    const pending = scope.fetch('/api/stats');
+    const dismiss = await vi.waitFor(() => {
+      const el = document.querySelector<HTMLButtonElement>('#openswarm-token-dismiss');
+      expect(el).toBeTruthy();
+      return el!;
+    });
+    dismiss.click();
+
+    const res = await pending;
+    expect(res.status).toBe(403);
+    expect(transport).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem(api.TOKEN_KEY)).toBeNull();
+  });
+
+  it('treats an empty submission as no answer, and Escape as a dismissal', async () => {
+    const { scope, transport } = scopeWith(() => authRefusal());
+
+    const pending = scope.fetch('/api/stats');
+    const input = await vi.waitFor(() => {
+      const el = document.querySelector<HTMLInputElement>('#openswarm-token-input');
+      expect(el).toBeTruthy();
+      return el!;
+    });
+    // Empty submit must not settle the prompt — the operator is still typing.
+    input.form!.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+    expect(document.querySelector('#openswarm-token-input')).toBeTruthy();
+
+    document.querySelector('#openswarm-token-prompt')!
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    const res = await pending;
+    expect(res.status).toBe(403);
+    expect(transport).toHaveBeenCalledTimes(1);
+  });
+
+  it('names the cause on screen instead of only failing', async () => {
+    // A bare "Forbidden" told the operator nothing — half of why a healthy
+    // daemon read as a dead one.
+    const { scope } = scopeWith(() => authRefusal());
+
+    void scope.fetch('/api/stats');
+    const banner = await vi.waitFor(() => {
+      const el = document.querySelector('#openswarm-token-prompt');
+      expect(el).toBeTruthy();
+      return el!;
+    });
+
+    expect(banner.textContent).toContain('OPENSWARM_WEB_TOKEN');
+    await answerPrompt('x');
+  });
+
+  it('does not prompt for a 403 that is not about the credential', async () => {
+    // The warehouse routes answer 403 for path containment ("Path escapes the
+    // warehouse"), which says nothing about who is calling. Prompting there
+    // asks a loopback operator — already authorized — to paste a credential
+    // for a symlink refusal, and overwrites the token they already had.
+    sessionStorage.setItem(api.TOKEN_KEY, 'good-token');
+    const { scope, transport } = scopeWith(
+      () => new Response('{"error":"Path escapes the warehouse"}', { status: 403 }),
+    );
+
+    const res = await scope.fetch('/api/warehouse/tree?path=../etc');
+
+    expect(res.status).toBe(403);
+    expect(document.querySelector('#openswarm-token-prompt')).toBeNull();
+    expect(transport).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem(api.TOKEN_KEY)).toBe('good-token');
+  });
+
+  it('keeps the old token when the entered one is also refused', async () => {
+    // Storing before the retry wrote a typo into the key warehouse.mjs reads,
+    // destroying a working token for the whole session on one bad paste.
+    sessionStorage.setItem(api.TOKEN_KEY, 'good-token');
+    const { scope } = scopeWith(() => authRefusal());
+
+    const pending = scope.fetch('/api/stats');
+    await answerPrompt('typo');
+    const res = await pending;
+
+    expect(res.status).toBe(403);
+    expect(sessionStorage.getItem(api.TOKEN_KEY)).toBe('good-token');
+  });
+
+  it('retries through the untouched transport, so a wrong token cannot recurse', async () => {
+    // If the retry went through the wrapper instead of the captured native
+    // fetch, a persistently refused token would chain prompt → 403 → prompt
+    // without bound. Both counts below stay flat under that mutation only if
+    // this is asserted directly.
+    const { scope, transport } = scopeWith(() => authRefusal());
+
+    const pending = scope.fetch('/api/stats');
+    await answerPrompt('wrong-token');
+    const res = await pending;
+
+    expect(res.status).toBe(403);
+    expect(transport).toHaveBeenCalledTimes(2);
+    expect(document.querySelectorAll('#openswarm-token-prompt')).toHaveLength(0);
+  });
+
+  it('stops asking once the operator has declined', async () => {
+    // Every call site reconnects or re-polls, so a prompt that forgets a
+    // refusal returns within seconds and steals focus each time.
+    const { scope } = scopeWith(() => authRefusal());
+
+    const first = scope.fetch('/api/stats');
+    const dismiss = await vi.waitFor(() => {
+      const el = document.querySelector<HTMLButtonElement>('#openswarm-token-dismiss');
+      expect(el).toBeTruthy();
+      return el!;
+    });
+    dismiss.click();
+    await first;
+
+    const second = await scope.fetch('/api/stats');
+    expect(second.status).toBe(403);
+    expect(document.querySelector('#openswarm-token-prompt')).toBeNull();
+  });
+
+  it('does not retry a Request whose body the first attempt consumed', async () => {
+    // Reissuing a used Request throws "Cannot construct a Request with a
+    // Request object that has already been used" — the caller would get a
+    // rejected promise where it expected a Response.
+    const { scope, transport } = scopeWith(() => authRefusal());
+
+    const res = await scope.fetch(new Request(new URL('/api/provider', location.href).href, { method: 'POST', body: '{}' }));
+
+    expect(res.status).toBe(403);
+    expect(transport).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('#openswarm-token-prompt')).toBeNull();
+  });
+
+  it('degrades to unauthenticated rather than throwing when storage is blocked', async () => {
+    // A browser set to block site data throws on getItem. An unhandled throw
+    // here would take down the wrapper every request now depends on.
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('The operation is insecure.');
+    });
+    const { scope, transport } = scopeWith(() => new Response('{}', { status: 200 }));
+
+    await expect(scope.fetch('/api/stats')).resolves.toBeDefined();
+    expect(headerOf(transport.mock.calls[0])).toBeNull();
+
+    getItem.mockRestore();
+  });
+});
+
+describe('live event stream over an authenticated fetch (AGT-4280)', () => {
+  // `EventSource` cannot set headers, so wrapping fetch alone left /api/events
+  // at 403 — measured in a real browser as 11 of 14 requests authorized, the
+  // three exceptions all being the SSE connection. The page loaded its data
+  // once and then never updated, which is most of what "dead daemon" looked
+  // like.
+
+  class FakeNativeEventSource {
+    static built: string[] = [];
+    constructor(public url: string) { FakeNativeEventSource.built.push(url); }
+    close(): void { /* nothing to release */ }
+  }
+
+  /** A scope whose fetch answers with an SSE body fed from `frames`. */
+  function sseScope(frames: string[], status = 200) {
+    const transport = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      if (status !== 200) return new Response('{"error":"Forbidden"}', { status });
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          const enc = new TextEncoder();
+          for (const f of frames) controller.enqueue(enc.encode(f));
+          controller.close();
+        },
+      });
+      return new Response(body, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+    });
+    const scope: Record<string, unknown> = {
+      fetch: transport as unknown as typeof fetch,
+      EventSource: FakeNativeEventSource,
+    };
+    api.install(scope as { fetch: typeof fetch });
+    api.installEventSource(scope);
+    return { scope, transport };
+  }
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    document.body.innerHTML = '';
+    api.resetForTests();
+    FakeNativeEventSource.built = [];
+  });
+
+  it('sends the token on the stream request', async () => {
+    sessionStorage.setItem(api.TOKEN_KEY, 'stream-token');
+    const { scope, transport } = sseScope(['data: {"type":"stats"}\n\n']);
+
+    const Ctor = scope.EventSource as new (url: string) => { onmessage: ((e: { data: string }) => void) | null };
+    const es = new Ctor('/api/events');
+    const seen: string[] = [];
+    es.onmessage = (e) => seen.push(e.data);
+
+    await vi.waitFor(() => expect(seen).toHaveLength(1));
+    expect(headerOf(transport.mock.calls[0])).toBe('stream-token');
+    expect(seen[0]).toBe('{"type":"stats"}');
+  });
+
+  it('leaves the native implementation alone when there is no token', () => {
+    // A trusted network position already works there, and the native object is
+    // far better tested than this stand-in.
+    const { scope } = sseScope([]);
+
+    const Ctor = scope.EventSource as new (url: string) => unknown;
+    const es = new Ctor('/api/events');
+
+    expect(es).toBeInstanceOf(FakeNativeEventSource);
+    expect(FakeNativeEventSource.built).toEqual(['/api/events']);
+  });
+
+  it('ignores the server comment frame and joins multi-line data', async () => {
+    // The server opens with `:connected\n\n`, which carries no payload; a
+    // message with empty data there would reach handleEvent as a JSON parse
+    // failure on every connect.
+    sessionStorage.setItem(api.TOKEN_KEY, 'stream-token');
+    const { scope } = sseScope([':connected\n\n', 'data: one\ndata: two\n\n']);
+
+    const Ctor = scope.EventSource as new (url: string) => { onmessage: ((e: { data: string }) => void) | null };
+    const es = new Ctor('/api/events');
+    const seen: string[] = [];
+    es.onmessage = (e) => seen.push(e.data);
+
+    await vi.waitFor(() => expect(seen).toHaveLength(1));
+    expect(seen[0]).toBe('one\ntwo');
+  });
+
+  it('reassembles a frame split across chunks', async () => {
+    sessionStorage.setItem(api.TOKEN_KEY, 'stream-token');
+    const { scope } = sseScope(['data: {"ty', 'pe":"log"}\n', '\n']);
+
+    const Ctor = scope.EventSource as new (url: string) => { onmessage: ((e: { data: string }) => void) | null };
+    const es = new Ctor('/api/events');
+    const seen: string[] = [];
+    es.onmessage = (e) => seen.push(e.data);
+
+    await vi.waitFor(() => expect(seen).toEqual(['{"type":"log"}']));
+  });
+
+  it('reports a finished stream as an error so the caller reconnects', async () => {
+    // Every call site reconnects from onerror. A stream that simply ended with
+    // no error would leave the page silently disconnected.
+    sessionStorage.setItem(api.TOKEN_KEY, 'stream-token');
+    const { scope } = sseScope(['data: x\n\n']);
+
+    const Ctor = scope.EventSource as new (url: string) => {
+      onmessage: ((e: { data: string }) => void) | null;
+      onerror: (() => void) | null;
+      close(): void;
+    };
+    const es = new Ctor('/api/events');
+    let errors = 0;
+    es.onerror = () => { errors += 1; es.close(); };
+
+    await vi.waitFor(() => expect(errors).toBe(1));
+    // close() inside onerror is what the real call sites do; it must not
+    // produce a second error.
+    await new Promise(r => setTimeout(r, 10));
+    expect(errors).toBe(1);
+  });
+
+  it('does not report an error for a stream the caller closed on purpose', async () => {
+    // close() aborts the request, which rejects the pending read and lands in
+    // the same catch that reports a dropped connection. Reporting it would
+    // make a deliberate close indistinguishable from a network drop — and
+    // dashboardHtml's connectSSE reconnects unconditionally from onerror, so
+    // a closed stream would resurrect itself every three seconds forever.
+    sessionStorage.setItem(api.TOKEN_KEY, 'stream-token');
+    let release: (() => void) | null = null;
+    const transport = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: a\n\n'));
+          // Stay open until the abort lands, so close() is what ends it.
+          init?.signal?.addEventListener('abort', () => {
+            try { controller.error(new Error('aborted')); } catch { /* already closed */ }
+          });
+          release = () => { try { controller.close(); } catch { /* closed */ } };
+        },
+      });
+      return new Response(body, { status: 200 });
+    });
+    const scope: Record<string, unknown> = {
+      fetch: transport as unknown as typeof fetch,
+      EventSource: FakeNativeEventSource,
+    };
+    api.install(scope as { fetch: typeof fetch });
+    api.installEventSource(scope);
+
+    const Ctor = scope.EventSource as new (url: string) => {
+      onmessage: ((e: { data: string }) => void) | null;
+      onerror: (() => void) | null;
+      close(): void;
+    };
+    const es = new Ctor('/api/events');
+    let errors = 0;
+    const seen: string[] = [];
+    es.onerror = () => { errors += 1; };
+    es.onmessage = (e) => seen.push(e.data);
+
+    await vi.waitFor(() => expect(seen).toEqual(['a']));
+    es.close();
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(errors).toBe(0);
+    void release;
+  });
+
+  it('stops delivering messages once closed', async () => {
+    sessionStorage.setItem(api.TOKEN_KEY, 'stream-token');
+    const { scope } = sseScope(['data: a\n\n', 'data: b\n\n']);
+
+    const Ctor = scope.EventSource as new (url: string) => {
+      onmessage: ((e: { data: string }) => void) | null;
+      onerror: (() => void) | null;
+      close(): void;
+    };
+    const es = new Ctor('/api/events');
+    const seen: string[] = [];
+    es.onmessage = (e) => { seen.push(e.data); es.close(); };
+
+    await vi.waitFor(() => expect(seen.length).toBeGreaterThan(0));
+    await new Promise(r => setTimeout(r, 20));
+    expect(seen).toEqual(['a']);
+  });
+});

--- a/src/support/webTokenBrowser.test.ts
+++ b/src/support/webTokenBrowser.test.ts
@@ -310,6 +310,30 @@ describe('browser access token seam (AGT-4280)', () => {
     expect(document.querySelector('#openswarm-token-prompt')).toBeNull();
   });
 
+  it('gates the GraphQL endpoint as well as /api', () => {
+    // The issue board posts to /graphql, and isMutatingGraphQLRequest puts it
+    // behind the same gate. It was the page missed on the first pass.
+    expect(api.isGatedRequest('/graphql')).toBe(true);
+    expect(api.isGatedRequest('/graphqlish')).toBe(false);
+  });
+
+  it('answers without a prompt when there is no body to attach one to', async () => {
+    // This script runs from <head>, so a request refused during head parsing
+    // has no document.body yet. Throwing there would take down the wrapper
+    // every later request depends on.
+    sessionStorage.setItem(api.TOKEN_KEY, 'tok');
+    const body = document.body;
+    Object.defineProperty(document, 'body', { value: null, configurable: true });
+    try {
+      const { scope, transport } = scopeWith(() => authRefusal());
+      const res = await scope.fetch('/api/stats');
+      expect(res.status).toBe(403);
+      expect(transport).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(document, 'body', { value: body, configurable: true });
+    }
+  });
+
   it('degrades to unauthenticated rather than throwing when storage is blocked', async () => {
     // A browser set to block site data throws on getItem. An unhandled throw
     // here would take down the wrapper every request now depends on.
@@ -441,6 +465,65 @@ describe('live event stream over an authenticated fetch (AGT-4280)', () => {
     // produce a second error.
     await new Promise(r => setTimeout(r, 10));
     expect(errors).toBe(1);
+  });
+
+  it('releases the stream when close() lands before the response does', async () => {
+    // Without an AbortController the request cannot be aborted, so a response
+    // that arrives after close() must have its body cancelled — otherwise the
+    // connection stays open while the caller reconnects every three seconds.
+    sessionStorage.setItem(api.TOKEN_KEY, 'stream-token');
+    let cancelled = false;
+    let deliver: ((r: Response) => void) | null = null;
+    const transport = vi.fn(() => new Promise<Response>((resolve) => { deliver = resolve; }));
+    const scope: Record<string, unknown> = {
+      fetch: transport as unknown as typeof fetch,
+      EventSource: FakeNativeEventSource,
+    };
+    api.install(scope as { fetch: typeof fetch });
+    api.installEventSource(scope);
+
+    const Ctor = scope.EventSource as new (url: string) => { close(): void; onerror: (() => void) | null };
+    const es = new Ctor('/api/events');
+    await vi.waitFor(() => expect(transport).toHaveBeenCalled());
+    es.close();
+    deliver!(new Response(new ReadableStream({
+      start() { /* never enqueues */ },
+      cancel() { cancelled = true; },
+    }), { status: 200 }));
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(cancelled).toBe(true);
+  });
+
+  it('revives the stream when the prompt supplies a token', async () => {
+    // The stand-in goes through the wrapped fetch, so a 403 on the stream
+    // prompts and retries — and the retried response is the one that gets
+    // pumped. Nothing asserted this path before.
+    let attempt = 0;
+    const transport = vi.fn(async (_i: RequestInfo | URL, init?: RequestInit) => {
+      attempt += 1;
+      if (new Headers(init?.headers).get('X-OpenSwarm-Token') !== 'late') return authRefusal();
+      return new Response(new ReadableStream<Uint8Array>({
+        start(c) { c.enqueue(new TextEncoder().encode('data: revived\n\n')); c.close(); },
+      }), { status: 200 });
+    });
+    const scope: Record<string, unknown> = {
+      fetch: transport as unknown as typeof fetch,
+      EventSource: FakeNativeEventSource,
+    };
+    api.install(scope as { fetch: typeof fetch });
+    api.installEventSource(scope);
+    // A token must exist for the stand-in to be chosen at construction time.
+    sessionStorage.setItem(api.TOKEN_KEY, 'stale');
+
+    const Ctor = scope.EventSource as new (url: string) => { onmessage: ((e: { data: string }) => void) | null; onerror: (() => void) | null };
+    const es = new Ctor('/api/events');
+    const seen: string[] = [];
+    es.onmessage = (e) => seen.push(e.data);
+    await answerPrompt('late');
+
+    await vi.waitFor(() => expect(seen).toEqual(['revived']));
+    expect(attempt).toBe(2);
   });
 
   it('does not report an error for a stream the caller closed on purpose', async () => {

--- a/tests/web/tokens.test.ts
+++ b/tests/web/tokens.test.ts
@@ -134,6 +134,34 @@ describe('page shells (AGT-4201)', () => {
     }
   });
 
+  it('every browser page installs the access-token seam before its own scripts', () => {
+    // The fix for AGT-4280 is six one-line <script src> edits; nothing else
+    // asserts they are present. Forgetting one is invisible — the page just
+    // 403s silently — and that is exactly what happened to the issue board,
+    // which was missed on the first pass. The script must also precede any
+    // page script, or the first requests go out unauthenticated.
+    const repoRoot = join(__dirname, '..', '..');
+    const serverRendered = [
+      join(repoRoot, 'src', 'support', 'dashboardHtml.ts'),
+      join(repoRoot, 'src', 'issues', 'issueBoardHtml.ts'),
+    ];
+    const pages = [...html, ...serverRendered];
+    for (const file of pages) {
+      const source = readFileSync(file, 'utf8');
+      const name = relative(repoRoot, file);
+      expect(source, `${name} does not load webToken.js`).toContain('/static/js/webToken.js');
+      const seam = source.indexOf('/static/js/webToken.js');
+      const firstInline = source.indexOf('<script>');
+      if (firstInline !== -1) {
+        expect(seam, `${name}: webToken.js must load before the inline script`).toBeLessThan(firstInline);
+      }
+      const firstModule = source.indexOf('<script type="module"');
+      if (firstModule !== -1) {
+        expect(seam, `${name}: webToken.js must load before the page module`).toBeLessThan(firstModule);
+      }
+    }
+  });
+
   it('share one navigation naming every page', () => {
     const routes = ['/app', '/chat', '/orchestration', '/threads', '/warehouse'];
     for (const file of html) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -100,6 +100,12 @@ const integrationBoundaryCoverageExcludes = [
   'src/support/repoMetadata.ts',
   'src/support/timeWindow.ts',
   'src/support/web.ts',
+  // Extracted verbatim from web.ts above (AGT-4280) so that file could get
+  // under the size gate. It instantiates and runs PairPipeline — the same
+  // effectful boundary as the agent roles excluded further up — and it was
+  // already outside the measured set when it lived in web.ts. Moving code
+  // between files must not change what the threshold is computed over.
+  'src/support/webExecTasks.ts',
   'src/support/dev.ts',
   'src/support/chatBackend.ts',
   'src/support/gitStatus.ts',

--- a/web/static/app.html
+++ b/web/static/app.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>OpenSwarm · Cockpit</title>
   <script src="/static/js/themeBoot.js"></script>
+  <script src="/static/js/webToken.js"></script>
   <link rel="stylesheet" href="/static/css/tokens.css" />
   <link rel="stylesheet" href="/static/css/shell.css" />
   <link rel="stylesheet" href="/static/css/cockpit.css" />

--- a/web/static/chat.html
+++ b/web/static/chat.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>OpenSwarm · Chat room</title>
   <script src="/static/js/themeBoot.js"></script>
+  <script src="/static/js/webToken.js"></script>
   <link rel="stylesheet" href="/static/css/tokens.css" />
   <link rel="stylesheet" href="/static/css/shell.css" />
   <link rel="stylesheet" href="/static/css/chat.css" />

--- a/web/static/js/webToken.js
+++ b/web/static/js/webToken.js
@@ -1,0 +1,462 @@
+// Browser-side access token for the daemon's HTTP API — a classic (non-module)
+// script so it runs synchronously in <head>, before any page's inline script
+// issues its first request. A deferred module would let those first calls go
+// out unauthenticated. Same placement rationale as themeBoot.js. (AGT-4280)
+//
+// The problem this exists to remove: `hasValidWebToken()` in support/web.ts
+// accepts only an `Authorization: Bearer` or `X-OpenSwarm-Token` header, and
+// the Supervisor dashboard sent neither — across 36 separate fetch call sites,
+// with no UI to enter a token and no query/cookie path. A browser could not
+// authenticate at all. The page worked only from a network position the server
+// already trusts (loopback, or — until the Tailscale trust was narrowed — any
+// CGNAT peer), so an operator on a LAN address got `403 Forbidden` on every
+// data endpoint while `/api/health` kept answering 200 from in front of the
+// gate. The dashboard rendered, showed nothing, and looked like a dead daemon.
+//
+// Two decisions worth stating, because both had a tempting cheaper option:
+//
+//   * The header is attached at ONE seam — a `window.fetch` wrapper — rather
+//     than at each call site. Editing 36 call sites gives 36 chances to miss
+//     one, and a missed one fails as a silent 403, which is this defect
+//     exactly. As a wrapper, "no request escapes" is a property of the page
+//     instead of a property of reviewer attention.
+//   * The token is NOT read from the URL. A `?token=` would work on the first
+//     try and then sit in browser history, in the referrer of every outbound
+//     link, and in any screenshot of the address bar. web/static/js/warehouse.mjs
+//     already established the alternative — a password input backed by
+//     sessionStorage — and this shares its storage key so one token unlocks
+//     both pages.
+
+(function () {
+  'use strict';
+
+  /** Shared with web/static/js/warehouse.mjs — one entry unlocks both pages. */
+  var TOKEN_KEY = 'openswarm.webToken';
+  var HEADER = 'X-OpenSwarm-Token';
+  /** Set by the server only on its authorization refusals (support/web.ts). */
+  var AUTH_HEADER = 'X-OpenSwarm-Auth';
+
+  // sessionStorage throws rather than returning null in a browser configured to
+  // block site data, and an unhandled throw here would take down the wrapper
+  // that every request now depends on. Absent storage degrades to "no token",
+  // which is the pre-existing behaviour, not a new failure.
+  function readToken() {
+    try {
+      return window.sessionStorage.getItem(TOKEN_KEY) || '';
+    } catch (err) {
+      return '';
+    }
+  }
+
+  function storeToken(token) {
+    try {
+      if (token) window.sessionStorage.setItem(TOKEN_KEY, token);
+      else window.sessionStorage.removeItem(TOKEN_KEY);
+    } catch (err) {
+      // Non-fatal: the token still authorizes this page for its lifetime via
+      // the in-memory value the caller holds.
+    }
+  }
+
+  /**
+   * The pathname of a same-origin request, or null for anything else.
+   *
+   * Cross-origin requests must never carry the token — it authorizes this
+   * daemon and nothing else. `input` may be a string, a URL, or a Request.
+   */
+  function sameOriginPath(input) {
+    var raw;
+    if (typeof input === 'string') raw = input;
+    else if (input && typeof input.url === 'string') raw = input.url;
+    else if (input && typeof input.href === 'string') raw = input.href;
+    else return null;
+    var url;
+    try {
+      // `document.baseURI`, not `location.href`: that is the base `fetch`
+      // resolves against. They differ under a `<base href>`, and an injected
+      // one would send `/api/x` to another host while this still called it
+      // same-origin — attaching the token to a cross-origin request.
+      url = new URL(raw, document.baseURI || window.location.href);
+    } catch (err) {
+      return null;
+    }
+    return url.origin === window.location.origin ? url.pathname : null;
+  }
+
+  /**
+   * Whether a request goes to a gated endpoint.
+   *
+   * Mirrors support/web.ts: `/api/*` and the GraphQL endpoint sit behind the
+   * authorization gates. `/api/health` is exempt there ("diagnostics, not
+   * authentication") but is included here anyway — sending the header to an
+   * endpoint that ignores it costs nothing, and leaving a carve-out in two
+   * places invites them to drift apart.
+   */
+  function isGatedRequest(input) {
+    var path = sameOriginPath(input);
+    if (!path) return false;
+    return path.indexOf('/api/') === 0 || path === '/graphql';
+  }
+
+  /**
+   * Whether the request can be issued a second time.
+   *
+   * A `Request` object's body is consumed by the first fetch — reissuing it
+   * throws `Cannot construct a Request with a Request object that has already
+   * been used` — and a `ReadableStream` body is equally single-shot. Returning
+   * the original 403 is worse than a retry but far better than a rejected
+   * promise where the caller expected a Response.
+   */
+  function isRetryable(input, init) {
+    if (typeof input !== 'string' && !(typeof URL === 'function' && input instanceof URL)) return false;
+    var body = init && init.body;
+    if (!body) return true;
+    return !(typeof ReadableStream === 'function' && body instanceof ReadableStream);
+  }
+
+  function withToken(input, init, token) {
+    var source = (init && init.headers) !== undefined
+      ? init.headers
+      : (input && input.headers) || undefined;
+    var headers = new Headers(source);
+    if (token) headers.set(HEADER, token);
+    var next = {};
+    if (init) {
+      for (var key in init) {
+        if (Object.prototype.hasOwnProperty.call(init, key)) next[key] = init[key];
+      }
+    }
+    next.headers = headers;
+    return next;
+  }
+
+  // ---- Recovery UI -------------------------------------------------------
+  // Built here rather than in each page's markup so any page that loads this
+  // script gets the recovery path, and so a page cannot ship the wrapper
+  // without the means to satisfy it.
+
+  // Colours come from tokens.css, which every page loading this script also
+  // links — hardcoded hex is a repo gate failure (tests/web/tokens.test.ts),
+  // and a second palette would drift from the theme the operator chose.
+  // Without tokens.css the banner renders unstyled but stays usable.
+  var promptEl = null;
+
+  function buildPrompt() {
+    if (promptEl) return promptEl;
+    var wrap = document.createElement('div');
+    wrap.id = 'openswarm-token-prompt';
+    wrap.setAttribute('role', 'dialog');
+    wrap.setAttribute('aria-label', 'Access token required');
+    wrap.style.cssText = [
+      'position:fixed', 'inset-inline:0', 'top:0', 'z-index:9999',
+      'display:flex', 'gap:8px', 'align-items:center', 'flex-wrap:wrap',
+      'padding:10px 14px', 'font:14px system-ui,sans-serif',
+      'background:var(--bg-elevated)', 'color:var(--fg-primary)',
+      'border-bottom:1px solid var(--border)',
+    ].join(';');
+
+    var label = document.createElement('span');
+    // The message names the cause and the fix. A bare "Forbidden" told the
+    // operator nothing, which is half of why this looked like a dead daemon.
+    label.textContent = 'This daemon requires an access token. Paste OPENSWARM_WEB_TOKEN to load data '
+      + '(Dismiss stops asking until you reload):';
+    label.style.cssText = 'flex:1 1 320px';
+
+    var input = document.createElement('input');
+    input.type = 'password';
+    input.id = 'openswarm-token-input';
+    input.autocomplete = 'off';
+    input.spellcheck = false;
+    input.setAttribute('aria-label', 'Access token');
+    input.style.cssText = 'flex:0 1 280px;padding:6px 8px;border-radius:var(--radius-md);border:1px solid var(--border-strong);background:var(--bg-app);color:inherit';
+
+    var button = document.createElement('button');
+    button.type = 'submit';
+    button.textContent = 'Unlock';
+    button.style.cssText = 'padding:6px 14px;border-radius:var(--radius-md);border:0;background:var(--accent);color:var(--fg-on-accent);cursor:pointer';
+
+    // Without a way out, an operator who does not have the token leaves every
+    // refused request pending forever and the page simply stops — a worse
+    // failure than the 403 it replaced, because nothing on screen even
+    // reports an error. Dismissing hands the original 403 back to the caller
+    // so its own error path runs.
+    var dismiss = document.createElement('button');
+    dismiss.type = 'button';
+    dismiss.id = 'openswarm-token-dismiss';
+    dismiss.textContent = 'Dismiss';
+    dismiss.style.cssText = 'padding:6px 14px;border-radius:var(--radius-md);border:1px solid var(--border-strong);background:transparent;color:inherit;cursor:pointer';
+
+    var form = document.createElement('form');
+    form.style.cssText = 'display:contents';
+    form.appendChild(input);
+    form.appendChild(button);
+    form.appendChild(dismiss);
+
+    wrap.appendChild(label);
+    wrap.appendChild(form);
+    promptEl = { root: wrap, form: form, input: input, dismiss: dismiss };
+    return promptEl;
+  }
+
+  /**
+   * Ask for the token once, however many requests failed.
+   *
+   * The dashboard fires several requests in one `Promise.all`, so a 403 storm
+   * is the normal case rather than the exception. Without this the operator
+   * would be handed one prompt per in-flight request.
+   */
+  var pending = null;
+  // Set once the operator says no. Every call site reconnects or re-polls —
+  // dashboardHtml's SSE after 3s, its pollers at 15/30/60s — so a prompt that
+  // forgets a refusal reappears seconds later and steals focus each time. That
+  // is the "page unusable" failure Dismiss was added to prevent, arriving
+  // through the reconnect loop instead of through a hung promise.
+  var declined = false;
+
+  function requestToken() {
+    if (declined) return Promise.resolve('');
+    if (pending) return pending;
+    pending = new Promise(function (resolve) {
+      if (!document.body) {
+        resolve('');
+        return;
+      }
+      var ui = buildPrompt();
+      if (!ui.root.isConnected) document.body.appendChild(ui.root);
+      ui.input.focus();
+
+      function settle(value) {
+        ui.form.removeEventListener('submit', onSubmit);
+        ui.dismiss.removeEventListener('click', onDismiss);
+        ui.root.removeEventListener('keydown', onKeydown);
+        ui.input.value = '';
+        if (ui.root.parentNode) ui.root.parentNode.removeChild(ui.root);
+        resolve(value);
+      }
+      function onSubmit(event) {
+        event.preventDefault();
+        var value = ui.input.value.trim();
+        if (!value) return;
+        settle(value);
+      }
+      function onDismiss() { declined = true; settle(''); }
+      function onKeydown(event) { if (event.key === 'Escape') { declined = true; settle(''); } }
+
+      ui.form.addEventListener('submit', onSubmit);
+      ui.dismiss.addEventListener('click', onDismiss);
+      ui.root.addEventListener('keydown', onKeydown);
+    }).then(function (token) {
+      pending = null;
+      return token;
+    });
+    return pending;
+  }
+
+  // ---- The seam ----------------------------------------------------------
+
+  var INSTALLED = '__openswarmWebTokenInstalled';
+
+  function install(target) {
+    var scope = target || window;
+    // Two copies of the script would give two prompts sharing one element id
+    // and up to three transport calls for one request.
+    if (scope[INSTALLED]) return scope.fetch;
+    var nativeFetch = scope.fetch.bind(scope);
+    try {
+      Object.defineProperty(scope, INSTALLED, { value: true, enumerable: false, configurable: true });
+    } catch (err) { scope[INSTALLED] = true; }
+
+    scope.fetch = function (input, init) {
+      if (!isGatedRequest(input)) return nativeFetch(input, init);
+
+      var token = readToken();
+      return nativeFetch(input, withToken(input, init, token)).then(function (response) {
+        // Only the gate's OWN refusal means "you need a token". 403 is also how
+        // the warehouse routes report path containment ("Path escapes the
+        // warehouse"), which says nothing about the caller — prompting there
+        // would ask a loopback operator, already authorized and possibly on a
+        // daemon with no token configured, to paste a credential for a symlink
+        // refusal, and would overwrite the token they already had.
+        if (response.status !== 403) return response;
+        if (response.headers.get(AUTH_HEADER) !== 'token-required') return response;
+        if (!isRetryable(input, init)) return response;
+        return requestToken().then(function (entered) {
+          // No token entered: hand back the original 403 so the caller's own
+          // error path runs. Retrying without one would loop.
+          if (!entered) return response;
+          return nativeFetch(input, withToken(input, init, entered)).then(function (retried) {
+            // Persist only what actually worked. Storing before the retry wrote
+            // a typo into the key warehouse.mjs also reads, destroying a valid
+            // token for the whole session on one mistyped paste.
+            if (retried.status !== 403) storeToken(entered);
+            return retried;
+          });
+        });
+      });
+    };
+
+    return nativeFetch;
+  }
+
+  // ---- Live event stream ---------------------------------------------------
+  //
+  // `EventSource` cannot set request headers — the spec gives it no way — so
+  // wrapping `fetch` fixes every data endpoint and leaves `/api/events` at 403.
+  // Measured in a real browser against the built dashboard: 11 of 14 requests
+  // carried the token and the three that did not were all the SSE connection.
+  // The page would load its data once and then never update again, which is
+  // most of what "the dashboard is dead" looked like in the first place.
+  //
+  // The alternatives were a token in the query string (lands in server access
+  // logs) or a cookie (adds a CSRF surface to a server that currently has
+  // none). Reading the stream with `fetch` instead keeps the credential in the
+  // header where it already is, and routes it through the seam above.
+  //
+  // Only the surface the four call sites actually use is implemented —
+  // `onopen`, `onmessage`, `onerror`, `close()`. None uses `addEventListener`
+  // for named events, `lastEventId`, or `instanceof`, and every one of them
+  // does its own reconnect on `onerror`, so this does not reconnect either.
+  // The server emits `data: <json>\n\n` frames and one `:connected` comment;
+  // there are no `event:` or `id:` fields to honour (core/eventHub.ts:227).
+
+  function makeTokenEventSource(scope, NativeEventSource) {
+    function TokenEventSource(url) {
+      var self = this;
+      this.readyState = 0;
+      this.url = url;
+      this.onopen = null;
+      this.onmessage = null;
+      this.onerror = null;
+      this._closed = false;
+      this._controller = typeof AbortController === 'function' ? new AbortController() : null;
+
+      // The wrapped fetch, deliberately: it attaches the token and, on a 403,
+      // offers the prompt and retries — so entering a token revives the stream
+      // along with everything else.
+      scope.fetch(url, {
+        signal: this._controller ? this._controller.signal : undefined,
+        cache: 'no-store',
+        headers: { Accept: 'text/event-stream' },
+      }).then(function (response) {
+        if (!response.ok || !response.body) throw new Error('SSE HTTP ' + response.status);
+        if (self._closed) {
+          // close() landed before the response did. Without an AbortController
+          // to have aborted it, the connection would otherwise stay open while
+          // the caller reconnects every three seconds, exhausting the per-host
+          // connection budget.
+          try { response.body.cancel(); } catch (err) { /* already released */ }
+          return undefined;
+        }
+        self.readyState = 1;
+        if (self.onopen) self.onopen({ type: 'open' });
+        return self._pump(response.body.getReader());
+      }).catch(function () {
+        self._fail();
+      });
+    }
+
+    TokenEventSource.prototype._pump = function (reader) {
+      var self = this;
+      var decoder = new TextDecoder();
+      var buffer = '';
+      function read() {
+        return reader.read().then(function (chunk) {
+          // A finished stream is a dropped connection as far as the caller is
+          // concerned — it reconnects on error, and without this it would sit
+          // silently on a stream that ended.
+          if (chunk.done) { self._fail(); return undefined; }
+          buffer += decoder.decode(chunk.value, { stream: true });
+          // Both delimiters, because stripping a trailing `\r` per line while
+          // splitting only on `\n\n` is a false reassurance: `\r\n\r\n`
+          // contains no `\n\n`, so a CRLF producer would buffer forever and
+          // dispatch nothing. The server writes `\n\n` today (eventHub.ts:242).
+          var index, width;
+          for (;;) {
+            var lf = buffer.indexOf('\n\n');
+            var crlf = buffer.indexOf('\r\n\r\n');
+            if (lf === -1 && crlf === -1) break;
+            if (crlf !== -1 && (lf === -1 || crlf < lf)) { index = crlf; width = 4; }
+            else { index = lf; width = 2; }
+            var block = buffer.slice(0, index);
+            buffer = buffer.slice(index + width);
+            var payload = [];
+            var lines = block.split('\n');
+            for (var i = 0; i < lines.length; i += 1) {
+              var line = lines[i].charAt(lines[i].length - 1) === '\r'
+                ? lines[i].slice(0, -1)
+                : lines[i];
+              // `:comment` frames (the server's `:connected` handshake) carry
+              // no payload and must not surface as a message with empty data.
+              if (line.indexOf('data:') !== 0) continue;
+              var value = line.slice(5);
+              payload.push(value.charAt(0) === ' ' ? value.slice(1) : value);
+            }
+            if (payload.length && !self._closed && self.onmessage) {
+              self.onmessage({ data: payload.join('\n') });
+            }
+          }
+          return read();
+        });
+      }
+      return read();
+    };
+
+    /** Report the drop once. Callers close() inside onerror, so re-entry is normal. */
+    TokenEventSource.prototype._fail = function () {
+      if (this._closed) return;
+      this._closed = true;
+      this.readyState = 2;
+      if (this.onerror) this.onerror({ type: 'error' });
+    };
+
+    TokenEventSource.prototype.close = function () {
+      this._closed = true;
+      this.readyState = 2;
+      if (this._controller) {
+        try { this._controller.abort(); } catch (err) { /* already aborted */ }
+      }
+    };
+
+    return function (url) {
+      // No token means either a trusted network position — where the native
+      // implementation already works and is better tested — or no credential
+      // to send, in which case this changes nothing. Keep the blast radius on
+      // the path that is actually broken.
+      if (!readToken()) return new NativeEventSource(url);
+      return new TokenEventSource(url);
+    };
+  }
+
+  var ES_INSTALLED = '__openswarmEventSourceInstalled';
+
+  function installEventSource(scope) {
+    if (scope[ES_INSTALLED]) return;
+    var Native = scope.EventSource;
+    // Needs fetch streaming; without it the native object is still the best
+    // available answer even though it cannot authenticate.
+    if (!Native || typeof TextDecoder !== 'function') return;
+    scope.EventSource = makeTokenEventSource(scope, Native);
+    try {
+      Object.defineProperty(scope, ES_INSTALLED, { value: true, enumerable: false, configurable: true });
+    } catch (err) { scope[ES_INSTALLED] = true; }
+  }
+
+  // Exposed for tests and for pages that want to manage the token themselves.
+  // Not a stable public API.
+  window.OpenSwarmWebToken = {
+    TOKEN_KEY: TOKEN_KEY,
+    HEADER: HEADER,
+    readToken: readToken,
+    storeToken: storeToken,
+    isGatedRequest: isGatedRequest,
+    install: install,
+    installEventSource: installEventSource,
+    // `declined` is deliberately module-scoped — it must outlive every request
+    // on the page — which makes it leak between tests. Same shape as the
+    // reset helpers elsewhere in the repo.
+    resetForTests: function () { declined = false; pending = null; promptEl = null; },
+  };
+
+  install(window);
+  installEventSource(window);
+})();

--- a/web/static/orchestration.html
+++ b/web/static/orchestration.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>OpenSwarm · Orchestration</title>
   <script src="/static/js/themeBoot.js"></script>
+  <script src="/static/js/webToken.js"></script>
   <link rel="stylesheet" href="/static/css/tokens.css" />
   <link rel="stylesheet" href="/static/css/shell.css" />
   <link rel="stylesheet" href="/static/css/orchestration.css" />

--- a/web/static/threads.html
+++ b/web/static/threads.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>OpenSwarm · Repository threads</title>
   <script src="/static/js/themeBoot.js"></script>
+  <script src="/static/js/webToken.js"></script>
   <link rel="stylesheet" href="/static/css/tokens.css" />
   <link rel="stylesheet" href="/static/css/shell.css" />
   <link rel="stylesheet" href="/static/css/threads.css" />

--- a/web/static/warehouse.html
+++ b/web/static/warehouse.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>OpenSwarm · Warehouse</title>
   <script src="/static/js/themeBoot.js"></script>
+  <script src="/static/js/webToken.js"></script>
   <link rel="stylesheet" href="/static/css/tokens.css" />
   <link rel="stylesheet" href="/static/css/shell.css" />
   <link rel="stylesheet" href="/static/css/warehouse.css" />


### PR DESCRIPTION
## What was broken

An operator opening the dashboard on a LAN address saw an empty page and read it as a dead daemon. The daemon was fine.

| Request | Before |
| --- | --- |
| `GET /api/health` | 200 — it sits **in front of** the gate by design |
| `GET /api/stats` | **403** |
| `GET /api/tasks` | **403** |
| `GET /api/events` | **403** |
| `POST /api/provider` | **403** → `Provider switch failed: Forbidden` |

`hasValidWebToken()` accepts only an `Authorization: Bearer` or `X-OpenSwarm-Token` header. No browser page sent either — 36 bare `fetch("/api/…")` call sites in `dashboardHtml.ts`, the shared `api.mjs` helper behind the module pages, the issue board's `/graphql` POST — and there was no UI to enter a token, no query path, no cookie path. **A browser could not authenticate at all.** The page worked only from a network position the server already trusts, and #579 closed the last one by narrowing Tailscale trust to an allowlist that is unset in production.

Because `/api/health` stayed 200, the container healthcheck stayed green the whole time.

## The fix

**One seam, not 36 call sites.** A classic script in `<head>` wraps `window.fetch` before any page script runs. Editing each call site gives 36 chances to miss one, and a missed one fails as a silent 403 — this defect exactly. As a wrapper, "no request escapes" is a property of the page rather than of reviewer attention, and `api.mjs` is covered without being touched.

**SSE too.** `EventSource` cannot set headers, so wrapping `fetch` alone left `/api/events` at 403 — measured in a real browser as 11 of 14 requests authorized, the three exceptions all being the stream. The page would load once and never update. A fetch-based stand-in reads the stream instead, keeping the credential in the header rather than a query string (server access logs) or a cookie (a CSRF surface this server does not have). It replaces `EventSource` only when a token is present, so a trusted-position operator keeps the native implementation.

**Only auth 403s prompt.** Refusals now carry `X-OpenSwarm-Auth: token-required`. The warehouse routes also answer 403, for path containment — prompting there would ask a loopback operator, already authorized, to paste a token for a symlink refusal and then overwrite the token they had.

The token is never read from the URL. `warehouse.mjs` had already established the alternative and this shares its storage key, so one entry unlocks every page.

## Two extractions

`webAuth.ts` is the authorization surface this change edits, now readable on its own. `webExecTasks.ts` is a **verbatim** move of a self-contained block — it is here because `web.ts` was 1650 lines, 150 over the repository's size gate, *before* this change, so any edit to that file was blocked. Neither move changes behaviour; `web.ts` is now 1468.

## Verification

- **5841 tests pass**, 0 failures
- **Fifteen claims mutation-tested.** Two survived initially and both were design holes, not test gaps: a prompt with no dismiss path (refused requests hung forever — worse than the 403, because nothing on screen said anything) and a missing guard that made a deliberate `close()` fire `onerror` into an unconditional reconnect
- **Independent review found five more**, all fixed and pinned: prompting on non-auth 403s, storing an unverified token (a typo destroyed a working one for the session), a dismissal that did not stick against the 3-second reconnect, the missed issue board, and a retry that threw on a consumed `Request`
- **Real browser against the built page**: 12 of 12 requests authorized, SSE status reads `LIVE`
- **CodeQL** security-and-quality: no findings in the new code
- A test now asserts the seam is present on all seven pages and loads before their scripts — the fix's efficacy rests on seven one-line edits, and the issue board was already missed once

## Workaround until this ships

```bash
ssh -N -L 3847:localhost:3847 vela   # loopback, so the gate passes
open http://localhost:3847
```

Closes AGT-4280

🤖 Generated with [Claude Code](https://claude.com/claude-code)