### PR TITLE
perf(draft): keep the pre-admission analysis across retries and restarts (AGT-4286)

### DIFF
--- a/src/automation/autonomousRunner.ts
+++ b/src/automation/autonomousRunner.ts
@@ -52,6 +52,7 @@ import {
 } from '../agents/pairPipeline.js';
 import type { DefaultRolesConfig } from '../core/types.js';
 import * as execution from './runnerExecution.js';
+import { pruneDraftCache, readDraftCache, writeDraftCache } from './draftCache.js';
 import { reportToDiscord, fetchLinearTasks, getTaskSource } from './runnerExecution.js';
 import { runLedgerRetrospective } from './ledgerRetrospective.js';
 import { t } from '../locale/index.js';
@@ -2394,6 +2395,10 @@ export class AutonomousRunner {
     broadcastEvent({ type: 'stats', data: this.buildStats() });
     broadcastEvent({ type: 'heartbeat' });
     this.syslog('▶ Heartbeat started');
+    // Swept here rather than on read: a read only knows the one row it asked
+    // for, so without this the table keeps every task the daemon ever drafted.
+    const pruned = pruneDraftCache();
+    if (pruned > 0) this.syslog(`  Pruned ${pruned} expired draft cache entr${pruned === 1 ? 'y' : 'ies'}`);
 
     try {
       const expiredLeases = this.durableRuns.reconcile();
@@ -2792,28 +2797,57 @@ export class AutonomousRunner {
           const fingerprint = JSON.stringify([
             c.task.title, c.task.description ?? '', c.task.trackerUpdatedAt ?? 0,
           ]);
-          const cached = this.preAdmissionScopeCache.get(cacheKey);
-          if ((c.task.fileScope?.length ?? 0) === 0 && cached?.fingerprint === fingerprint) {
-            c.task.fileScope = [...cached.fileScope];
+          const wanted = (c.task.fileScope?.length ?? 0) === 0;
+          const apply = (entry: {
+            fileScope: string[]; draft: NonNullable<TaskItem['preAdmissionDraft']>;
+            description?: string; executionCommentsLoaded?: boolean;
+          }): void => {
+            c.task.fileScope = [...entry.fileScope];
             c.task.fileScopeSource = 'drafted';
-            c.task.preAdmissionDraft = { ...cached.draft, relevantFiles: [...cached.fileScope] };
-            c.task.description = cached.description;
-            c.task.executionCommentsLoaded = cached.executionCommentsLoaded;
+            c.task.preAdmissionDraft = { ...entry.draft, relevantFiles: [...entry.fileScope] };
+            c.task.description = entry.description;
+            c.task.executionCommentsLoaded = entry.executionCommentsLoaded;
+          };
+
+          const cached = this.preAdmissionScopeCache.get(cacheKey);
+          if (wanted && cached?.fingerprint === fingerprint) {
+            apply(cached);
             return;
+          }
+          // The in-memory map is a hot path in front of the durable row, not
+          // the record itself. It holds 256 entries against ~275 active runs
+          // and does not survive a restart, while RETRY_AT backoff is counted
+          // in hours — so on its own it missed on nearly every retry and the
+          // draft was recomputed at ~$0.0043 a call. (AGT-4286)
+          if (wanted) {
+            const durable = readDraftCache<NonNullable<TaskItem['preAdmissionDraft']>>(
+              c.task.id, fingerprint,
+            );
+            if (durable) {
+              apply(durable);
+              this.preAdmissionScopeCache.set(cacheKey, {
+                fingerprint, fileScope: [...durable.fileScope], draft: durable.draft,
+                description: durable.description,
+                executionCommentsLoaded: durable.executionCommentsLoaded,
+              });
+              return;
+            }
           }
           await resolveTaskFileScope(c.task, projPath, {
             draftTask: () => execution.runPreAdmissionDraft(this.getExecCtx(), c.task, projPath),
           });
           if (c.task.fileScopeSource === 'drafted' && c.task.preAdmissionDraft) {
-            this.preAdmissionScopeCache.delete(cacheKey);
-            this.preAdmissionScopeCache.set(cacheKey, {
+            const entry = {
               fingerprint, fileScope: [...(c.task.fileScope ?? [])], draft: c.task.preAdmissionDraft,
               description: c.task.description,
               executionCommentsLoaded: c.task.executionCommentsLoaded,
-            });
+            };
+            this.preAdmissionScopeCache.delete(cacheKey);
+            this.preAdmissionScopeCache.set(cacheKey, entry);
             if (this.preAdmissionScopeCache.size > 256) {
               this.preAdmissionScopeCache.delete(this.preAdmissionScopeCache.keys().next().value!);
             }
+            writeDraftCache(c.task.id, entry);
           }
         }));
 

--- a/src/automation/draftCache.test.ts
+++ b/src/automation/draftCache.test.ts
@@ -1,0 +1,155 @@
+// ============================================
+// OpenSwarm — the draft survives a restart (AGT-4286)
+// ============================================
+//
+// The analysis was already cached by a fingerprint that deliberately omits the
+// attempt number, so reuse across retries was the intended behaviour. It never
+// happened: the store was an in-memory Map, 256 entries against ~275 active
+// runs, wiped by every daemon restart, while RETRY_AT backoff is counted in
+// hours. Measured cost of that gap: 13,122 draft calls for 2,797 attempts —
+// 4.7 per attempt — at $56.38 a day.
+//
+// These tests are about the property the Map could not have: an entry written
+// by one process is readable by the next.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  DRAFT_CACHE_TTL_MS, pruneDraftCache, readDraftCache, resetDraftCacheForTests, writeDraftCache,
+} from './draftCache.js';
+
+let dir: string;
+const ORIGINAL = process.env.OPENSWARM_AUTOMATION_DB;
+
+const DRAFT = { taskType: 'bugfix', intentSummary: 'fix the guard', suggestedApproach: 'invert it' };
+const entry = (fingerprint: string) => ({
+  fingerprint,
+  draft: DRAFT,
+  fileScope: ['src/a.ts', 'src/b.ts'],
+  description: 'the issue body',
+  executionCommentsLoaded: true,
+});
+
+beforeEach(() => {
+  // Per-test file: vitest.setup globals are shared across fork workers, so a
+  // fixed path lets one test's rows reach another's assertions.
+  dir = mkdtempSync(join(tmpdir(), 'openswarm-draftcache-'));
+  process.env.OPENSWARM_AUTOMATION_DB = join(dir, 'automation.db');
+  resetDraftCacheForTests();
+});
+
+afterEach(() => {
+  resetDraftCacheForTests();
+  if (ORIGINAL === undefined) delete process.env.OPENSWARM_AUTOMATION_DB;
+  else process.env.OPENSWARM_AUTOMATION_DB = ORIGINAL;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('durable draft cache (AGT-4286)', () => {
+  it('returns what was written, for the same inputs', () => {
+    writeDraftCache('issue-1', entry('fp-a'));
+
+    const got = readDraftCache('issue-1', 'fp-a');
+
+    expect(got?.draft).toEqual(DRAFT);
+    expect(got?.fileScope).toEqual(['src/a.ts', 'src/b.ts']);
+    expect(got?.description).toBe('the issue body');
+    expect(got?.executionCommentsLoaded).toBe(true);
+  });
+
+  it('survives the handle being dropped, which is the whole point', () => {
+    // A daemon restart is this, plus a new process. The in-memory Map could
+    // not do it, and autodeploy restarted the daemon twice on the day this
+    // was measured.
+    writeDraftCache('issue-1', entry('fp-a'));
+    resetDraftCacheForTests();
+
+    expect(readDraftCache('issue-1', 'fp-a')?.draft).toEqual(DRAFT);
+  });
+
+  it('misses when the issue text changed, without destroying the entry', () => {
+    // A reader cannot tell whether its own fingerprint is the newer one or a
+    // stale one it is still carrying. Deleting on mismatch let an out-of-date
+    // caller wipe a freshly written entry and force the next attempt to pay
+    // for the draft again — the exact cost this cache exists to remove.
+    writeDraftCache('issue-1', entry('fp-a'));
+
+    expect(readDraftCache('issue-1', 'fp-b')).toBeUndefined();
+    expect(readDraftCache('issue-1', 'fp-a')?.draft).toEqual(DRAFT);
+  });
+
+  it('misses for a task that was never drafted', () => {
+    expect(readDraftCache('nobody', 'fp-a')).toBeUndefined();
+  });
+
+  it('expires past the TTL rather than handing back a stale tree', () => {
+    // The fingerprint tracks issue text, not the working tree, so a very old
+    // draft can describe code that has since moved.
+    const written = Date.now();
+    writeDraftCache('issue-1', entry('fp-a'), written);
+
+    expect(readDraftCache('issue-1', 'fp-a', written + DRAFT_CACHE_TTL_MS - 1_000)?.draft).toEqual(DRAFT);
+    expect(readDraftCache('issue-1', 'fp-a', written + DRAFT_CACHE_TTL_MS + 1_000)).toBeUndefined();
+  });
+
+  it('replaces the entry when the same task is drafted again', () => {
+    writeDraftCache('issue-1', entry('fp-a'));
+    writeDraftCache('issue-1', { ...entry('fp-b'), draft: { taskType: 'feature' } });
+
+    expect(readDraftCache('issue-1', 'fp-a')).toBeUndefined();
+    expect(readDraftCache('issue-1', 'fp-b')?.draft).toEqual({ taskType: 'feature' });
+  });
+
+  it('sweeps expired rows, so the table cannot grow forever', () => {
+    const old = Date.now() - DRAFT_CACHE_TTL_MS - 1_000;
+    writeDraftCache('stale-1', entry('fp-a'), old);
+    writeDraftCache('stale-2', entry('fp-a'), old);
+    writeDraftCache('fresh', entry('fp-a'));
+
+    expect(pruneDraftCache()).toBe(2);
+    expect(readDraftCache('fresh', 'fp-a')?.draft).toEqual(DRAFT);
+  });
+
+  it('refuses to store an entry with no analysis in it', () => {
+    // A half-written row would hand the pipeline an undefined draft on the
+    // next attempt, which is worse than recomputing.
+    writeDraftCache('issue-1', { ...entry('fp-a'), draft: undefined });
+
+    expect(readDraftCache('issue-1', 'fp-a')).toBeUndefined();
+  });
+
+  it('does not let an empty write destroy the analysis already stored', () => {
+    // This is what the write guard is actually for. The read guard alone
+    // catches the empty row on the way out, but by then the good entry it
+    // replaced is gone and the next attempt pays for the draft again.
+    writeDraftCache('issue-1', entry('fp-a'));
+    writeDraftCache('issue-1', { ...entry('fp-a'), draft: undefined });
+
+    expect(readDraftCache('issue-1', 'fp-a')?.draft).toEqual(DRAFT);
+  });
+
+  it('recomputes instead of throwing when the store cannot be opened', () => {
+    // A read-only mount or a full disk must cost one recompute, never a run.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    resetDraftCacheForTests();
+    process.env.OPENSWARM_AUTOMATION_DB = join(dir, 'no', 'such', 'dir', 'automation.db');
+
+    expect(() => writeDraftCache('issue-1', entry('fp-a'))).not.toThrow();
+    expect(readDraftCache('issue-1', 'fp-a')).toBeUndefined();
+    expect(pruneDraftCache()).toBe(0);
+  });
+
+  it('follows the path when a test redirects the database mid-flight', () => {
+    writeDraftCache('issue-1', entry('fp-a'));
+    const second = mkdtempSync(join(tmpdir(), 'openswarm-draftcache-2-'));
+    try {
+      process.env.OPENSWARM_AUTOMATION_DB = join(second, 'automation.db');
+      expect(readDraftCache('issue-1', 'fp-a')).toBeUndefined();
+    } finally {
+      rmSync(second, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/automation/draftCache.ts
+++ b/src/automation/draftCache.ts
@@ -1,0 +1,170 @@
+// ============================================
+// OpenSwarm — the draft analysis, kept across retries (AGT-4286)
+// ============================================
+//
+// Measured on vela over 24h: the draft stage made 13,122 calls costing $56.38,
+// a third of the $168.32 total, at a 30.5% prompt-cache hit rate while every
+// other stage sat at 83-88%. The ledger for the same window recorded 2,797
+// attempts across 275 runs — 4.7 draft calls per attempt. The analysis was
+// being recomputed on nearly every retry of the same task.
+//
+// It was already cached by the right key. `autonomousRunner` fingerprints a
+// task as [title, description, trackerUpdatedAt], which deliberately omits the
+// attempt number so a retry reuses the previous analysis. What failed was the
+// storage: an in-memory Map, capped at 256 entries against 275 active runs,
+// wiped by every daemon restart — twice on the day this was measured, both
+// from autodeploy — while RETRY_AT backoff is counted in hours. Nothing in
+// memory outlives the gap it needs to cross.
+//
+// Its own table rather than `automation_runs.metadata_json`: that column is
+// written whole, as `metadata_json = COALESCE(?, metadata_json)`, and
+// `observeTask` rewrites it on every scheduling pass. A key parked there would
+// be erased by the next observation.
+//
+// Ruled out first, by measurement, so the next reader does not re-litigate:
+// the model is not the expensive one (qwen is $0.270/1M uncached against
+// deepseek's $0.414); prompt ordering has nothing to hoist (the static
+// template is ~378 of 22,896 tokens); and the provider does cache — two direct
+// calls with an identical prefix returned 24,221 of 24,222 tokens cached.
+
+import Database from 'better-sqlite3';
+import { defaultAutomationDbPath } from './automationDbPath.js';
+
+/** What the pre-admission pass computed, and the inputs it was computed from. */
+export interface CachedDraftEntry<TDraft = unknown> {
+  fingerprint: string;
+  draft: TDraft;
+  fileScope: string[];
+  description?: string;
+  executionCommentsLoaded?: boolean;
+}
+
+/**
+ * How long a stored analysis stays usable.
+ *
+ * The fingerprint covers the issue text, not the tree, so a reused draft can
+ * describe an older working copy. The in-memory cache had the same property
+ * within one scheduling cycle; persisting it widens that window, and this is
+ * the bound on how far. Long enough to span RETRY_AT backoff and a redeploy,
+ * short enough that a branch cannot drift a whole day underneath it.
+ */
+export const DRAFT_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
+
+let db: Database.Database | undefined;
+let openedPath: string | undefined;
+
+function connect(): Database.Database | undefined {
+  const path = defaultAutomationDbPath();
+  if (db && openedPath === path) return db;
+  // A path change means a test redirected the store; drop the old handle.
+  if (db) { try { db.close(); } catch { /* already closed */ } db = undefined; }
+  try {
+    const next = new Database(path);
+    next.pragma('journal_mode = WAL');
+    next.exec(`
+      CREATE TABLE IF NOT EXISTS draft_cache (
+        issue_id TEXT PRIMARY KEY,
+        fingerprint TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_draft_cache_updated ON draft_cache(updated_at);
+    `);
+    db = next;
+    openedPath = path;
+    return db;
+  } catch (err) {
+    // A cache is an optimisation. If the database cannot be opened — a
+    // read-only mount, a full disk — the caller recomputes, which is exactly
+    // what it did before this existed. Never fail a run over a cache.
+    console.warn('[DraftCache] Unavailable, drafts will be recomputed:', err instanceof Error ? err.message : err);
+    return undefined;
+  }
+}
+
+/** Drop the handle so the next call re-resolves the path. Tests redirect the DB. */
+export function resetDraftCacheForTests(): void {
+  if (db) { try { db.close(); } catch { /* already closed */ } }
+  db = undefined;
+  openedPath = undefined;
+}
+
+/**
+ * The stored analysis for this task, if it was computed from the same inputs
+ * and is still inside the TTL.
+ *
+ * A fingerprint mismatch is a miss, NOT a delete. The reader cannot tell
+ * whether its own fingerprint is the newer one or the older one — a caller
+ * holding a stale task object would otherwise destroy a freshly written entry
+ * and force the next attempt to recompute, which is the cost this exists to
+ * remove. Expiry is different: a row past the TTL is stale for every reader,
+ * so that one is dropped on sight and swept by `pruneDraftCache`.
+ */
+export function readDraftCache<TDraft>(
+  issueId: string,
+  fingerprint: string,
+  now: number = Date.now(),
+): CachedDraftEntry<TDraft> | undefined {
+  const handle = connect();
+  if (!handle || !issueId) return undefined;
+  try {
+    const row = handle
+      .prepare('SELECT fingerprint, payload_json, updated_at FROM draft_cache WHERE issue_id = ?')
+      .get(issueId) as { fingerprint: string; payload_json: string; updated_at: number } | undefined;
+    if (!row) return undefined;
+    if (row.fingerprint !== fingerprint) return undefined;
+    if (now - row.updated_at > DRAFT_CACHE_TTL_MS) {
+      handle.prepare('DELETE FROM draft_cache WHERE issue_id = ?').run(issueId);
+      return undefined;
+    }
+    const parsed = JSON.parse(row.payload_json) as CachedDraftEntry<TDraft>;
+    // A payload without a draft is not a hit — recomputing is correct, and
+    // returning a half-entry would hand the pipeline an undefined analysis.
+    if (!parsed || typeof parsed !== 'object' || parsed.draft === undefined) return undefined;
+    return { ...parsed, fingerprint: row.fingerprint };
+  } catch (err) {
+    console.warn('[DraftCache] Read failed, recomputing:', err instanceof Error ? err.message : err);
+    return undefined;
+  }
+}
+
+/** Store the analysis for later attempts. Best-effort: a failed write just costs one recompute. */
+export function writeDraftCache<TDraft>(
+  issueId: string,
+  entry: CachedDraftEntry<TDraft>,
+  now: number = Date.now(),
+): void {
+  const handle = connect();
+  if (!handle || !issueId || entry.draft === undefined) return;
+  try {
+    handle.prepare(`
+      INSERT INTO draft_cache(issue_id, fingerprint, payload_json, updated_at)
+      VALUES(?, ?, ?, ?)
+      ON CONFLICT(issue_id) DO UPDATE SET
+        fingerprint = excluded.fingerprint,
+        payload_json = excluded.payload_json,
+        updated_at = excluded.updated_at
+    `).run(issueId, entry.fingerprint, JSON.stringify(entry), now);
+  } catch (err) {
+    console.warn('[DraftCache] Write failed:', err instanceof Error ? err.message : err);
+  }
+}
+
+/**
+ * Delete entries past the TTL.
+ *
+ * Called from the heartbeat rather than on every read: a read only knows about
+ * the one row it asked for, so without a sweep the table keeps every task the
+ * daemon ever drafted. Returns the number removed.
+ */
+export function pruneDraftCache(now: number = Date.now()): number {
+  const handle = connect();
+  if (!handle) return 0;
+  try {
+    const cutoff = now - DRAFT_CACHE_TTL_MS;
+    return handle.prepare('DELETE FROM draft_cache WHERE updated_at < ?').run(cutoff).changes;
+  } catch (err) {
+    console.warn('[DraftCache] Prune failed:', err instanceof Error ? err.message : err);
+    return 0;
+  }
+}


### PR DESCRIPTION
## The number

24h on vela: **draft = 13,122 calls / $56.38**, a third of the $168.32 total, at a **30.5%** prompt-cache hit rate while every other stage sits at 83-88%.

| stage | calls | in/call | cached% | $/call | $ |
| --- | ---: | ---: | ---: | ---: | ---: |
| worker | 50,050 | 35,333 | 84.4% | 0.0018 | 90.23 |
| **draft** | **13,122** | **22,896** | **30.5%** | **0.0043** | **56.38** |
| reviewer | 7,872 | 24,606 | 88.3% | 0.0014 | 10.74 |

The ledger for the same window: **2,797 attempts across 275 runs**. 13,122 ÷ 2,797 = **4.7 draft calls per attempt** — it was recomputed on nearly every retry of the same task.

## Ruled out first, by measurement

So the next reader does not re-litigate them:

- **The model is not the expensive one.** Cache-adjusted, qwen is **$0.270/1M uncached** against deepseek's **$0.414**. Moving draft to what the worker runs would cost **53% more** per token.
- **Prompt ordering has nothing to hoist.** The static template in `buildDraftPrompt` is 1,512 chars (~378 tokens) of a 22,896-token call — **2%**.
- **The provider does cache.** Two direct OpenRouter calls with an identical prefix: `cached=24,221 / 24,222` (99.996%), with and without an explicit `cache_control` marker.
- **Batching is the wrong lever.** Draft is on the critical path — the task waits for it. Batch trades latency for ~50%; this removes ~90% with no latency, and batching only makes redundant calls *cheaper* rather than removing the redundancy.

## The actual cause

The key was already right — `[title, description, trackerUpdatedAt]`, deliberately omitting the attempt number so a retry reuses the analysis. The **storage** failed:

1. an in-memory `Map`, wiped by every daemon restart (twice on the measured day, both autodeploy)
2. capped at 256 entries against ~275 active runs
3. RETRY_AT backoff is counted in **hours**

## Design notes

- **Its own table, its own module.** Not `automation_runs.metadata_json` — that column is written whole as `COALESCE(?, metadata_json)` and rewritten by `observeTask` every scheduling pass, so a key parked there is erased by the next observation. Not `runLedger.ts` — it is exactly 1500 lines and would fail the size gate.
- **The Map stays** as a hot path in front of the durable row, so a same-cycle hit still costs no I/O.
- **Never fails a run.** An unopenable database logs once and the caller recomputes — exactly what it did before this existed.

## Two behaviours found by mutation, not review

- **A fingerprint mismatch is a MISS, not a delete.** A reader cannot tell whether its fingerprint is the newer one or a stale one it is still carrying; deleting let an out-of-date caller wipe a freshly written entry, reintroducing the cost this removes.
- **An entry with no analysis is never written.** The read guard alone catches the empty row on the way out — but by then the good entry it replaced is gone.

## Verification

- 5882 tests pass; 11 new cache tests
- Five claims mutation-checked, all fail when broken
- Expected 13,122 → ~2,800 calls, $56/day → ~$6. **To be confirmed against `by=stage` 24h after deploy — not claimed here.**

Closes AGT-4286

🤖 Generated with [Claude Code](https://claude.com/claude-code)