### PR TITLE
fix(web): keep formatTokens monotonic across the k/M boundaries

### DIFF
--- a/tests/web/format.test.ts
+++ b/tests/web/format.test.ts
@@ -51,6 +51,19 @@ describe('formatTokens', () => {
     expect(formatTokens(2_500_000)).toBe('2.5M');
     expect(formatTokens(undefined)).toBe('');
   });
+
+  it('never renders a bare "1000" for a sub-thousand count', () => {
+    // Math.round(999.5) is 1000 — the old `< 1000` branch returned "1000"
+    // while 1000 itself rendered "1.0k", breaking monotonicity.
+    expect(formatTokens(999.5)).toBe('1.0k');
+    expect(formatTokens(999.4)).toBe('999');
+    expect(formatTokens(999)).toBe('999');
+  });
+
+  it('promotes 999999 to M instead of rendering "1000.0k"', () => {
+    expect(formatTokens(999_999)).toBe('1.0M');
+    expect(formatTokens(999_949)).toBe('999.9k');
+  });
 });
 
 describe('shortenPath', () => {

--- a/web/static/js/format.mjs
+++ b/web/static/js/format.mjs
@@ -41,9 +41,15 @@ export function formatCost(usd) {
 /** "1.2k" / "847" — token counts, compact but never misleadingly rounded to 0. */
 export function formatTokens(count) {
   if (typeof count !== 'number' || !Number.isFinite(count) || count < 0) return '';
-  if (count < 1000) return String(Math.round(count));
-  if (count < 1_000_000) return `${(count / 1000).toFixed(1)}k`;
-  return `${(count / 1_000_000).toFixed(1)}M`;
+  const rounded = Math.round(count);
+  if (rounded < 1000) return String(rounded);
+  if (rounded < 1_000_000) {
+    // (999999 / 1000).toFixed(1) is "1000.0" — promote to M so the k/M
+    // boundary cannot render "1000.0k" next to "1.0M" for the next integer.
+    if (rounded >= 999_950) return `${(rounded / 1_000_000).toFixed(1)}M`;
+    return `${(rounded / 1000).toFixed(1)}k`;
+  }
+  return `${(rounded / 1_000_000).toFixed(1)}M`;
 }
 
 /**


### PR DESCRIPTION
﻿## Summary

Fixes a rounding-boundary inconsistency in the dashboard token formatter: `formatTokens(999.5)` returned the bare string `"1000"` while `formatTokens(1000)` returned `"1.0k"`, so a sub-thousand count displayed identically to a rounded-up thousand and broke monotonicity (`999 -> "999"`, `999.5 -> "1000"`, `1000 -> "1.0k"`). Same class of defect existed at the k/M edge (`999999 -> "1000.0k"` vs `1000000 -> "1.0M"`).

- `web/static/js/format.mjs:42-53` — round once with `Math.round`, branch on the rounded value, and promote `>= 999950` to `M` so neither boundary can render `"1000"` / `"1000.0k"`.
- `tests/web/format.test.ts:56-68` — regression tests pinning `999.5 -> "1.0k"`, `999.4/999 -> "999"`, `999999 -> "1.0M"`, `999949 -> "999.9k"`.

Reproduced before the fix with `node --import=tsx` importing `web/static/js/format.mjs`: `formatTokens(999.5) === "1000"`, `formatTokens(999.6) === "1000"`. After the fix: `1.0k`, `999`, `999`, `1.0k`, `1.0M`, `999.9k`, `1.2k`, `2.5M` for the probe sequence.

## Related issue

No open issue exists (the repo currently has zero open issues). This is a proactive, no-behavior-change-except-the-bug fix discovered by scanning the dashboard formatting helpers (`web/static/js/format.mjs`) and its coverage (`tests/web/format.test.ts`).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Docs

## Checklist

- [x] `npm run lint` passes (no new warnings; `format.mjs` clean)
- [x] `npm run typecheck` passes (unaffected; dashboard JS is not in `tsconfig.check.json`)
- [x] `npm run build` passes (unaffected)
- [x] `npm test` passes for the touched area (`tests/web/format.test.ts`: 8 passed)
- [ ] Docs updated if behavior changed (display-only bug fix; no docs change needed)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
