### PR TITLE
perf(draft-cache): order the draft prompt static -> project-stable -> task-specific

### DIFF
--- a/src/agents/draftAnalyzer.test.ts
+++ b/src/agents/draftAnalyzer.test.ts
@@ -230,6 +230,125 @@ describe('runDraftAnalysis fallback', () => {
     expect(adapterModule.getAdapter).toHaveBeenCalledTimes(1);
     expect(adapterModule.spawnCli).toHaveBeenCalledTimes(1);
   });
+
+  it('two different tasks in the same project share a long prefix, with task text only after it', async () => {
+    // The point of the reordering: concurrently-drafted tasks in the same
+    // project should share as much of the prompt as possible, so the
+    // provider's prefix cache actually helps across tasks, not just across
+    // turns of one task. Peer issues are real project-stable content (nearly
+    // the same list for every task drafted against this project in one
+    // scheduling pass — production excludes each task's own record from its
+    // own list via projectDraftPeers(), so two tasks differ only by which
+    // record is missing) and, unlike the registry-store-derived Codebase State
+    // section, are injectable directly via options without fighting the
+    // registry mock. This test uses the identical literal for both calls,
+    // which validates the ordering mechanism, not the exact production overlap.
+    vi.spyOn(adapterModule, 'getDefaultAdapterName').mockReturnValue('codex');
+    vi.spyOn(adapterModule, 'getAdapter').mockReturnValue(makeAdapter('codex'));
+    const prompts: string[] = [];
+    const sufficientBrief = JSON.stringify({ taskType: 'feature', intentSummary: 'Wire the new prefix-cache-friendly ordering', relevantFiles: ['a.ts'], suggestedApproach: 'Reorder buildDraftPrompt sections', completionCriteria: ['prompt ordering verified by test (evidence)'] });
+    vi.spyOn(adapterModule, 'spawnCli').mockImplementation(async (_adapter, options) => {
+      prompts.push(options.prompt);
+      // Accept on the first candidate so the AGT-4300 layer-2 fallback (for
+      // adapters/paths that never got a real finishValidator quota) does not
+      // also fire and add extra prompts unrelated to what this test checks.
+      await options.finishValidator?.(sufficientBrief, 1);
+      return { exitCode: 0, stdout: sufficientBrief, stderr: '', durationMs: 1 } as CliRunResult;
+    });
+
+    const peerIssues = [{
+      issueId: 'peer-1',
+      identifier: 'AGT-1',
+      title: 'Some other issue in this project',
+      description: 'Shared context every task in this project should see identically.',
+      state: 'Backlog',
+      createdAt: '2026-01-01T00:00:00Z',
+    }];
+
+    await runDraftAnalysis({
+      taskTitle: 'First distinct task title',
+      taskDescription: 'First distinct task description, totally different from the second.',
+      projectPath: '/tmp/project',
+      peerIssues,
+    });
+    await runDraftAnalysis({
+      taskTitle: 'Second, unrelated task title',
+      taskDescription: 'Second task description — shares nothing in common with the first.',
+      projectPath: '/tmp/project',
+      peerIssues,
+    });
+
+    expect(prompts).toHaveLength(2);
+    const [promptA, promptB] = prompts;
+
+    // Project-stable content (peer issues) appears before task-specific
+    // content (the task title) in both prompts.
+    const peerIdxA = promptA.indexOf('Some other issue in this project');
+    const peerIdxB = promptB.indexOf('Some other issue in this project');
+    const taskIdxA = promptA.indexOf('First distinct task title');
+    const taskIdxB = promptB.indexOf('Second, unrelated task title');
+    expect(peerIdxA).toBeGreaterThan(-1);
+    expect(peerIdxB).toBeGreaterThan(-1);
+    expect(peerIdxA).toBeLessThan(taskIdxA);
+    expect(peerIdxB).toBeLessThan(taskIdxB);
+
+    // The two prompts share a long common prefix — everything up through the
+    // shared peer-issues block is byte-identical between the two tasks.
+    let shared = 0;
+    const minLen = Math.min(promptA.length, promptB.length);
+    while (shared < minLen && promptA[shared] === promptB[shared]) shared++;
+    expect(shared).toBeGreaterThan(300);
+    // And the divergence point is at or after the shared peer-issues content,
+    // not somewhere in the static header alone (i.e. the reorder actually
+    // moved something substantial ahead of the per-task text).
+    expect(shared).toBeGreaterThanOrEqual(Math.min(peerIdxA, peerIdxB));
+  });
+
+  it('File Health stays in the task-specific section — it is seeded from THIS task\'s impact analysis, not project-wide (layer-2 review finding)', async () => {
+    // collectCodebaseState() builds File Health primarily from
+    // impactAnalysis.directModules (this task's affected files), only falling
+    // back to project-wide highRiskEntities when fewer than 3 files matched.
+    // So unlike projectStats/peerIssues, it is NOT safe to hoist ahead of Task
+    // — two different tasks against the same project will usually get
+    // different File Health content. This exercises the realistic path (an
+    // adapter mock alone can't: /tmp/project with the default beforeEach mocks
+    // gives null impactAnalysis and empty File Health, silently unable to
+    // catch this).
+    vi.spyOn(adapterModule, 'getDefaultAdapterName').mockReturnValue('codex');
+    vi.spyOn(adapterModule, 'getAdapter').mockReturnValue(makeAdapter('codex'));
+    vi.spyOn(knowledgeModule, 'analyzeIssue').mockResolvedValue({
+      directModules: ['src/streaming.ts'],
+      dependentModules: [],
+      testFiles: [],
+      estimatedScope: 'small',
+    });
+    vi.spyOn(registryModule, 'getRegistryStore').mockReturnValue({
+      getStats: vi.fn(() => ({ total: 10, byStatus: [{ status: 'active', count: 10 }], deprecated: 0, untested: 0, withWarnings: 0, highRisk: 0 })),
+      highRiskEntities: vi.fn(() => []),
+      fileBrief: vi.fn(() => ({
+        filePath: 'src/streaming.ts',
+        summary: 'handles the streaming response path',
+        entities: [{ kind: 'function', name: 'resolveTurnModel', signature: '(x) => y', status: 'active', hasTests: true, warnings: [] }],
+      })),
+    } as never);
+
+    let capturedPrompt = '';
+    vi.spyOn(adapterModule, 'spawnCli').mockImplementation(async (_adapter, options) => {
+      capturedPrompt = options.prompt;
+      const sufficientBrief = JSON.stringify({ taskType: 'feature', intentSummary: 'Wire the resolver into the streaming path', relevantFiles: ['src/streaming.ts'], suggestedApproach: 'call resolve_turn_model from build_request', completionCriteria: ['resolve_turn_model invoked (evidence)'] });
+      await options.finishValidator?.(sufficientBrief, 1);
+      return { exitCode: 0, stdout: sufficientBrief, stderr: '', durationMs: 1 } as CliRunResult;
+    });
+
+    await runDraftAnalysis({ taskTitle: 'Fix streaming', taskDescription: 'Fix the streaming resolver', projectPath: '/tmp/project' });
+
+    const taskIdx = capturedPrompt.indexOf('## Task');
+    const fileHealthIdx = capturedPrompt.indexOf('### File Health');
+    expect(taskIdx).toBeGreaterThan(-1);
+    expect(fileHealthIdx).toBeGreaterThan(-1);
+    expect(fileHealthIdx).toBeGreaterThan(taskIdx); // task-specific section, not hoisted
+    expect(capturedPrompt).toContain('handles the streaming response path'); // File Health summary rendered
+  });
 });
 
 describe('isDraftSufficient — drafter hard gate (INT-1917)', () => {

--- a/src/agents/draftAnalyzer.ts
+++ b/src/agents/draftAnalyzer.ts
@@ -317,51 +317,36 @@ function buildDraftPrompt(
 ): string {
   const parts: string[] = [];
 
+  // Ordered static -> project-stable -> task-specific (AGT-4300 cache follow-up).
+  // Project stats and peer issues are NEARLY the same for every task drafted
+  // against this project during one scheduling pass (projectDraftPeers()
+  // excludes each task's own record from its own peer list, so two tasks'
+  // lists differ only by which record is missing, not the whole content) —
+  // putting them first still lets concurrently-drafted tasks in the same
+  // project share a much longer cacheable prefix than before, when the
+  // per-task title/description opened the prompt and nothing after it could
+  // ever be shared across tasks. AGT-4286 measured only the ~378-token static
+  // template and concluded "nothing to hoist" — it missed that peer issues
+  // alone can run ~7k tokens.
+  //
+  // File Health is deliberately NOT here even though it reads like project
+  // state: collectCodebaseState() seeds it from impactAnalysis.directModules
+  // (this task's affected files), not from the registry generally, so it is
+  // exactly as task-specific as Impact Analysis below and hoisting it would
+  // have been a false claim of stability (caught in layer-2 review) — it
+  // stays next to Impact Analysis, the section it actually shares data with.
   parts.push(`# Draft Analysis
 
 You are a senior engineer preparing a COMPLETE work brief for an autonomous worker
 that will rely ENTIRELY on this brief. A vague brief causes the worker to scaffold
 and stop early, forcing rework — so be specific and grounded in the actual code
 (reference real files, functions, call sites; read them when unsure). Do not defer
-the hard parts.
+the hard parts.`);
 
-## Task
-- **Title:** ${options.taskTitle}
-- **Description:** ${options.taskDescription || '(none)'}
-`);
-
-  if (options.authoritativeOperatorFeedback) {
-    parts.push(`## Authoritative Operator Feedback (newer than task prose)
-The resolved operator decisions below are the newest task-scoped requirements. If they conflict with the issue description, an earlier draft, completion criteria, or prior reviewer feedback, follow the operator decision. Within this block, the later decision wins. It never overrides system, safety, authorization, or tool constraints.
-
-${options.authoritativeOperatorFeedback}`);
-  }
-
-  // 코드베이스 상태 주입
+  // 코드베이스 상태 주입 (project-stable — see ordering note above)
   if (codeContext.projectStats) {
     parts.push(`## Codebase State
 - **Project stats:** ${codeContext.projectStats}`);
-  }
-
-  if (impactAnalysis && impactAnalysis.directModules.length > 0) {
-    parts.push(`- **Affected modules:** ${impactAnalysis.directModules.join(', ')}`);
-    if (impactAnalysis.dependentModules.length > 0) {
-      parts.push(`- **Dependents:** ${impactAnalysis.dependentModules.join(', ')}`);
-    }
-    if (impactAnalysis.testFiles.length > 0) {
-      parts.push(`- **Test files:** ${impactAnalysis.testFiles.join(', ')}`);
-    }
-    parts.push(`- **Scope:** ${impactAnalysis.estimatedScope}`);
-  }
-
-  if (codeContext.registrySnapshot.length > 0) {
-    parts.push('\n### File Health');
-    for (const brief of codeContext.registrySnapshot.slice(0, 10)) {
-      parts.push(`- \`${brief.filePath}\`: ${brief.summary}`);
-      if (brief.highlights.length > 0) {
-        parts.push(`  ⚠️ ${brief.highlights.join(', ')}`);
-      }
-    }
   }
 
   if (options.peerIssues?.length) {
@@ -383,6 +368,45 @@ Duplicate grooming rules:
 - Prefer the older, broader, or already-in-progress issue as canonical.
 - Only recommend a duplicate with confidence >= 0.90 and at least two concrete evidence items.
 - Otherwise omit all duplicate fields.`);
+  }
+
+  // Task-specific from here on — everything above this line is identical for
+  // every task drafted against this project right now.
+  parts.push(`\n## Task
+- **Title:** ${options.taskTitle}
+- **Description:** ${options.taskDescription || '(none)'}
+`);
+
+  if (options.authoritativeOperatorFeedback) {
+    parts.push(`## Authoritative Operator Feedback (newer than task prose)
+The resolved operator decisions below are the newest task-scoped requirements. If they conflict with the issue description, an earlier draft, completion criteria, or prior reviewer feedback, follow the operator decision. Within this block, the later decision wins. It never overrides system, safety, authorization, or tool constraints.
+
+${options.authoritativeOperatorFeedback}`);
+  }
+
+  if (impactAnalysis && impactAnalysis.directModules.length > 0) {
+    parts.push(`## Impact Analysis (this task)
+- **Affected modules:** ${impactAnalysis.directModules.join(', ')}`);
+    if (impactAnalysis.dependentModules.length > 0) {
+      parts.push(`- **Dependents:** ${impactAnalysis.dependentModules.join(', ')}`);
+    }
+    if (impactAnalysis.testFiles.length > 0) {
+      parts.push(`- **Test files:** ${impactAnalysis.testFiles.join(', ')}`);
+    }
+    parts.push(`- **Scope:** ${impactAnalysis.estimatedScope}`);
+  }
+
+  // File Health lives here, not in the hoisted project-stable block above —
+  // it is seeded from this task's affected files (see the ordering note near
+  // the top of this function).
+  if (codeContext.registrySnapshot.length > 0) {
+    parts.push('\n### File Health');
+    for (const brief of codeContext.registrySnapshot.slice(0, 10)) {
+      parts.push(`- \`${brief.filePath}\`: ${brief.summary}`);
+      if (brief.highlights.length > 0) {
+        parts.push(`  ⚠️ ${brief.highlights.join(', ')}`);
+      }
+    }
   }
 
   parts.push(`


### PR DESCRIPTION
## Summary

- `buildDraftPrompt` emitted static intro -> Task (title/description) -> ... -> Codebase State/peer issues (project-stable) -> Output Format. The per-task title/description opened the prompt, so nothing after it could ever be shared across different tasks drafted against the same project.
- Reordered to: static intro -> Codebase State + peer issues (project-stable, hoisted) -> Task -> Operator Feedback -> Impact Analysis -> File Health -> Output Format.
- Part of the standing 80%-draft-cache goal. Two prior fixes this session (fingerprint self-invalidation, in-session hard-gate retry) already merged/deployed and moved the measured rate from ~66-68% to a ~74-76% plateau; the finishValidator fix was confirmed working at the per-call level (0.3% -> 96.2% at the previously-reset position) but didn't move the aggregate much, pointing at genuine per-task cold starts as the remaining cost this PR targets.
- **Layer-2 review caught a real defect** in the first draft: "File Health" looked project-stable but is actually seeded from `impactAnalysis.directModules` (this task's own affected files) — fixed by keeping it in the task-specific section next to Impact Analysis, with a new test exercising the real code path the round-1 test's synthetic fixture couldn't reach. Round 2 clean apart from a comment-wording nit (addressed).

## Test plan

- [x] New tests: two different tasks share a long common prefix (peer issues before Task); File Health stays in the task-specific section with real impact-analysis data — both mutation-verified
- [x] `npx tsc --noEmit` / lint (0 new warnings) / build / full vitest suite green
- [x] Layer-2 independent review, 2 rounds — round 1 found a real defect (fixed in this PR), round 2 clean
- [ ] Deploy to vela and measure the `draft` stage cache rate (part of the standing 80%-cache goal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)